### PR TITLE
Fix WalletState shutdown panic, other -race fixes

### DIFF
--- a/go/stellar/global.go
+++ b/go/stellar/global.go
@@ -31,6 +31,7 @@ func ServiceInit(g *libkb.GlobalContext, walletState *WalletState, badger *badge
 	g.SetStellar(s)
 	g.AddLogoutHook(s, "stellar")
 	g.AddDbNukeHook(s, "stellar")
+	g.PushShutdownHook(s.Shutdown)
 }
 
 type Stellar struct {
@@ -104,6 +105,11 @@ func (s *Stellar) OnLogout(mctx libkb.MetaContext) error {
 }
 
 func (s *Stellar) OnDbNuke(mctx libkb.MetaContext) error {
+	s.Clear(mctx)
+	return nil
+}
+
+func (s *Stellar) Shutdown(mctx libkb.MetaContext) error {
 	s.Clear(mctx)
 	return nil
 }

--- a/go/stellar/stellarsvc/anchor_test.go
+++ b/go/stellar/stellarsvc/anchor_test.go
@@ -202,6 +202,7 @@ var validAnchorTests = []anchorTest{
 
 func TestAnchorInteractor(t *testing.T) {
 	tc := SetupTest(t, "AnchorInteractor", 1)
+	defer tc.Cleanup()
 	for i, test := range errAnchorTests {
 		accountID, seed := randomStellarKeypair()
 		ai := newAnchorInteractor(accountID, &seed, test.Asset)

--- a/go/stellar/stellarsvc/service_test.go
+++ b/go/stellar/stellarsvc/service_test.go
@@ -1381,13 +1381,14 @@ func TestShutdown(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
-		go func() {
+		go func(index int) {
+			time.Sleep(time.Duration(index*10) * time.Millisecond)
 			_, err := tcs[0].Srv.BalancesLocal(context.Background(), accountID)
 			if err != nil {
 				t.Error(err)
 			}
 			wg.Done()
-		}()
+		}(i)
 	}
 
 	wg.Add(1)

--- a/go/stellar/wallet_state.go
+++ b/go/stellar/wallet_state.go
@@ -34,6 +34,7 @@ type WalletState struct {
 	refreshGroup   *singleflight.Group
 	refreshReqs    chan stellar1.AccountID
 	refreshCount   int
+	backgroundStop chan struct{}
 	backgroundDone chan struct{}
 	rateGroup      *singleflight.Group
 	shutdownOnce   sync.Once
@@ -50,14 +51,16 @@ var _ remote.Remoter = (*WalletState)(nil)
 // used for any network calls.
 func NewWalletState(g *libkb.GlobalContext, r remote.Remoter) *WalletState {
 	ws := &WalletState{
-		Contextified: libkb.NewContextified(g),
-		Remoter:      r,
-		accounts:     make(map[stellar1.AccountID]*AccountState),
-		rates:        make(map[string]rateEntry),
-		refreshGroup: &singleflight.Group{},
-		refreshReqs:  make(chan stellar1.AccountID, 100),
-		rateGroup:    &singleflight.Group{},
-		options:      NewOptions(),
+		Contextified:   libkb.NewContextified(g),
+		Remoter:        r,
+		accounts:       make(map[stellar1.AccountID]*AccountState),
+		rates:          make(map[string]rateEntry),
+		refreshGroup:   &singleflight.Group{},
+		refreshReqs:    make(chan stellar1.AccountID, 100),
+		backgroundDone: make(chan struct{}),
+		backgroundStop: make(chan struct{}),
+		rateGroup:      &singleflight.Group{},
+		options:        NewOptions(),
 	}
 
 	g.PushShutdownHook(ws.Shutdown)
@@ -75,7 +78,7 @@ func (w *WalletState) Shutdown(mctx libkb.MetaContext) error {
 		mctx.Debug("WalletState shutting down")
 		w.Lock()
 		w.resetWithLock(mctx)
-		close(w.refreshReqs)
+		close(w.backgroundStop)
 		w.bkgCancelFn()
 		mctx.Debug("waiting for background refresh requests to finish")
 		select {
@@ -358,24 +361,30 @@ func (w *WalletState) ForceSeqnoRefresh(mctx libkb.MetaContext, accountID stella
 // the account state if sufficient time has passed since the
 // last refresh.
 func (w *WalletState) backgroundRefresh(ctx context.Context) {
-	w.backgroundDone = make(chan struct{})
-	for accountID := range w.refreshReqs {
-		a, ok := w.accountState(accountID)
-		if !ok {
-			continue
-		}
-		a.RLock()
-		rt := a.rtime
-		a.RUnlock()
+	mctx := libkb.NewMetaContext(ctx, w.G()).WithLogTag("WABR")
+	var done bool
+	for !done {
+		select {
+		case accountID := <-w.refreshReqs:
+			a, ok := w.accountState(accountID)
+			if !ok {
+				continue
+			}
+			a.RLock()
+			rt := a.rtime
+			a.RUnlock()
 
-		mctx := libkb.NewMetaContext(ctx, w.G()).WithLogTag("WABR")
-		if time.Since(rt) < 120*time.Second {
-			mctx.Debug("WalletState.backgroundRefresh skipping for %s due to recent refresh", accountID)
-			continue
-		}
+			if time.Since(rt) < 120*time.Second {
+				mctx.Debug("WalletState.backgroundRefresh skipping for %s due to recent refresh", accountID)
+				continue
+			}
 
-		if err := a.Refresh(mctx, w.G().NotifyRouter, "background"); err != nil {
-			mctx.Debug("WalletState.backgroundRefresh error for %s: %s", accountID, err)
+			if err := a.Refresh(mctx, w.G().NotifyRouter, "background"); err != nil {
+				mctx.Debug("WalletState.backgroundRefresh error for %s: %s", accountID, err)
+			}
+		case <-w.backgroundStop:
+			mctx.Debug("WalletState.backgroundRefresh: stop channel closed, stopping the loop")
+			done = true
 		}
 	}
 	close(w.backgroundDone)
@@ -908,16 +917,16 @@ func (a *AccountState) RemovePendingTx(ctx context.Context, txID stellar1.Transa
 // Balances returns the balances that have already been fetched for
 // this account.
 func (a *AccountState) Balances(ctx context.Context) ([]stellar1.Balance, error) {
-	a.RLock()
-	defer a.RUnlock()
+	a.Lock()
+	defer a.Unlock()
 	a.enqueueRefreshReq()
 	return a.balances, nil
 }
 
 // Details returns the account details that have already been fetched for this account.
 func (a *AccountState) Details(ctx context.Context) (stellar1.AccountDetails, error) {
-	a.RLock()
-	defer a.RUnlock()
+	a.Lock()
+	defer a.Unlock()
 	a.enqueueRefreshReq()
 	if a.details == nil {
 		return stellar1.AccountDetails{AccountID: a.accountID}, nil
@@ -928,8 +937,8 @@ func (a *AccountState) Details(ctx context.Context) (stellar1.AccountDetails, er
 // PendingPayments returns the pending payments that have already been fetched for
 // this account.
 func (a *AccountState) PendingPayments(ctx context.Context, limit int) ([]stellar1.PaymentSummary, error) {
-	a.RLock()
-	defer a.RUnlock()
+	a.Lock()
+	defer a.Unlock()
 	a.enqueueRefreshReq()
 	if limit > 0 && limit < len(a.pending) {
 		return a.pending[:limit], nil
@@ -940,8 +949,8 @@ func (a *AccountState) PendingPayments(ctx context.Context, limit int) ([]stella
 // RecentPayments returns the recent payments that have already been fetched for
 // this account.
 func (a *AccountState) RecentPayments(ctx context.Context) (stellar1.PaymentsPage, error) {
-	a.RLock()
-	defer a.RUnlock()
+	a.Lock()
+	defer a.Unlock()
 	a.enqueueRefreshReq()
 	if a.recent == nil {
 		return stellar1.PaymentsPage{}, nil
@@ -979,8 +988,7 @@ func (a *AccountState) updateEntry(entry stellar1.BundleEntry) {
 }
 
 // enqueueRefreshReq adds an account ID to the refresh request queue.
-// It doesn't attempt to add if a.done.  Should be called
-// after RLock() or Lock()
+// It doesn't attempt to add if a.done.  Should be called after Lock().
 func (a *AccountState) enqueueRefreshReq() {
 	if a.done {
 		return


### PR DESCRIPTION
I saw a panic in WalletState in a CI run:

```
panic: send on closed channel

goroutine 227843 [running]:
github.com/keybase/client/go/stellar.(*AccountState).enqueueRefreshReq(0xc1f3e21180)
	/tmp/jenkins-67764100/workspace/client/master/13328/go/src/github.com/keybase/client/go/stellar/wallet_state.go:988 +0xed
github.com/keybase/client/go/stellar.(*AccountState).Details(0xc1f3e21180, 0x2a96b20, 0xc235ac67b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/jenkins-67764100/workspace/client/master/13328/go/src/github.com/keybase/client/go/stellar/wallet_state.go:921 +0x99
github.com/keybase/client/go/stellar.(*WalletState).Details(0xc12be4a500, 0x2a96b20, 0xc235ac67b0, 0xc125f5cc00, 0x38, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/jenkins-67764100/workspace/client/master/13328/go/src/github.com/keybase/client/go/stellar/wallet_state.go:432 +0x10b
github.com/keybase/client/go/stellar.AccountDetails(0x2a96b20, 0xc235ac67b0, 0xc106156000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/tmp/jenkins-67764100/workspace/client/master/13328/go/src/github.com/keybase/client/go/stellar/stellar.go:2065 +0xc6

```

This removes the closing of that channel and instead uses a stop channel to stop the background loop.

In debugging it, I was running `go test -race` a lot and found a few other issues, so some fixes for those in here too.
