### PR TITLE
journeycards tests, KEYBASE_TEST_LOG_AFTER_FAIL

### DIFF
--- a/go/chat/journey_card_test.go
+++ b/go/chat/journey_card_test.go
@@ -212,7 +212,7 @@ func TestJourneycardDismissTeamwide(t *testing.T) {
 	}
 
 	t.Logf("Advanced time forward enough for CHANNEL_INACTIVE to be eligible")
-	err = tc0.ChatG.JourneyCardManager.(*JourneyCardManager).TimeTravel(ctx0, uid0, time.Hour*24*40)
+	err = tc0.ChatG.JourneyCardManager.(*JourneyCardManager).TimeTravel(ctx0, uid0, time.Hour*24*40+1)
 	require.NoError(t, err)
 	for _, convID := range allConvIDs {
 		requireJourneycard(convID, chat1.JourneycardType_CHANNEL_INACTIVE)

--- a/go/chat/journey_card_test.go
+++ b/go/chat/journey_card_test.go
@@ -141,7 +141,6 @@ func TestJourneycardDismissTeamwide(t *testing.T) {
 
 	t.Logf("create other channels")
 	topicNames := []string{"c-a", "c-b", "c-c"}
-	var otherConvs []chat1.ConversationLocal
 	allConvIDs := []chat1.ConversationID{teamConv.Id}
 	_ = allConvIDs
 	allConvInfos := []chat1.ConversationInfoLocal{teamConv}
@@ -155,7 +154,6 @@ func TestJourneycardDismissTeamwide(t *testing.T) {
 				MembersType:   chat1.ConversationMembersType_TEAM,
 			})
 		require.NoError(t, err)
-		otherConvs = append(otherConvs, res.Conv)
 		allConvIDs = append(allConvIDs, res.Conv.GetConvID())
 		allConvInfos = append(allConvInfos, res.Conv.Info)
 	}
@@ -281,6 +279,7 @@ func TestJourneycardPersist(t *testing.T) {
 
 	t.Logf("After deleting in-memory cache the journeycard statys in its original location")
 	js, err := tc0.ChatG.JourneyCardManager.(*JourneyCardManager).get(ctx0, uid0)
+	require.NoError(t, err)
 	js.lru.Purge()
 	jc3 := requireJourneycard(teamConv.Id, chat1.JourneycardType_ADD_PEOPLE, 1)
 	require.Equal(t, jc1.PrevID, jc3.PrevID)

--- a/go/logger/test_logger.go
+++ b/go/logger/test_logger.go
@@ -65,6 +65,9 @@ func (log *TestLogger) common(ctx context.Context, lvl logging.Level, useFatal b
 			globalFailReported[name] = struct{}{}
 		}
 		globalFailReportedLock.Unlock()
+		if stringListContains(strings.ToLower(os.Getenv("KEYBASE_TEST_LOG_AFTER_FAIL")), []string{"0", "false", "n", "no"}) {
+			return
+		}
 	}
 
 	if os.Getenv("KEYBASE_TEST_DUP_LOG_TO_STDOUT") != "" {
@@ -191,3 +194,12 @@ func (log *TestLogger) CloneWithAddedDepth(depth int) Logger {
 
 // no-op stubs to fulfill the Logger interface
 func (log *TestLogger) SetExternalHandler(_ ExternalHandler) {}
+
+func stringListContains(s string, a []string) bool {
+	for _, t := range a {
+		if s == t {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Some tests
- Move time travel offset so it works better
- Env var `KEYBASE_TEST_LOG_AFTER_FAIL` for hiding post-failure `[X]` logs. Does not change default behavior.