### PR TITLE
teams: fix loader to not request old RKMs and prevs

### DIFF
--- a/go/teams/errors.go
+++ b/go/teams/errors.go
@@ -532,3 +532,16 @@ type NeedHiddenChainRotationError struct{}
 func (e NeedHiddenChainRotationError) Error() string {
 	return "need hidden chain rotation"
 }
+
+type MissingReaderKeyMaskError struct {
+	gen keybase1.PerTeamKeyGeneration
+	app keybase1.TeamApplication
+}
+
+func NewMissingReaderKeyMaskError(gen keybase1.PerTeamKeyGeneration, app keybase1.TeamApplication) error {
+	return MissingReaderKeyMaskError{gen, app}
+}
+
+func (e MissingReaderKeyMaskError) Error() string {
+	return fmt.Sprintf("missing reader key mask for gen:%v app:%v", e.gen, e.app)
+}

--- a/go/teams/loader2.go
+++ b/go/teams/loader2.go
@@ -879,10 +879,10 @@ func (l *TeamLoader) checkReaderKeyMaskCoverage(mctx libkb.MetaContext,
 			continue
 		}
 		if _, ok := state.ReaderKeyMasks[app]; !ok {
-			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
+			return NewMissingReaderKeyMaskError(gen, app)
 		}
 		if _, ok := state.ReaderKeyMasks[app][gen]; !ok {
-			return fmt.Errorf("missing reader key mask for gen:%v app:%v", gen, app)
+			return NewMissingReaderKeyMaskError(gen, app)
 		}
 	}
 

--- a/go/teams/loader_ctx.go
+++ b/go/teams/loader_ctx.go
@@ -150,9 +150,7 @@ func (l *LoaderContextG) getLinksFromServerCommon(ctx context.Context,
 	}
 	if lows != nil {
 		arg.Args["low"] = libkb.I{Val: int(lows.Seqno)}
-		// At some point to save bandwidth these could be hooked up.
-		// "per_team_key_low":    libkb.I{Val: int(lows.PerTeamKey)},
-		// "reader_key_mask_low": libkb.I{Val: int(lows.PerTeamKey)},
+		arg.Args["per_team_key_low"] = libkb.I{Val: int(lows.PerTeamKey)}
 		arg.Args["hidden_low"] = libkb.I{Val: int(lows.HiddenChainSeqno)}
 	}
 	if len(requestSeqnos) > 0 {


### PR DESCRIPTION
- if we find a hole, due to a bug or some bad upgrade path, then we revert to the previous behavior