### PR TITLE
Fix cursor alignment on multiline inputs for Android.

### DIFF
--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -270,7 +270,7 @@ const styles = styleSheetCreate(() => ({
   multiline: platformStyles({
     isMobile: {
       height: undefined,
-      textAlignVertical: 'bottom', // android centers by default
+      textAlignVertical: 'top', // android centers by default
     },
   }),
   singleline: {padding: 0},


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. I'm not sure why we'd want it to be aligned to the bottom, and I tested the cases from the PR where this was added (https://github.com/keybase/client/pull/19521).

This fixes the cursor being aligned to the bottom of a multiline input on Android.