### PR TITLE
root_metadata: return error from `loadCachedBlockChanges`

### DIFF
--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -1381,8 +1381,11 @@ func (md *MDOpsStandard) put(ctx context.Context, rmd *RootMetadata,
 		return ImmutableRootMetadata{}, err
 	}
 
-	rmd = rmd.loadCachedBlockChanges(
+	rmd, err = rmd.loadCachedBlockChanges(
 		ctx, bps, md.log, md.vlog, md.config.Codec())
+	if err != nil {
+		return ImmutableRootMetadata{}, err
+	}
 	irmd := MakeImmutableRootMetadata(
 		rmd, verifyingKey, mdID, md.config.Clock().Now(), true)
 	// Revisions created locally should always override anything else

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -2369,8 +2369,11 @@ func (j *tlfJournal) doPutMD(
 	// the journal, to guarantee it will be replaced if the journal is
 	// converted into a branch before any of the upper layer have a
 	// chance to cache it.
-	rmd = rmd.loadCachedBlockChanges(
+	rmd, err = rmd.loadCachedBlockChanges(
 		ctx, bps, j.log, j.vlog, j.config.Codec())
+	if err != nil {
+		return ImmutableRootMetadata{}, false, err
+	}
 	irmd = MakeImmutableRootMetadata(
 		rmd, verifyingKey, mdID, j.config.Clock().Now(), false)
 
@@ -2547,8 +2550,11 @@ func (j *tlfJournal) doResolveBranch(
 	// chance to cache it. Revisions created locally should always
 	// override anything else in the cache, so use `Replace` rather
 	// than `Put`.
-	rmd = rmd.loadCachedBlockChanges(
+	rmd, err = rmd.loadCachedBlockChanges(
 		ctx, bps, j.log, j.vlog, j.config.Codec())
+	if err != nil {
+		return ImmutableRootMetadata{}, false, err
+	}
 	irmd = MakeImmutableRootMetadata(
 		rmd, verifyingKey, mdID, j.config.Clock().Now(), false)
 	err = j.config.MDCache().Replace(irmd, irmd.BID())


### PR DESCRIPTION
Previously this just panic'd on an error, which could lead to a smiliar issue to the one that exposed HOTPOT-1553 (fixed in 91e6a458). There's no reason not to handle the error in the normal way.

Issue: HOTPOT-1674