### PR TITLE
keep member page up to date on member role

### DIFF
--- a/shared/teams/team/member/container.tsx
+++ b/shared/teams/team/member/container.tsx
@@ -14,7 +14,7 @@ type OwnProps = Container.RouteProps<{username: string; teamID: Types.TeamID}>
 
 const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   const username = Container.getRouteProps(ownProps, 'username', '')
-  const teamID = Container.getRouteProps(ownProps, 'teamID', '')
+  const teamID = Container.getRouteProps(ownProps, 'teamID', Types.noTeamID)
   const teamDetails = Constants.getTeamDetails(state, teamID)
   const {teamname} = teamDetails
   const disabledReasonsForRolePicker = Constants.getDisabledReasonsForRolePicker(state, teamID, username)
@@ -134,6 +134,7 @@ export default Container.connect(
           dispatchProps._onRemoveMember(stateProps.teamID, stateProps._username)
         }
       },
+      teamID: stateProps.teamID,
       teamname: stateProps.teamname,
       user,
       you,

--- a/shared/teams/team/member/index.tsx
+++ b/shared/teams/team/member/index.tsx
@@ -3,6 +3,7 @@ import * as Types from '../../../constants/types/teams'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import {FloatingRolePicker, roleIconMap} from '../../role-picker'
+import {useTeamDetailsSubscribe} from '../../subscriber'
 
 type RolePickerSpecificProps = {
   isRolePickerOpen: boolean
@@ -23,6 +24,7 @@ export type MemberProps = {
     type: Types.TeamRoleType | null
     username: string
   }
+  teamID: Types.TeamID
   teamname: string
   you: {
     type: Types.TeamRoleType | null
@@ -37,6 +39,7 @@ export type MemberProps = {
 export type Props = MemberProps & RolePickerSpecificProps
 
 export const TeamMember = (props: Props) => {
+  useTeamDetailsSubscribe(props.teamID)
   const {user, you} = props
   const iconType = user.type && roleIconMap[user.type]
   return (


### PR DESCRIPTION
Previously, when you updated a member's role, the page would spin for a bit and then return to showing their old role. Now it shows the updated role.