### PR TITLE
indexer: handle full indexing pass that were interrupted

### DIFF
--- a/go/kbfs/search/errors.go
+++ b/go/kbfs/search/errors.go
@@ -7,6 +7,7 @@ package search
 import (
 	"fmt"
 
+	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/kbfsmd"
 	"github.com/keybase/client/go/kbfs/tlf"
 )
@@ -23,4 +24,14 @@ func (e RevisionGCdError) Error() string {
 	return fmt.Sprintf(
 		"Revision %d for TLF %s is too old to index (last gc rev=%d)",
 		e.Rev, e.TlfID, e.LastGCRev)
+}
+
+// OldPtrNotFound indicates that the old pointer for a given file
+// couldn't be found in the index.
+type OldPtrNotFound struct {
+	OldPtr data.BlockPointer
+}
+
+func (e OldPtrNotFound) Error() string {
+	return fmt.Sprintf("Old pointer %s not found in the index", e.OldPtr)
 }

--- a/go/kbfs/search/errors.go
+++ b/go/kbfs/search/errors.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/kbfs/kbfsmd"
+	"github.com/keybase/client/go/kbfs/tlf"
+)
+
+// RevisionGCdError indicates that a revision has been
+// garbage-collected and cannot be indexed.
+type RevisionGCdError struct {
+	TlfID     tlf.ID
+	Rev       kbfsmd.Revision
+	LastGCRev kbfsmd.Revision
+}
+
+func (e RevisionGCdError) Error() string {
+	return fmt.Sprintf(
+		"Revision %d for TLF %s is too old to index (last gc rev=%d)",
+		e.Rev, e.TlfID, e.LastGCRev)
+}

--- a/go/kbfs/search/indexed_block_db_test.go
+++ b/go/kbfs/search/indexed_block_db_test.go
@@ -78,21 +78,25 @@ func TestIndexedBlockDb(t *testing.T) {
 	}
 	ver1 := uint64(1)
 	docID1 := "1"
+	dirDone1 := false
 
 	t.Log("Put block MD into the db.")
-	_, _, err = db.Get(ctx, ptr1)
+	_, _, _, err = db.Get(ctx, ptr1)
 	require.Error(t, err) // not dbd yet
-	err = db.Put(ctx, tlfID, ptr1, ver1, docID1)
+	err = db.Put(ctx, tlfID, ptr1, ver1, docID1, dirDone1)
 	require.NoError(t, err)
 
 	t.Log("Get block MD from the db.")
-	getVer1, getDocID1, err := db.Get(ctx, ptr1)
+	getVer1, getDocID1, getDirDone1, err := db.Get(ctx, ptr1)
 	require.NoError(t, err)
-	checkWrite := func(expectedVer, ver uint64, expectedDocID, docID string) {
+	checkWrite := func(
+		expectedVer, ver uint64, expectedDocID, docID string,
+		expectedDirDone, dirDone bool) {
 		require.Equal(t, expectedVer, ver)
 		require.Equal(t, expectedDocID, docID)
+		require.Equal(t, expectedDirDone, dirDone)
 	}
-	checkWrite(ver1, getVer1, docID1, getDocID1)
+	checkWrite(ver1, getVer1, docID1, getDocID1, dirDone1, getDirDone1)
 
 	t.Log("A second entry.")
 	id2, err := kbfsblock.MakeTemporaryID()
@@ -104,20 +108,21 @@ func TestIndexedBlockDb(t *testing.T) {
 	}
 	ver2 := uint64(1)
 	docID2 := "2"
+	dirDone2 := true
 
-	err = db.Put(ctx, tlfID, ptr2, ver2, docID2)
+	err = db.Put(ctx, tlfID, ptr2, ver2, docID2, dirDone2)
 	require.NoError(t, err)
-	getVer2, getDocID2, err := db.Get(ctx, ptr2)
+	getVer2, getDocID2, getDirDone2, err := db.Get(ctx, ptr2)
 	require.NoError(t, err)
-	checkWrite(ver2, getVer2, docID2, getDocID2)
+	checkWrite(ver2, getVer2, docID2, getDocID2, dirDone2, getDirDone2)
 
 	t.Log("Override the first block with new version.")
 	ver1 = 2
-	err = db.Put(ctx, tlfID, ptr1, ver1, docID1)
+	err = db.Put(ctx, tlfID, ptr1, ver1, docID1, dirDone1)
 	require.NoError(t, err)
-	getVer1, getDocID1, err = db.Get(ctx, ptr1)
+	getVer1, getDocID1, getDirDone1, err = db.Get(ctx, ptr1)
 	require.NoError(t, err)
-	checkWrite(ver1, getVer1, docID1, getDocID1)
+	checkWrite(ver1, getVer1, docID1, getDocID1, dirDone1, getDirDone1)
 
 	t.Log("Add a pointer with the same ID, but a non-zero ref nonce")
 	nonce, err := kbfsblock.MakeRefNonce()
@@ -132,14 +137,15 @@ func TestIndexedBlockDb(t *testing.T) {
 	}
 	ver3 := uint64(1)
 	docID3 := "3"
-	err = db.Put(ctx, tlfID, ptr3, ver3, docID3)
+	dirDone3 := false
+	err = db.Put(ctx, tlfID, ptr3, ver3, docID3, dirDone3)
 	require.NoError(t, err)
-	getVer3, getDocID3, err := db.Get(ctx, ptr3)
+	getVer3, getDocID3, getDirDone3, err := db.Get(ctx, ptr3)
 	require.NoError(t, err)
-	checkWrite(ver3, getVer3, docID3, getDocID3)
-	getVer2, getDocID2, err = db.Get(ctx, ptr2)
+	checkWrite(ver3, getVer3, docID3, getDocID3, dirDone3, getDirDone3)
+	getVer2, getDocID2, getDirDone2, err = db.Get(ctx, ptr2)
 	require.NoError(t, err)
-	checkWrite(ver2, getVer2, docID2, getDocID2)
+	checkWrite(ver2, getVer2, docID2, getDocID2, dirDone2, getDirDone2)
 
 	t.Log("Get new doc IDs")
 	res, err := db.GetNextDocIDs(11)
@@ -156,15 +162,15 @@ func TestIndexedBlockDb(t *testing.T) {
 	require.NoError(t, err)
 	db, done2 := newIndexedBlockDbForTestWithStorage(t, blockS, tlfS)
 	defer done2()
-	getVer1, getDocID1, err = db.Get(ctx, ptr1)
+	getVer1, getDocID1, getDirDone1, err = db.Get(ctx, ptr1)
 	require.NoError(t, err)
-	checkWrite(ver1, getVer1, docID1, getDocID1)
-	getVer2, getDocID2, err = db.Get(ctx, ptr2)
+	checkWrite(ver1, getVer1, docID1, getDocID1, dirDone1, getDirDone1)
+	getVer2, getDocID2, getDirDone2, err = db.Get(ctx, ptr2)
 	require.NoError(t, err)
-	checkWrite(ver2, getVer2, docID2, getDocID2)
-	getVer3, getDocID3, err = db.Get(ctx, ptr3)
+	checkWrite(ver2, getVer2, docID2, getDocID2, dirDone2, getDirDone2)
+	getVer3, getDocID3, getDirDone3, err = db.Get(ctx, ptr3)
 	require.NoError(t, err)
-	checkWrite(ver3, getVer3, docID3, getDocID3)
+	checkWrite(ver3, getVer3, docID3, getDocID3, dirDone3, getDirDone3)
 	res, err = db.GetNextDocIDs(1)
 	require.NoError(t, err)
 	require.Len(t, res, 1)

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -97,13 +97,14 @@ func writeFile(
 	if newFile {
 		ids, err := i.blocksDb.GetNextDocIDs(1)
 		require.NoError(t, err)
-		usedDocID, err := i.indexChild(ctx, rootNode, "", namePPS, ids[0], 1)
+		dirDoneFn, err := i.indexChild(ctx, rootNode, "", namePPS, ids[0], 1)
 		require.NoError(t, err)
-		require.True(t, usedDocID)
+		require.NotNil(t, dirDoneFn)
 	} else {
-		err := i.updateChild(
+		dirDoneFn, err := i.updateChild(
 			ctx, rootNode, "", namePPS, oldMD.BlockInfo.BlockPointer, 1)
 		require.NoError(t, err)
+		require.NotNil(t, dirDoneFn)
 	}
 
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -311,6 +311,8 @@ func TestFullIndexSyncedTlf(t *testing.T) {
 			Mode: keybase1.FolderSyncMode_ENABLED,
 		})
 	require.NoError(t, err)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
 	err = i.waitForSyncs(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
* Reorganize the root-block-fetch code in `folderBranchOps` a bit, to make sure it triggers the indexer callbacks in all cases when the root block is set or changes.
* For each TLF, track the revision that was started and the revision that was completed.
* If a revision was started, but not completed, start the index over again at the revision on the next trigger.
* Skip indexing individual files and directories that have already been indexed (based on their block pointers).
* Track whether all the children of a directory have been fully indexed; if so, it can be skipped without visiting each individual child.  (Add a new `DirDone` field to the DB for this.)
* Add a test that interrupts a full index, and restarts it.

Issue: HOTPOT-1763