### PR TITLE
Fix bot creator display bugs

### DIFF
--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -50,6 +50,7 @@ export const Bot = (props: BotProps) => {
           usernames={[ownerUser ?? botUsername]}
           type="BodySmall"
           withProfileCardPopup={true}
+          onUsernameClicked="profile"
         />
       )}
     </Kb.Box2>

--- a/shared/teams/team/rows/bot-row/bot/index.tsx
+++ b/shared/teams/team/rows/bot-row/bot/index.tsx
@@ -50,9 +50,9 @@ export const TeamBotRow = (props: Props) => {
       >
         {props.botAlias || props.username}
       </Kb.Text>
-      <Kb.Text type="BodySmall">&nbsp;• by </Kb.Text>
+      <Kb.Text type="BodySmall">&nbsp;• by&nbsp;</Kb.Text>
       {props.ownerTeam ? (
-        <Kb.TeamWithPopup prefix="@" inline={true} teamName={props.ownerTeam} type="BodySmall" />
+        <Kb.Text type="BodySmall">{`@${props.ownerTeam}`}</Kb.Text>
       ) : (
         <Kb.ConnectedUsernames
           prefix="@"
@@ -60,6 +60,7 @@ export const TeamBotRow = (props: Props) => {
           usernames={[props.ownerUser ?? props.username]}
           type="BodySmall"
           withProfileCardPopup={true}
+          onUsernameClicked="profile"
         />
       )}
     </Kb.Box2>


### PR DESCRIPTION
This PR fixes some issues with the bot creator ("by @<username>") display on bot rows by adding an `onUsernameClicked` action for bots owned by a user, and removing the broken team popup for bots owned by teams. Also fixes an issue where there wasn't a space between "by" and "@" on team bot rows.