### PR TITLE
Update static wallet disclaimer text to latest server-side version

### DIFF
--- a/shared/wallets/onboarding/disclaimer.tsx
+++ b/shared/wallets/onboarding/disclaimer.tsx
@@ -232,42 +232,36 @@ const StaticDisclaimer = () => (
       volatile.
     </Kb.Text>
     <Kb.Text type="Body" style={styles.bodyText}>
-      3. KEYBASE'S STELLAR WALLET IS BRAND NEW, AND YOU ARE AMONG ITS FIRST TESTERS. Seriously, don't race off
-      and buy more cryptocurrency than you're willing to lose. And don't manage tokens in Keybase that you're
-      not willing to lose. We could have an exploitable bug in an early release. You're using this app at your
-      own risk.{' '}
-      <Kb.Text type="BodyExtrabold" style={styles.bodyText}>
-        Keybase will not reimburse for any lost cryptocurrency due to user error or Keybase error of any kind.
-      </Kb.Text>
-    </Kb.Text>
-    <Kb.Text type="Body" style={styles.bodyText}>
-      4. BY DESIGN, WE CAN'T RECOVER YOUR PRIVATE KEY. We don't actually hold your funds, we simply help you
+      3. BY DESIGN, WE CAN'T RECOVER YOUR PRIVATE KEY. We don't actually hold your funds, we simply help you
       encrypt your keys. If you lose all your Keybase installs and paper keys, and if you haven't backed up
       your Stellar private key, you'll lose your Stellar account. Knowing your Keybase password is not enough
       info. Similarly, knowing your PGP private key isn't enough info. You must have access to a Keybase
       install (logged in as you) or Keybase paper key to recover your Stellar private key.
     </Kb.Text>
     <Kb.Text type="Body" style={styles.bodyText}>
-      5. CRYPTOCURRENCY ISN'T REALLY ANONYMOUS. When you sign your first or "default" Stellar address into
+      4. CRYPTOCURRENCY ISN'T REALLY ANONYMOUS. When you sign your first or "default" Stellar address into
       your signature chain on Keybase, you are announcing it publicly as a known address for you. Assume that
       all your transactions from that account are public. You can have as many Stellar accounts as you like in
       Keybase, but whenever you make one your default, that one is then announced as yours. Consider that data
       permanent.
     </Kb.Text>
     <Kb.Text type="Body" style={styles.bodyText}>
-      6. DON'T "RESET" YOUR KEYBASE ACCOUNT. If you reset your Keybase account, that will let you recover your
+      5. DON'T "RESET" YOUR KEYBASE ACCOUNT. If you reset your Keybase account, that will let you recover your
       Keybase username, by killing all your keys. You'll lose your Stellar account in Keybase. So don't do a
       Keybase account reset unless you've backed up your Stellar private key(s).
     </Kb.Text>
     <Kb.Text type="Body" style={styles.bodyText}>
-      7. AVOID SOCIAL ATTACKS. People may beg of thee for thine cryptocurrency. Pay attention to usernames,
+      6. AVOID SOCIAL ATTACKS. People may beg of thee for thine cryptocurrency. Pay attention to usernames,
       not photos and full names. Follow people on Keybase, so they turn green, which is a cryptographically
       signed action. And don't ever install software that other people send you, even if you trust those
       people. That software may be some kind of social worm. Keybase cannot be responsible for lost tokens due
-      to bugs, hacks, or social attacks. Or anything else for that matter.
+      to bugs, hacks, or social attacks. Or anything else for that matter.{' '}
+      <Kb.Text type="BodyExtrabold" style={styles.bodyText}>
+        Keybase will not reimburse for any lost cryptocurrency due to user error or Keybase error of any kind.
+      </Kb.Text>
     </Kb.Text>
     <Kb.Text type="Body" style={styles.bodyText}>
-      8. YOU AGREE TO LEARN MORE ABOUT STELLAR. You agree to learn about Stellar by visiting{' '}
+      7. YOU AGREE TO LEARN MORE ABOUT STELLAR. You agree to learn about Stellar by visiting{' '}
       <Kb.Text
         type="BodyPrimaryLink"
         onClick={() => openURL('https://www.stellar.org')}
@@ -279,7 +273,7 @@ const StaticDisclaimer = () => (
       enemies' enemies.
     </Kb.Text>
     <Kb.Text type="Body" style={styles.bodyText}>
-      9. FINALLY HAVE FUN WHILE YOU CAN. Something is coming.
+      8. FINALLY HAVE FUN WHILE YOU CAN. Something is coming.
     </Kb.Text>
 
     {/* Spacer to get over the gradient at the end. */}

--- a/shared/wallets/onboarding/disclaimer.tsx
+++ b/shared/wallets/onboarding/disclaimer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Constants from '../../constants/wallets'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
+import openURL from '../../util/open-url'
 import {addTicker, removeTicker, TickerID} from '../../util/second-timer'
 
 type DisclaimerProps = {
@@ -184,10 +185,7 @@ class Disclaimer extends React.Component<DisclaimerProps, DisclaimerState> {
         <Kb.Box2 direction="vertical" fullWidth={true} centerChildren={true} style={styles.container}>
           <Kb.Box2 direction="vertical" style={styles.header}>
             <Kb.Text center={true} type="Header" style={styles.headerText}>
-              Almost done.
-            </Kb.Text>
-            <Kb.Text center={true} type="Header" style={styles.headerText}>
-              It's important you read this.
+              Almost done. Important warnings here!
             </Kb.Text>
           </Kb.Box2>
           {Styles.isMobile ? (
@@ -214,88 +212,74 @@ class Disclaimer extends React.Component<DisclaimerProps, DisclaimerState> {
 const StaticDisclaimer = () => (
   <>
     <Kb.Text type="Body" style={styles.bodyText}>
-      We believe Keybase can help make cryptocurrency usable for 2 reasons:
+      1. WHAT IS STELLAR? Stellar is an open financial network. Anyone can use Stellar to send payments, issue
+      tokens, create smart contracts, store value, and other activities on the Stellar network. Stellar is
+      powered by free, open-source software and is hosted by independent computers across the globe. No one
+      entity can control the Stellar network.
     </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      • we can make your Stellar private key sync with encryption across your devices, without exposing it to
-      our servers. cool!
-    </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      • we can help you send and receive crypto just by knowing usernames. You can say goodbye to ugly
-      "addresses" you have to pass around insecurely.
-    </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      And we believe Stellar is in{' '}
-      <Kb.Text style={styles.bodyText} type="BodyItalic">
-        a unique position
-      </Kb.Text>{' '}
-      to solve payments because:
+      2. WHAT IS A LUMEN? Lumens (also referred to as "XLM") are cryptocurrency that are the native asset of
+      the Stellar network. Lumens are required to use the Stellar network: they’re needed for transaction
+      fees, account maintenance fees, and more. Read more about how you can use Lumens here:{' '}
+      <Kb.Text
+        type="BodyPrimaryLink"
+        onClick={() => openURL('https://www.stellar.org/lumens/')}
+        style={styles.bodyText}
+      >
+        https://www.stellar.org/lumens/
+      </Kb.Text>
+      . Note that Lumens can always be used for the Stellar network, but their fiat value could be highly
+      volatile.
     </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      • it's ultra fast and ultra cheap
-    </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      • it natively understands currencies and tokens
-    </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      • the network itself has a decentralized exchange built into it
-    </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      • it doesn't burn more electricity than small nations
-    </Kb.Text>
-
-    <Kb.Text type="Body" style={Styles.collapseStyles([styles.bodyText, styles.bodyBullet])}>
-      But there are a few things you must agree to understand before using Stellar on Keybase:
-    </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      1. IT'S BRAND NEW AND YOU ARE AMONG ITS FIRST TESTERS. Seriously, don't race off and buy more
-      cryptocurrency than you're willing to lose. And don't manage tokens in Keybase that you're not willing
-      to lose. We could have an exploitable bug in an early release. You're using this app at your own risk.{' '}
+      3. KEYBASE'S STELLAR WALLET IS BRAND NEW, AND YOU ARE AMONG ITS FIRST TESTERS. Seriously, don't race off
+      and buy more cryptocurrency than you're willing to lose. And don't manage tokens in Keybase that you're
+      not willing to lose. We could have an exploitable bug in an early release. You're using this app at your
+      own risk.{' '}
       <Kb.Text type="BodyExtrabold" style={styles.bodyText}>
         Keybase will not reimburse for any lost cryptocurrency due to user error or Keybase error of any kind.
       </Kb.Text>
     </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      2. BY DESIGN, WE CAN'T RECOVER YOUR PRIVATE KEY. We don't actually hold your funds, we simply help you
+      4. BY DESIGN, WE CAN'T RECOVER YOUR PRIVATE KEY. We don't actually hold your funds, we simply help you
       encrypt your keys. If you lose all your Keybase installs and paper keys, and if you haven't backed up
       your Stellar private key, you'll lose your Stellar account. Knowing your Keybase password is not enough
       info. Similarly, knowing your PGP private key isn't enough info. You must have access to a Keybase
       install (logged in as you) or Keybase paper key to recover your Stellar private key.
     </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      3. CRYPTOCURRENCY ISN'T REALLY ANONYMOUS. When you sign your first or "default" Stellar address into
+      5. CRYPTOCURRENCY ISN'T REALLY ANONYMOUS. When you sign your first or "default" Stellar address into
       your signature chain on Keybase, you are announcing it publicly as a known address for you. Assume that
       all your transactions from that account are public. You can have as many Stellar accounts as you like in
       Keybase, but whenever you make one your default, that one is then announced as yours. Consider that data
-      permanent.{' '}
+      permanent.
     </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      4. DON'T "RESET" YOUR KEYBASE ACCOUNT. If you reset your Keybase account, that will let you recover your
+      6. DON'T "RESET" YOUR KEYBASE ACCOUNT. If you reset your Keybase account, that will let you recover your
       Keybase username, by killing all your keys. You'll lose your Stellar account in Keybase. So don't do a
-      Keybase account reset unless you've backed up your Stellar private key(s).{' '}
+      Keybase account reset unless you've backed up your Stellar private key(s).
     </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      5. AVOID SOCIAL ATTACKS. People may beg of thee for thine cryptocurrency. Pay attention to usernames,
+      7. AVOID SOCIAL ATTACKS. People may beg of thee for thine cryptocurrency. Pay attention to usernames,
       not photos and full names. Follow people on Keybase, so they turn green, which is a cryptographically
       signed action. And don't ever install software that other people send you, even if you trust those
       people. That software may be some kind of social worm. Keybase cannot be responsible for lost tokens due
-      to bugs, hacks, or social attacks. Or anything else for that matter.{' '}
+      to bugs, hacks, or social attacks. Or anything else for that matter.
     </Kb.Text>
-
     <Kb.Text type="Body" style={styles.bodyText}>
-      6. FINALLY HAVE FUN WHILE YOU CAN. Something is coming.
+      8. YOU AGREE TO LEARN MORE ABOUT STELLAR. You agree to learn about Stellar by visiting{' '}
+      <Kb.Text
+        type="BodyPrimaryLink"
+        onClick={() => openURL('https://www.stellar.org')}
+        style={styles.bodyText}
+      >
+        https://www.stellar.org
+      </Kb.Text>{' '}
+      and by testing Stellar-in-Keybase, simply by sending Lumens to people you care about, or at least your
+      enemies' enemies.
+    </Kb.Text>
+    <Kb.Text type="Body" style={styles.bodyText}>
+      9. FINALLY HAVE FUN WHILE YOU CAN. Something is coming.
     </Kb.Text>
 
     {/* Spacer to get over the gradient at the end. */}

--- a/shared/wallets/onboarding/intro.tsx
+++ b/shared/wallets/onboarding/intro.tsx
@@ -44,12 +44,12 @@ const Intro = (props: IntroProps) => {
     >
       <Kb.Box2 direction="vertical" fullWidth={true} centerChildren={true} style={styles.container}>
         <Kb.Text center={true} type="Header" style={styles.headerText}>
-          {props.headerTitle || 'Keybase supports Stellar wallets.'}
+          {props.headerTitle || 'Keybase now supports Stellar.'}
         </Kb.Text>
 
         <Kb.Markdown style={styles.bodyText} styleOverride={bodyOverride}>
           {props.headerBody ||
-            'You can now send or request Stellar Lumens to any Keybase user on *Earth*. Transactions settle in seconds, and cost a fraction of a penny.\n\nWhen sending and receiving Lumens, we automatically do the conversion in your favorite currency. We went ahead and set it to *USD*.'}
+            'Stellar is built right into Keybase as a cryptographically-secure wallet. On Stellar, transactions settle in seconds, and they cost a fraction of a penny.'}
         </Kb.Markdown>
 
         <Kb.Icon


### PR DESCRIPTION
@keybase/react-hackers 

While the airdrop was running we used server-side disclaimer text for the wallet onboarding, but that text stopped being received by clients when the airdrop RPCs started to return an "expired" error -- the clients switched back to seeing the fallback text embedded in the client instead.  No big deal, but let's update the client-side version to match the most recent server-side version.