### PR TITLE
PICNIC-787 - Crypto errors banners and SBS warning banners

### DIFF
--- a/shared/actions/crypto-gen.tsx
+++ b/shared/actions/crypto-gen.tsx
@@ -29,17 +29,15 @@ type _ClearInputPayload = {readonly operation: Types.Operations}
 type _ClearRecipientsPayload = {readonly operation: Types.Operations}
 type _DownloadEncryptedTextPayload = void
 type _DownloadSignedTextPayload = void
-type _OnOperationErrorPayload = {
-  readonly operation: Types.Operations
-  readonly errorType: Types.ErrorTypes
-  readonly errorMessage: HiddenString
-}
+type _OnOperationErrorPayload = {readonly operation: Types.Operations; readonly errorMessage: HiddenString}
 type _OnOperationSuccessPayload = {
   readonly operation: Types.Operations
   readonly output: HiddenString
   readonly outputSender?: HiddenString
   readonly outputSigned: boolean
   readonly outputType: Types.OutputType
+  readonly warning?: boolean
+  readonly warningMessage?: HiddenString
 }
 type _ResetOperationPayload = {readonly operation: Types.Operations}
 type _SaltpackDecryptPayload = {readonly input: HiddenString; readonly type: Types.InputTypes}

--- a/shared/actions/crypto.tsx
+++ b/shared/actions/crypto.tsx
@@ -221,9 +221,9 @@ const saltpackEncrypt = async (
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Verify, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform encryption operation'),
-          errorType: '',
+          errorMessage: new HiddenString(message),
           operation: Constants.Operations.Encrypt,
         })
       }
@@ -247,12 +247,14 @@ const saltpackEncrypt = async (
           outputSender: options.sign ? new HiddenString(username) : undefined,
           outputSigned: options.sign,
           outputType: type,
+          warning: encryptRes.usedUnresolvedSBS,
+          warningMessage: new HiddenString(encryptRes.unresolvedSBSAssertion),
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Verify, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform encryption operation'),
-          errorType: '',
+          errorMessage: new HiddenString(message),
           operation: Constants.Operations.Encrypt,
         })
       }
@@ -291,9 +293,9 @@ const saltpackDecrypt = async (action: CryptoGen.SaltpackDecryptPayload, logger:
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Decrypt, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform decrypt operation'),
-          errorType: '',
+          errorMessage: new HiddenString(message),
           operation: Constants.Operations.Decrypt,
         })
       }
@@ -320,9 +322,9 @@ const saltpackDecrypt = async (action: CryptoGen.SaltpackDecryptPayload, logger:
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Decrypt, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform decrypt operation'),
-          errorType: '',
+          errorMessage: new HiddenString(message),
           operation: Constants.Operations.Decrypt,
         })
       }
@@ -361,10 +363,10 @@ const saltpackSign = async (
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Sign, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform decrypt operation'),
-          errorType: '',
-          operation: Constants.Operations.Decrypt,
+          errorMessage: new HiddenString(message),
+          operation: Constants.Operations.Sign,
         })
       }
     }
@@ -385,10 +387,10 @@ const saltpackSign = async (
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Sign, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform decrypt operation'),
-          errorType: '',
-          operation: Constants.Operations.Decrypt,
+          errorMessage: new HiddenString(message),
+          operation: Constants.Operations.Sign,
         })
       }
     }
@@ -425,10 +427,10 @@ const saltpackVerify = async (action: CryptoGen.SaltpackVerifyPayload, logger: S
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Verify, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform verify operation'),
-          errorType: '',
-          operation: Constants.Operations.Decrypt,
+          errorMessage: new HiddenString(message),
+          operation: Constants.Operations.Verify,
         })
       }
     }
@@ -451,10 +453,10 @@ const saltpackVerify = async (action: CryptoGen.SaltpackVerifyPayload, logger: S
         })
       } catch (err) {
         logger.error(err)
+        const message = Constants.getStatusCodeMessage(err.code, Constants.Operations.Verify, type)
         return CryptoGen.createOnOperationError({
-          errorMessage: new HiddenString('Failed to perform verify operation'),
-          errorType: '',
-          operation: Constants.Operations.Decrypt,
+          errorMessage: new HiddenString(message),
+          operation: Constants.Operations.Verify,
         })
       }
     }

--- a/shared/actions/crypto.tsx
+++ b/shared/actions/crypto.tsx
@@ -241,6 +241,7 @@ const saltpackEncrypt = async (
           },
           Constants.encryptStringWaitingKey
         )
+        const warningMessage = Constants.getWarningMessageForSBS(encryptRes.unresolvedSBSAssertion)
         return CryptoGen.createOnOperationSuccess({
           operation: Constants.Operations.Encrypt,
           output: new HiddenString(encryptRes.ciphertext),
@@ -248,7 +249,7 @@ const saltpackEncrypt = async (
           outputSigned: options.sign,
           outputType: type,
           warning: encryptRes.usedUnresolvedSBS,
-          warningMessage: new HiddenString(encryptRes.unresolvedSBSAssertion),
+          warningMessage: new HiddenString(warningMessage),
         })
       } catch (err) {
         logger.error(err)

--- a/shared/actions/json/crypto.json
+++ b/shared/actions/json/crypto.json
@@ -41,12 +41,13 @@
       "output": "HiddenString",
       "outputSender?": "HiddenString",
       "outputSigned": "boolean",
-      "outputType": "Types.OutputType"
+      "outputType": "Types.OutputType",
+      "warning?": "boolean",
+      "warningMessage?": "HiddenString"
     },
     "onOperationError": {
       "_description": "On saltpack RPC error response",
       "operation": "Types.Operations",
-      "errorType": "Types.ErrorTypes",
       "errorMessage": "HiddenString"
     },
     "resetOperation": {

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -109,7 +109,7 @@ const defaultCommonState = {
   bytesComplete: 0,
   bytesTotal: 0,
   errorMessage: new HiddenString(''),
-  errorType: '' as Types.ErrorTypes,
+  errorType: undefined,
   input: new HiddenString(''),
   inputType: 'text' as Types.InputTypes,
   output: new HiddenString(''),

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -110,9 +110,11 @@ export const getWarningMessageForSBS = (sbsAssertion: string) =>
   `Note: Encrypted for "${sbsAssertion}" who is not yet a keybase user. One of your devices will need to be online after they join keybase in order for them to decrypt the message. `
 
 export const getStatusCodeMessage = (code: number, operation: Types.Operations, type: Types.InputTypes) => {
-  const inputType = type === 'text' ? 'ciphertext' : 'file'
-  const action = type === 'text' ? 'enter' : 'drop a'
-  const addInput = type === 'text' ? 'ciphertext' : 'encrypted file'
+  const inputType =
+    type === 'text' ? (operation === Operations.Verify ? 'singed message' : 'ciphertext') : 'file'
+  const action = type === 'text' ? (operation === Operations.Verify ? 'enter a' : 'enter') : 'drop a'
+  const addInput =
+    type === 'text' ? (operation === Operations.Verify ? 'singed message' : 'ciphertext') : 'encrypted file'
   const invalidInputMessage = `This ${inputType} is not in a valid Saltpack format. Please ${action} Saltpack ${addInput}.`
 
   const statusCodeToMessage = {

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -107,7 +107,7 @@ export const getStringWaitingKey = (operation: Types.Operations) => operationToS
 export const getFileWaitingKey = (operation: Types.Operations) => operationToFileWaitingKey[operation]
 
 export const getWarningMessageForSBS = (sbsAssertion: string) =>
-  `Note: Encrypted for "${sbsAssertion}" who is not yet a keybase user. One of your devices will need to be online after they join keybase in order for them to decrypt the message. `
+  `Note: Encrypted for "${sbsAssertion}" who is not yet a Keybase user. One of your devices will need to be online after they join Keybase in order for them to decrypt the message.`
 
 export const getStatusCodeMessage = (code: number, operation: Types.Operations, type: Types.InputTypes) => {
   const inputType =

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -108,9 +108,15 @@ export const getFileWaitingKey = (operation: Types.Operations) => operationToFil
 
 export const getWarningMessageForSBS = (sbsAssertion: string) =>
   `Note: Encrypted for "${sbsAssertion}" who is not yet a keybase user. One of your devices will need to be online after they join keybase in order for them to decrypt the message. `
+
 export const getStatusCodeMessage = (code: number, operation: Types.Operations, type: Types.InputTypes) => {
+  const inputType = type === 'text' ? 'ciphertext' : 'file'
+  const action = type === 'text' ? 'enter' : 'drop a'
+  const addInput = type === 'text' ? 'ciphertext' : 'encrypted file'
+  const invalidInputMessage = `This ${inputType} is not in a valid Saltpack format. Please ${action} Saltpack ${addInput}.`
+
   const statusCodeToMessage = {
-    [RPCTypes.StatusCode.scstreamunknown]: `Invalid ${operation} input, ${type} must be valid Saltpack.`,
+    [RPCTypes.StatusCode.scstreamunknown]: invalidInputMessage,
     [RPCTypes.StatusCode
       .scsigcannotverify]: `Wrong saltpack message type: wanted an attached signature, but got a signed and encrypted message instead`,
   } as const

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -111,16 +111,16 @@ export const getWarningMessageForSBS = (sbsAssertion: string) =>
 
 export const getStatusCodeMessage = (code: number, operation: Types.Operations, type: Types.InputTypes) => {
   const inputType =
-    type === 'text' ? (operation === Operations.Verify ? 'singed message' : 'ciphertext') : 'file'
+    type === 'text' ? (operation === Operations.Verify ? 'signed message' : 'ciphertext') : 'file'
   const action = type === 'text' ? (operation === Operations.Verify ? 'enter a' : 'enter') : 'drop a'
   const addInput =
-    type === 'text' ? (operation === Operations.Verify ? 'singed message' : 'ciphertext') : 'encrypted file'
+    type === 'text' ? (operation === Operations.Verify ? 'signed message' : 'ciphertext') : 'encrypted file'
   const invalidInputMessage = `This ${inputType} is not in a valid Saltpack format. Please ${action} Saltpack ${addInput}.`
 
   const statusCodeToMessage = {
     [RPCTypes.StatusCode.scstreamunknown]: invalidInputMessage,
     [RPCTypes.StatusCode
-      .scsigcannotverify]: `Wrong saltpack message type: wanted an attached signature, but got a signed and encrypted message instead`,
+      .scsigcannotverify]: `Wrong message type: wanted an attached signature, but got a signed and encrypted message instead.`,
   } as const
   return statusCodeToMessage[code] || `Failed to ${operation} ${type}.`
 }

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -1,4 +1,5 @@
 import * as TeamBuildingConstants from './team-building'
+import * as RPCTypes from './types/rpc-gen'
 import * as Types from './types/crypto'
 import HiddenString from '../util/hidden-string'
 import {IconType} from '../common-adapters/icon.constants-gen'
@@ -105,11 +106,19 @@ export const getOutputFileIcon = (operation: Types.Operations) => operationToOut
 export const getStringWaitingKey = (operation: Types.Operations) => operationToStringWaitingKey[operation]
 export const getFileWaitingKey = (operation: Types.Operations) => operationToFileWaitingKey[operation]
 
+export const getStatusCodeMessage = (code: number, operation: Types.Operations, type: Types.InputTypes) => {
+  const statusCodeToMessage = {
+    [RPCTypes.StatusCode.scstreamunknown]: `Invalid ${operation} input, ${type} must be valid Saltpack.`,
+    [RPCTypes.StatusCode
+      .scsigcannotverify]: `Wrong saltpack message type: wanted an attached signature, but got a signed and encrypted message instead`,
+  } as const
+  return statusCodeToMessage[code] || `Failed to ${operation} ${type}.`
+}
+
 const defaultCommonState = {
   bytesComplete: 0,
   bytesTotal: 0,
   errorMessage: new HiddenString(''),
-  errorType: undefined,
   input: new HiddenString(''),
   inputType: 'text' as Types.InputTypes,
   output: new HiddenString(''),
@@ -117,6 +126,7 @@ const defaultCommonState = {
   outputSigned: false,
   outputStatus: undefined,
   outputType: undefined,
+  warningMessage: new HiddenString(''),
 }
 
 export const makeState = (): Types.State => ({

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -106,6 +106,8 @@ export const getOutputFileIcon = (operation: Types.Operations) => operationToOut
 export const getStringWaitingKey = (operation: Types.Operations) => operationToStringWaitingKey[operation]
 export const getFileWaitingKey = (operation: Types.Operations) => operationToFileWaitingKey[operation]
 
+export const getWarningMessageForSBS = (sbsAssertion: string) =>
+  `Note: Encrypted for "${sbsAssertion}" who is not yet a keybase user. One of your devices will need to be online after they join keybase in order for them to decrypt the message. `
 export const getStatusCodeMessage = (code: number, operation: Types.Operations, type: Types.InputTypes) => {
   const statusCodeToMessage = {
     [RPCTypes.StatusCode.scstreamunknown]: `Invalid ${operation} input, ${type} must be valid Saltpack.`,

--- a/shared/constants/types/crypto.tsx
+++ b/shared/constants/types/crypto.tsx
@@ -32,14 +32,14 @@ export type TextType = 'cipher' | 'plain'
 export type Operations = 'encrypt' | 'decrypt' | 'sign' | 'verify'
 export type InputTypes = 'text' | 'file'
 export type OutputType = 'text' | 'file'
-export type ErrorTypes = ''
+export type ErrorTypes = 'error' | 'warning'
 export type OutputStatus = 'success' | 'error'
 
 export type CommonState = {
   bytesComplete: number
   bytesTotal: number
   errorMessage: HiddenString
-  errorType: ErrorTypes
+  errorType?: ErrorTypes
   input: HiddenString
   inputType: InputTypes
   output: HiddenString

--- a/shared/constants/types/crypto.tsx
+++ b/shared/constants/types/crypto.tsx
@@ -32,14 +32,13 @@ export type TextType = 'cipher' | 'plain'
 export type Operations = 'encrypt' | 'decrypt' | 'sign' | 'verify'
 export type InputTypes = 'text' | 'file'
 export type OutputType = 'text' | 'file'
-export type ErrorTypes = 'error' | 'warning'
 export type OutputStatus = 'success' | 'error'
 
 export type CommonState = {
   bytesComplete: number
   bytesTotal: number
+  warningMessage: HiddenString
   errorMessage: HiddenString
-  errorType?: ErrorTypes
   input: HiddenString
   inputType: InputTypes
   output: HiddenString

--- a/shared/crypto/input/index.tsx
+++ b/shared/crypto/input/index.tsx
@@ -21,6 +21,12 @@ type FileProps = {
   onClearFiles: () => void
 }
 
+type OperationBannerProps = {
+  type: 'info' | 'warning' | 'error'
+  infoMessage: string
+  message: string
+}
+
 const operationToEmptyInputWidth = {
   [Constants.Operations.Encrypt]: 153,
   [Constants.Operations.Decrypt]: 266,
@@ -36,7 +42,7 @@ const operationToEmptyInputWidth = {
  * Afte user enters text:
  *  - Multiline input
  */
-const TextInput = (props: TextProps) => {
+export const TextInput = (props: TextProps) => {
   const {value, placeholder, textType, operation, onChangeText, onSetFile} = props
   const emptyWidth = operationToEmptyInputWidth[operation]
 
@@ -129,7 +135,7 @@ const TextInput = (props: TextProps) => {
   )
 }
 
-const FileInput = (props: FileProps) => {
+export const FileInput = (props: FileProps) => {
   const {path, size, operation} = props
   const fileIcon = Constants.getInputFileIcon(operation)
   return (
@@ -164,9 +170,25 @@ const FileInput = (props: FileProps) => {
   )
 }
 
+export const OperationBanner = (props: OperationBannerProps) => {
+  const color = props.type === 'error' ? 'red' : props.type === 'warning' ? 'yellow' : 'grey'
+  return (
+    <Kb.Banner color={color} style={styles.banner}>
+      <Kb.BannerParagraph
+        bannerColor={color}
+        content={props.type === 'info' ? props.infoMessage : props.message}
+      />
+    </Kb.Banner>
+  )
+}
+
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      banner: {
+        ...Styles.padding(Styles.globalMargins.tiny),
+        minHeight: 40,
+      },
       browseFile: {
         flexShrink: 0,
       },
@@ -227,4 +249,3 @@ const styles = Styles.styleSheetCreate(
     } as const)
 )
 
-export {TextInput, FileInput}

--- a/shared/crypto/input/index.tsx
+++ b/shared/crypto/input/index.tsx
@@ -248,4 +248,3 @@ const styles = Styles.styleSheetCreate(
       },
     } as const)
 )
-

--- a/shared/crypto/input/index.tsx
+++ b/shared/crypto/input/index.tsx
@@ -23,7 +23,7 @@ type FileProps = {
 
 type OperationBannerProps = {
   type: 'info' | 'warning' | 'error'
-  infoMessage: string
+  infoMessage?: string
   message: string
 }
 
@@ -176,7 +176,7 @@ export const OperationBanner = (props: OperationBannerProps) => {
     <Kb.Banner color={color} style={styles.banner}>
       <Kb.BannerParagraph
         bannerColor={color}
-        content={props.type === 'info' ? props.infoMessage : props.message}
+        content={props.type === 'info' && props.infoMessage ? props.infoMessage : props.message}
       />
     </Kb.Banner>
   )

--- a/shared/crypto/operations/decrypt/container.tsx
+++ b/shared/crypto/operations/decrypt/container.tsx
@@ -12,6 +12,7 @@ export default Container.namedConnect(
   (state: Container.TypedState) => ({
     bytesComplete: state.crypto.decrypt.bytesComplete,
     bytesTotal: state.crypto.decrypt.bytesTotal,
+    errorMessage: state.crypto.decrypt.errorMessage.stringValue(),
     input: state.crypto.decrypt.input.stringValue(),
     inputType: state.crypto.decrypt.inputType,
     output: state.crypto.decrypt.output.stringValue(),
@@ -19,6 +20,7 @@ export default Container.namedConnect(
     outputSigned: state.crypto.decrypt.outputSigned,
     outputStatus: state.crypto.decrypt.outputStatus,
     outputType: state.crypto.decrypt.outputType,
+    warningMessage: state.crypto.decrypt.warningMessage.stringValue(),
   }),
   (dispatch: Container.TypedDispatch) => ({
     onClearInput: () => dispatch(CryptoGen.createClearInput({operation})),
@@ -29,6 +31,7 @@ export default Container.namedConnect(
       dispatch(FSGen.createOpenLocalPathInSystemFileManager({localPath: path})),
   }),
   (stateProps, dispatchProps) => ({
+    errorMessage: stateProps.errorMessage,
     input: stateProps.input,
     inputType: stateProps.inputType,
     onClearInput: dispatchProps.onClearInput,
@@ -41,6 +44,7 @@ export default Container.namedConnect(
     outputStatus: stateProps.outputStatus,
     outputType: stateProps.outputType,
     progress: stateProps.bytesComplete === 0 ? 0 : stateProps.bytesComplete / stateProps.bytesTotal,
+    warningMessage: stateProps.warningMessage,
   }),
   'DecryptContainer'
 )(Decrypt)

--- a/shared/crypto/operations/decrypt/index.tsx
+++ b/shared/crypto/operations/decrypt/index.tsx
@@ -44,9 +44,7 @@ const Decrypt = (props: Props) => {
         prompt="Drop a file to decrypt"
       >
         <Kb.Box2 direction="vertical" fullHeight={true}>
-          {props.outputStatus === 'error' && props.errorMessage && (
-            <OperationBanner type="error" message={props.errorMessage} />
-          )}
+          {props.errorMessage && <OperationBanner type="error" message={props.errorMessage} />}
           {props.inputType === 'file' ? (
             <FileInput
               path={props.input}

--- a/shared/crypto/operations/decrypt/index.tsx
+++ b/shared/crypto/operations/decrypt/index.tsx
@@ -3,7 +3,7 @@ import * as Constants from '../../../constants/crypto'
 import * as Types from '../../../constants/types/crypto'
 import * as Kb from '../../../common-adapters'
 import debounce from 'lodash/debounce'
-import {TextInput, FileInput} from '../../input'
+import {TextInput, FileInput, OperationBanner} from '../../input'
 import OperationOutput, {OutputBar, SignedSender} from '../../output'
 
 type Props = {
@@ -20,6 +20,8 @@ type Props = {
   outputType?: Types.OutputType
   progress: number
   username?: string
+  errorMessage: string
+  warningMessage: string
 }
 
 // We want to debuonce the onChangeText callback for our input so we are not sending an RPC on every keystroke
@@ -42,6 +44,9 @@ const Decrypt = (props: Props) => {
         prompt="Drop a file to decrypt"
       >
         <Kb.Box2 direction="vertical" fullHeight={true}>
+          {props.outputStatus === 'error' && props.errorMessage && (
+            <OperationBanner type="error" message={props.errorMessage} />
+          )}
           {props.inputType === 'file' ? (
             <FileInput
               path={props.input}

--- a/shared/crypto/operations/encrypt/container.tsx
+++ b/shared/crypto/operations/encrypt/container.tsx
@@ -12,6 +12,8 @@ export default Container.namedConnect(
   (state: Container.TypedState) => ({
     bytesComplete: state.crypto.encrypt.bytesComplete,
     bytesTotal: state.crypto.encrypt.bytesTotal,
+    errorMessage: state.crypto.encrypt.errorMessage.stringValue(),
+    errorType: state.crypto.encrypt.errorType,
     hasRecipients: state.crypto.encrypt.meta.hasRecipients,
     hasSBS: state.crypto.encrypt.meta.hasSBS,
     input: state.crypto.encrypt.input.stringValue(),
@@ -35,6 +37,8 @@ export default Container.namedConnect(
       dispatch(FSGen.createOpenLocalPathInSystemFileManager({localPath: path})),
   }),
   (stateProps, dispatchProps) => ({
+    errorMessage: stateProps.errorMessage,
+    errorType: stateProps.errorType,
     hasRecipients: stateProps.hasRecipients,
     hasSBS: stateProps.hasSBS,
     input: stateProps.input,

--- a/shared/crypto/operations/encrypt/container.tsx
+++ b/shared/crypto/operations/encrypt/container.tsx
@@ -13,7 +13,6 @@ export default Container.namedConnect(
     bytesComplete: state.crypto.encrypt.bytesComplete,
     bytesTotal: state.crypto.encrypt.bytesTotal,
     errorMessage: state.crypto.encrypt.errorMessage.stringValue(),
-    errorType: state.crypto.encrypt.errorType,
     hasRecipients: state.crypto.encrypt.meta.hasRecipients,
     hasSBS: state.crypto.encrypt.meta.hasSBS,
     input: state.crypto.encrypt.input.stringValue(),
@@ -25,6 +24,7 @@ export default Container.namedConnect(
     outputType: state.crypto.encrypt.outputType,
     recipients: state.crypto.encrypt.recipients,
     username: state.config.username,
+    warningMessage: state.crypto.encrypt.warningMessage.stringValue(),
   }),
   (dispatch: Container.TypedDispatch) => ({
     onClearInput: () => dispatch(CryptoGen.createClearInput({operation})),
@@ -38,7 +38,6 @@ export default Container.namedConnect(
   }),
   (stateProps, dispatchProps) => ({
     errorMessage: stateProps.errorMessage,
-    errorType: stateProps.errorType,
     hasRecipients: stateProps.hasRecipients,
     hasSBS: stateProps.hasSBS,
     input: stateProps.input,
@@ -57,6 +56,7 @@ export default Container.namedConnect(
     progress: stateProps.bytesComplete === 0 ? 0 : stateProps.bytesComplete / stateProps.bytesTotal,
     recipients: stateProps.recipients,
     username: stateProps.username,
+    warningMessage: stateProps.warningMessage,
   }),
   'EncryptContainer'
 )(Encrypt)

--- a/shared/crypto/operations/encrypt/container.tsx
+++ b/shared/crypto/operations/encrypt/container.tsx
@@ -29,7 +29,7 @@ export default Container.namedConnect(
   (dispatch: Container.TypedDispatch) => ({
     onClearInput: () => dispatch(CryptoGen.createClearInput({operation})),
     onCopyOutput: (text: string) => dispatch(ConfigGen.createCopyToClipboard({text})),
-    onDownloadText: () => dispatch(CryptoGen.createDownloadEncryptedText()),
+    onSaveAsText: () => dispatch(CryptoGen.createDownloadEncryptedText()),
     onSetInput: (inputType: Types.InputTypes, inputValue: string) =>
       dispatch(CryptoGen.createSetInput({operation, type: inputType, value: new HiddenString(inputValue)})),
     onSetOptions: (options: Types.EncryptOptions) => dispatch(CryptoGen.createSetEncryptOptions({options})),
@@ -45,7 +45,7 @@ export default Container.namedConnect(
     noIncludeSelf: stateProps.noIncludeSelf,
     onClearInput: dispatchProps.onClearInput,
     onCopyOutput: dispatchProps.onCopyOutput,
-    onDownloadText: dispatchProps.onDownloadText,
+    onSaveAsText: dispatchProps.onSaveAsText,
     onSetInput: dispatchProps.onSetInput,
     onSetOptions: dispatchProps.onSetOptions,
     onShowInFinder: dispatchProps.onShowInFinder,

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -91,7 +91,7 @@ const Encrypt = (props: Props) => {
         <OperationBanner
           type={bannertype}
           infoMessage="Encrypt to anyone, even if they're not on Keybase yet."
-          message={props.errorMessage}
+          message={props.errorMessage || props.warningMessage}
         />
         <Recipients operation="encrypt" />
         <Kb.Box2 direction="vertical" fullHeight={true}>

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -5,11 +5,13 @@ import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import debounce from 'lodash/debounce'
 import openURL from '../../../util/open-url'
-import {TextInput, FileInput} from '../../input'
+import {TextInput, FileInput, OperationBanner} from '../../input'
 import OperationOutput, {OutputBar, OutputInfoBanner, SignedSender} from '../../output'
 import Recipients from '../../recipients/container'
 
 type Props = {
+  errorType?: 'error' | 'warning'
+  errorMessage: string
   input: string
   inputType: Types.InputTypes
   noIncludeSelf: boolean
@@ -76,6 +78,7 @@ const Encrypt = (props: Props) => {
         props.recipients?.length > 1 ? youAnd('your recipients') : youAnd(props.recipients[0])
       } can decipher it.`
     : ''
+  const bannertype = props.errorType ? props.errorType : 'info'
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
       <Kb.DragAndDrop
@@ -86,6 +89,11 @@ const Encrypt = (props: Props) => {
         prompt="Drop a file to encrypt"
       >
         <Kb.Banner color="grey">
+          <OperationBanner
+            type={bannertype}
+            infoMessage="Encrypt to anyone, even if they're not on Keybase yet."
+            message={props.errorMessage}
+          />
           <Kb.BannerParagraph
             bannerColor="grey"
             content="Encrypt to anyone, even if they're not on Keybase yet."

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -15,7 +15,7 @@ type Props = {
   noIncludeSelf: boolean
   onClearInput: () => void
   onCopyOutput: (text: string) => void
-  onDownloadText: () => void
+  onSaveAsText: () => void
   onShowInFinder: (path: string) => void
   onSetInput: (inputType: Types.InputTypes, inputValue: string) => void
   onSetOptions: (options: Types.EncryptOptions) => void
@@ -170,7 +170,7 @@ const Encrypt = (props: Props) => {
               outputStatus={props.outputStatus}
               outputType={props.outputType}
               onCopyOutput={props.onCopyOutput}
-              onDownloadText={props.onDownloadText}
+              onSaveAsText={props.onSaveAsText}
               onShowInFinder={props.onShowInFinder}
             />
           </Kb.Box2>

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -10,8 +10,6 @@ import OperationOutput, {OutputBar, OutputInfoBanner, SignedSender} from '../../
 import Recipients from '../../recipients/container'
 
 type Props = {
-  errorType?: 'error' | 'warning'
-  errorMessage: string
   input: string
   inputType: Types.InputTypes
   noIncludeSelf: boolean
@@ -30,6 +28,8 @@ type Props = {
   progress: number
   recipients: Array<string>
   username?: string
+  errorMessage: string
+  warningMessage: string
 }
 
 type EncryptOptionsProps = {
@@ -78,7 +78,7 @@ const Encrypt = (props: Props) => {
         props.recipients?.length > 1 ? youAnd('your recipients') : youAnd(props.recipients[0])
       } can decipher it.`
     : ''
-  const bannertype = props.errorType ? props.errorType : 'info'
+  const bannertype = props.errorMessage ? 'error' : props.warningMessage ? 'warning' : 'info'
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
       <Kb.DragAndDrop
@@ -88,17 +88,11 @@ const Encrypt = (props: Props) => {
         onAttach={onAttach}
         prompt="Drop a file to encrypt"
       >
-        <Kb.Banner color="grey">
-          <OperationBanner
-            type={bannertype}
-            infoMessage="Encrypt to anyone, even if they're not on Keybase yet."
-            message={props.errorMessage}
-          />
-          <Kb.BannerParagraph
-            bannerColor="grey"
-            content="Encrypt to anyone, even if they're not on Keybase yet."
-          />
-        </Kb.Banner>
+        <OperationBanner
+          type={bannertype}
+          infoMessage="Encrypt to anyone, even if they're not on Keybase yet."
+          message={props.errorMessage}
+        />
         <Recipients operation="encrypt" />
         <Kb.Box2 direction="vertical" fullHeight={true}>
           {props.inputType === 'file' ? (

--- a/shared/crypto/operations/sign/container.tsx
+++ b/shared/crypto/operations/sign/container.tsx
@@ -24,7 +24,7 @@ export default Container.namedConnect(
   (dispatch: Container.TypedDispatch) => ({
     onClearInput: () => dispatch(CryptoGen.createClearInput({operation})),
     onCopyOutput: (text: string) => dispatch(ConfigGen.createCopyToClipboard({text})),
-    onDownloadText: () => dispatch(CryptoGen.createDownloadSignedText()),
+    onSaveAsText: () => dispatch(CryptoGen.createDownloadSignedText()),
     onSetInput: (inputType: Types.InputTypes, inputValue: string) =>
       dispatch(CryptoGen.createSetInput({operation, type: inputType, value: new HiddenString(inputValue)})),
     onShowInFinder: (path: string) =>
@@ -36,7 +36,7 @@ export default Container.namedConnect(
     inputType: stateProps.inputType,
     onClearInput: dispatchProps.onClearInput,
     onCopyOutput: dispatchProps.onCopyOutput,
-    onDownloadText: dispatchProps.onDownloadText,
+    onSaveAsText: dispatchProps.onSaveAsText,
     onSetInput: dispatchProps.onSetInput,
     onShowInFinder: dispatchProps.onShowInFinder,
     output: stateProps.output,

--- a/shared/crypto/operations/sign/container.tsx
+++ b/shared/crypto/operations/sign/container.tsx
@@ -12,12 +12,14 @@ export default Container.namedConnect(
   (state: Container.TypedState) => ({
     bytesComplete: state.crypto.sign.bytesComplete,
     bytesTotal: state.crypto.sign.bytesTotal,
+    errorMessage: state.crypto.sign.errorMessage.stringValue(),
     input: state.crypto.sign.input.stringValue(),
     inputType: state.crypto.sign.inputType,
     output: state.crypto.sign.output.stringValue(),
     outputSender: state.crypto.sign.outputSender?.stringValue(),
     outputStatus: state.crypto.sign.outputStatus,
     outputType: state.crypto.sign.outputType,
+    warningMessage: state.crypto.sign.warningMessage.stringValue(),
   }),
   (dispatch: Container.TypedDispatch) => ({
     onClearInput: () => dispatch(CryptoGen.createClearInput({operation})),
@@ -29,6 +31,7 @@ export default Container.namedConnect(
       dispatch(FSGen.createOpenLocalPathInSystemFileManager({localPath: path})),
   }),
   (stateProps, dispatchProps) => ({
+    errorMessage: stateProps.errorMessage,
     input: stateProps.input,
     inputType: stateProps.inputType,
     onClearInput: dispatchProps.onClearInput,
@@ -41,6 +44,7 @@ export default Container.namedConnect(
     outputStatus: stateProps.outputStatus,
     outputType: stateProps.outputType,
     progress: stateProps.bytesComplete === 0 ? 0 : stateProps.bytesComplete / stateProps.bytesTotal,
+    warningMessage: stateProps.warningMessage,
   }),
   'SignContainer'
 )(Sign)

--- a/shared/crypto/operations/sign/index.tsx
+++ b/shared/crypto/operations/sign/index.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
 import * as Constants from '../../../constants/crypto'
 import * as Types from '../../../constants/types/crypto'
-import * as Styles from '../../../styles'
 import * as Kb from '../../../common-adapters'
 import debounce from 'lodash/debounce'
 import openURL from '../../../util/open-url'
-import {TextInput, FileInput} from '../../input'
+import {TextInput, FileInput, OperationBanner} from '../../input'
 import OperationOutput, {OutputBar, OutputInfoBanner, SignedSender} from '../../output'
 
 type Props = {
@@ -21,6 +20,8 @@ type Props = {
   outputStatus?: Types.OutputStatus
   outputType?: Types.OutputType
   progress: number
+  errorMessage: string
+  warningMessage: string
 }
 
 // We want to debuonce the onChangeText callback for our input so we are not sending an RPC on every keystroke
@@ -33,6 +34,7 @@ const Sign = (props: Props) => {
     setInputValue('')
     props.onSetInput('file', localPaths[0])
   }
+  const bannertype = props.errorMessage ? 'error' : props.warningMessage ? 'warning' : 'info'
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
       <Kb.DragAndDrop
@@ -43,11 +45,11 @@ const Sign = (props: Props) => {
         prompt="Drop a file to sign"
       >
         <Kb.Box2 direction="vertical" fullHeight={true}>
-          <Kb.Banner color="grey" style={styles.banner}>
-            <Kb.Text type="BodySmallSemibold" center={true} style={styles.signInputInfoBanner}>
-              Add your cryptographic signature to a message or file.
-            </Kb.Text>
-          </Kb.Banner>
+          <OperationBanner
+            type={bannertype}
+            infoMessage="Add your cryptographic signature to a message or file."
+            message={props.errorMessage}
+          />
           {props.inputType === 'file' ? (
             <FileInput
               path={props.input}
@@ -120,19 +122,5 @@ const Sign = (props: Props) => {
     </Kb.Box2>
   )
 }
-
-const styles = Styles.styleSheetCreate(
-  () =>
-    ({
-      banner: {
-        ...Styles.padding(Styles.globalMargins.tiny),
-        minHeight: 40,
-      },
-      signInputInfoBanner: {
-        paddingBottom: Styles.globalMargins.tiny,
-        paddingTop: Styles.globalMargins.tiny,
-      },
-    } as const)
-)
 
 export default Sign

--- a/shared/crypto/operations/sign/index.tsx
+++ b/shared/crypto/operations/sign/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   inputType: Types.InputTypes
   onClearInput: () => void
   onCopyOutput: (text: string) => void
-  onDownloadText: () => void
+  onSaveAsText: () => void
   onSetInput: (inputType: Types.InputTypes, inputValue: string) => void
   onShowInFinder: (path: string) => void
   output: string
@@ -113,7 +113,7 @@ const Sign = (props: Props) => {
               outputStatus={props.outputStatus}
               outputType={props.outputType}
               onCopyOutput={props.onCopyOutput}
-              onDownloadText={props.onDownloadText}
+              onSaveAsText={props.onSaveAsText}
               onShowInFinder={props.onShowInFinder}
             />
           </Kb.Box2>

--- a/shared/crypto/operations/verify/container.tsx
+++ b/shared/crypto/operations/verify/container.tsx
@@ -12,12 +12,14 @@ export default Container.namedConnect(
   (state: Container.TypedState) => ({
     bytesComplete: state.crypto.verify.bytesComplete,
     bytesTotal: state.crypto.verify.bytesTotal,
+    errorMessage: state.crypto.verify.errorMessage.stringValue(),
     input: state.crypto.verify.input.stringValue(),
     inputType: state.crypto.verify.inputType,
     output: state.crypto.verify.output.stringValue(),
     outputSender: state.crypto.verify.outputSender?.stringValue(),
     outputStatus: state.crypto.verify.outputStatus,
     outputType: state.crypto.verify.outputType,
+    warningMessage: state.crypto.verify.warningMessage.stringValue(),
   }),
   (dispatch: Container.TypedDispatch) => ({
     onClearInput: () => dispatch(CryptoGen.createClearInput({operation})),
@@ -28,6 +30,7 @@ export default Container.namedConnect(
       dispatch(FSGen.createOpenLocalPathInSystemFileManager({localPath: path})),
   }),
   (stateProps, dispatchProps) => ({
+    errorMessage: stateProps.errorMessage,
     input: stateProps.input,
     inputType: stateProps.inputType,
     onClearInput: dispatchProps.onClearInput,
@@ -39,6 +42,7 @@ export default Container.namedConnect(
     outputStatus: stateProps.outputStatus,
     outputType: stateProps.outputType,
     progress: stateProps.bytesComplete === 0 ? 0 : stateProps.bytesComplete / stateProps.bytesTotal,
+    warningMessage: stateProps.warningMessage,
   }),
   'VerifyContainer'
 )(Verify)

--- a/shared/crypto/operations/verify/index.tsx
+++ b/shared/crypto/operations/verify/index.tsx
@@ -3,7 +3,7 @@ import * as Constants from '../../../constants/crypto'
 import * as Types from '../../../constants/types/crypto'
 import * as Kb from '../../../common-adapters'
 import debounce from 'lodash/debounce'
-import {TextInput, FileInput} from '../../input'
+import {TextInput, FileInput, OperationBanner} from '../../input'
 import OperationOutput, {SignedSender, OutputBar} from '../../output'
 
 type Props = {
@@ -18,6 +18,8 @@ type Props = {
   outputStatus?: Types.OutputStatus
   outputType?: Types.OutputType
   progress: number
+  errorMessage: string
+  warningMessage: string
 }
 
 // We want to debuonce the onChangeText callback for our input so we are not sending an RPC on every keystroke
@@ -30,6 +32,7 @@ const Verify = (props: Props) => {
     setInputValue('')
     props.onSetInput('file', localPaths[0])
   }
+
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
       <Kb.DragAndDrop
@@ -40,6 +43,9 @@ const Verify = (props: Props) => {
         prompt="Drop a file to verify"
       >
         <Kb.Box2 direction="vertical" fullHeight={true}>
+          {props.outputStatus === 'error' && props.errorMessage && (
+            <OperationBanner type="error" message={props.errorMessage} />
+          )}
           {props.inputType === 'file' ? (
             <FileInput
               path={props.input}

--- a/shared/crypto/operations/verify/index.tsx
+++ b/shared/crypto/operations/verify/index.tsx
@@ -43,9 +43,7 @@ const Verify = (props: Props) => {
         prompt="Drop a file to verify"
       >
         <Kb.Box2 direction="vertical" fullHeight={true}>
-          {props.outputStatus === 'error' && props.errorMessage && (
-            <OperationBanner type="error" message={props.errorMessage} />
-          )}
+          {props.errorMessage && <OperationBanner type="error" message={props.errorMessage} />}
           {props.inputType === 'file' ? (
             <FileInput
               path={props.input}

--- a/shared/crypto/output/index.stories.tsx
+++ b/shared/crypto/output/index.stories.tsx
@@ -4,7 +4,7 @@ import * as Constants from '../../constants/crypto'
 import Output, {OutputBar, SignedSender} from '.'
 
 const onCopyOutput = Sb.action('onCopyOutput')
-const onDownloadText = Sb.action('onDownloadText')
+const onSaveAsText = Sb.action('onSaveAsText')
 const onShowInFinder = Sb.action('onShowInFinder')
 
 const encryptOutput = `
@@ -75,7 +75,7 @@ const load = () => {
       output="secret stuff"
       outputStatus="success"
       onCopyOutput={onCopyOutput}
-      onDownloadText={onDownloadText}
+      onSaveAsText={onSaveAsText}
       onShowInFinder={onShowInFinder}
     />
   ))

--- a/shared/crypto/output/index.tsx
+++ b/shared/crypto/output/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 type OutputBarProps = {
   onCopyOutput: (text: string) => void
-  onDownloadText?: () => void
+  onSaveAsText?: () => void
   onShowInFinder: (path: string) => void
   operation: Types.Operations
   output: string
@@ -96,7 +96,7 @@ export const OutputInfoBanner = (props: OutputInfoProps) => {
 }
 
 export const OutputBar = (props: OutputBarProps) => {
-  const {output, onCopyOutput, onDownloadText, onShowInFinder} = props
+  const {output, onCopyOutput, onSaveAsText, onShowInFinder} = props
   const waitingKey = Constants.getStringWaitingKey(props.operation)
   const waiting = Container.useAnyWaiting(waitingKey)
   const attachmentRef = React.useRef<Kb.Box2>(null)
@@ -139,13 +139,8 @@ export const OutputBar = (props: OutputBarProps) => {
                 onClick={() => copy()}
               />
             </Kb.Box2>
-            {onDownloadText && (
-              <Kb.Button
-                mode="Secondary"
-                label="Download as TXT"
-                onClick={onDownloadText}
-                disabled={waiting}
-              />
+            {onSaveAsText && (
+              <Kb.Button mode="Secondary" label="Save as TXT" onClick={onSaveAsText} disabled={waiting} />
             )}
           </Kb.ButtonBar>
         )}

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -34,6 +34,8 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     draftState[operation].output = new HiddenString('')
     draftState[operation].outputStatus = undefined
     draftState[operation].outputType = undefined
+    draftState[operation].errorMessage = new HiddenString('')
+    draftState[operation].warningMessage = new HiddenString('')
   },
   [CryptoGen.clearRecipients]: (draftState, action) => {
     const {operation} = action.payload
@@ -51,6 +53,8 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       draftState.encrypt.output = new HiddenString('')
       draftState.encrypt.outputStatus = undefined
       draftState.encrypt.outputType = undefined
+      draftState.encrypt.errorMessage = new HiddenString('')
+      draftState.encrypt.warningMessage = new HiddenString('')
     }
   },
   [CryptoGen.setRecipients]: (draftState, action) => {
@@ -102,6 +106,10 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     if (!draftState[operation].input.stringValue()) {
       return
     }
+
+    // Reset errors and warnings
+    draftState[operation].errorMessage = new HiddenString('')
+    draftState[operation].warningMessage = new HiddenString('')
 
     // Warning was set alongside successful output
     if (warning && warningMessage) {

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -87,7 +87,15 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     draftState[operation].input = value
   },
   [CryptoGen.onOperationSuccess]: (draftState, action) => {
-    const {operation, output, outputSigned, outputSender, outputType} = action.payload
+    const {
+      operation,
+      output,
+      outputSigned,
+      outputSender,
+      outputType,
+      warning,
+      warningMessage,
+    } = action.payload
     if (operationGuard(operation, action)) return
 
     // Bail if the user has cleared the input before the RPC has returned a result
@@ -95,11 +103,28 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       return
     }
 
+    // Warning was set alongside successful output
+    if (warning && warningMessage) {
+      draftState[operation].warningMessage = warningMessage
+    }
+
     draftState[operation].output = output
     draftState[operation].outputStatus = 'success'
     draftState[operation].outputType = outputType
     draftState[operation].outputSigned = outputSigned
     draftState[operation].outputSender = outputSender
+  },
+  [CryptoGen.onOperationError]: (draftState, action) => {
+    const {operation, errorMessage} = action.payload
+    if (operationGuard(operation, action)) return
+
+    // Clear output
+    draftState[operation].output = new HiddenString('')
+    draftState[operation].outputType = undefined
+
+    // Set error
+    draftState[operation].outputStatus = 'error'
+    draftState[operation].errorMessage = errorMessage
   },
   [CryptoGen.saltpackProgress]: (draftState, action) => {
     const {bytesComplete, bytesTotal, operation} = action.payload


### PR DESCRIPTION
1. Error banners based on error status codes
2. Error banners with default error messages
3. SBS warnings for encrypting to users not on keybase
4. Change `Download as TXT` to `Save as TXT`
@keybase/react-hackers @keybase/picnicsquad @cjb 