### PR TITLE
Reuse node image's default 1000:1000 "node" account as "keybase"

### DIFF
--- a/packaging/linux/docker/node-slim/Dockerfile
+++ b/packaging/linux/docker/node-slim/Dockerfile
@@ -29,9 +29,9 @@ RUN gpg --import /gosu_key.asc \
 COPY --from=base /usr/bin/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
-RUN useradd --create-home --shell /bin/bash keybase \
-    && mkdir -p /var/log/keybase \
-    && chown keybase:keybase /var/log/keybase
+RUN mv /home/node /home/keybase \
+    && usermod -l keybase -d /home/keybase -m node \
+    && groupmod -n keybase node
 VOLUME [ "/home/keybase/.config/keybase", "/home/keybase/.cache/keybase" ]
 
 COPY --from=base /usr/bin/keybase /usr/bin/keybase

--- a/packaging/linux/docker/node-slim/Dockerfile
+++ b/packaging/linux/docker/node-slim/Dockerfile
@@ -29,8 +29,7 @@ RUN gpg --import /gosu_key.asc \
 COPY --from=base /usr/bin/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
-RUN mv /home/node /home/keybase \
-    && usermod -l keybase -d /home/keybase -m node \
+RUN usermod -l keybase -d /home/keybase -m node \
     && groupmod -n keybase node
 VOLUME [ "/home/keybase/.config/keybase", "/home/keybase/.cache/keybase" ]
 

--- a/packaging/linux/docker/node/Dockerfile
+++ b/packaging/linux/docker/node/Dockerfile
@@ -29,9 +29,9 @@ RUN gpg --import /gosu_key.asc \
 COPY --from=base /usr/bin/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
-RUN useradd --create-home --shell /bin/bash keybase \
-    && mkdir -p /var/log/keybase \
-    && chown keybase:keybase /var/log/keybase
+RUN mv /home/node /home/keybase \
+    && usermod -l keybase -d /home/keybase -m node \
+    && groupmod -n keybase node
 VOLUME [ "/home/keybase/.config/keybase", "/home/keybase/.cache/keybase" ]
 
 COPY --from=base /usr/bin/keybase /usr/bin/keybase

--- a/packaging/linux/docker/node/Dockerfile
+++ b/packaging/linux/docker/node/Dockerfile
@@ -29,8 +29,7 @@ RUN gpg --import /gosu_key.asc \
 COPY --from=base /usr/bin/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
-RUN mv /home/node /home/keybase \
-    && usermod -l keybase -d /home/keybase -m node \
+RUN usermod -l keybase -d /home/keybase -m node \
     && groupmod -n keybase node
 VOLUME [ "/home/keybase/.config/keybase", "/home/keybase/.cache/keybase" ]
 

--- a/packaging/linux/docker/slim/Dockerfile
+++ b/packaging/linux/docker/slim/Dockerfile
@@ -30,9 +30,7 @@ RUN gpg --import /gosu_key.asc \
 COPY packaging/linux/docker/slim/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
-RUN useradd --create-home --shell /bin/bash keybase \
-    && mkdir -p /var/log/keybase \
-    && chown keybase:keybase /var/log/keybase
+RUN useradd --create-home --shell /bin/bash keybase
 VOLUME [ "/home/keybase/.config/keybase", "/home/keybase/.cache/keybase" ]
 
 COPY --from=base /usr/bin/keybase /usr/bin/keybase

--- a/packaging/linux/docker/slim/entrypoint.sh
+++ b/packaging/linux/docker/slim/entrypoint.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # chown the data dirs if running as root, then rerun the script as keybase
 if [[ "$(id -u)" -eq "0" ]]; then
     chown -R keybase:keybase \
-        /home/keybase/.config/keybase \
-        /home/keybase/.cache/keybase
+        /home/keybase/.config \
+        /home/keybase/.cache
     exec gosu keybase ${BASH_SOURCE[0]} "$@"
     exit 0
 fi

--- a/packaging/linux/docker/standard/Dockerfile
+++ b/packaging/linux/docker/standard/Dockerfile
@@ -50,9 +50,7 @@ RUN gpg --import /gosu_key.asc \
 COPY packaging/linux/docker/standard/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 
-RUN useradd --create-home --shell /bin/bash keybase \
-    && mkdir -p /var/log/keybase \
-    && chown keybase:keybase /var/log/keybase
+RUN useradd --create-home --shell /bin/bash keybase
 VOLUME [ "/home/keybase/.config/keybase", "/home/keybase/.cache/keybase" ]
 
 COPY --from=builder /binaries/amd64/usr/bin/keybase /usr/bin/keybase

--- a/packaging/linux/docker/standard/entrypoint.sh
+++ b/packaging/linux/docker/standard/entrypoint.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # chown the data dirs if running as root, then rerun the script as keybase
 if [[ "$(id -u)" -eq "0" ]]; then
     chown -R keybase:keybase \
-        /home/keybase/.config/keybase \
-        /home/keybase/.cache/keybase
+        /home/keybase/.config \
+        /home/keybase/.cache
     exec gosu keybase ${BASH_SOURCE[0]} "$@"
     exit 0
 fi


### PR DESCRIPTION
`keybaseio/client:stable-node`'s `keybase` UID is 1001 and `keybaseio/client:stable`'s is 1000. This fixes it.