### PR TITLE
[Y2K-1124] Update blocking in the people search screen

### DIFF
--- a/shared/profile/user/actions/index.tsx
+++ b/shared/profile/user/actions/index.tsx
@@ -27,7 +27,6 @@ type Props = {
   onRequestLumens: () => void
   onSendLumens: () => void
   onUnfollow: () => void
-  onUnblock: () => void
   onManageBlocking: () => void
   state: Types.DetailsState
   username: string

--- a/shared/team-building/search-result/people-result.tsx
+++ b/shared/team-building/search-result/people-result.tsx
@@ -26,7 +26,7 @@ const PeopleResult = React.memo((props: ResultProps) => {
   // action button specific definitions
   const dispatch = Container.useDispatch()
   const myUsername = Container.useSelector(state => state.config.username)
-  const blocks = Container.useSelector(state => state.users.blockMap.get(keybaseUsername))
+  const blocks = Container.useSelector(state => state.users.blockMap.get(keybaseUsername || ''))
   const blocked = blocks?.chatBlocked
   const decoratedUsername = keybaseUsername ? keybaseUsername : `${serviceUsername}@${props.resultForService}`
 

--- a/shared/team-building/search-result/people-result.tsx
+++ b/shared/team-building/search-result/people-result.tsx
@@ -37,41 +37,36 @@ const PeopleResult = React.memo((props: ResultProps) => {
         path: [{props: {username: keybaseUsername}, selected: 'profileAddToTeam'}],
       })
     )
-  const onOpenPrivateFolder = React.useCallback(() => {
+  const onOpenPrivateFolder = () => {
     dispatch(RouteTreeGen.createNavigateUp())
     dispatch(
       FsConstants.makeActionForOpenPathInFilesTab(
         FsTypes.stringToPath(`/keybase/private/${decoratedUsername},${myUsername}`)
       )
     )
-  }, [dispatch, myUsername, decoratedUsername])
-  const onBrowsePublicFolder = React.useCallback(() => {
+  }
+  const onBrowsePublicFolder = () => {
     dispatch(RouteTreeGen.createNavigateUp())
     dispatch(
       FsConstants.makeActionForOpenPathInFilesTab(
         FsTypes.stringToPath(`/keybase/public/${decoratedUsername}`)
       )
     )
-  }, [dispatch, decoratedUsername])
+  }
 
-  const onManageBlocking = React.useCallback(
-    () =>
-      keybaseUsername &&
-      dispatch(
-        RouteTreeGen.createNavigateAppend({
-          path: [{props: {username: keybaseUsername}, selected: 'chatBlockingModal'}],
-        })
-      ),
-    [dispatch, keybaseUsername]
-  )
-  const onReload = React.useCallback(
-    () => keybaseUsername && dispatch(UsersGen.createGetBlockState({usernames: [keybaseUsername]})),
-    [dispatch, keybaseUsername]
-  )
-  const onChat = React.useCallback(() => {
+  const onManageBlocking = () =>
+    keybaseUsername &&
+    dispatch(
+      RouteTreeGen.createNavigateAppend({
+        path: [{props: {username: keybaseUsername}, selected: 'chatBlockingModal'}],
+      })
+    )
+  const onReload = () =>
+    keybaseUsername && dispatch(UsersGen.createGetBlockState({usernames: [keybaseUsername]}))
+  const onChat = () => {
     dispatch(RouteTreeGen.createNavigateUp())
     dispatch(Chat2Gen.createPreviewConversation({participants: [decoratedUsername], reason: 'search'}))
-  }, [dispatch, decoratedUsername])
+  }
   const onSendLumens = () =>
     keybaseUsername &&
     dispatch(
@@ -180,7 +175,7 @@ const DropdownButton = Kb.OverlayParentHOC((p: Kb.PropsWithOverlay<DropdownProps
       onClick={e => {
         e.stopPropagation()
         p.toggleShowingMenu()
-        p.onReload && p.onReload()
+        p.onReload?.()
       }}
       ref={p.setAttachmentRef}
     >

--- a/shared/team-building/search-result/people-result.tsx
+++ b/shared/team-building/search-result/people-result.tsx
@@ -75,18 +75,15 @@ const PeopleResult = React.memo((props: ResultProps) => {
         to: keybaseUsername,
       })
     )
-  const onBlock = () =>
-    keybaseUsername &&
-    dispatch(
-      RouteTreeGen.createNavigateAppend({
-        path: [{props: {username: keybaseUsername}, selected: 'chatBlockingModal'}],
-      })
-    )
-  const onUnblock = React.useCallback(
+  const onManageBlocking = React.useCallback(
     () =>
       keybaseUsername &&
-      dispatch(ProfileGen.createSubmitUnblockUser({guiID: userDetails.guiID, username: keybaseUsername})),
-    [dispatch, keybaseUsername, userDetails.guiID]
+      dispatch(
+        RouteTreeGen.createNavigateAppend({
+          path: [{props: {username: keybaseUsername}, selected: 'chatBlockingModal'}],
+        })
+      ),
+    [dispatch, keybaseUsername]
   )
   const onChat = () => {
     dispatch(RouteTreeGen.createNavigateUp())
@@ -102,8 +99,7 @@ const PeopleResult = React.memo((props: ResultProps) => {
       onBrowsePublicFolder={onBrowsePublicFolder}
       onSendLumens={onSendLumens}
       onRequestLumens={onRequestLumens}
-      onBlock={!resultIsMe ? onBlock : undefined}
-      onUnblock={!resultIsMe ? onUnblock : undefined}
+      onManageBlocking={!resultIsMe ? onManageBlocking : undefined}
       blocked={blocked}
     />
   ) : (
@@ -139,8 +135,7 @@ type DropdownProps = {
   onBrowsePublicFolder?: () => void
   onSendLumens?: () => void
   onRequestLumens?: () => void
-  onBlock?: () => void
-  onUnblock?: () => void
+  onManageBlocking?: () => void
   blocked?: boolean
   onUnfollow?: () => void
 }
@@ -164,11 +159,12 @@ const DropdownButton = Kb.OverlayParentHOC((p: Kb.PropsWithOverlay<DropdownProps
       onClick: p.onBrowsePublicFolder,
       title: 'Browse public folder',
     },
-    p.onUnblock &&
-      p.onBlock &&
-      (p.blocked
-        ? {danger: true, icon: 'iconfont-add', onClick: p.onUnblock, title: 'Unblock'}
-        : {danger: true, icon: 'iconfont-remove', onClick: p.onBlock, title: 'Block'}),
+    p.onManageBlocking && {
+      danger: true,
+      icon: 'iconfont-add',
+      onClick: p.onManageBlocking,
+      title: p.blocked ? 'Manage blocking' : 'Block',
+    },
   ].reduce<Kb.MenuItems>((arr, i) => {
     i && arr.push(i as Kb.MenuItem)
     return arr


### PR DESCRIPTION
Currently the blocking metadata is retrieved from one of two sources:
* state.tracker2.usernameToDetails
* state.users.blockMap

`blockMap` is the most likely to be true, and it's also the easiest to update. So I changed the existing code to update `blockMap` for a given user when the dropdown menu is opened. I could also update the usercard instead, but that's much heavier.

I didn't make it so _every_ row is updated in search, since you usually don't care. And we'd need to update the usercard for _all_ search results to get the 💩 avatar to show up correctly, or we'd need to refactor the avatar to use the `blockMap`. Either way this would result in individual RPCs per row, something we don't want to do. A global RPC for the whole set of search results would be harder to memoize, since the list changes on each entry to the search screen.

So my current solution is a balance of tradeoffs based on us not wanting to spend too much time on this.

cc @zapu @heronhaye 