### PR TITLE
Crypto in GUI fixes

### DIFF
--- a/shared/actions/crypto-gen.tsx
+++ b/shared/actions/crypto-gen.tsx
@@ -59,7 +59,7 @@ type _SaltpackProgressPayload = {
 type _SaltpackSignPayload = {readonly input: HiddenString; readonly type: Types.InputTypes}
 type _SaltpackStartPayload = {readonly filename: HiddenString; readonly operation: Types.Operations}
 type _SaltpackVerifyPayload = {readonly input: HiddenString; readonly type: Types.InputTypes}
-type _SetEncryptOptionsPayload = {readonly options: Types.EncryptOptions; readonly noIncludeSelf?: boolean}
+type _SetEncryptOptionsPayload = {readonly options: Types.EncryptOptions; readonly hideIncludeSelf?: boolean}
 type _SetInputPayload = {
   readonly operation: Types.Operations
   readonly type: Types.InputTypes
@@ -193,7 +193,7 @@ export const createSetInputThrottled = (payload: _SetInputThrottledPayload): Set
  */
 export const createSetInput = (payload: _SetInputPayload): SetInputPayload => ({payload, type: setInput})
 /**
- * Sets options for encrypt operations. Also takkes 'noIncludeSelf' to disable includeSelf when user includes themselves as a recipient
+ * Sets options for encrypt operations. Also takkes 'hideIncludeSelf' to disable includeSelf when user includes themselves as a recipient
  */
 export const createSetEncryptOptions = (payload: _SetEncryptOptionsPayload): SetEncryptOptionsPayload => ({
   payload,

--- a/shared/actions/crypto.tsx
+++ b/shared/actions/crypto.tsx
@@ -37,7 +37,7 @@ const onSetRecipients = (state: TypedState, _: TeamBuildingGen.FinishedTeamBuild
 
   // User set themselves as a recipient, so don't show 'includeSelf' option
   if (usernames.includes(currentUser)) {
-    actions.push(CryptoGen.createSetEncryptOptions({noIncludeSelf: true, options}))
+    actions.push(CryptoGen.createSetEncryptOptions({hideIncludeSelf: true, options}))
   }
   actions.push(
     CryptoGen.createSetRecipients({

--- a/shared/actions/crypto.tsx
+++ b/shared/actions/crypto.tsx
@@ -36,7 +36,8 @@ const onSetRecipients = (state: TypedState, _: TeamBuildingGen.FinishedTeamBuild
   ]
 
   // User set themselves as a recipient, so don't show 'includeSelf' option
-  if (usernames.includes(currentUser)) {
+  // However we don't want to set hideIncludeSelf if we are also encrypting to an SBS user (since we must force includeSelf)
+  if (usernames.includes(currentUser) && !hasSBS) {
     actions.push(CryptoGen.createSetEncryptOptions({hideIncludeSelf: true, options}))
   }
   actions.push(

--- a/shared/actions/json/crypto.json
+++ b/shared/actions/json/crypto.json
@@ -37,9 +37,9 @@
       "value": "HiddenString"
     },
     "setEncryptOptions": {
-      "_description": "Sets options for encrypt operations. Also takkes 'noIncludeSelf' to disable includeSelf when user includes themselves as a recipient",
+      "_description": "Sets options for encrypt operations. Also takkes 'hideIncludeSelf' to disable includeSelf when user includes themselves as a recipient",
       "options": "Types.EncryptOptions",
-      "noIncludeSelf?": "boolean"
+      "hideIncludeSelf?": "boolean"
     },
     "onOperationSuccess": {
       "_description": "On saltpack RPC successful response. input is the operation that started it",

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -149,7 +149,7 @@ export const makeState = (): Types.State => ({
     meta: {
       hasRecipients: false,
       hasSBS: false,
-      noIncludeSelf: false,
+      hideIncludeSelf: false,
     },
     options: {
       includeSelf: true,

--- a/shared/constants/crypto.tsx
+++ b/shared/constants/crypto.tsx
@@ -119,8 +119,7 @@ export const getStatusCodeMessage = (code: number, operation: Types.Operations, 
 
   const statusCodeToMessage = {
     [RPCTypes.StatusCode.scstreamunknown]: invalidInputMessage,
-    [RPCTypes.StatusCode
-      .scsigcannotverify]: `Wrong message type: wanted an attached signature, but got a signed and encrypted message instead.`,
+    [RPCTypes.StatusCode.scsigcannotverify]: `Cannot verify ${type === 'text' ? 'message' : 'file'}`,
   } as const
   return statusCodeToMessage[code] || `Failed to ${operation} ${type}.`
 }

--- a/shared/constants/types/crypto.tsx
+++ b/shared/constants/types/crypto.tsx
@@ -63,7 +63,7 @@ export type EncrypState = CommonState & {
   meta: {
     hasRecipients: boolean
     hasSBS: boolean
-    noIncludeSelf: boolean
+    hideIncludeSelf: boolean
   }
   options: EncryptOptions
   recipients: Array<string> // Only for encrypt operation

--- a/shared/crypto/operations/encrypt/container.tsx
+++ b/shared/crypto/operations/encrypt/container.tsx
@@ -26,7 +26,7 @@ export default Container.namedConnect(
   (stateProps, dispatchProps) => {
     const {_encrypt, username} = stateProps
     const {errorMessage, input, inputType, options, meta} = _encrypt
-    const {noIncludeSelf, hasSBS, hasRecipients} = meta
+    const {hideIncludeSelf, hasSBS, hasRecipients} = meta
     const {bytesComplete, bytesTotal, recipients, warningMessage} = _encrypt
     const {output, outputStatus, outputType, outputMatchesInput} = _encrypt
     const {onClearInput, onCopyOutput, onSaveAsText, onSetInput, onSetOptions, onShowInFinder} = dispatchProps
@@ -35,9 +35,9 @@ export default Container.namedConnect(
       errorMessage: errorMessage.stringValue(),
       hasRecipients,
       hasSBS,
+      hideIncludeSelf,
       input: input.stringValue(),
       inputType,
-      noIncludeSelf,
       onClearInput,
       onCopyOutput,
       onSaveAsText,

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -55,6 +55,7 @@ const EncryptOptions = React.memo((props: EncryptOptionsProps) => {
       )}
       <Kb.Checkbox
         label="Sign"
+        disabled={hasSBS}
         checked={sign}
         onCheck={newValue => onSetOptions({includeSelf, sign: newValue})}
       />

--- a/shared/crypto/operations/encrypt/index.tsx
+++ b/shared/crypto/operations/encrypt/index.tsx
@@ -11,7 +11,7 @@ import Recipients from '../../recipients/container'
 type Props = {
   input: string
   inputType: Types.InputTypes
-  noIncludeSelf: boolean
+  hideIncludeSelf: boolean
   onClearInput: () => void
   onCopyOutput: (text: string) => void
   onSaveAsText: () => void
@@ -35,17 +35,17 @@ type Props = {
 type EncryptOptionsProps = {
   hasRecipients: boolean
   hasSBS: boolean
-  noIncludeSelf: boolean
+  hideIncludeSelf: boolean
   onSetOptions: (options: Types.EncryptOptions) => void
   options: Types.EncryptOptions
 }
 
 const EncryptOptions = React.memo((props: EncryptOptionsProps) => {
-  const {hasRecipients, hasSBS, noIncludeSelf, onSetOptions, options} = props
+  const {hasRecipients, hasSBS, hideIncludeSelf, onSetOptions, options} = props
   const {includeSelf, sign} = options
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true} gap="medium" style={styles.optionsContainer}>
-      {noIncludeSelf ? null : (
+      {hideIncludeSelf ? null : (
         <Kb.Checkbox
           label="Include yourself"
           disabled={hasSBS || !hasRecipients}
@@ -121,7 +121,7 @@ const Encrypt = (props: Props) => {
           <EncryptOptions
             hasRecipients={props.hasRecipients}
             hasSBS={props.hasSBS}
-            noIncludeSelf={props.noIncludeSelf}
+            hideIncludeSelf={props.hideIncludeSelf}
             options={props.options}
             onSetOptions={props.onSetOptions}
           />

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -49,10 +49,9 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       encrypt.bytesComplete = 0
       encrypt.bytesTotal = 0
       encrypt.recipients = initialState.encrypt.recipients
-      encrypt.meta.hasRecipients = false
-      encrypt.meta.noIncludeSelf = false
       // Reset options since they depend on the recipients
       encrypt.options = initialState.encrypt.options
+      encrypt.meta = initialState.encrypt.meta
       encrypt.output = new HiddenString('')
       encrypt.outputStatus = undefined
       encrypt.outputType = undefined
@@ -67,13 +66,18 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
 
     if (operation !== Constants.Operations.Encrypt) return
 
-    const {encrypt} = draftState
-    if (!encrypt.recipients.length && recipients.length) {
-      encrypt.meta.hasRecipients = true
-      encrypt.meta.hasSBS = hasSBS
+    const op = draftState.encrypt
+    if (!op.recipients.length && recipients.length) {
+      op.meta.hasRecipients = true
+      op.meta.hasSBS = hasSBS
     }
+    // Force signing when user is SBS
+    if (hasSBS) {
+      op.options.sign = true
+    }
+
     if (recipients) {
-      encrypt.recipients = recipients
+      op.recipients = recipients
     }
   },
   [CryptoGen.setEncryptOptions]: (draftState, action) => {

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -122,6 +122,7 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       | undefined
 
     switch (input?.type) {
+      // fallthrough
       case CryptoGen.saltpackDecrypt:
       case CryptoGen.saltpackEncrypt:
       case CryptoGen.saltpackSign:
@@ -137,14 +138,17 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     const op = draftState[operation]
 
     if (inputAction) {
-      outputMatchesInput = inputAction.payload.input.stringValue() === op.input.stringValue()
+      const currentInputMatchesRPCInput = inputAction.payload.input.stringValue() === op.input.stringValue()
+      const haveOutput = !!op.output.stringValue()
+      outputMatchesInput = currentInputMatchesRPCInput
 
-      // existing does match? just ignore this
-      if (op.outputMatchesInput) {
+      // If the store's input matches its output, then we don't need to update with the value of the returning RPC.
+      // However if the user encrypted to a user and then cleared the recipients (no output in the store) then allow the returning RPC to update the output
+      if (op.outputMatchesInput && haveOutput) {
         return
       }
 
-      // otherwise show the output but don't let them interact with it, its temporary
+      // Otherwise show the output but don't let them interact with it because the output is stale (newer RPC coming back)
       op.outputMatchesInput = outputMatchesInput
     }
 

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -77,7 +77,7 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     }
   },
   [CryptoGen.setEncryptOptions]: (draftState, action) => {
-    const {options: newOptions, noIncludeSelf} = action.payload
+    const {options: newOptions, hideIncludeSelf} = action.payload
     const {encrypt} = draftState
     const oldOptions = encrypt.options
     encrypt.options = {
@@ -85,8 +85,8 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       ...newOptions,
     }
     // User set themselves as a recipient so don't show the 'includeSelf' option for encrypt (since they're encrypting to themselves)
-    if (noIncludeSelf) {
-      encrypt.meta.noIncludeSelf = noIncludeSelf
+    if (hideIncludeSelf) {
+      encrypt.meta.hideIncludeSelf = hideIncludeSelf
       encrypt.options.includeSelf = false
     }
   },

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -55,6 +55,7 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       encrypt.output = new HiddenString('')
       encrypt.outputStatus = undefined
       encrypt.outputType = undefined
+      encrypt.outputMatchesInput = false
       encrypt.errorMessage = new HiddenString('')
       encrypt.warningMessage = new HiddenString('')
     }
@@ -142,13 +143,10 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     const op = draftState[operation]
 
     if (inputAction) {
-      const currentInputMatchesRPCInput = inputAction.payload.input.stringValue() === op.input.stringValue()
-      const haveOutput = !!op.output.stringValue()
-      outputMatchesInput = currentInputMatchesRPCInput
+      outputMatchesInput = inputAction.payload.input.stringValue() === op.input.stringValue()
 
       // If the store's input matches its output, then we don't need to update with the value of the returning RPC.
-      // However if the user encrypted to a user and then cleared the recipients (no output in the store) then allow the returning RPC to update the output
-      if (op.outputMatchesInput && haveOutput) {
+      if (op.outputMatchesInput) {
         return
       }
 


### PR DESCRIPTION
1. Now populates the output text when clearing recipients
2. Rename `noIncludeSelf` to `hideIncludeSelf`
3. Force signing when recipients has SBS
4. Fixes bug where including yourself as a recipient with an SBS user would error
5. Update verify error text to `cannot verify` temporarily