### PR TITLE
search: add an indexer function to index a single file

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -842,8 +842,17 @@ func (c *ConfigLocal) MaxNameBytes() uint32 {
 	return c.maxNameBytes
 }
 
+// SetStorageRoot sets the storage root directory for this config.
+func (c *ConfigLocal) SetStorageRoot(storageRoot string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.storageRoot = storageRoot
+}
+
 // StorageRoot implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) StorageRoot() string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.storageRoot
 }
 
@@ -1447,7 +1456,8 @@ func (c *ConfigLocal) MakeBlockMetadataStoreIfNotExists() (err error) {
 	if c.blockMetadataStore != nil {
 		return nil
 	}
-	c.blockMetadataStore, err = newDiskBlockMetadataStore(c, c.mode)
+	c.blockMetadataStore, err = newDiskBlockMetadataStore(
+		c, c.mode, c.storageRoot)
 	if err != nil {
 		// TODO (KBFS-3659): when we can open levelDB read-only,
 		//  do that instead of returning a Noop version.

--- a/go/kbfs/libkbfs/disk_block_metadata_store.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store.go
@@ -56,11 +56,11 @@ type diskBlockMetadataStore struct {
 
 // newDiskBlockMetadataStore creates a new disk BlockMetadata storage.
 func newDiskBlockMetadataStore(
-	config diskBlockMetadataStoreConfig, mode InitMode) (
+	config diskBlockMetadataStoreConfig, mode InitMode, storageRoot string) (
 	BlockMetadataStore, error) {
 	log := config.MakeLogger("BMS")
 	db, err := ldbutils.OpenVersionedLevelDb(
-		log, config.StorageRoot(), blockMetadataFolderName,
+		log, storageRoot, blockMetadataFolderName,
 		currentBlockMetadataStoreVersion, blockMetadataDbFilename, mode)
 	if err != nil {
 		return nil, err

--- a/go/kbfs/libkbfs/disk_block_metadata_store_test.go
+++ b/go/kbfs/libkbfs/disk_block_metadata_store_test.go
@@ -47,7 +47,8 @@ func makeBlockMetadataStoreForTest(t *testing.T) (
 		log:         logger.NewTestLogger(t),
 		storageRoot: tempdir,
 	}
-	s, err := newDiskBlockMetadataStore(&config, modeTest{modeDefault{}})
+	s, err := newDiskBlockMetadataStore(
+		&config, modeTest{modeDefault{}}, config.StorageRoot())
 	require.NoError(t, err)
 	return s, tempdir
 }

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -397,8 +397,7 @@ func makeMDServer(kbCtx Context, config Config, mdserverAddr string,
 	if serverRootDir, ok := parseRootDir(mdserverAddr); ok {
 		log.Debug("Using on-disk mdserver at %s", serverRootDir)
 		// local persistent MD server
-		mdPath := filepath.Join(serverRootDir, "kbfs_md")
-		return NewMDServerDir(mdServerLocalConfigAdapter{config}, mdPath)
+		return MakeDiskMDServer(config, serverRootDir)
 	}
 
 	remote, err := rpc.ParsePrioritizedRoundRobinRemote(mdserverAddr)
@@ -459,10 +458,7 @@ func makeBlockServer(kbCtx Context, config Config, bserverAddr string,
 	if serverRootDir, ok := parseRootDir(bserverAddr); ok {
 		log.Debug("Using on-disk bserver at %s", serverRootDir)
 		// local persistent block server
-		blockPath := filepath.Join(serverRootDir, "kbfs_block")
-		bserverLog := config.MakeLogger("BSD")
-		return NewBlockServerDir(config.Codec(),
-			bserverLog, blockPath), nil
+		return MakeDiskBlockServer(config, serverRootDir), nil
 	}
 
 	remote, err := rpc.ParsePrioritizedRoundRobinRemote(bserverAddr)

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -49,12 +49,14 @@ const (
 // TODO: Move more common code here.
 func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger.Logger) *ConfigLocal {
 	mode := modeTest{NewInitModeFromType(modeType)}
-	config := NewConfigLocal(mode, loggerFn, "", DiskCacheModeOff, env.NewContextFromGlobalContext(&libkb.GlobalContext{
+	g := &libkb.GlobalContext{
 		// Env is needed by simplefs.
 		Env: libkb.NewEnv(nil, nil, func() logger.Logger {
 			return loggerFn("G")
 		}),
-	}))
+	}
+	g.MobileAppState = libkb.NewMobileAppState(g)
+	config := NewConfigLocal(mode, loggerFn, "", DiskCacheModeOff, env.NewContextFromGlobalContext(g))
 	config.SetVLogLevel(libkb.VLog1String)
 
 	bops := NewBlockOpsStandard(

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -414,3 +414,16 @@ func (ksp KeybaseServicePassthrough) NewChat(
 	_ Config, _ InitParams, _ Context, _ logger.Logger) (Chat, error) {
 	return ksp.config.Chat(), nil
 }
+
+// MakeDiskMDServer creates a disk-based local MD server.
+func MakeDiskMDServer(config Config, serverRootDir string) (MDServer, error) {
+	mdPath := filepath.Join(serverRootDir, "kbfs_md")
+	return NewMDServerDir(mdServerLocalConfigAdapter{config}, mdPath)
+}
+
+// MakeDiskBlockServer creates a disk-based local block server.
+func MakeDiskBlockServer(config Config, serverRootDir string) BlockServer {
+	blockPath := filepath.Join(serverRootDir, "kbfs_block")
+	bserverLog := config.MakeLogger("BSD")
+	return NewBlockServerDir(config.Codec(), bserverLog, blockPath)
+}

--- a/go/kbfs/search/doc_types.go
+++ b/go/kbfs/search/doc_types.go
@@ -1,0 +1,137 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"context"
+	"mime"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/blevesearch/bleve/mapping"
+	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+)
+
+const (
+	maxTextToIndex = uint64(10 * 1024 * 1024)
+
+	// Copied from net/http/sniff.go: the algorithm uses at most
+	// sniffLen bytes to make its decision.
+	sniffLen = uint64(512)
+)
+
+type indexedBase struct {
+	Name     string
+	TlfID    tlf.ID
+	Revision kbfsmd.Revision
+	Mtime    time.Time
+}
+
+type indexedTextFile struct {
+	indexedBase
+	Text string
+}
+
+var _ mapping.Classifier = indexedTextFile{}
+
+func (itf indexedTextFile) Type() string {
+	return textFileType
+}
+
+type indexedHTMLFile struct {
+	indexedBase
+	HTML string
+}
+
+var _ mapping.Classifier = indexedHTMLFile{}
+
+func (ihf indexedHTMLFile) Type() string {
+	return htmlFileType
+}
+
+func getContentType(
+	ctx context.Context, config libkbfs.Config, n libkbfs.Node,
+	ei data.EntryInfo) (contentType string, err error) {
+	name := n.GetBasename()
+	contentType = mime.TypeByExtension(filepath.Ext(name.Plaintext()))
+	if len(contentType) > 0 {
+		return contentType, nil
+	}
+
+	bufLen := sniffLen
+	if ei.Size < bufLen {
+		bufLen = ei.Size
+	}
+	buf := make([]byte, bufLen)
+
+	nBytes, err := config.KBFSOps().Read(ctx, n, buf, 0)
+	if err != nil {
+		return "", err
+	}
+	if nBytes < int64(len(buf)) {
+		buf = buf[:nBytes]
+	}
+
+	return http.DetectContentType(buf), nil
+}
+
+func getTextToIndex(
+	ctx context.Context, config libkbfs.Config, n libkbfs.Node,
+	ei data.EntryInfo) (data string, err error) {
+	bufLen := ei.Size
+	if bufLen > maxTextToIndex {
+		bufLen = maxTextToIndex
+	}
+	buf := make([]byte, bufLen)
+	nBytes, err := config.KBFSOps().Read(ctx, n, buf, 0)
+	if err != nil {
+		return "", err
+	}
+	if nBytes < int64(len(buf)) {
+		buf = buf[:nBytes]
+	}
+
+	return string(buf), nil
+}
+
+func makeDoc(
+	ctx context.Context, config libkbfs.Config, n libkbfs.Node,
+	ei data.EntryInfo, revision kbfsmd.Revision, mtime time.Time) (
+	interface{}, error) {
+	contentType, err := getContentType(ctx, config, n, ei)
+	if err != nil {
+		return nil, err
+	}
+
+	base := indexedBase{
+		Name:     n.GetBasename().Plaintext(),
+		TlfID:    n.GetFolderBranch().Tlf,
+		Revision: revision,
+		Mtime:    mtime,
+	}
+	s := strings.Split(contentType, ";")
+	switch s[0] {
+	case "text/html", "text/xml":
+		text, err := getTextToIndex(ctx, config, n, ei)
+		if err != nil {
+			return nil, err
+		}
+		return indexedHTMLFile{base, text}, nil
+	case "text/plain":
+		text, err := getTextToIndex(ctx, config, n, ei)
+		if err != nil {
+			return nil, err
+		}
+		return indexedTextFile{base, text}, nil
+	default:
+		// Unindexable content type.
+		return base, nil
+	}
+}

--- a/go/kbfs/search/indexed_block_db.go
+++ b/go/kbfs/search/indexed_block_db.go
@@ -211,7 +211,7 @@ func (db *IndexedBlockDb) GetNextDocIDs(n int) ([]string, error) {
 // blockMD is per-block metadata for an individual indexed block.
 type blockMD struct {
 	// Exported only for serialization.
-	IndexVersion uint   `codec:"i"`
+	IndexVersion uint64 `codec:"i"`
 	DocID        string `codec:"d"`
 }
 
@@ -290,7 +290,7 @@ func (db *IndexedBlockDb) checkDbLocked(
 // Get returns the version and doc ID for the given block.
 func (db *IndexedBlockDb) Get(
 	ctx context.Context, ptr data.BlockPointer) (
-	indexVersion uint, docID string, err error) {
+	indexVersion uint64, docID string, err error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 	err = db.checkDbLocked(ctx, "IBD(Get)")
@@ -307,8 +307,8 @@ func (db *IndexedBlockDb) Get(
 
 // Put saves the version and doc ID for the given block.
 func (db *IndexedBlockDb) Put(
-	ctx context.Context, tlfID tlf.ID, ptr data.BlockPointer, indexVersion uint,
-	docID string) error {
+	ctx context.Context, tlfID tlf.ID, ptr data.BlockPointer,
+	indexVersion uint64, docID string) error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 	err := db.checkDbLocked(ctx, "IBD(Put)")

--- a/go/kbfs/search/indexed_block_db_test.go
+++ b/go/kbfs/search/indexed_block_db_test.go
@@ -76,7 +76,7 @@ func TestIndexedBlockDb(t *testing.T) {
 		KeyGen:  kbfsmd.FirstValidKeyGen,
 		DataVer: 1,
 	}
-	ver1 := uint(1)
+	ver1 := uint64(1)
 	docID1 := "1"
 
 	t.Log("Put block MD into the db.")
@@ -88,7 +88,7 @@ func TestIndexedBlockDb(t *testing.T) {
 	t.Log("Get block MD from the db.")
 	getVer1, getDocID1, err := db.Get(ctx, ptr1)
 	require.NoError(t, err)
-	checkWrite := func(expectedVer, ver uint, expectedDocID, docID string) {
+	checkWrite := func(expectedVer, ver uint64, expectedDocID, docID string) {
 		require.Equal(t, expectedVer, ver)
 		require.Equal(t, expectedDocID, docID)
 	}
@@ -102,7 +102,7 @@ func TestIndexedBlockDb(t *testing.T) {
 		KeyGen:  kbfsmd.FirstValidKeyGen,
 		DataVer: 1,
 	}
-	ver2 := uint(1)
+	ver2 := uint64(1)
 	docID2 := "2"
 
 	err = db.Put(ctx, tlfID, ptr2, ver2, docID2)
@@ -130,7 +130,7 @@ func TestIndexedBlockDb(t *testing.T) {
 			RefNonce: nonce,
 		},
 	}
-	ver3 := uint(1)
+	ver3 := uint64(1)
 	docID3 := "3"
 	err = db.Put(ctx, tlfID, ptr3, ver3, docID3)
 	require.NoError(t, err)

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -1,0 +1,195 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blevesearch/bleve"
+	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/idutil"
+	"github.com/keybase/client/go/kbfs/libcontext"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func testInitConfig(
+	ctx context.Context, config libkbfs.Config, session idutil.SessionInfo,
+	log logger.Logger) (
+	newCtx context.Context, newConfig libkbfs.Config,
+	configShutdown func(context.Context) error, err error) {
+	configLocal, ok := config.(*libkbfs.ConfigLocal)
+	if !ok {
+		panic(fmt.Sprintf("Wrong config type: %T", config))
+	}
+
+	newConfig = libkbfs.ConfigAsUserWithMode(
+		configLocal, session.Name, libkbfs.InitSingleOp)
+
+	kbCtx := config.KbContext()
+	params, err := Params(kbCtx, config.StorageRoot(), session.UID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	newConfig.(*libkbfs.ConfigLocal).SetStorageRoot(params.StorageRoot)
+
+	mdserver, err := libkbfs.MakeDiskMDServer(config, params.StorageRoot)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	newConfig.SetMDServer(mdserver)
+
+	bserver := libkbfs.MakeDiskBlockServer(config, params.StorageRoot)
+	newConfig.SetBlockServer(bserver)
+
+	newCtx, err = libcontext.NewContextWithCancellationDelayer(
+		libkbfs.CtxWithRandomIDReplayable(
+			ctx, ctxIDKey, ctxOpID, newConfig.MakeLogger("")))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return newCtx, newConfig, func(context.Context) error {
+		mdserver.Shutdown()
+		bserver.Shutdown(ctx)
+		return nil
+	}, nil
+}
+
+func writeFile(
+	ctx context.Context, t *testing.T, kbfsOps libkbfs.KBFSOps, i *Indexer,
+	rootNode, node libkbfs.Node, name, text string, usedDocIDExpected bool) {
+	oldMD, err := kbfsOps.GetNodeMetadata(ctx, node)
+	require.NoError(t, err)
+
+	err = kbfsOps.Write(ctx, node, []byte(text), 0)
+	require.NoError(t, err)
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+
+	t.Log("Wait for index to load")
+	err = i.waitForIndex(ctx)
+	require.NoError(t, err)
+
+	if !usedDocIDExpected {
+		// For this test, since the indexer isn't discovering the
+		// updated files for itself, we have to manually update the
+		// docID in the indexed blocks db, to ensure it will be re-used.
+		t.Log("Update the doc ID")
+		oldPtr := oldMD.BlockInfo.BlockPointer
+		newMD, err := kbfsOps.GetNodeMetadata(ctx, node)
+		require.NoError(t, err)
+		newPtr := newMD.BlockInfo.BlockPointer
+		v, docID, err := i.blocksDb.Get(ctx, oldPtr)
+		require.NoError(t, err)
+		tlfID := rootNode.GetFolderBranch().Tlf
+		err = i.blocksDb.Put(ctx, tlfID, newPtr, v, docID)
+		require.NoError(t, err)
+		err = i.blocksDb.Delete(ctx, tlfID, oldPtr)
+		require.NoError(t, err)
+	}
+
+	t.Log("Index the file")
+	ids, err := i.blocksDb.GetNextDocIDs(1)
+	require.NoError(t, err)
+	namePPS := data.NewPathPartString(name, nil)
+	usedDocID, err := i.indexChild(ctx, rootNode, "", namePPS, ids[0], 1)
+	require.NoError(t, err)
+	require.Equal(t, usedDocIDExpected, usedDocID)
+
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+}
+
+func writeNewFile(
+	ctx context.Context, t *testing.T, kbfsOps libkbfs.KBFSOps, i *Indexer,
+	rootNode libkbfs.Node, name, text string) {
+	t.Logf("Making file %s", name)
+	namePPS := data.NewPathPartString(name, nil)
+	n, _, err := kbfsOps.CreateFile(
+		ctx, rootNode, namePPS, false, libkbfs.NoExcl)
+	require.NoError(t, err)
+	writeFile(ctx, t, kbfsOps, i, rootNode, n, name, text, true)
+}
+
+func TestIndexFile(t *testing.T) {
+	ctx := libcontext.BackgroundContextWithCancellationDelayer()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+
+	tempdir, err := ioutil.TempDir("", "indexTest")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+	config.SetStorageRoot(tempdir)
+
+	i, err := newIndexerWithConfigInit(config, testInitConfig)
+	require.NoError(t, err)
+	defer func() {
+		err := i.Shutdown(ctx)
+		require.NoError(t, err)
+	}()
+
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
+	require.NoError(t, err)
+	kbfsOps := config.KBFSOps()
+	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, data.MasterBranch)
+	require.NoError(t, err)
+	const aText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+	const aName = "a"
+	writeNewFile(ctx, t, kbfsOps, i, rootNode, aName, aText)
+	const bHTML = "Mauris et <a href=neque>sit</a> amet nisi " +
+		"<b>condimentum</b> fringilla vel non augue"
+	writeNewFile(ctx, t, kbfsOps, i, rootNode, "b.html", bHTML)
+
+	search := func(word string, expected int) {
+		query := bleve.NewQueryStringQuery(word)
+		request := bleve.NewSearchRequest(query)
+		result, err := i.index.Search(request)
+		require.NoError(t, err)
+		require.Len(t, result.Hits, expected)
+	}
+
+	t.Log("Search for plaintext")
+	search("dolor", 1)
+
+	t.Log("Search for lower-case")
+	search("lorem", 1)
+
+	t.Log("Search for html")
+	search("condimentum", 1)
+
+	t.Log("Search for word in html tag, which shouldn't be indexed")
+	search("neque", 0)
+
+	t.Log("Search for shared word")
+	search("sit", 2)
+
+	t.Log("Re-index a file using the same docID")
+	aNode, _, err := kbfsOps.Lookup(
+		ctx, rootNode, data.NewPathPartString(aName, nil))
+	require.NoError(t, err)
+	const aNewText = "Ut feugiat dolor in tortor viverra, ac egestas justo " +
+		"tincidunt."
+	writeFile(ctx, t, kbfsOps, i, rootNode, aNode, aName, aNewText, false)
+
+	t.Log("Search for old and new words")
+	search("dolor", 1) // two hits in same doc
+	search("tortor", 1)
+}

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -43,6 +43,14 @@ func testInitConfig(
 	}
 	newConfig.(*libkbfs.ConfigLocal).SetStorageRoot(params.StorageRoot)
 
+	// We use disk-based servers here, instead of memory-based ones
+	// which would normally be preferrable in a test, because bleve
+	// writes out a config file during kvstore-registration that needs
+	// to persist across the multiple indexer instances that will be
+	// made during the test (one on startup, and one when the user
+	// login notification is triggered).  If we use mem-based storage,
+	// the config file is lost when the first indexer instance is
+	// destroyed, and bleve won't work after that.
 	mdserver, err := libkbfs.MakeDiskMDServer(config, params.StorageRoot)
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
This function will eventually be called by a larger, automated process that will be introduced in future work.

Indexing a file involves:

* Passing in a docID that can be used if the blockpointer doesn't have one yet.
* Looking up the current blockpointer using the node metadata.
* Figuring out the content type of the document using mime extensions and/or content sniffing.
* Creating an indexable document struct for the document based on its content type, and populating that.
* Indexing that using Bleve.
* Recording the blockPtr -> docID and docID -> parentDocID mappings in local databases.

This also introduces some more general fixes and cleanups to get the `Indexer` to work and clean up after itself in a test setting.

Issue: HOTPOT-1490

