### PR TITLE
Do not stack convs (mobile only)

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2381,12 +2381,7 @@ const navigateToThreadRoute = (conversationIDKey: Types.ConversationIDKey, fromK
     return
   }
 
-  // looking at the pending screen?
-  if (
-    visible?.routeName === 'chatConversation' &&
-    (visible.params?.conversationIDKey === Constants.pendingWaitingConversationIDKey ||
-      visible.params?.conversationIDKey === Constants.pendingErrorConversationIDKey)
-  ) {
+  if (visible?.routeName === 'chatConversation') {
     replace = true
   }
 


### PR DESCRIPTION
With stacking convs once you get two or three convs on top of each other it takes a lot of swipes/taps to get back to the inbox. And since the nav bar is hidden in convs you can't switch tabs until you get to the inbox.

A benefit of stacking convs is that when you go back, you end up back in the conversation you came from.