### PR TITLE
Don't return UnboxError for too many open files

### DIFF
--- a/go/libkb/erasable_kv_store.go
+++ b/go/libkb/erasable_kv_store.go
@@ -263,6 +263,9 @@ func (s *FileErasableKVStore) get(mctx MetaContext, key string, val interface{})
 	noiseKey := s.noiseKey(key)
 	noise, err := s.read(mctx, noiseKey)
 	if err != nil {
+		if IsTooManyFilesError(err) {
+			return err
+		}
 		return NewUnboxError(err)
 	}
 	var noiseBytes NoiseBytes
@@ -270,6 +273,9 @@ func (s *FileErasableKVStore) get(mctx MetaContext, key string, val interface{})
 
 	data, err := s.read(mctx, key)
 	if err != nil {
+		if IsTooManyFilesError(err) {
+			return err
+		}
 		return NewUnboxError(err)
 	}
 

--- a/go/libkb/errors.go
+++ b/go/libkb/errors.go
@@ -2908,3 +2908,7 @@ func (e HiddenMerkleError) Error() string {
 }
 
 var _ error = HiddenMerkleError{}
+
+func IsTooManyFilesError(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "too many open files")
+}


### PR DESCRIPTION
DeviceEKStorage deletes corrupted eks if an `UnboxError` is returned, treat too many open files as a transient error instead