### PR TITLE
teamsearch: hook up team result RPCs to UI

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -30,7 +30,6 @@ import {saveAttachmentToCameraRoll, showShareActionSheet} from '../platform-spec
 import {privateFolderWithUsers, teamFolder} from '../../constants/config'
 import {RPCError} from '../../util/errors'
 import * as Container from '../../util/container'
-import flags from '../../util/feature-flags'
 
 const onConnect = async () => {
   try {
@@ -1638,27 +1637,21 @@ function* inboxSearch(_: Container.TypedState, action: Chat2Gen.InboxSearchPaylo
       })
     )
 
-  const onOpenTeamHits = (
-    // TODO fix type when rpc exists
-    resp: any // RPCChatTypes.MessageTypes['chat.1.chatUi.chatSearchOpenTeamHits']['inParam']
-  ) =>
+  const onOpenTeamHits = (resp: RPCChatTypes.MessageTypes['chat.1.chatUi.chatSearchTeamHits']['inParam']) =>
     Saga.put(
       Chat2Gen.createInboxSearchOpenTeamsResults({
-        results: (resp.hits.hits || []).reduce(
-          /*<Array<Types.InboxSearchOpenTeamHit>>*/ (arr, h) => {
-            const {description, name, teamID, publicAdmins, numMembers, inTeam} = h
-            arr.push({
-              description,
-              inTeam,
-              name,
-              numMembers,
-              publicAdmins,
-              teamID: Types.stringToConversationIDKey(teamID),
-            })
-            return arr
-          },
-          []
-        ),
+        results: (resp.hits.hits || []).reduce<Array<Types.InboxSearchOpenTeamHit>>((arr, h) => {
+          const {description, name, id, publicAdmins, memberCount, inTeam} = h
+          arr.push({
+            description: description ?? '',
+            id: Types.stringToConversationIDKey(id),
+            inTeam,
+            memberCount,
+            name,
+            publicAdmins: publicAdmins ?? [],
+          })
+          return arr
+        }, []),
       })
     )
 
@@ -1686,12 +1679,12 @@ function* inboxSearch(_: Container.TypedState, action: Chat2Gen.InboxSearchPaylo
   try {
     yield RPCChatTypes.localSearchInboxRpcSaga({
       incomingCallMap: {
-        // 'chat.1.chatUi.chatSearchOpenTeamHits': onOpenTeamHits,
         'chat.1.chatUi.chatSearchConvHits': onConvHits,
         'chat.1.chatUi.chatSearchInboxDone': onDone,
         'chat.1.chatUi.chatSearchInboxHit': onTextHit,
         'chat.1.chatUi.chatSearchInboxStart': onStart,
         'chat.1.chatUi.chatSearchIndexStatus': onIndexStatus,
+        'chat.1.chatUi.chatSearchTeamHits': onOpenTeamHits,
       },
       params: {
         identifyBehavior: RPCTypes.TLFIdentifyBehavior.chatGui,
@@ -1709,7 +1702,7 @@ function* inboxSearch(_: Container.TypedState, action: Chat2Gen.InboxSearchPaylo
             query.stringValue().length > 0
               ? Constants.inboxSearchMaxNameResults
               : Constants.inboxSearchMaxUnreadNameResults,
-          maxTeams: 0,
+          maxTeams: 3,
           reindexMode: RPCChatTypes.ReIndexingMode.postsearchSync,
           sentAfter: 0,
           sentBefore: 0,
@@ -1724,42 +1717,6 @@ function* inboxSearch(_: Container.TypedState, action: Chat2Gen.InboxSearchPaylo
       logger.error('search failed: ' + e.message)
       yield Saga.put(Chat2Gen.createInboxSearchSetTextStatus({status: 'error'}))
     }
-  }
-
-  // mock data
-  if (flags.openTeamSearch && __DEV__) {
-    console.log('MOCK open teams data, TODO plumb!')
-    yield Saga.delay(1000)
-    yield onOpenTeamHits({
-      hits: {
-        hits: [
-          {
-            description: 'team a',
-            inTeam: true,
-            name: 'keybasefriends',
-            numMembers: 123,
-            publicAdmins: ['adm1', 'adm2'],
-            teamID: '67c99659bdc24920b56ccec3a42dd424',
-          },
-          {
-            description: 'team b',
-            inTeam: false,
-            name: 'chia_network.public',
-            numMembers: 123,
-            publicAdmins: ['adm3'],
-            teamID: '5fb23b28c317e32742cf194b42ae0525',
-          },
-          {
-            description: 'team c',
-            inTeam: false,
-            name: 'stellar.public',
-            numMembers: 123,
-            publicAdmins: ['adm4', 'adm5'],
-            teamID: '5fb23b28c317e32742cf194b42ae0525',
-          },
-        ],
-      },
-    })
   }
 }
 

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -663,7 +663,7 @@
     },
     "inboxSearchOpenTeamsResults": {
       "_description": "Inbox search open teams results received",
-      "results": "Array<Types.InboxSearchOpenTeamHit>",
+      "results": "Array<Types.InboxSearchOpenTeamHit>"
     },
     "inboxSearchNameResults": {
       "_description": "Inbox search name results received",
@@ -898,9 +898,9 @@
       "role": "TeamsTypes.TeamRoleType | null"
     },
     "showInfoPanel": {
-        "tab?": "'settings' | 'members' | 'attachments' | 'bots'",
-        "show": "boolean",
-        "conversationIDKey?": "Types.ConversationIDKey"
+      "tab?": "'settings' | 'members' | 'attachments' | 'bots'",
+      "show": "boolean",
+      "conversationIDKey?": "Types.ConversationIDKey"
     },
     "dismissJourneycard": {
       "_description": "Dismiss a journeycard",

--- a/shared/chat/inbox-search/index.tsx
+++ b/shared/chat/inbox-search/index.tsx
@@ -240,7 +240,7 @@ type OpenTeamProps = Types.InboxSearchOpenTeamHit & {
 }
 const OpenTeamRow = (p: OpenTeamProps) => {
   const [hovering, setHovering] = React.useState(false)
-  const {selected, name, description, memberCount, publicAdmins, id, inTeam} = p
+  const {name, description, memberCount, publicAdmins, id, inTeam} = p
   const dispatch = Container.useDispatch()
   const popupAnchor = React.useRef(null)
   const {showingPopup, setShowingPopup, popup} = Kb.usePopup(popupAnchor, () => (
@@ -263,6 +263,8 @@ const OpenTeamRow = (p: OpenTeamProps) => {
       visible={showingPopup}
     />
   ))
+
+  const selected = showingPopup
 
   return (
     <Kb.ClickableBox onClick={() => setShowingPopup(!showingPopup)} style={{width: '100%'}}>

--- a/shared/chat/inbox-search/index.tsx
+++ b/shared/chat/inbox-search/index.tsx
@@ -63,8 +63,8 @@ class InboxSearch extends React.Component<Props, State> {
       <OpenTeamRow
         description={item.description}
         name={item.name}
-        teamID={item.teamID}
-        numMembers={item.numMembers}
+        id={item.id}
+        memberCount={item.memberCount}
         inTeam={item.inTeam}
         publicAdmins={item.publicAdmins}
         selected={false}
@@ -240,26 +240,26 @@ type OpenTeamProps = Types.InboxSearchOpenTeamHit & {
 }
 const OpenTeamRow = (p: OpenTeamProps) => {
   const [hovering, setHovering] = React.useState(false)
-  const {selected, name, description, numMembers, publicAdmins, teamID, inTeam} = p
+  const {selected, name, description, memberCount, publicAdmins, id, inTeam} = p
   const dispatch = Container.useDispatch()
   const popupAnchor = React.useRef(null)
   const {showingPopup, setShowingPopup, popup} = Kb.usePopup(popupAnchor, () => (
     <TeamInfo
       attachTo={() => popupAnchor.current}
-      description={description}
+      description={description ?? ''}
       inTeam={inTeam}
       isOpen={true}
       name={name}
-      membersCount={numMembers}
+      membersCount={memberCount}
       position="right center"
       onChat={undefined}
       onHidden={() => setShowingPopup(false)}
       onJoinTeam={() => dispatch(TeamsGen.createJoinTeam({teamname: name}))}
       onViewTeam={() => {
         dispatch(RouteTreeGen.createClearModals())
-        dispatch(RouteTreeGen.createNavigateAppend({path: [{props: {teamID}, selected: 'team'}]}))
+        dispatch(RouteTreeGen.createNavigateAppend({path: [{props: {teamID: id}, selected: 'team'}]}))
       }}
-      publicAdmins={publicAdmins}
+      publicAdmins={publicAdmins ?? []}
       visible={showingPopup}
     />
   ))
@@ -276,6 +276,8 @@ const OpenTeamRow = (p: OpenTeamProps) => {
           {
             backgroundColor: selected ? Styles.globalColors.blue : Styles.globalColors.white,
             height: rowHeight,
+            paddingLeft: Styles.globalMargins.xtiny,
+            paddingRight: Styles.globalMargins.xtiny,
           },
         ])}
         onMouseLeave={() => setHovering(false)}
@@ -284,7 +286,7 @@ const OpenTeamRow = (p: OpenTeamProps) => {
         <TeamAvatar teamname={name} isMuted={false} isSelected={false} isHovered={hovering} />
         <Kb.Box2 direction="vertical" style={{flexGrow: 1}}>
           <Kb.Text
-            type="Body"
+            type="BodySemibold"
             style={Styles.collapseStyles([
               {color: selected ? Styles.globalColors.white : Styles.globalColors.black},
             ])}
@@ -295,12 +297,12 @@ const OpenTeamRow = (p: OpenTeamProps) => {
             {name}
           </Kb.Text>
           <Kb.Text
-            type="Body"
+            type="BodySmall"
             style={Styles.collapseStyles([
-              {color: selected ? Styles.globalColors.white : Styles.globalColors.black},
+              {color: selected ? Styles.globalColors.white : Styles.globalColors.black_50},
             ])}
             title={`#${description}`}
-            lineClamp={Styles.isMobile ? 1 : undefined}
+            lineClamp={1}
             ellipsizeMode="tail"
           >
             {description}

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -62,9 +62,9 @@ export type InboxSearchOpenTeamHit = {
   description: string
   inTeam: boolean
   name: string
-  numMembers: number
+  memberCount: number
   publicAdmins: Array<string>
-  teamID: Team.TeamID
+  id: Team.TeamID
 }
 
 export type InboxSearchInfo = {


### PR DESCRIPTION
This PR hooks up `chatSearchTeamHits` to the inbox search ui, and cleans up the styles for open team results.