### PR TITLE
PICNIC-825 - Loading with waiting key for all string operations

### DIFF
--- a/shared/actions/crypto.tsx
+++ b/shared/actions/crypto.tsx
@@ -201,14 +201,17 @@ const saltpackEncrypt = async (
   switch (type) {
     case 'file': {
       try {
-        const fileRes = await RPCTypes.saltpackSaltpackEncryptFileRpcPromise({
-          filename: input.stringValue(),
-          opts: {
-            includeSelf: options.includeSelf,
-            recipients: recipients,
-            signed: options.sign,
+        const fileRes = await RPCTypes.saltpackSaltpackEncryptFileRpcPromise(
+          {
+            filename: input.stringValue(),
+            opts: {
+              includeSelf: options.includeSelf,
+              recipients: recipients,
+              signed: options.sign,
+            },
           },
-        })
+          Constants.encryptFileWaitingKey
+        )
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Encrypt,
           output: new HiddenString(fileRes.filename),
@@ -227,14 +230,17 @@ const saltpackEncrypt = async (
     }
     case 'text': {
       try {
-        const encryptRes = await RPCTypes.saltpackSaltpackEncryptStringRpcPromise({
-          opts: {
-            includeSelf: options.includeSelf,
-            recipients: recipients,
-            signed: options.sign,
+        const encryptRes = await RPCTypes.saltpackSaltpackEncryptStringRpcPromise(
+          {
+            opts: {
+              includeSelf: options.includeSelf,
+              recipients: recipients,
+              signed: options.sign,
+            },
+            plaintext: input.stringValue(),
           },
-          plaintext: input.stringValue(),
-        })
+          Constants.encryptStringWaitingKey
+        )
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Encrypt,
           output: new HiddenString(encryptRes.ciphertext),
@@ -266,9 +272,12 @@ const saltpackDecrypt = async (action: CryptoGen.SaltpackDecryptPayload, logger:
   switch (type) {
     case 'file': {
       try {
-        const result = await RPCTypes.saltpackSaltpackDecryptFileRpcPromise({
-          encryptedFilename: input.stringValue(),
-        })
+        const result = await RPCTypes.saltpackSaltpackDecryptFileRpcPromise(
+          {
+            encryptedFilename: input.stringValue(),
+          },
+          Constants.decryptFileWaitingKey
+        )
         const {decryptedFilename, info, signed} = result
         const {sender} = info
         const {username} = sender
@@ -291,9 +300,12 @@ const saltpackDecrypt = async (action: CryptoGen.SaltpackDecryptPayload, logger:
     }
     case 'text': {
       try {
-        const result = await RPCTypes.saltpackSaltpackDecryptStringRpcPromise({
-          ciphertext: input.stringValue(),
-        })
+        const result = await RPCTypes.saltpackSaltpackDecryptStringRpcPromise(
+          {
+            ciphertext: input.stringValue(),
+          },
+          Constants.decryptStringWaitingKey
+        )
         const {plaintext, info, signed} = result
         const {sender} = info
         const {username} = sender
@@ -334,9 +346,12 @@ const saltpackSign = async (
   switch (type) {
     case 'file': {
       try {
-        const signedFilename = await RPCTypes.saltpackSaltpackSignFileRpcPromise({
-          filename: input.stringValue(),
-        })
+        const signedFilename = await RPCTypes.saltpackSaltpackSignFileRpcPromise(
+          {
+            filename: input.stringValue(),
+          },
+          Constants.signFileWaitingKey
+        )
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Sign,
           output: new HiddenString(signedFilename),
@@ -355,9 +370,12 @@ const saltpackSign = async (
     }
     case 'text': {
       try {
-        const ciphertext = await RPCTypes.saltpackSaltpackSignStringRpcPromise({
-          plaintext: input.stringValue(),
-        })
+        const ciphertext = await RPCTypes.saltpackSaltpackSignStringRpcPromise(
+          {
+            plaintext: input.stringValue(),
+          },
+          Constants.signStringWaitingKey
+        )
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Sign,
           output: new HiddenString(ciphertext),
@@ -388,9 +406,12 @@ const saltpackVerify = async (action: CryptoGen.SaltpackVerifyPayload, logger: S
   switch (type) {
     case 'file': {
       try {
-        const result = await RPCTypes.saltpackSaltpackVerifyFileRpcPromise({
-          signedFilename: input.stringValue(),
-        })
+        const result = await RPCTypes.saltpackSaltpackVerifyFileRpcPromise(
+          {
+            signedFilename: input.stringValue(),
+          },
+          Constants.verifyFileWaitingKey
+        )
         const {verifiedFilename, sender, verified} = result
         const {username} = sender
         const outputSigned = verified
@@ -413,7 +434,10 @@ const saltpackVerify = async (action: CryptoGen.SaltpackVerifyPayload, logger: S
     }
     case 'text': {
       try {
-        const result = await RPCTypes.saltpackSaltpackVerifyStringRpcPromise({signedMsg: input.stringValue()})
+        const result = await RPCTypes.saltpackSaltpackVerifyStringRpcPromise(
+          {signedMsg: input.stringValue()},
+          Constants.verifyStringWaitingKey
+        )
         const {plaintext, sender, verified} = result
         const {username} = sender
         const outputSigned = verified

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -5,6 +5,31 @@ import {IconType} from '../common-adapters/icon.constants-gen'
 
 export const saltpackDocumentation = 'https://saltpack.org'
 
+// String waiting keys
+export const encryptStringWaitingKey = 'crypto:encrypt:string' as Types.StringWaitingKey
+export const decryptStringWaitingKey = 'crypto:decrypt:string' as Types.StringWaitingKey
+export const signStringWaitingKey = 'crypto:sign:string' as Types.StringWaitingKey
+export const verifyStringWaitingKey = 'crypto:verify:string' as Types.StringWaitingKey
+export const allStringWaitingKeys = [
+  encryptStringWaitingKey,
+  decryptStringWaitingKey,
+  signStringWaitingKey,
+  verifyStringWaitingKey,
+]
+
+// File waiting keys
+export const encryptFileWaitingKey = 'crypto:encrypt:file' as Types.FileWaitingKey
+export const decryptFileWaitingKey = 'crypto:decrypt:file' as Types.FileWaitingKey
+export const signFileWaitingKey = 'crypto:sign:file' as Types.FileWaitingKey
+export const verifyFileWaitingKey = 'crypto:verify:file' as Types.FileWaitingKey
+export const allFileWaitingKeys = [
+  encryptFileWaitingKey,
+  decryptFileWaitingKey,
+  signFileWaitingKey,
+  verifyFileWaitingKey,
+]
+
+// Tab keys
 export const encryptTab = 'encryptTab'
 export const decryptTab = 'decryptTab'
 export const signTab = 'signTab'
@@ -47,7 +72,7 @@ export const Operations: {[key: string]: Types.Operations} = {
   Verify: 'verify',
 }
 
-const operationToInputFileIcon: {[K in Types.Operations]: IconType} = {
+const operationToInputFileIcon: {[k in Types.Operations]: IconType} = {
   decrypt: 'icon-file-saltpack-encrypted-64',
   encrypt: 'icon-file-64',
   sign: 'icon-file-64',
@@ -61,8 +86,24 @@ const operationToOutputFileIcon: {[k in Types.Operations]: IconType} = {
   verify: 'icon-file-64',
 } as const
 
+const operationToStringWaitingKey: {[k in Types.Operations]: Types.StringWaitingKey} = {
+  decrypt: decryptStringWaitingKey,
+  encrypt: encryptStringWaitingKey,
+  sign: signStringWaitingKey,
+  verify: verifyStringWaitingKey,
+} as const
+
+const operationToFileWaitingKey: {[k in Types.Operations]: Types.FileWaitingKey} = {
+  decrypt: decryptFileWaitingKey,
+  encrypt: encryptFileWaitingKey,
+  sign: signFileWaitingKey,
+  verify: verifyFileWaitingKey,
+} as const
+
 export const getInputFileIcon = (operation: Types.Operations) => operationToInputFileIcon[operation]
 export const getOutputFileIcon = (operation: Types.Operations) => operationToOutputFileIcon[operation]
+export const getStringWaitingKey = (operation: Types.Operations) => operationToStringWaitingKey[operation]
+export const getFileWaitingKey = (operation: Types.Operations) => operationToFileWaitingKey[operation]
 
 const defaultCommonState = {
   bytesComplete: 0,

--- a/shared/constants/types/crypto.tsx
+++ b/shared/constants/types/crypto.tsx
@@ -2,6 +2,17 @@ import * as TeamBuildingTypes from './team-building'
 import HiddenString from '../../util/hidden-string'
 import {IconType} from '../../common-adapters/icon.constants-gen'
 
+export type StringWaitingKey =
+  | 'crypto:encrypt:string'
+  | 'crypto:decrypt:string'
+  | 'crypto:sign:string'
+  | 'crypto:verify:string'
+export type FileWaitingKey =
+  | 'crypto:encrypt:file'
+  | 'crypto:decrypt:file'
+  | 'crypto:sign:file'
+  | 'crypto:verify:file'
+
 type EncryptTab = 'encryptTab'
 type DecryptTab = 'decryptTab'
 type SignTab = 'signTab'

--- a/shared/crypto/operations/decrypt/index.tsx
+++ b/shared/crypto/operations/decrypt/index.tsx
@@ -84,6 +84,7 @@ const Decrypt = (props: Props) => {
               onShowInFinder={props.onShowInFinder}
             />
             <OutputBar
+              operation={Constants.Operations.Decrypt}
               output={props.output}
               outputStatus={props.outputStatus}
               outputType={props.outputType}

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -158,6 +158,7 @@ const Encrypt = (props: Props) => {
               onShowInFinder={props.onShowInFinder}
             />
             <OutputBar
+              operation={Constants.Operations.Encrypt}
               output={props.output}
               outputStatus={props.outputStatus}
               outputType={props.outputType}

--- a/shared/crypto/operations/sign/index.tsx
+++ b/shared/crypto/operations/sign/index.tsx
@@ -102,6 +102,7 @@ const Sign = (props: Props) => {
               onShowInFinder={props.onShowInFinder}
             />
             <OutputBar
+              operation={Constants.Operations.Sign}
               output={props.output}
               outputStatus={props.outputStatus}
               outputType={props.outputType}

--- a/shared/crypto/operations/verify/index.tsx
+++ b/shared/crypto/operations/verify/index.tsx
@@ -81,6 +81,7 @@ const Verify = (props: Props) => {
               onShowInFinder={props.onShowInFinder}
             />
             <OutputBar
+              operation={Constants.Operations.Verify}
               output={props.output}
               outputStatus={props.outputStatus}
               outputType={props.outputType}

--- a/shared/crypto/output/index.stories.tsx
+++ b/shared/crypto/output/index.stories.tsx
@@ -70,6 +70,7 @@ const load = () => {
 
   Sb.storiesOf('Crypto/Output/Bar', module).add('Download - Copy', () => (
     <OutputBar
+      operation={Constants.Operations.Encrypt}
       output="secret stuff"
       outputStatus="success"
       onCopyOutput={onCopyOutput}

--- a/shared/crypto/output/index.tsx
+++ b/shared/crypto/output/index.tsx
@@ -3,6 +3,7 @@ import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as Constants from '../../constants/crypto'
 import * as Types from '../../constants/types/crypto'
+import * as Container from '../../util/container'
 import {getStyle} from '../../common-adapters/text'
 
 type Props = {
@@ -15,11 +16,12 @@ type Props = {
 }
 
 type OutputBarProps = {
+  onCopyOutput: (text: string) => void
+  onShowInFinder: (path: string) => void
+  operation: Types.Operations
   output: string
   outputStatus?: Types.OutputStatus
   outputType?: Types.OutputType
-  onCopyOutput: (text: string) => void
-  onShowInFinder: (path: string) => void
 }
 
 type OutputSignedProps = {
@@ -41,6 +43,8 @@ type OutputInfoProps = {
 const largeOutputLimit = 120
 
 export const SignedSender = (props: OutputSignedProps) => {
+  const waitingKey = Constants.getStringWaitingKey(props.operation)
+  const waiting = Container.useAnyWaiting(waitingKey)
   const canSelfSign =
     props.operation === Constants.Operations.Encrypt || props.operation === Constants.Operations.Sign
 
@@ -50,7 +54,7 @@ export const SignedSender = (props: OutputSignedProps) => {
 
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center" style={styles.signedContainer}>
-      <Kb.Box2 direction="horizontal" gap="xtiny" alignItems="center">
+      <Kb.Box2 direction="horizontal" gap="xtiny" alignItems="center" style={styles.signedSender}>
         {props.signed && props.signedBy
           ? [
               <Kb.Avatar key="avatar" size={16} username={props.signedBy} />,
@@ -71,6 +75,7 @@ export const SignedSender = (props: OutputSignedProps) => {
               </Kb.Text>,
             ]}
       </Kb.Box2>
+      {waiting && <Kb.ProgressIndicator type="Small" white={false} />}
     </Kb.Box2>
   )
 }
@@ -85,6 +90,8 @@ export const OutputInfoBanner = (props: OutputInfoProps) => {
 
 export const OutputBar = (props: OutputBarProps) => {
   const {output, onCopyOutput, onShowInFinder} = props
+  const waitingKey = Constants.getStringWaitingKey(props.operation)
+  const waiting = Container.useAnyWaiting(waitingKey)
   const attachmentRef = React.useRef<Kb.Box2>(null)
   const [showingToast, setShowingToast] = React.useState(false)
 
@@ -118,9 +125,14 @@ export const OutputBar = (props: OutputBarProps) => {
                   Copied to clipboard
                 </Kb.Text>
               </Kb.Toast>
-              <Kb.Button mode="Secondary" label="Copy to clipboard" onClick={() => copy()} />
+              <Kb.Button
+                mode="Secondary"
+                label="Copy to clipboard"
+                disabled={waiting}
+                onClick={() => copy()}
+              />
             </Kb.Box2>
-            <Kb.Button mode="Secondary" label="Download as TXT" />
+            <Kb.Button mode="Secondary" label="Download as TXT" disabled={waiting} />
           </Kb.ButtonBar>
         )}
       </Kb.Box2>
@@ -139,6 +151,8 @@ export const OutputBar = (props: OutputBarProps) => {
 }
 
 const Output = (props: Props) => {
+  const waitingKey = Constants.getStringWaitingKey(props.operation)
+  const waiting = Container.useAnyWaiting(waitingKey)
   // Output text can be 24 px when output is less that 120 characters
   const outputTextIsLarge =
     props.operation === Constants.Operations.Decrypt || props.operation === Constants.Operations.Verify
@@ -176,7 +190,7 @@ const Output = (props: Props) => {
             <Kb.Text
               key={index}
               type={props.textType === 'cipher' ? 'Terminal' : 'Body'}
-              selectable={true}
+              selectable={!waiting}
               style={Styles.collapseStyles([styles.output, outputLargeStyle])}
             >
               {line}
@@ -242,12 +256,16 @@ const styles = Styles.styleSheetCreate(
         color: Styles.globalColors.black_50,
       },
       signedContainer: {
+        minHeight: Styles.globalMargins.mediumLarge,
         paddingLeft: Styles.globalMargins.tiny,
         paddingRight: Styles.globalMargins.tiny,
         paddingTop: Styles.globalMargins.tiny,
       },
       signedIcon: {
         color: Styles.globalColors.green,
+      },
+      signedSender: {
+        ...Styles.globalStyles.flexGrow,
       },
       toastText: {
         color: Styles.globalColors.white,


### PR DESCRIPTION
Shows a spinner when encrypting/decrypting/signing/verifying string input

Makes output text unselectable while RPC is in flight

Makes copy to clipboard and download as file unselectable while RPC is in flight