### PR TITLE
fix: teamname => teamID in messageAuthorIsBot

### DIFF
--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -475,7 +475,7 @@ export const messageAuthorIsBot = (
         TeamConstants.userIsRoleInTeam(state, teamID, message.author, 'bot')
     : meta.teamType === 'adhoc' && participantInfo.name.length > 0 // teams without info may have type adhoc with an empty participant name list
     ? !participantInfo.name.includes(message.author) // if adhoc, check if author in participants
-    : false // if we don't have team information, don't show bot icon)
+    : false // if we don't have team information, don't show bot icon
 }
 
 export {

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -469,13 +469,13 @@ export const messageAuthorIsBot = (
   message: Types.Message,
   participantInfo: Types.ParticipantInfo
 ) => {
-  const teamname = meta.teamname
-  return teamname
-    ? TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'restrictedbot') ||
-        TeamConstants.userIsRoleInTeam(state, teamname, message.author, 'bot')
+  const teamID = meta.teamID
+  return teamID
+    ? TeamConstants.userIsRoleInTeam(state, teamID, message.author, 'restrictedbot') ||
+        TeamConstants.userIsRoleInTeam(state, teamID, message.author, 'bot')
     : meta.teamType === 'adhoc' && participantInfo.name.length > 0 // teams without info may have type adhoc with an empty participant name list
     ? !participantInfo.name.includes(message.author) // if adhoc, check if author in participants
-    : false // if we don't have team information, don't show bot icon
+    : false // if we don't have team information, don't show bot icon)
 }
 
 export {


### PR DESCRIPTION
Fixes an issue with `messageAuthorIsBot` not returning the correct value. This issue was caused by changes to the `userIsRoleInTeam` function, which now takes a team ID instead of a team name. 