### PR TITLE
search: add a function to rename a file in the index

### DIFF
--- a/go/kbfs/search/doc_types.go
+++ b/go/kbfs/search/doc_types.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/blevesearch/bleve/mapping"
 	"github.com/keybase/client/go/kbfs/data"
@@ -28,7 +29,6 @@ const (
 )
 
 type indexedBase struct {
-	Name     string
 	TlfID    tlf.ID
 	Revision kbfsmd.Revision
 	Mtime    time.Time
@@ -101,37 +101,68 @@ func getTextToIndex(
 	return string(buf), nil
 }
 
+type indexedName struct {
+	indexedBase
+	Name          string
+	TokenizedName string
+}
+
+var _ mapping.Classifier = indexedName{}
+
+func (in indexedName) Type() string {
+	return textFileType
+}
+
+func removePunct(r rune) rune {
+	if unicode.IsPunct(r) {
+		return ' '
+	}
+	return r
+}
+
 func makeDoc(
 	ctx context.Context, config libkbfs.Config, n libkbfs.Node,
 	ei data.EntryInfo, revision kbfsmd.Revision, mtime time.Time) (
-	interface{}, error) {
-	contentType, err := getContentType(ctx, config, n, ei)
-	if err != nil {
-		return nil, err
-	}
-
+	doc, nameDoc interface{}, err error) {
 	base := indexedBase{
-		Name:     n.GetBasename().Plaintext(),
 		TlfID:    n.GetFolderBranch().Tlf,
 		Revision: revision,
 		Mtime:    mtime,
+	}
+
+	// Name goes in a separate doc, so we can rename a file without
+	// having to re-index all of its contents.  Turn all punctuation
+	// into spaces to allow for matching individual words within the
+	// filename.
+	fullName := n.GetBasename().Plaintext()
+	tokenizedName := strings.Map(removePunct, fullName)
+	name := indexedName{
+		indexedBase:   base,
+		Name:          fullName,
+		TokenizedName: tokenizedName,
+	}
+
+	// Make a doc for the contents, depending on the content type.
+	contentType, err := getContentType(ctx, config, n, ei)
+	if err != nil {
+		return nil, nil, err
 	}
 	s := strings.Split(contentType, ";")
 	switch s[0] {
 	case "text/html", "text/xml":
 		text, err := getTextToIndex(ctx, config, n, ei)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return indexedHTMLFile{base, text}, nil
+		return indexedHTMLFile{base, text}, name, nil
 	case "text/plain":
 		text, err := getTextToIndex(ctx, config, n, ei)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return indexedTextFile{base, text}, nil
+		return indexedTextFile{base, text}, name, nil
 	default:
 		// Unindexable content type.
-		return base, nil
+		return base, name, nil
 	}
 }

--- a/go/kbfs/search/doc_types.go
+++ b/go/kbfs/search/doc_types.go
@@ -158,6 +158,11 @@ func makeDoc(
 	// having to re-index all of its contents.
 	name := makeNameDocWithBase(n, base)
 
+	// Non-files only get a name to index.
+	if ei.Type != data.File && ei.Type != data.Exec {
+		return nil, name, nil
+	}
+
 	// Make a doc for the contents, depending on the content type.
 	contentType, err := getContentType(ctx, config, n, ei)
 	if err != nil {

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -188,4 +188,11 @@ func TestIndexFile(t *testing.T) {
 	t.Log("Search for old and new words")
 	search("dolor", 1) // two hits in same doc
 	search("tortor", 1)
+
+	t.Log("Add a hit in a filename")
+	const dText = "Cras volutpat mi in purus interdum, sit amet luctus " +
+		"velit accumsan."
+	const dName = "dolor.txt"
+	writeNewFile(ctx, t, kbfsOps, i, rootNode, dName, dText)
+	search("dolor", 2)
 }

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,6 +123,14 @@ func writeNewFile(
 	writeFile(ctx, t, kbfsOps, i, rootNode, n, name, text, true)
 }
 
+func testSearch(t *testing.T, i *Indexer, word string, expected int) {
+	query := bleve.NewQueryStringQuery(word)
+	request := bleve.NewSearchRequest(query)
+	result, err := i.index.Search(request)
+	require.NoError(t, err)
+	require.Len(t, result.Hits, expected)
+}
+
 func TestIndexFile(t *testing.T) {
 	ctx := libcontext.BackgroundContextWithCancellationDelayer()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -134,7 +143,8 @@ func TestIndexFile(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	config.SetStorageRoot(tempdir)
 
-	i, err := newIndexerWithConfigInit(config, testInitConfig)
+	i, err := newIndexerWithConfigInit(
+		config, testInitConfig, kvstoreNamePrefix+"_TestIndexFile")
 	require.NoError(t, err)
 	defer func() {
 		err := i.Shutdown(ctx)
@@ -154,28 +164,20 @@ func TestIndexFile(t *testing.T) {
 		"<b>condimentum</b> fringilla vel non augue"
 	writeNewFile(ctx, t, kbfsOps, i, rootNode, "b.html", bHTML)
 
-	search := func(word string, expected int) {
-		query := bleve.NewQueryStringQuery(word)
-		request := bleve.NewSearchRequest(query)
-		result, err := i.index.Search(request)
-		require.NoError(t, err)
-		require.Len(t, result.Hits, expected)
-	}
-
 	t.Log("Search for plaintext")
-	search("dolor", 1)
+	testSearch(t, i, "dolor", 1)
 
 	t.Log("Search for lower-case")
-	search("lorem", 1)
+	testSearch(t, i, "lorem", 1)
 
 	t.Log("Search for html")
-	search("condimentum", 1)
+	testSearch(t, i, "condimentum", 1)
 
 	t.Log("Search for word in html tag, which shouldn't be indexed")
-	search("neque", 0)
+	testSearch(t, i, "neque", 0)
 
 	t.Log("Search for shared word")
-	search("sit", 2)
+	testSearch(t, i, "sit", 2)
 
 	t.Log("Re-index a file using the same docID")
 	aNamePPS := data.NewPathPartString(aName, nil)
@@ -186,15 +188,15 @@ func TestIndexFile(t *testing.T) {
 	writeFile(ctx, t, kbfsOps, i, rootNode, aNode, aName, aNewText, false)
 
 	t.Log("Search for old and new words")
-	search("dolor", 1) // two hits in same doc
-	search("tortor", 1)
+	testSearch(t, i, "dolor", 1) // two hits in same doc
+	testSearch(t, i, "tortor", 1)
 
 	t.Log("Add a hit in a filename")
 	const dText = "Cras volutpat mi in purus interdum, sit amet luctus " +
 		"velit accumsan."
 	const dName = "dolor.txt"
 	writeNewFile(ctx, t, kbfsOps, i, rootNode, dName, dText)
-	search("dolor", 2)
+	testSearch(t, i, "dolor", 2)
 
 	t.Log("Rename the file")
 	const newDName = "neque.txt"
@@ -209,8 +211,8 @@ func TestIndexFile(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	search("dolor", 1)
-	search("neque", 1)
+	testSearch(t, i, "dolor", 1)
+	testSearch(t, i, "neque", 1)
 
 	t.Log("Delete a file")
 	md, err := kbfsOps.GetNodeMetadata(ctx, aNode)
@@ -225,5 +227,96 @@ func TestIndexFile(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	search("tortor", 0)
+	testSearch(t, i, "tortor", 0)
+}
+
+func TestFullIndexSyncedTlf(t *testing.T) {
+	ctx := libcontext.BackgroundContextWithCancellationDelayer()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+
+	tempdir, err := ioutil.TempDir("", "indexTest")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+	config.SetStorageRoot(tempdir)
+
+	err = config.EnableDiskLimiter(tempdir)
+	require.NoError(t, err)
+	config.SetDiskCacheMode(libkbfs.DiskCacheModeLocal)
+	err = config.MakeDiskBlockCacheIfNotExists()
+	require.NoError(t, err)
+
+	i, err := newIndexerWithConfigInit(
+		config, testInitConfig, kvstoreNamePrefix+"_TestFullIndexSyncedTlf")
+	require.NoError(t, err)
+	defer func() {
+		err := i.Shutdown(ctx)
+		require.NoError(t, err)
+	}()
+
+	h, err := tlfhandle.ParseHandle(
+		ctx, config.KBPKI(), config.MDOps(), nil, "user1", tlf.Private)
+	require.NoError(t, err)
+	kbfsOps := config.KBFSOps()
+	rootNode, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, data.MasterBranch)
+	require.NoError(t, err)
+
+	t.Log("Create two dirs with two files each")
+	mkfiles := func(dirName, text1, text2 string) {
+		dirNamePPS := data.NewPathPartString(dirName, nil)
+		dirNode, _, err := kbfsOps.CreateDir(ctx, rootNode, dirNamePPS)
+		require.NoError(t, err)
+		f1Name := dirName + "_file1"
+		f1NamePPS := data.NewPathPartString(f1Name, nil)
+		f1Node, _, err := kbfsOps.CreateFile(
+			ctx, dirNode, f1NamePPS, false, libkbfs.NoExcl)
+		require.NoError(t, err)
+		err = kbfsOps.Write(ctx, f1Node, []byte(text1), 0)
+		require.NoError(t, err)
+		f2Name := dirName + "_file2"
+		f2NamePPS := data.NewPathPartString(f2Name, nil)
+		f2Node, _, err := kbfsOps.CreateFile(
+			ctx, dirNode, f2NamePPS, false, libkbfs.NoExcl)
+		require.NoError(t, err)
+		err = kbfsOps.Write(ctx, f2Node, []byte(text2), 0)
+		require.NoError(t, err)
+	}
+
+	aName := "alpha"
+	const a1Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+	const a2Text = "Mauris et neque sit amet nisi condimentum fringilla " +
+		"vel non augue"
+	mkfiles(aName, a1Text, a2Text)
+
+	bName := "beta"
+	const b1Text = "Ut feugiat dolor in tortor viverra, ac egestas justo " +
+		"tincidunt."
+	const b2Text = "Cras volutpat mi in purus interdum, sit amet luctus " +
+		"velit accumsan."
+	mkfiles(bName, b1Text, b2Text)
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+
+	t.Log("Wait for index to load")
+	err = i.waitForIndex(ctx)
+	require.NoError(t, err)
+
+	t.Log("Enable syncing")
+	_, err = kbfsOps.SetSyncConfig(
+		ctx, rootNode.GetFolderBranch().Tlf, keybase1.FolderSyncConfig{
+			Mode: keybase1.FolderSyncMode_ENABLED,
+		})
+	require.NoError(t, err)
+	err = i.waitForSyncs(ctx)
+	require.NoError(t, err)
+
+	t.Log("Check searches")
+	testSearch(t, i, "dolor", 2)
+	testSearch(t, i, "feugiat", 1)
+	testSearch(t, i, aName, 3) // Child nodes have "alpha" in their name too
+	testSearch(t, i, "file1", 2)
 }

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -195,4 +195,16 @@ func TestIndexFile(t *testing.T) {
 	const dName = "dolor.txt"
 	writeNewFile(ctx, t, kbfsOps, i, rootNode, dName, dText)
 	search("dolor", 2)
+
+	t.Log("Rename the file")
+	const newDName = "neque.txt"
+	newDNamePPS := data.NewPathPartString(newDName, nil)
+	err = kbfsOps.Rename(
+		ctx, rootNode, data.NewPathPartString(dName, nil), rootNode,
+		newDNamePPS)
+	require.NoError(t, err)
+	err = i.renameChild(ctx, rootNode, "", newDNamePPS, 1)
+	require.NoError(t, err)
+	search("dolor", 1)
+	search("neque", 1)
 }


### PR DESCRIPTION
[Based on #22092 -- review that one first.]

Also, index filenames separately from contents.  This will let us rename documents without having to re-index their contents.  And tokenize the names by removing the punctuation.

Issue: HOTPOT-1492
