### PR TITLE
Support /team/foo deep linking

### DIFF
--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -295,6 +295,7 @@
   "keybase.1.teams.teamRename": {"promise": true},
   "keybase.1.teams.teamSetSettings": {"promise": true},
   "keybase.1.teams.uploadTeamAvatar": {"promise": true},
+  "keybase.1.teams.getTeamID": {"promise": true},
   "keybase.1.test.echo": {"promise": true},
   "keybase.1.track.checkTracking": {"promise": true},
   "keybase.1.track.dismissWithToken": {"promise": true},

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -16,7 +16,7 @@ const handleTeamPageLink = (teamname: string, action: 'add_or_invite' | 'manage_
   const addMembers = action === 'add_or_invite' ? true : undefined
   return [
     RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}),
-    TeamsGen.createShowTeamByName({teamname, initialTab, addMembers}),
+    TeamsGen.createShowTeamByName({addMembers, initialTab, teamname}),
   ]
 }
 

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -78,10 +78,12 @@ const handleKeybaseLink = (action: DeeplinksGen.HandleKeybaseLinkPayload) => {
     case 'team-page': // keybase://team-page/{team_name}/{manage_settings,add_or_invite}?
       if (parts.length >= 2) {
         const teamName = parts[1]
-        const actionPart = parts[2]
-        const action =
-          actionPart === 'add_or_invite' || actionPart === 'manage_settings' ? actionPart : undefined
-        return handleTeamPageLink(teamName, action)
+        if (teamName.length) {
+          const actionPart = parts[2]
+          const action =
+            actionPart === 'add_or_invite' || actionPart === 'manage_settings' ? actionPart : undefined
+          return handleTeamPageLink(teamName, action)
+        }
       }
       break
     default:

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -106,9 +106,11 @@ const handleAppLink = (state: Container.TypedState, action: DeeplinksGen.LinkPay
 
     const teamLink = Constants.urlToTeamDeepLink(url)
     if (teamLink) {
+      const initialTab = teamLink.action === 'manage_settings' ? 'settings' : undefined
+      const addMembers = teamLink.action === 'add_or_invite' ? true : undefined
       return [
         RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}),
-        TeamsGen.createShowTeamByName({teamName: teamLink.teamName}),
+        TeamsGen.createShowTeamByName({teamName: teamLink.teamName, initialTab, addMembers}),
       ]
     }
   }

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -7,6 +7,7 @@ import * as RouteTreeGen from './route-tree-gen'
 import * as Saga from '../util/saga'
 import * as Tabs from '../constants/tabs'
 import * as WalletsGen from './wallets-gen'
+import * as TeamsGen from './teams-gen'
 import URL from 'url-parse'
 import logger from '../logger'
 
@@ -85,6 +86,7 @@ const handleAppLink = (state: Container.TypedState, action: DeeplinksGen.LinkPay
   } else {
     // Normal deeplink
     const url = new URL(action.payload.link)
+    console.log('zzz Deep Link', action.payload.link, url, url.query, typeof url.query)
     const username = Constants.urlToUsername(url)
     if (username === 'phone-app') {
       const phones = state.settings.phoneNumbers.phones
@@ -99,6 +101,14 @@ const handleAppLink = (state: Container.TypedState, action: DeeplinksGen.LinkPay
       return [
         RouteTreeGen.createNavigateAppend({path: [Tabs.peopleTab]}),
         ProfileGen.createShowUserProfile({username}),
+      ]
+    }
+
+    const teamLink = Constants.urlToTeamDeepLink(url)
+    if (teamLink) {
+      return [
+        RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}),
+        TeamsGen.createShowTeamByName({teamName: teamLink.teamName}),
       ]
     }
   }

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -76,7 +76,6 @@ const handleKeybaseLink = (action: DeeplinksGen.HandleKeybaseLinkPayload) => {
       }
       break
     case 'team-page': // keybase://team-page/{team_name}/{manage_settings,add_or_invite}
-      console.log('team page deeplink', parts)
       if (parts.length == 3) {
         const teamName = parts[1]
         const action = parts[2]
@@ -105,7 +104,6 @@ const handleAppLink = (state: Container.TypedState, action: DeeplinksGen.LinkPay
   } else {
     // Normal deeplink
     const url = new URL(action.payload.link)
-    console.log('zzz Deep Link', action.payload.link, url, url.query, typeof url.query)
     const username = Constants.urlToUsername(url)
     if (username === 'phone-app') {
       const phones = state.settings.phoneNumbers.phones

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -75,13 +75,13 @@ const handleKeybaseLink = (action: DeeplinksGen.HandleKeybaseLinkPayload) => {
         }
       }
       break
-    case 'team-page': // keybase://team-page/{team_name}/{manage_settings,add_or_invite}
-      if (parts.length == 3) {
+    case 'team-page': // keybase://team-page/{team_name}/{manage_settings,add_or_invite}?
+      if (parts.length >= 2) {
         const teamName = parts[1]
-        const action = parts[2]
-        if (action === 'add_or_invite' || action === 'manage_settings') {
-          return handleTeamPageLink(teamName, action)
-        }
+        const actionPart = parts[2]
+        const action =
+          actionPart === 'add_or_invite' || actionPart === 'manage_settings' ? actionPart : undefined
+        return handleTeamPageLink(teamName, action)
       }
       break
     default:

--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -11,12 +11,12 @@ import * as TeamsGen from './teams-gen'
 import URL from 'url-parse'
 import logger from '../logger'
 
-const handleTeamPageLink = (teamName: string, action: 'add_or_invite' | 'manage_settings' | undefined) => {
+const handleTeamPageLink = (teamname: string, action: 'add_or_invite' | 'manage_settings' | undefined) => {
   const initialTab = action === 'manage_settings' ? 'settings' : undefined
   const addMembers = action === 'add_or_invite' ? true : undefined
   return [
     RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}),
-    TeamsGen.createShowTeamByName({teamName: teamName, initialTab, addMembers}),
+    TeamsGen.createShowTeamByName({teamname, initialTab, addMembers}),
   ]
 }
 

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -317,6 +317,9 @@
       "_description": "Set filtering for the subteams tab.",
       "filter": "string",
       "parentTeam?": "Types.TeamID"
+    },
+    "showTeamByName": {
+      "teamName": "string"
     }
   }
 }

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -319,7 +319,7 @@
       "parentTeam?": "Types.TeamID"
     },
     "showTeamByName": {
-      "teamName": "string",
+      "teamname": "string",
       "initialTab?": "Types.TabKey",
       "addMembers?": "boolean"
     }

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -319,7 +319,9 @@
       "parentTeam?": "Types.TeamID"
     },
     "showTeamByName": {
-      "teamName": "string"
+      "teamName": "string",
+      "initialTab?": "Types.TabKey",
+      "addMembers?": "boolean"
     }
   }
 }

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -264,7 +264,11 @@ type _SetUpdatedTopicPayload = {
   readonly newTopic: string
 }
 type _SettingsErrorPayload = {readonly error: string}
-type _ShowTeamByNamePayload = {readonly teamName: string}
+type _ShowTeamByNamePayload = {
+  readonly teamName: string
+  readonly initialTab?: Types.TabKey
+  readonly addMembers?: boolean
+}
 type _TeamCreatedPayload = {
   readonly fromChat: boolean
   readonly teamID: Types.TeamID

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -265,7 +265,7 @@ type _SetUpdatedTopicPayload = {
 }
 type _SettingsErrorPayload = {readonly error: string}
 type _ShowTeamByNamePayload = {
-  readonly teamName: string
+  readonly teamname: string
   readonly initialTab?: Types.TabKey
   readonly addMembers?: boolean
 }

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -74,6 +74,7 @@ export const setTeamsWithChosenChannels = 'teams:setTeamsWithChosenChannels'
 export const setUpdatedChannelName = 'teams:setUpdatedChannelName'
 export const setUpdatedTopic = 'teams:setUpdatedTopic'
 export const settingsError = 'teams:settingsError'
+export const showTeamByName = 'teams:showTeamByName'
 export const teamCreated = 'teams:teamCreated'
 export const teamLoaded = 'teams:teamLoaded'
 export const toggleInvitesCollapsed = 'teams:toggleInvitesCollapsed'
@@ -263,6 +264,7 @@ type _SetUpdatedTopicPayload = {
   readonly newTopic: string
 }
 type _SettingsErrorPayload = {readonly error: string}
+type _ShowTeamByNamePayload = {readonly teamName: string}
 type _TeamCreatedPayload = {
   readonly fromChat: boolean
   readonly teamID: Types.TeamID
@@ -561,6 +563,10 @@ export const createSettingsError = (payload: _SettingsErrorPayload): SettingsErr
   payload,
   type: settingsError,
 })
+export const createShowTeamByName = (payload: _ShowTeamByNamePayload): ShowTeamByNamePayload => ({
+  payload,
+  type: showTeamByName,
+})
 export const createTeamCreated = (payload: _TeamCreatedPayload): TeamCreatedPayload => ({
   payload,
   type: teamCreated,
@@ -803,6 +809,10 @@ export type SettingsErrorPayload = {
   readonly payload: _SettingsErrorPayload
   readonly type: typeof settingsError
 }
+export type ShowTeamByNamePayload = {
+  readonly payload: _ShowTeamByNamePayload
+  readonly type: typeof showTeamByName
+}
 export type TeamCreatedPayload = {readonly payload: _TeamCreatedPayload; readonly type: typeof teamCreated}
 export type TeamLoadedPayload = {readonly payload: _TeamLoadedPayload; readonly type: typeof teamLoaded}
 export type ToggleInvitesCollapsedPayload = {
@@ -897,6 +907,7 @@ export type Actions =
   | SetUpdatedChannelNamePayload
   | SetUpdatedTopicPayload
   | SettingsErrorPayload
+  | ShowTeamByNamePayload
   | TeamCreatedPayload
   | TeamLoadedPayload
   | ToggleInvitesCollapsedPayload

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1300,15 +1300,15 @@ async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload, logger: Sa
   }
   return [
     RouteTreeGen.createNavigateAppend({
-      path: [
-        {props: {initialTab, teamID}, selected: 'team'},
-        // BUG: This doesn't actually go this route when addMembers is true, it
-        // just stacks team builder without stacking `team` screen first.
-        ...(addMembers
-          ? [{props: {namespace: 'teams', teamID, title: ''}, selected: 'teamsTeamBuilder'}]
-          : []),
-      ],
+      path: [{props: {initialTab, teamID}, selected: 'team'}],
     }),
+    ...(addMembers
+      ? [
+          RouteTreeGen.createNavigateAppend({
+            path: [{props: {namespace: 'teams', teamID, title: ''}, selected: 'teamsTeamBuilder'}],
+          }),
+        ]
+      : []),
   ]
 }
 

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1295,7 +1295,7 @@ async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload, logger: Sa
   try {
     teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName})
   } catch (e) {
-    logger.info(`showTeamByName: team "${teamName} cannot be loaded: ${e.toString()}`)
+    logger.info(`showTeamByName: team "${teamName}" cannot be loaded: ${e.toString()}`)
     return null
   }
   return [

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1289,6 +1289,12 @@ function* teamBuildingSaga() {
   yield* Saga.chainAction(TeamsGen.addedToTeam, closeTeamBuilderOrSetError)
 }
 
+async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload) {
+  const {teamName} = action.payload
+  const teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName})
+  return [RouteTreeGen.createNavigateAppend({path: [{props: {teamID}, selected: 'team'}]})]
+}
+
 const teamsSaga = function*() {
   yield* Saga.chainAction(TeamsGen.leaveTeam, leaveTeam)
   yield* Saga.chainGenerator<TeamsGen.DeleteTeamPayload>(TeamsGen.deleteTeam, deleteTeam)
@@ -1365,6 +1371,8 @@ const teamsSaga = function*() {
   )
 
   yield* Saga.chainAction2(TeamsGen.clearNavBadges, clearNavBadges)
+
+  yield* Saga.chainAction(TeamsGen.showTeamByName, showTeamByName)
 
   // Hook up the team building sub saga
   yield* teamBuildingSaga()

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1290,9 +1290,18 @@ function* teamBuildingSaga() {
 }
 
 async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload) {
-  const {teamName} = action.payload
+  const {teamName, initialTab, addMembers} = action.payload
   const teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName})
-  return [RouteTreeGen.createNavigateAppend({path: [{props: {teamID}, selected: 'team'}]})]
+  return [
+    RouteTreeGen.createNavigateAppend({
+      path: [
+        {props: {initialTab, teamID}, selected: 'team'},
+        ...(addMembers
+          ? [{props: {namespace: 'teams', teamID, title: ''}, selected: 'teamsTeamBuilder'}]
+          : []),
+      ],
+    }),
+  ]
 }
 
 const teamsSaga = function*() {

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1290,12 +1290,12 @@ function* teamBuildingSaga() {
 }
 
 async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload, logger: Saga.SagaLogger) {
-  const {teamName, initialTab, addMembers} = action.payload
+  const {teamname, initialTab, addMembers} = action.payload
   let teamID: string
   try {
-    teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName})
+    teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName: teamname})
   } catch (e) {
-    logger.info(`showTeamByName: team "${teamName}" cannot be loaded: ${e.toString()}`)
+    logger.info(`showTeamByName: team "${teamname}" cannot be loaded: ${e.toString()}`)
     return null
   }
   return [

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -960,6 +960,7 @@ export type TypedActionsMap = {
   'teams:setTeamRoleMap': teams.SetTeamRoleMapPayload
   'teams:toggleInvitesCollapsed': teams.ToggleInvitesCollapsedPayload
   'teams:setSubteamFilter': teams.SetSubteamFilterPayload
+  'teams:showTeamByName': teams.ShowTeamByNamePayload
   'tracker2:load': tracker2.LoadPayload
   'tracker2:updatedDetails': tracker2.UpdatedDetailsPayload
   'tracker2:updateResult': tracker2.UpdateResultPayload

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -72,6 +72,9 @@ export const urlToUsername = (url: URL) => {
 }
 
 export const urlToTeamDeepLink = (url: URL) => {
+  // TODO: generalize rest of the deeplink URL checks from urlToUsername so they
+  // are also checked for team links here.
+
   // Similar regexp to username but allow `.` for subteams
   const match = url.pathname.match(/^\/team\/((?:[a-zA-Z0-9][a-zA-Z0-9_.-]?)+)\/?$/)
   if (!match) {
@@ -79,12 +82,12 @@ export const urlToTeamDeepLink = (url: URL) => {
   }
 
   const teamName = match[1]
-  if (teamName.length < 2 || teamName.length > 16) {
+  if (teamName.length < 2 || teamName.length > 255) {
     return null
   }
 
   // `url.query` has a wrong type in @types/url-parse. It's a `string` in the
-  // code we are pulling in, but a [string]string object in @types.
+  // code, but @types claim it's a {[k: string]: string | undefined}.
   const queryString: string = url.query as any
 
   // URLSearchParams is not available in react-native. See if any of recognized

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -26,30 +26,38 @@ export const prepareAccountRows = <T extends {username: string; hasStoredSecret:
   myUsername: string
 ): Array<T> => accountRows.filter(account => account.username !== myUsername)
 
-export const urlToUsername = (url: URL) => {
-  const protocol = url.protocol
+function isKeybaseIoUrl(url: URL) {
+  const {protocol} = url
   if (protocol !== 'http:' && protocol !== 'https:') {
-    return null
+    return false
   }
 
   if (url.username || url.password) {
-    return null
+    return false
   }
 
-  const hostname = url.hostname
+  const {hostname} = url
   if (hostname !== 'keybase.io' && hostname !== 'www.keybase.io') {
-    return null
+    return false
   }
 
-  const port = url.port
+  const {port} = url
   if (port) {
     if (protocol === 'http:' && port !== '80') {
-      return null
+      return false
     }
 
     if (protocol === 'https:' && port !== '443') {
-      return null
+      return false
     }
+  }
+
+  return true
+}
+
+export const urlToUsername = (url: URL) => {
+  if (!isKeybaseIoUrl(url)) {
+    return null
   }
 
   const pathname = url.pathname
@@ -72,8 +80,9 @@ export const urlToUsername = (url: URL) => {
 }
 
 export const urlToTeamDeepLink = (url: URL) => {
-  // TODO: generalize rest of the deeplink URL checks from urlToUsername so they
-  // are also checked for team links here.
+  if (!isKeybaseIoUrl(url)) {
+    return null
+  }
 
   // Similar regexp to username but allow `.` for subteams
   const match = url.pathname.match(/^\/team\/((?:[a-zA-Z0-9][a-zA-Z0-9_.-]?)+)\/?$/)

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -97,7 +97,7 @@ export const urlToTeamDeepLink = (url: URL) => {
 
   // `url.query` has a wrong type in @types/url-parse. It's a `string` in the
   // code, but @types claim it's a {[k: string]: string | undefined}.
-  const queryString: string = url.query as any
+  const queryString = (url.query as any) as string
 
   // URLSearchParams is not available in react-native. See if any of recognized
   // query parameters is passed using regular expressions.

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -89,7 +89,7 @@ export const urlToTeamDeepLink = (url: URL) => {
 
   // URLSearchParams is not available in react-native. See if any of recognized
   // query parameters is passed using regular expressions.
-  const action = ['add_or_invite', 'manage_settings'].find(x =>
+  const action = (['add_or_invite', 'manage_settings'] as const).find(x =>
     queryString.match(`[?&]applink=${x}([?&].+)?$`)
   )
   return {action, teamName}

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1319,6 +1319,10 @@ export type MessageTypes = {
     inParam: {readonly teamID: TeamID}
     outParam: TeamAndMemberShowcase
   }
+  'keybase.1.teams.getTeamID': {
+    inParam: {readonly teamName: String}
+    outParam: TeamID
+  }
   'keybase.1.teams.getTeamRoleMap': {
     inParam: void
     outParam: TeamRoleMapAndVersion
@@ -3652,6 +3656,7 @@ export const signupSignupRpcSaga = (p: {params: MessageTypes['keybase.1.signup.s
 export const teamsGetAnnotatedTeamRpcPromise = (params: MessageTypes['keybase.1.teams.getAnnotatedTeam']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getAnnotatedTeam']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getAnnotatedTeam', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.getTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamAndMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamAndMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const teamsGetTeamIDRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamID']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamID']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamID', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamRoleMapRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamRoleMap']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamRoleMap']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamRoleMap', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.setTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTeamMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.setTeamMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTeamMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTeamMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -4083,7 +4088,6 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.teams.findNextMerkleRootAfterTeamRemoval'
 // 'keybase.1.teams.findNextMerkleRootAfterTeamRemovalBySigningKey'
 // 'keybase.1.teams.profileTeamLoad'
-// 'keybase.1.teams.getTeamID'
 // 'keybase.1.teams.getTeamName'
 // 'keybase.1.teams.ftl'
 // 'keybase.1.teamsUi.confirmRootTeamDelete'

--- a/shared/teams/team/container.tsx
+++ b/shared/teams/team/container.tsx
@@ -11,11 +11,13 @@ import makeRows from './rows'
 import flags from '../../util/feature-flags'
 import TabsStateNew from './container.new'
 
-type TabsStateOwnProps = Container.RouteProps<{teamID: Types.TeamID}>
+type TabsStateOwnProps = Container.RouteProps<{teamID: Types.TeamID; initialTab?: Types.TabKey}>
 type OwnProps = TabsStateOwnProps & {
   selectedTab: Types.TabKey
   setSelectedTab: (tab: Types.TabKey) => void
 }
+
+const defaultTab: Types.TabKey = 'members'
 
 // keep track during session
 const lastSelectedTabs = {}
@@ -26,7 +28,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
     throw new Error('There was a problem loading the team page, please report this error.')
   }
 
-  const selectedTab = ownProps.selectedTab || 'members'
+  const selectedTab = ownProps.selectedTab || defaultTab
 
   return {
     invitesCollapsed: state.teams.invitesCollapsed,
@@ -87,7 +89,12 @@ class TabsState extends React.PureComponent<TabsStateOwnProps, {selectedTab: Typ
       ? undefined
       : () => <SubHeader teamID={Container.getRouteProps(ownProps, 'teamID', '')} />,
   })
-  state = {selectedTab: lastSelectedTabs[Container.getRouteProps(this.props, 'teamID', '')] || 'members'}
+  state = {
+    selectedTab:
+      Container.getRouteProps(this.props, 'initialTab', '') ||
+      lastSelectedTabs[Container.getRouteProps(this.props, 'teamID', '')] ||
+      defaultTab,
+  }
   private setSelectedTab = selectedTab => {
     lastSelectedTabs[Container.getRouteProps(this.props, 'teamID', '')] = selectedTab
     this.setState({selectedTab})
@@ -95,7 +102,8 @@ class TabsState extends React.PureComponent<TabsStateOwnProps, {selectedTab: Typ
   componentDidUpdate(prevProps: TabsStateOwnProps) {
     const teamID = Container.getRouteProps(this.props, 'teamID', '')
     if (teamID !== Container.getRouteProps(prevProps, 'teamID', '')) {
-      this.setSelectedTab(lastSelectedTabs[teamID] || 'members')
+      const routeTab = Container.getRouteProps(this.props, 'initialTab', '')
+      this.setSelectedTab(routeTab || lastSelectedTabs[teamID] || defaultTab)
     }
   }
   render() {


### PR DESCRIPTION
This PR adds support for deep linking into `https://keybase.io/team/foo` pages which will result in navigating to a team tab of the specific team (assuming it exists).

Additionally there is a query parameter that's recognized: `applink`, which is optional and takes one of the following values right now: `add_or_invite`, `manage_settings`. `add_or_invite` will navigate to team builder of the team, and `manage_settings` will switch to Settings tab in navigated team page.

There are the following issues with this PR:
1) Navigating to team-builder does not stack team page properly (see my inline comment below).
2) Code for deep linking lives in at least two places and I don't understand why:
- `shared/actions/deeplinks.tsx` - this is where I added the team link support.
- `shared/actions/config/index.tsx` `routeToInitialScreen`
  - also `shared/actions/config/index.tsx` `maybeLoadAppLink` coming from `loadedSettings` action.

My PR seems to be working both when the app is in the background and when it's not launched (force-killed beforehand). 

Help @cjb @chrisnojima  ?

When this mystery is solved I'll improve the code in `urlToTeamDeepLink` by generalizing URL checks from `urlToUsername` (check protocol, check in-url username/password, check port etc.) and using them in all deep link parsing.

cc @keybase/y2ksquad @keybase/react-hackers 

EDIT:

Now also a `keybase://team-page/teamname/action` deep-link is supported. This gives us a support for this kind of link in desktop as well. Website PR makes it so `keybase.io/team/foo?applink=...` will try to redirect you to `keybase://` deep-link, and when Keybase is installed (and user accepts the redirect), it will show the appropriate tab / modal. 