### PR TITLE
PICNIC-830 - Fix wallet nav height

### DIFF
--- a/shared/wallets/nav-header/index.tsx
+++ b/shared/wallets/nav-header/index.tsx
@@ -83,6 +83,7 @@ const styles = Styles.styleSheetCreate(
         isElectron: {...Styles.desktopStyles.windowDraggingClickable},
       }),
       accountInfo: {
+        maxHeight: 39,
         paddingBottom: Styles.globalMargins.xtiny,
         paddingLeft: Styles.globalMargins.xsmall,
       },


### PR DESCRIPTION
Was off by 2px because of text height in the account info section of the header

cc @cjb @keybase/picnicsquad 