### PR TITLE
pass pidfile to watchdog for cleaner terminations

### DIFF
--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -922,14 +922,14 @@
 		{
 			"checksumSHA1": "SkzqJzOqrobx0rcaUKGoFgsWcuc=",
 			"path": "github.com/keybase/go-updater/process",
-			"revision": "587c926461284b281f08649725f4de8b8c7a59a5",
-			"revisionTime": "2020-01-27T20:29:22Z"
+			"revision": "f8c077b6a42e5e5fe1015d564b7c80d27ae1304a",
+			"revisionTime": "2020-01-27T21:02:54Z"
 		},
 		{
-			"checksumSHA1": "/pCj/k5mmwxiRnYjf7bVeSfsiRA=",
+			"checksumSHA1": "i/O8DL3IG15EOv40nQNvaiLiEJo=",
 			"path": "github.com/keybase/go-updater/watchdog",
-			"revision": "587c926461284b281f08649725f4de8b8c7a59a5",
-			"revisionTime": "2020-01-27T20:29:22Z"
+			"revision": "f8c077b6a42e5e5fe1015d564b7c80d27ae1304a",
+			"revisionTime": "2020-01-27T21:02:54Z"
 		},
 		{
 			"checksumSHA1": "rRRQUZrxRapCpdmV2BUgmJRE/ww=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -922,14 +922,14 @@
 		{
 			"checksumSHA1": "SkzqJzOqrobx0rcaUKGoFgsWcuc=",
 			"path": "github.com/keybase/go-updater/process",
-			"revision": "f8c077b6a42e5e5fe1015d564b7c80d27ae1304a",
-			"revisionTime": "2020-01-27T21:02:54Z"
+			"revision": "6159d2a95109f407eb2085c9d1cb44616255c9a2",
+			"revisionTime": "2020-01-29T15:26:34Z"
 		},
 		{
-			"checksumSHA1": "i/O8DL3IG15EOv40nQNvaiLiEJo=",
+			"checksumSHA1": "BHej8BG0YwRT7akGpNnzLOmfees=",
 			"path": "github.com/keybase/go-updater/watchdog",
-			"revision": "f8c077b6a42e5e5fe1015d564b7c80d27ae1304a",
-			"revisionTime": "2020-01-27T21:02:54Z"
+			"revision": "6159d2a95109f407eb2085c9d1cb44616255c9a2",
+			"revisionTime": "2020-01-29T15:26:34Z"
 		},
 		{
 			"checksumSHA1": "rRRQUZrxRapCpdmV2BUgmJRE/ww=",


### PR DESCRIPTION
see https://github.com/keybase/go-updater/pull/190 for a more detailed explanation (i.e. tests) for how this is intended to work.

### problem
when the watchdog starts up, it terminates existing running processes for its programs before starting them up. terminating processes in windows is not graceful; they just die in the middle of whatever they were doing. and it seems like sometimes, this can cause an issue with the next service starting up. it thinks the previous iteration is still running because its pidfile was not unlocked during a graceful shutdown. i can't actually dupe this locally, but I've seen it in logs a few times. here's an example `ce58e5e84bb9b6aabcd97d1c` and you can see the unrecoverable error by grepping the service logs for `exiting with error error locking`.

### solution
when starting the watchdog, tell it about the pidfile of the service. this way, if it needs to terminate that process because it's running under another watchdog, it can then also check if it needs to delete the pidfile as well. 
