### PR TITLE
Unresolved SBS warning plumbing

### DIFF
--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -167,9 +167,9 @@ func (c *CmdEncrypt) Run() error {
 
 	if res.UsedUnresolvedSBS {
 		dui := c.G().UI.GetDumbOutputUI()
-		dui.PrintfStderr("\nNote: Encrypted for %q who is not yet a keybase user.\n\n", res.UnresolvedSBSAssertion)
-		dui.PrintfStderr("One of your devices will need to be online after they join keybase\n")
-		dui.PrintfStderr("in order for them to decrypt the message.\n\n")
+		_, _ = dui.PrintfStderr("\nNote: Encrypted for %q who is not yet a keybase user.\n\n", res.UnresolvedSBSAssertion)
+		_, _ = dui.PrintfStderr("One of your devices will need to be online after they join keybase\n")
+		_, _ = dui.PrintfStderr("in order for them to decrypt the message.\n\n")
 	}
 
 	return nil

--- a/go/client/cmd_encrypt.go
+++ b/go/client/cmd_encrypt.go
@@ -156,9 +156,23 @@ func (c *CmdEncrypt) Run() error {
 	}
 
 	arg := keybase1.SaltpackEncryptArg{Source: src, Sink: snk, Opts: c.opts}
-	err = cli.SaltpackEncrypt(context.TODO(), arg)
-	cerr := c.filter.Close(err)
-	return libkb.PickFirstError(err, cerr)
+	res, err := cli.SaltpackEncrypt(context.TODO(), arg)
+	if err != nil {
+		return err
+	}
+	err = c.filter.Close(err)
+	if err != nil {
+		return err
+	}
+
+	if res.UsedUnresolvedSBS {
+		dui := c.G().UI.GetDumbOutputUI()
+		dui.PrintfStderr("\nNote: Encrypted for %q who is not yet a keybase user.\n\n", res.UnresolvedSBSAssertion)
+		dui.PrintfStderr("One of your devices will need to be online after they join keybase\n")
+		dui.PrintfStderr("in order for them to decrypt the message.\n\n")
+	}
+
+	return nil
 }
 
 func (c *CmdEncrypt) GetUsage() libkb.Usage {

--- a/go/client/cmd_test_crypto.go
+++ b/go/client/cmd_test_crypto.go
@@ -70,16 +70,16 @@ func (s *CmdTestCrypto) Run() (err error) {
 			Signed:      true,
 		},
 	}
-	ciphertext, err := cli.SaltpackEncryptString(mctx.Ctx(), arg)
+	sres, err := cli.SaltpackEncryptString(mctx.Ctx(), arg)
 	if err != nil {
 		return err
 	}
 	dui.Printf("ciphertext:\n\n")
-	dui.Printf("%s\n\n", ciphertext)
+	dui.Printf("%s\n\n", sres.Ciphertext)
 
 	dui.Printf("decrypting ciphertext\n")
 	decArg := keybase1.SaltpackDecryptStringArg{
-		Ciphertext: ciphertext,
+		Ciphertext: sres.Ciphertext,
 	}
 	res, err := cli.SaltpackDecryptString(mctx.Ctx(), decArg)
 	if err != nil {
@@ -120,14 +120,14 @@ func (s *CmdTestCrypto) Run() (err error) {
 			Signed:      true,
 		},
 	}
-	efPath, err := cli.SaltpackEncryptFile(mctx.Ctx(), efArg)
+	efres, err := cli.SaltpackEncryptFile(mctx.Ctx(), efArg)
 	if err != nil {
 		return err
 	}
-	dui.Printf("encrypted file: %s\n", efPath)
+	dui.Printf("encrypted file result: %+v\n", efres)
 
-	dui.Printf("decrypting file: %s\n", efPath)
-	dfArg := keybase1.SaltpackDecryptFileArg{EncryptedFilename: efPath}
+	dui.Printf("decrypting file: %s\n", efres.Filename)
+	dfArg := keybase1.SaltpackDecryptFileArg{EncryptedFilename: efres.Filename}
 	dfres, err := cli.SaltpackDecryptFile(mctx.Ctx(), dfArg)
 	if err != nil {
 		return err

--- a/go/engine/saltpack_encrypt.go
+++ b/go/engine/saltpack_encrypt.go
@@ -26,6 +26,10 @@ type SaltpackEncrypt struct {
 
 	newKeyfinderHook (func(arg libkb.SaltpackRecipientKeyfinderArg) libkb.SaltpackRecipientKeyfinderEngineInterface)
 
+	// keep track if an SBS recipient was used so callers can tell the user
+	UsedSBS      bool
+	SBSAssertion string
+
 	// Legacy encryption-only messages include a lot more information about
 	// receivers, and it's nice to keep the helpful errors working while those
 	// messages are still around.
@@ -125,6 +129,8 @@ func (e *SaltpackEncrypt) Run(m libkb.MetaContext) (err error) {
 			Identifier: key.Identifier,
 		})
 	}
+
+	e.UsedSBS, e.SBSAssertion = kf.UsedUnresolvedSBSAssertion()
 
 	// This flag determines whether saltpack is used in signcryption (false)
 	// vs encryption (true) format.

--- a/go/engine/saltpack_user_keyfinder.go
+++ b/go/engine/saltpack_user_keyfinder.go
@@ -17,6 +17,8 @@ type SaltpackUserKeyfinder struct {
 	Arg                           libkb.SaltpackRecipientKeyfinderArg
 	RecipientEntityKeyMap         map[keybase1.UserOrTeamID]([]keybase1.KID)
 	RecipientDeviceAndPaperKeyMap map[keybase1.UID]([]keybase1.KID)
+	UsingSBS                      bool
+	SBSAssertion                  string
 }
 
 var _ libkb.Engine2 = (*SaltpackUserKeyfinder)(nil)
@@ -69,6 +71,10 @@ func (e *SaltpackUserKeyfinder) GetPublicKIDs() []keybase1.KID {
 
 func (e *SaltpackUserKeyfinder) GetSymmetricKeys() []libkb.SaltpackReceiverSymmetricKey {
 	return []libkb.SaltpackReceiverSymmetricKey{}
+}
+
+func (e *SaltpackUserKeyfinder) UsedUnresolvedSBSAssertion() (bool, string) {
+	return e.UsingSBS, e.SBSAssertion
 }
 
 func (e *SaltpackUserKeyfinder) Run(m libkb.MetaContext) (err error) {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -1111,6 +1111,7 @@ type SaltpackRecipientKeyfinderEngineInterface interface {
 	Engine2
 	GetPublicKIDs() []keybase1.KID
 	GetSymmetricKeys() []SaltpackReceiverSymmetricKey
+	UsedUnresolvedSBSAssertion() (bool, string)
 }
 
 type SaltpackRecipientKeyfinderArg struct {

--- a/go/protocol/keybase1/saltpack.go
+++ b/go/protocol/keybase1/saltpack.go
@@ -132,6 +132,18 @@ func (o SaltpackVerifyOptions) DeepCopy() SaltpackVerifyOptions {
 	}
 }
 
+type SaltpackEncryptResult struct {
+	UsedUnresolvedSBS      bool   `codec:"usedUnresolvedSBS" json:"usedUnresolvedSBS"`
+	UnresolvedSBSAssertion string `codec:"unresolvedSBSAssertion" json:"unresolvedSBSAssertion"`
+}
+
+func (o SaltpackEncryptResult) DeepCopy() SaltpackEncryptResult {
+	return SaltpackEncryptResult{
+		UsedUnresolvedSBS:      o.UsedUnresolvedSBS,
+		UnresolvedSBSAssertion: o.UnresolvedSBSAssertion,
+	}
+}
+
 type SaltpackEncryptedMessageInfo struct {
 	Devices          []Device       `codec:"devices" json:"devices"`
 	NumAnonReceivers int            `codec:"numAnonReceivers" json:"numAnonReceivers"`
@@ -179,6 +191,34 @@ func (o SaltpackFrontendEncryptOptions) DeepCopy() SaltpackFrontendEncryptOption
 		})(o.Recipients),
 		Signed:      o.Signed,
 		IncludeSelf: o.IncludeSelf,
+	}
+}
+
+type SaltpackEncryptStringResult struct {
+	UsedUnresolvedSBS      bool   `codec:"usedUnresolvedSBS" json:"usedUnresolvedSBS"`
+	UnresolvedSBSAssertion string `codec:"unresolvedSBSAssertion" json:"unresolvedSBSAssertion"`
+	Ciphertext             string `codec:"ciphertext" json:"ciphertext"`
+}
+
+func (o SaltpackEncryptStringResult) DeepCopy() SaltpackEncryptStringResult {
+	return SaltpackEncryptStringResult{
+		UsedUnresolvedSBS:      o.UsedUnresolvedSBS,
+		UnresolvedSBSAssertion: o.UnresolvedSBSAssertion,
+		Ciphertext:             o.Ciphertext,
+	}
+}
+
+type SaltpackEncryptFileResult struct {
+	UsedUnresolvedSBS      bool   `codec:"usedUnresolvedSBS" json:"usedUnresolvedSBS"`
+	UnresolvedSBSAssertion string `codec:"unresolvedSBSAssertion" json:"unresolvedSBSAssertion"`
+	Filename               string `codec:"filename" json:"filename"`
+}
+
+func (o SaltpackEncryptFileResult) DeepCopy() SaltpackEncryptFileResult {
+	return SaltpackEncryptFileResult{
+		UsedUnresolvedSBS:      o.UsedUnresolvedSBS,
+		UnresolvedSBSAssertion: o.UnresolvedSBSAssertion,
+		Filename:               o.Filename,
 	}
 }
 
@@ -313,12 +353,12 @@ type SaltpackVerifyFileArg struct {
 }
 
 type SaltpackInterface interface {
-	SaltpackEncrypt(context.Context, SaltpackEncryptArg) error
+	SaltpackEncrypt(context.Context, SaltpackEncryptArg) (SaltpackEncryptResult, error)
 	SaltpackDecrypt(context.Context, SaltpackDecryptArg) (SaltpackEncryptedMessageInfo, error)
 	SaltpackSign(context.Context, SaltpackSignArg) error
 	SaltpackVerify(context.Context, SaltpackVerifyArg) error
-	SaltpackEncryptString(context.Context, SaltpackEncryptStringArg) (string, error)
-	SaltpackEncryptFile(context.Context, SaltpackEncryptFileArg) (string, error)
+	SaltpackEncryptString(context.Context, SaltpackEncryptStringArg) (SaltpackEncryptStringResult, error)
+	SaltpackEncryptFile(context.Context, SaltpackEncryptFileArg) (SaltpackEncryptFileResult, error)
 	SaltpackDecryptString(context.Context, SaltpackDecryptStringArg) (SaltpackPlaintextResult, error)
 	SaltpackDecryptFile(context.Context, SaltpackDecryptFileArg) (SaltpackFileResult, error)
 	SaltpackSignString(context.Context, SaltpackSignStringArg) (string, error)
@@ -342,7 +382,7 @@ func SaltpackProtocol(i SaltpackInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]SaltpackEncryptArg)(nil), args)
 						return
 					}
-					err = i.SaltpackEncrypt(ctx, typedArgs[0])
+					ret, err = i.SaltpackEncrypt(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -519,8 +559,8 @@ type SaltpackClient struct {
 	Cli rpc.GenericClient
 }
 
-func (c SaltpackClient) SaltpackEncrypt(ctx context.Context, __arg SaltpackEncryptArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncrypt", []interface{}{__arg}, nil, 0*time.Millisecond)
+func (c SaltpackClient) SaltpackEncrypt(ctx context.Context, __arg SaltpackEncryptArg) (res SaltpackEncryptResult, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncrypt", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
@@ -539,12 +579,12 @@ func (c SaltpackClient) SaltpackVerify(ctx context.Context, __arg SaltpackVerify
 	return
 }
 
-func (c SaltpackClient) SaltpackEncryptString(ctx context.Context, __arg SaltpackEncryptStringArg) (res string, err error) {
+func (c SaltpackClient) SaltpackEncryptString(ctx context.Context, __arg SaltpackEncryptStringArg) (res SaltpackEncryptStringResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptString", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 
-func (c SaltpackClient) SaltpackEncryptFile(ctx context.Context, __arg SaltpackEncryptFileArg) (res string, err error) {
+func (c SaltpackClient) SaltpackEncryptFile(ctx context.Context, __arg SaltpackEncryptFileArg) (res SaltpackEncryptFileResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.saltpack.saltpackEncryptFile", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
+++ b/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
@@ -271,7 +271,8 @@ func (e *SaltpackRecipientKeyfinderEngine) lookupAndAddImplicitTeamKeys(m libkb.
 		return err
 	}
 	m.Debug("adding team key for implicit team %v", impTeamName)
-	m.Warning("encrypting for %v who is not yet a keybase user (or does not have a provisioned device): one of your devices will need to be online after they join keybase (or provision a new device), or they won't be able to decrypt it.", validSocialAssertionOrExistingUser)
+	e.UsingSBS = true
+	e.SBSAssertion = validSocialAssertionOrExistingUser
 	e.SymmetricEntityKeyMap[team.ID] = appKey
 
 	return nil

--- a/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
+++ b/go/saltpackkeys/saltpack_recipient_keyfinder_engine.go
@@ -274,5 +274,5 @@ func (e *SaltpackRecipientKeyfinderEngine) lookupAndAddImplicitTeamKeys(m libkb.
 	m.Warning("encrypting for %v who is not yet a keybase user (or does not have a provisioned device): one of your devices will need to be online after they join keybase (or provision a new device), or they won't be able to decrypt it.", validSocialAssertionOrExistingUser)
 	e.SymmetricEntityKeyMap[team.ID] = appKey
 
-	return err
+	return nil
 }

--- a/protocol/avdl/keybase1/saltpack.avdl
+++ b/protocol/avdl/keybase1/saltpack.avdl
@@ -45,7 +45,14 @@ protocol saltpack {
     bytes signature; // detached signature data (binary or armored), can be empty
   }
 
-  void saltpackEncrypt(int sessionID, Stream source, Stream sink, SaltpackEncryptOptions opts);
+  record SaltpackEncryptResult {
+    @lint("ignore")
+    boolean usedUnresolvedSBS;
+    @lint("ignore")
+    string unresolvedSBSAssertion;
+  }
+
+  SaltpackEncryptResult saltpackEncrypt(int sessionID, Stream source, Stream sink, SaltpackEncryptOptions opts);
 
   record SaltpackEncryptedMessageInfo {
     array<Device> devices;
@@ -68,8 +75,24 @@ protocol saltpack {
     boolean includeSelf;
   }
 
-  string saltpackEncryptString(int sessionID, string plaintext, SaltpackFrontendEncryptOptions opts);
-  string saltpackEncryptFile(int sessionID, string filename, SaltpackFrontendEncryptOptions opts);
+  record SaltpackEncryptStringResult {
+    @lint("ignore")
+    boolean usedUnresolvedSBS;
+    @lint("ignore")
+    string unresolvedSBSAssertion;
+    string ciphertext;
+  }
+
+  SaltpackEncryptStringResult saltpackEncryptString(int sessionID, string plaintext, SaltpackFrontendEncryptOptions opts);
+
+  record SaltpackEncryptFileResult {
+    @lint("ignore")
+    boolean usedUnresolvedSBS;
+    @lint("ignore")
+    string unresolvedSBSAssertion;
+    string filename;
+  }
+  SaltpackEncryptFileResult saltpackEncryptFile(int sessionID, string filename, SaltpackFrontendEncryptOptions opts);
 
   record SaltpackPlaintextResult {
     SaltpackEncryptedMessageInfo info;

--- a/protocol/json/keybase1/saltpack.json
+++ b/protocol/json/keybase1/saltpack.json
@@ -124,6 +124,22 @@
     },
     {
       "type": "record",
+      "name": "SaltpackEncryptResult",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "usedUnresolvedSBS",
+          "lint": "ignore"
+        },
+        {
+          "type": "string",
+          "name": "unresolvedSBSAssertion",
+          "lint": "ignore"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "SaltpackEncryptedMessageInfo",
       "fields": [
         {
@@ -165,6 +181,46 @@
         {
           "type": "boolean",
           "name": "includeSelf"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SaltpackEncryptStringResult",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "usedUnresolvedSBS",
+          "lint": "ignore"
+        },
+        {
+          "type": "string",
+          "name": "unresolvedSBSAssertion",
+          "lint": "ignore"
+        },
+        {
+          "type": "string",
+          "name": "ciphertext"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SaltpackEncryptFileResult",
+      "fields": [
+        {
+          "type": "boolean",
+          "name": "usedUnresolvedSBS",
+          "lint": "ignore"
+        },
+        {
+          "type": "string",
+          "name": "unresolvedSBSAssertion",
+          "lint": "ignore"
+        },
+        {
+          "type": "string",
+          "name": "filename"
         }
       ]
     },
@@ -269,7 +325,7 @@
           "type": "SaltpackEncryptOptions"
         }
       ],
-      "response": null
+      "response": "SaltpackEncryptResult"
     },
     "saltpackDecrypt": {
       "request": [
@@ -349,7 +405,7 @@
           "type": "SaltpackFrontendEncryptOptions"
         }
       ],
-      "response": "string"
+      "response": "SaltpackEncryptStringResult"
     },
     "saltpackEncryptFile": {
       "request": [
@@ -366,7 +422,7 @@
           "type": "SaltpackFrontendEncryptOptions"
         }
       ],
-      "response": "string"
+      "response": "SaltpackEncryptFileResult"
     },
     "saltpackDecryptString": {
       "request": [

--- a/shared/actions/crypto.tsx
+++ b/shared/actions/crypto.tsx
@@ -168,7 +168,7 @@ const saltpackEncrypt = async (
   switch (type) {
     case 'file': {
       try {
-        const file = await RPCTypes.saltpackSaltpackEncryptFileRpcPromise({
+        const fileRes = await RPCTypes.saltpackSaltpackEncryptFileRpcPromise({
           filename: input.stringValue(),
           opts: {
             includeSelf: options.includeSelf,
@@ -178,7 +178,7 @@ const saltpackEncrypt = async (
         })
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Encrypt,
-          output: new HiddenString(file),
+          output: new HiddenString(fileRes.filename),
           outputSender: options.sign ? new HiddenString(username) : undefined,
           outputSigned: options.sign,
           outputType: type,
@@ -194,7 +194,7 @@ const saltpackEncrypt = async (
     }
     case 'text': {
       try {
-        const ciphertext = await RPCTypes.saltpackSaltpackEncryptStringRpcPromise({
+        const encryptRes = await RPCTypes.saltpackSaltpackEncryptStringRpcPromise({
           opts: {
             includeSelf: options.includeSelf,
             recipients: recipients,
@@ -204,7 +204,7 @@ const saltpackEncrypt = async (
         })
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Encrypt,
-          output: new HiddenString(ciphertext),
+          output: new HiddenString(encryptRes.ciphertext),
           outputSender: options.sign ? new HiddenString(username) : undefined,
           outputSigned: options.sign,
           outputType: type,

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1213,11 +1213,11 @@ export type MessageTypes = {
   }
   'keybase.1.saltpack.saltpackEncryptFile': {
     inParam: {readonly filename: String; readonly opts: SaltpackFrontendEncryptOptions}
-    outParam: String
+    outParam: SaltpackEncryptFileResult
   }
   'keybase.1.saltpack.saltpackEncryptString': {
     inParam: {readonly plaintext: String; readonly opts: SaltpackFrontendEncryptOptions}
-    outParam: String
+    outParam: SaltpackEncryptStringResult
   }
   'keybase.1.saltpack.saltpackSignFile': {
     inParam: {readonly filename: String}
@@ -2944,7 +2944,10 @@ export type RevokedProof = {readonly proof: RemoteProof; readonly diff: TrackDif
 export type RuntimeStats = {readonly processStats?: Array<ProcessRuntimeStats> | null; readonly dbStats?: Array<DbStats> | null; readonly convLoaderActive: Boolean; readonly selectiveSyncActive: Boolean}
 export type SHA512 = Bytes
 export type SaltpackDecryptOptions = {readonly interactive: Boolean; readonly forceRemoteCheck: Boolean; readonly usePaperKey: Boolean}
+export type SaltpackEncryptFileResult = {readonly usedUnresolvedSBS: Boolean; readonly unresolvedSBSAssertion: String; readonly filename: String}
 export type SaltpackEncryptOptions = {readonly recipients?: Array<String> | null; readonly teamRecipients?: Array<String> | null; readonly authenticityType: AuthenticityType; readonly useEntityKeys: Boolean; readonly useDeviceKeys: Boolean; readonly usePaperKeys: Boolean; readonly noSelfEncrypt: Boolean; readonly binary: Boolean; readonly saltpackVersion: Int; readonly useKBFSKeysOnlyForTesting: Boolean}
+export type SaltpackEncryptResult = {readonly usedUnresolvedSBS: Boolean; readonly unresolvedSBSAssertion: String}
+export type SaltpackEncryptStringResult = {readonly usedUnresolvedSBS: Boolean; readonly unresolvedSBSAssertion: String; readonly ciphertext: String}
 export type SaltpackEncryptedMessageInfo = {readonly devices?: Array<Device> | null; readonly numAnonReceivers: Int; readonly receiverIsAnon: Boolean; readonly sender: SaltpackSender}
 export type SaltpackFileResult = {readonly info: SaltpackEncryptedMessageInfo; readonly decryptedFilename: String; readonly signed: Boolean}
 export type SaltpackFrontendEncryptOptions = {readonly recipients?: Array<String> | null; readonly signed: Boolean; readonly includeSelf: Boolean}


### PR DESCRIPTION
This gets a warning about using an unresolved SBS recipient out of the log output and properly plumbed all the way up...

CLI uses it now, frontend can integrate.

cc @thebearjew 