### PR TITLE
PICNIC-773 - Show hellobot card via new conversation

### DIFF
--- a/shared/chat/conversation/messages/special-top-message.tsx
+++ b/shared/chat/conversation/messages/special-top-message.tsx
@@ -207,7 +207,6 @@ export default Container.namedConnect(
       meta.retentionPolicy.type !== 'retain' &&
       !(meta.retentionPolicy.type === 'inherit' && meta.teamRetentionPolicy.type === 'retain')
     const isHelloBotConversation =
-      hasLoadedEver &&
       meta.teamType === 'adhoc' &&
       participantInfo.all.length === 2 &&
       participantInfo.all.includes('hellobot')


### PR DESCRIPTION
Only change is that we no longer check that the conversation with hellobot has any messages (`messageOrdinals`).