### PR TITLE
autogit: avoid possible panic

### DIFF
--- a/go/kbfs/libgit/browser.go
+++ b/go/kbfs/libgit/browser.go
@@ -141,6 +141,10 @@ func NewBrowser(
 
 func (b *Browser) getCommitFile(
 	ctx context.Context, hash plumbing.Hash) (*diffFile, error) {
+	if b.repo == nil {
+		return nil, errors.New("Empty repo")
+	}
+
 	commit, err := b.repo.CommitObject(hash)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
A user hit a panic below this code a long time ago, because of a `nil` `b.repo`.  I couldn't repro it or see how it was exactly possible, and the code has changed a bit since that version so it might not be possible anymore.  In any case, it seems like a safe check to have, so might as well add it in.

Issue: HOTPOT-1697