### PR TITLE
service: decrypt favorites into slice pointer, not slice itself

### DIFF
--- a/go/service/kbfs.go
+++ b/go/service/kbfs.go
@@ -185,6 +185,6 @@ func (h *KBFSHandler) EncryptFavorites(ctx context.Context,
 // DecryptFavorites decrypts cached favorites stored on disk.
 func (h *KBFSHandler) DecryptFavorites(ctx context.Context,
 	dataToEncrypt []byte) (res []byte, err error) {
-	err = encrypteddb.DecodeBox(ctx, dataToEncrypt, h.getKeyFn(), res)
+	err = encrypteddb.DecodeBox(ctx, dataToEncrypt, h.getKeyFn(), &res)
 	return res, err
 }


### PR DESCRIPTION
It seems like loading favorites from the cache has never worked, which broke favorites listing when startup happened while offline.

cc: @jakob223 

Issue: HOTPOT-1819