### PR TITLE
loading bar doesnt move thread around

### DIFF
--- a/shared/chat/conversation/normal/index.desktop.tsx
+++ b/shared/chat/conversation/normal/index.desktop.tsx
@@ -49,10 +49,6 @@ class Conversation extends React.PureComponent<Props> {
         >
           {this.props.threadLoadedOffline && <Offline />}
           <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.innerContainer}>
-            <ThreadLoadStatus conversationIDKey={this.props.conversationIDKey} />
-            {!this.props.showThreadSearch && (
-              <PinnedMessage conversationIDKey={this.props.conversationIDKey} />
-            )}
             <ListArea
               onFocusInput={this.props.onFocusInput}
               scrollListDownCounter={this.props.scrollListDownCounter}
@@ -60,7 +56,12 @@ class Conversation extends React.PureComponent<Props> {
               scrollListUpCounter={this.props.scrollListUpCounter}
               conversationIDKey={this.props.conversationIDKey}
             />
-
+            <Kb.Box2 direction="vertical" fullWidth={true} style={{left: 0, position: 'absolute', top: 0}}>
+              <ThreadLoadStatus conversationIDKey={this.props.conversationIDKey} />
+              {!this.props.showThreadSearch && (
+                <PinnedMessage conversationIDKey={this.props.conversationIDKey} />
+              )}
+            </Kb.Box2>
             {this.props.showThreadSearch && (
               <ThreadSearch
                 style={styles.threadSearchStyle}


### PR DESCRIPTION
The load status can bounce the thread around on desktop, so just float it on top with the pinned message.