### PR TITLE
JOIN+LEAVE messages are visible

### DIFF
--- a/go/chat/journey_card_test.go
+++ b/go/chat/journey_card_test.go
@@ -195,12 +195,7 @@ func TestJourneycardDismissTeamwide(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("the messages: %v", chat1.MessageUnboxedDebugList(thread.Messages))
 		require.True(t, len(thread.Messages) >= 1)
-		// Skip initial JOIN/LEAVE message. There was a bug where journeycards couldn't attach to JOIN/LEAVE messages (TRIAGE-1738).
 		msg := thread.Messages[0]
-		if msg.Valid__ != nil && (msg.Valid__.ClientHeader.MessageType == chat1.MessageType_JOIN || msg.Valid__.ClientHeader.MessageType == chat1.MessageType_LEAVE) {
-			require.True(t, len(thread.Messages) >= 2, "need more messages for LEAVE workaround")
-			msg = thread.Messages[1]
-		}
 		require.NotNil(t, msg.Journeycard__, "requireJourneycard expects a journeycard")
 		require.Equal(t, cardType, msg.Journeycard().CardType, "card type")
 	}

--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -789,7 +789,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		// the conversation source configured in the global context
 		var summaries []chat1.MessageSummary
 		snippetSummary, err := utils.PickLatestMessageSummary(conversationRemote,
-			append(chat1.VisibleChatMessageTypes(), chat1.MessageType_DELETEHISTORY))
+			append(append([]chat1.MessageType{}, chat1.VisibleChatMessageTypes()...), chat1.MessageType_DELETEHISTORY))
 		if err == nil {
 			summaries = append(summaries, snippetSummary)
 		}

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -149,7 +149,7 @@ func (rc RemoteConversation) GetTopicType() chat1.TopicType {
 }
 
 func (rc RemoteConversation) IsLocallyRead() bool {
-	return rc.LocalReadMsgID >= rc.Conv.MaxVisibleMsgID() // xxx same problem with LEAVE and "unread"
+	return rc.LocalReadMsgID >= rc.Conv.MaxVisibleMsgID()
 }
 
 func (rc RemoteConversation) MaxVisibleMsgID() chat1.MessageID {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -149,7 +149,7 @@ func (rc RemoteConversation) GetTopicType() chat1.TopicType {
 }
 
 func (rc RemoteConversation) IsLocallyRead() bool {
-	return rc.LocalReadMsgID >= rc.Conv.MaxVisibleMsgID()
+	return rc.LocalReadMsgID >= rc.Conv.MaxVisibleMsgID() // xxx same problem with LEAVE and "unread"
 }
 
 func (rc RemoteConversation) MaxVisibleMsgID() chat1.MessageID {

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -951,7 +951,7 @@ func GetConvMtime(rc types.RemoteConversation) (res gregor1.Time) {
 func GetConvPriorityScore(rc types.RemoteConversation) float64 {
 	readMsgID := rc.GetReadMsgID()
 	maxMsgID := rc.Conv.ReaderInfo.MaxMsgid
-	mtime := GetConvMtime(rc) // xxx does leaving causing a bump all the way up to inbox top?
+	mtime := GetConvMtime(rc)
 	dur := math.Abs(float64(time.Since(mtime.Time())) / float64(time.Hour))
 	return 100 / math.Pow(dur+float64(maxMsgID-readMsgID), 0.5)
 }
@@ -2765,7 +2765,7 @@ func DBConvLess(a pager.InboxEntry, b pager.InboxEntry) bool {
 func ExportToSummary(i chat1.InboxUIItem) (s chat1.ConvSummary) {
 	s.Id = i.ConvID
 	s.IsDefaultConv = i.IsDefaultConv
-	s.Unread = i.ReadMsgID < i.MaxVisibleMsgID // xxx this could cause a LEAVE message to make a conv appear unread.
+	s.Unread = i.ReadMsgID < i.MaxVisibleMsgID
 	s.ActiveAt = i.Time.UnixSeconds()
 	s.ActiveAtMs = i.Time.UnixMilliseconds()
 	s.FinalizeInfo = i.FinalizeInfo

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -440,6 +440,14 @@ func IsVisibleChatMessageType(messageType chat1.MessageType) bool {
 	return checkMessageTypeQual(messageType, chat1.VisibleChatMessageTypes())
 }
 
+func IsBadgeableMessageType(messageType chat1.MessageType) bool {
+	return checkMessageTypeQual(messageType, chat1.BadgeableMessageTypes())
+}
+
+func IsNonEmptyConvMessageType(messageType chat1.MessageType) bool {
+	return checkMessageTypeQual(messageType, chat1.NonEmptyConvMessageTypes())
+}
+
 func IsEditableByEditMessageType(messageType chat1.MessageType) bool {
 	return checkMessageTypeQual(messageType, chat1.EditableMessageTypesByEdit())
 }
@@ -457,10 +465,6 @@ func IsDeleteableByDeleteMessageType(valid chat1.MessageUnboxedValid) bool {
 		return true
 	}
 	return chat1.IsSystemMsgDeletableByDelete(typ)
-}
-
-func IsNonEmptyConvMessageType(messageType chat1.MessageType) bool {
-	return checkMessageTypeQual(messageType, chat1.NonEmptyConvMessageTypes())
 }
 
 func IsCollapsibleMessageType(messageType chat1.MessageType) bool {

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UIAdapter converts between the Identify2 UI that Identify2 engine expects, and the
-// Identify3UI interface that the frontend is soon to implement. It's going to maintain the
+// Identify3UI interface that the frontend implements. It's maintains the
 // state machine that was previously implemented in JS.
 type UIAdapter struct {
 	sync.Mutex

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -248,7 +248,7 @@ func VisibleChatMessageTypes() []MessageType {
 	return visibleMessageTypes
 }
 
-var nonEmptyConvMessageTypes = []MessageType{
+var badgeableMessageTypes = []MessageType{
 	MessageType_TEXT,
 	MessageType_ATTACHMENT,
 	MessageType_SYSTEM,
@@ -259,10 +259,16 @@ var nonEmptyConvMessageTypes = []MessageType{
 	MessageType_PIN,
 }
 
+// Message types that cause badges.
+// JOIN and LEAVE are Visible but are too minute to badge.
+func BadgeableMessageTypes() []MessageType {
+	return badgeableMessageTypes
+}
+
 // A conversation is considered 'empty' unless it has one of these message types.
-// Used for filtering empty convs out of the the inbox. And badging.
+// Used for filtering empty convs out of the the inbox.
 func NonEmptyConvMessageTypes() []MessageType {
-	return nonEmptyConvMessageTypes
+	return badgeableMessageTypes
 }
 
 var editableMessageTypesByEdit = []MessageType{

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1573,7 +1573,7 @@ func (c Conversation) IsUnread() bool {
 
 func (c Conversation) IsUnreadFromMsgID(readMsgID MessageID) bool {
 	maxMsgID := c.MaxVisibleMsgID()
-	return maxMsgID > 0 && maxMsgID > readMsgID // xxx same problem with unread LEAVE messages.
+	return maxMsgID > 0 && maxMsgID > readMsgID
 }
 
 func (c Conversation) HasMemberStatus(status ConversationMemberStatus) bool {

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -242,6 +242,8 @@ var visibleMessageTypes = []MessageType{
 	MessageType_PIN,
 }
 
+// Visible chat messages appear visually as a message in the conv.
+// For counterexample REACTION and DELETE_HISTORY have visual effects but do not appear as a message.
 func VisibleChatMessageTypes() []MessageType {
 	return visibleMessageTypes
 }
@@ -258,7 +260,7 @@ var nonEmptyConvMessageTypes = []MessageType{
 }
 
 // A conversation is considered 'empty' unless it has one of these message types.
-// Used for example for filtering empty convs out of the the inbox.
+// Used for filtering empty convs out of the the inbox. And badging.
 func NonEmptyConvMessageTypes() []MessageType {
 	return nonEmptyConvMessageTypes
 }

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/keybase/client/go/protocol/gregor1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -2739,6 +2740,17 @@ func (m MessageSystemBulkAddToConv) String() string {
 	return fmt.Sprintf(prefix, suffix)
 }
 
+func withDeterminer(s string) string {
+	r, size := utf8.DecodeRuneInString(s)
+	if size == 0 || r == utf8.RuneError {
+		return "a " + s
+	}
+	if strings.Contains("aeiou", string(r)) {
+		return "an " + s
+	}
+	return "a " + s
+}
+
 func (m MessageSystem) String() string {
 	typ, err := m.SystemType()
 	if err != nil {
@@ -2748,13 +2760,13 @@ func (m MessageSystem) String() string {
 	case MessageSystemType_ADDEDTOTEAM:
 		output := fmt.Sprintf("Added @%s to the team", m.Addedtoteam().Addee)
 		if role := m.Addedtoteam().Role; role != keybase1.TeamRole_NONE {
-			output += fmt.Sprintf(" as a %q", role.HumanString())
+			output += fmt.Sprintf(" as %v", withDeterminer(role.HumanString()))
 		}
 		return output
 	case MessageSystemType_INVITEADDEDTOTEAM:
 		var roleText string
 		if role := m.Inviteaddedtoteam().Role; role != keybase1.TeamRole_NONE {
-			roleText = fmt.Sprintf(" as a %q", role.HumanString())
+			roleText = fmt.Sprintf(" as %v", withDeterminer(role.HumanString()))
 		}
 		output := fmt.Sprintf("Added @%s to the team (invited by @%s%s)",
 			m.Inviteaddedtoteam().Invitee, m.Inviteaddedtoteam().Inviter, roleText)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -232,10 +232,8 @@ func IsSystemMsgDeletableByDelete(typ MessageSystemType) bool {
 var visibleMessageTypes = []MessageType{
 	MessageType_TEXT,
 	MessageType_ATTACHMENT,
-	// TODO TRIAGE-1738 Join and leave are visible but changing this list kicks off some other bugs around notifications (HOTPOT-1688).
-	// Scour the effects before changing this list.
-	// MessageType_JOIN,
-	// MessageType_LEAVE,
+	MessageType_JOIN,
+	MessageType_LEAVE,
 	MessageType_SYSTEM,
 	MessageType_SENDPAYMENT,
 	MessageType_REQUESTPAYMENT,

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -246,6 +246,23 @@ func VisibleChatMessageTypes() []MessageType {
 	return visibleMessageTypes
 }
 
+var nonEmptyConvMessageTypes = []MessageType{
+	MessageType_TEXT,
+	MessageType_ATTACHMENT,
+	MessageType_SYSTEM,
+	MessageType_SENDPAYMENT,
+	MessageType_REQUESTPAYMENT,
+	MessageType_FLIP,
+	MessageType_HEADLINE,
+	MessageType_PIN,
+}
+
+// A conversation is considered 'empty' unless it has one of these message types.
+// Used for example for filtering empty convs out of the the inbox.
+func NonEmptyConvMessageTypes() []MessageType {
+	return nonEmptyConvMessageTypes
+}
+
 var editableMessageTypesByEdit = []MessageType{
 	MessageType_TEXT,
 }
@@ -1556,7 +1573,7 @@ func (c Conversation) IsUnread() bool {
 
 func (c Conversation) IsUnreadFromMsgID(readMsgID MessageID) bool {
 	maxMsgID := c.MaxVisibleMsgID()
-	return maxMsgID > 0 && maxMsgID > readMsgID
+	return maxMsgID > 0 && maxMsgID > readMsgID // xxx same problem with unread LEAVE messages.
 }
 
 func (c Conversation) HasMemberStatus(status ConversationMemberStatus) bool {


### PR DESCRIPTION
Make JOIN and LEAVE messages "visible". The immediate benefit is that journeycards will be able to show up below such messages.

This seems to work. Client `go/chat` tests pass. But there is some risk this causes bugs. I think this change will make it proportionally less risky to add more messages or functionality that switches based on visibility.