### PR TITLE
Make attachment captions markdown

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1688,7 +1688,7 @@ func PresentDecoratedTextBody(ctx context.Context, g *globals.Context, msg chat1
 	case chat1.MessageType_REQUESTPAYMENT:
 		body = msgBody.Requestpayment().Note
 	case chat1.MessageType_ATTACHMENT:
-		body = msgBody.Attachment().GetTitle()
+		body = msgBody.Attachment().Object.Title
 	default:
 		return nil
 	}

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1687,6 +1687,8 @@ func PresentDecoratedTextBody(ctx context.Context, g *globals.Context, msg chat1
 		body = msgBody.Flip().Text
 	case chat1.MessageType_REQUESTPAYMENT:
 		body = msgBody.Requestpayment().Note
+	case chat1.MessageType_ATTACHMENT:
+		body = msgBody.Attachment().GetTitle()
 	default:
 		return nil
 	}

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -83,7 +83,7 @@ const Connected = (props: OwnProps) => {
       previewWidth={clampedWidth}
       progress={transferProgress}
       progressLabel={fileURL ? undefined : 'Loading'}
-      title={title}
+      title={message.decoratedText ? message.decoratedText.stringValue() : title}
     />
   )
 }

--- a/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
@@ -69,9 +69,9 @@ class _Fullscreen extends React.Component<Props & Kb.OverlayParentProps, State> 
         <Kb.Box style={styles.container}>
           <Kb.HotKey hotKeys={this.hotKeys} onHotKey={this.onHotKey} />
           <Kb.Box style={styles.headerFooter}>
-            <Kb.Text lineClamp={2} type="BodySemibold" style={{color: Styles.globalColors.black, flex: 1}}>
+            <Kb.Markdown lineClamp={2} style={{flex: 1}} meta={{message: this.props.message}}>
               {this.props.title}
-            </Kb.Text>
+            </Kb.Markdown>
             <Kb.Icon
               ref={this.props.setAttachmentRef}
               type="iconfont-ellipsis"

--- a/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
@@ -69,7 +69,11 @@ class _Fullscreen extends React.Component<Props & Kb.OverlayParentProps, State> 
         <Kb.Box style={styles.container}>
           <Kb.HotKey hotKeys={this.hotKeys} onHotKey={this.onHotKey} />
           <Kb.Box style={styles.headerFooter}>
-            <Kb.Markdown lineClamp={2} style={{flex: 1}} meta={{message: this.props.message}}>
+            <Kb.Markdown
+              lineClamp={2}
+              style={Styles.globalStyles.flexOne}
+              meta={{message: this.props.message}}
+            >
               {this.props.title}
             </Kb.Markdown>
             <Kb.Icon

--- a/shared/chat/conversation/messages/attachment/file/container.tsx
+++ b/shared/chat/conversation/messages/attachment/file/container.tsx
@@ -50,6 +50,7 @@ export default Container.connect(
       errorMsg: message.transferErrMsg || '',
       fileName: message.fileName,
       hasProgress,
+      message,
       onDownload: () => {
         if (Container.isMobile) {
           dispatchProps._onShare(message)
@@ -64,7 +65,7 @@ export default Container.connect(
           ? () => dispatchProps._onShowInFinder(message)
           : undefined,
       progress: message.transferProgress,
-      title: message.title || message.fileName,
+      title: message.decoratedText?.stringValue() || message.title || message.fileName,
       transferState,
     }
   }

--- a/shared/chat/conversation/messages/attachment/file/index.tsx
+++ b/shared/chat/conversation/messages/attachment/file/index.tsx
@@ -24,44 +24,53 @@ const FileAttachment = React.memo((props: Props) => {
   return (
     <>
       <ShowToastAfterSaving transferState={props.transferState} />
-      <Kb.ClickableBox onClick={props.onDownload} style={styles.fullWidth}>
-        <Kb.Box style={styles.containerStyle}>
-          <Kb.Box2 direction="horizontal" fullWidth={true} gap="tiny" centerChildren={true}>
-            <Kb.Icon type={iconType} style={styles.iconStyle} />
-            <Kb.Box2 direction="vertical" fullWidth={true} style={styles.titleStyle}>
+      <Kb.Box style={styles.containerStyle}>
+        <Kb.Box2 direction="horizontal" fullWidth={true} gap="tiny" centerChildren={true}>
+          <Kb.Icon type={iconType} style={styles.iconStyle} onClick={props.onDownload} />
+          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.titleStyle}>
+            {props.fileName === props.title ? (
+              // if the title is the filename, don't try to parse it as markdown
+              <Kb.Text type="BodySemibold" onClick={props.onDownload}>
+                {props.fileName}
+              </Kb.Text>
+            ) : (
               <Kb.Markdown meta={{message: props.message}} selectable={true}>
                 {props.title}
               </Kb.Markdown>
-              {props.fileName !== props.title && <Kb.Text type="BodyTiny">{props.fileName}</Kb.Text>}
-            </Kb.Box2>
+            )}
+            {props.fileName !== props.title && (
+              <Kb.Text type="BodyTiny" onClick={props.onDownload}>
+                {props.fileName}
+              </Kb.Text>
+            )}
           </Kb.Box2>
-          {!!props.arrowColor && (
-            <Kb.Box style={styles.downloadedIconWrapperStyle}>
-              <Kb.Icon type="iconfont-download" style={styles.downloadedIcon} color={props.arrowColor} />
-            </Kb.Box>
-          )}
-          {!!progressLabel && (
-            <Kb.Box style={styles.progressContainerStyle}>
-              <Kb.Text type="BodySmall" style={styles.progressLabelStyle}>
-                {progressLabel}
-              </Kb.Text>
-              {props.hasProgress && <Kb.ProgressBar ratio={props.progress} />}
-            </Kb.Box>
-          )}
-          {!!props.errorMsg && (
-            <Kb.Box style={styles.progressContainerStyle}>
-              <Kb.Text type="BodySmall" style={styles.error}>
-                Failed to download attachment, please retry
-              </Kb.Text>
-            </Kb.Box>
-          )}
-          {props.onShowInFinder && (
-            <Kb.Text type="BodySmallPrimaryLink" onClick={props.onShowInFinder} style={styles.linkStyle}>
-              Show in {Styles.fileUIName}
+        </Kb.Box2>
+        {!!props.arrowColor && (
+          <Kb.Box style={styles.downloadedIconWrapperStyle}>
+            <Kb.Icon type="iconfont-download" style={styles.downloadedIcon} color={props.arrowColor} />
+          </Kb.Box>
+        )}
+        {!!progressLabel && (
+          <Kb.Box style={styles.progressContainerStyle}>
+            <Kb.Text type="BodySmall" style={styles.progressLabelStyle}>
+              {progressLabel}
             </Kb.Text>
-          )}
-        </Kb.Box>
-      </Kb.ClickableBox>
+            {props.hasProgress && <Kb.ProgressBar ratio={props.progress} />}
+          </Kb.Box>
+        )}
+        {!!props.errorMsg && (
+          <Kb.Box style={styles.progressContainerStyle}>
+            <Kb.Text type="BodySmall" style={styles.error}>
+              Failed to download attachment, please retry
+            </Kb.Text>
+          </Kb.Box>
+        )}
+        {props.onShowInFinder && (
+          <Kb.Text type="BodySmallPrimaryLink" onClick={props.onShowInFinder} style={styles.linkStyle}>
+            Show in {Styles.fileUIName}
+          </Kb.Text>
+        )}
+      </Kb.Box>
     </>
   )
 })
@@ -71,6 +80,7 @@ const styles = Styles.styleSheetCreate(
     ({
       containerStyle: {
         ...Styles.globalStyles.flexBoxColumn,
+        width: '100%',
       },
       downloadedIcon: {
         maxHeight: 14,
@@ -87,7 +97,6 @@ const styles = Styles.styleSheetCreate(
         right: 0,
       },
       error: {color: Styles.globalColors.redDark},
-      fullWidth: {width: '100%'},
       iconStyle: {
         height: 32,
         width: 32,

--- a/shared/chat/conversation/messages/attachment/file/index.tsx
+++ b/shared/chat/conversation/messages/attachment/file/index.tsx
@@ -11,6 +11,7 @@ type Props = {
   onShowInFinder?: () => void
   title: string
   fileName: string
+  message: Types.MessageAttachment
   progress: number
   transferState: Types.MessageAttachmentTransferState
   hasProgress: boolean
@@ -28,7 +29,9 @@ const FileAttachment = React.memo((props: Props) => {
           <Kb.Box2 direction="horizontal" fullWidth={true} gap="tiny" centerChildren={true}>
             <Kb.Icon type={iconType} style={styles.iconStyle} />
             <Kb.Box2 direction="vertical" fullWidth={true} style={styles.titleStyle}>
-              <Kb.Text type="BodySemibold">{props.title}</Kb.Text>
+              <Kb.Markdown meta={{message: props.message}} selectable={true}>
+                {props.title}
+              </Kb.Markdown>
               {props.fileName !== props.title && <Kb.Text type="BodyTiny">{props.fileName}</Kb.Text>}
             </Kb.Box2>
           </Kb.Box2>

--- a/shared/chat/conversation/messages/attachment/image/container.tsx
+++ b/shared/chat/conversation/messages/attachment/image/container.tsx
@@ -87,7 +87,7 @@ export default Container.connect(
       path: message.previewURL,
       progress: message.transferProgress,
       showButton: buttonType,
-      title: message.title,
+      title: message.decoratedText ? message.decoratedText.stringValue() : message.title,
       toggleMessageMenu: ownProps.toggleMessageMenu,
       transferState: message.transferState,
       videoDuration: message.videoDuration || '',

--- a/shared/chat/conversation/messages/attachment/image/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   path: string
   fullPath: string
   fileName: string
+  message: Types.MessageAttachment
   progress: number
   transferState: Types.MessageAttachmentTransferState
   showButton: null | 'play' | 'film'
@@ -171,9 +172,13 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                       )}
                     </Kb.Box2>
                     {this.props.title.length > 0 && (
-                      <Kb.Text type="Body" style={Styles.collapseStyles([styles.title])}>
+                      <Kb.Markdown
+                        style={Styles.collapseStyles([styles.title])}
+                        meta={{message: this.props.message}}
+                        allowFontScaling={true}
+                      >
                         {this.props.title}
-                      </Kb.Text>
+                      </Kb.Markdown>
                     )}
                   </Kb.Box2>
                 )}

--- a/shared/chat/conversation/messages/attachment/image/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image/index.tsx
@@ -176,6 +176,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                       <Kb.Markdown
                         style={Styles.collapseStyles([styles.title])}
                         meta={{message: this.props.message}}
+                        selectable={true}
                         allowFontScaling={true}
                       >
                         {this.props.title}

--- a/shared/chat/conversation/messages/attachment/image/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image/index.tsx
@@ -84,12 +84,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
             />
           </Kb.Box2>
           {!this.props.isCollapsed && (
-            <Kb.ClickableBox
-              style={styles.imageContainer}
-              onClick={this._onClick}
-              onDoubleClick={this._onDoubleClick}
-              onLongPress={this.props.toggleMessageMenu}
-            >
+            <Kb.Box2 direction="vertical" fullWidth={true} style={styles.imageContainer}>
               <Kb.Box
                 style={Styles.collapseStyles([
                   styles.backgroundContainer,
@@ -104,73 +99,79 @@ class ImageAttachment extends React.PureComponent<Props, State> {
               >
                 {!!this.props.path && (
                   <Kb.Box2 direction="vertical" alignItems="center">
-                    <Kb.Box2
-                      direction="vertical"
-                      alignItems="center"
-                      style={{
-                        height: this.props.height,
-                        margin: 3,
-                        overflow: 'hidden',
-                        width: this.props.width,
-                      }}
+                    <Kb.ClickableBox
+                      onClick={this._onClick}
+                      onDoubleClick={this._onDoubleClick}
+                      onLongPress={this.props.toggleMessageMenu}
                     >
-                      <ImageRender
-                        ref={ref => {
-                          this.imageRef = ref
+                      <Kb.Box2
+                        direction="vertical"
+                        alignItems="center"
+                        style={{
+                          height: this.props.height,
+                          margin: 3,
+                          overflow: 'hidden',
+                          width: this.props.width,
                         }}
-                        src={this.props.path}
-                        videoSrc={this.props.fullPath}
-                        onLoad={this._setLoaded}
-                        onLoadedVideo={this._setVideoLoaded}
-                        loaded={this.state.loaded}
-                        inlineVideoPlayable={this.props.inlineVideoPlayable}
-                        height={this.props.height}
-                        width={this.props.width}
-                        style={Styles.collapseStyles([
-                          styles.image,
-                          {
-                            backgroundColor: this.state.loaded ? undefined : Styles.globalColors.fastBlank,
-                            height: this.props.height,
-                            width: this.props.width,
-                          },
-                        ])}
-                      />
-                      {!this.state.playingVideo && (
-                        <Kb.Box
+                      >
+                        <ImageRender
+                          ref={ref => {
+                            this.imageRef = ref
+                          }}
+                          src={this.props.path}
+                          videoSrc={this.props.fullPath}
+                          onLoad={this._setLoaded}
+                          onLoadedVideo={this._setVideoLoaded}
+                          loaded={this.state.loaded}
+                          inlineVideoPlayable={this.props.inlineVideoPlayable}
+                          height={this.props.height}
+                          width={this.props.width}
                           style={Styles.collapseStyles([
-                            styles.absoluteContainer,
+                            styles.image,
                             {
+                              backgroundColor: this.state.loaded ? undefined : Styles.globalColors.fastBlank,
                               height: this.props.height,
                               width: this.props.width,
                             },
                           ])}
-                        >
-                          {!!this.props.showButton && (
-                            <Kb.Icon
-                              type={this.props.showButton === 'play' ? 'icon-play-64' : 'icon-film-64'}
-                              style={styles.playButton}
-                            />
-                          )}
-                          {this.props.videoDuration.length > 0 && this.state.loaded && (
-                            <Kb.Box style={styles.durationContainer}>
-                              <Kb.Text type="BodyTinyBold" style={styles.durationText}>
-                                {this.props.videoDuration}
-                              </Kb.Text>
-                            </Kb.Box>
-                          )}
-                          {!!this.props.arrowColor && (
-                            <Kb.Box style={styles.downloadedIconWrapper}>
+                        />
+                        {!this.state.playingVideo && (
+                          <Kb.Box
+                            style={Styles.collapseStyles([
+                              styles.absoluteContainer,
+                              {
+                                height: this.props.height,
+                                width: this.props.width,
+                              },
+                            ])}
+                          >
+                            {!!this.props.showButton && (
                               <Kb.Icon
-                                type="iconfont-download"
-                                style={styles.downloadIcon}
-                                color={this.props.arrowColor}
+                                type={this.props.showButton === 'play' ? 'icon-play-64' : 'icon-film-64'}
+                                style={styles.playButton}
                               />
-                            </Kb.Box>
-                          )}
-                          {!this.state.loaded && <Kb.ProgressIndicator style={styles.progress} />}
-                        </Kb.Box>
-                      )}
-                    </Kb.Box2>
+                            )}
+                            {this.props.videoDuration.length > 0 && this.state.loaded && (
+                              <Kb.Box style={styles.durationContainer}>
+                                <Kb.Text type="BodyTinyBold" style={styles.durationText}>
+                                  {this.props.videoDuration}
+                                </Kb.Text>
+                              </Kb.Box>
+                            )}
+                            {!!this.props.arrowColor && (
+                              <Kb.Box style={styles.downloadedIconWrapper}>
+                                <Kb.Icon
+                                  type="iconfont-download"
+                                  style={styles.downloadIcon}
+                                  color={this.props.arrowColor}
+                                />
+                              </Kb.Box>
+                            )}
+                            {!this.state.loaded && <Kb.ProgressIndicator style={styles.progress} />}
+                          </Kb.Box>
+                        )}
+                      </Kb.Box2>
+                    </Kb.ClickableBox>
                     {this.props.title.length > 0 && (
                       <Kb.Markdown
                         style={Styles.collapseStyles([styles.title])}
@@ -195,7 +196,7 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                 )}
                 {this.props.hasProgress && <Kb.ProgressBar ratio={this.props.progress} />}
               </Kb.Box>
-            </Kb.ClickableBox>
+            </Kb.Box2>
           )}
           {this.props.onShowInFinder && (
             <Kb.Text
@@ -273,11 +274,10 @@ const styles = Styles.styleSheetCreate(
         position: 'relative',
       },
       imageContainer: {
-        ...Styles.globalStyles.flexBoxColumn,
         alignItems: 'flex-start',
+        alignSelf: 'flex-start',
         paddingBottom: Styles.globalMargins.xtiny,
         paddingTop: Styles.globalMargins.xtiny,
-        width: '100%',
       },
       link: {
         color: Styles.globalColors.black_50,

--- a/shared/common-adapters/markdown/index.d.ts
+++ b/shared/common-adapters/markdown/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as Styles from '../../styles'
 import {StylesTextCrossPlatform} from '../../common-adapters/text'
-import {MessageText} from '../../constants/types/chat2'
+import {MessageText, MessageAttachment} from '../../constants/types/chat2'
 
 type MarkdownComponentType =
   | 'inline-code'
@@ -27,7 +27,7 @@ export type MarkdownCreateComponent = (
 ) => React.ReactNode | null
 
 export type MarkdownMeta = {
-  message: MessageText
+  message: MessageText | MessageAttachment
 }
 
 export type StyleOverride = {

--- a/shared/common-adapters/markdown/service-decoration.tsx
+++ b/shared/common-adapters/markdown/service-decoration.tsx
@@ -109,7 +109,7 @@ export type Props = {
   json: string
   onClick?: () => void
   allowFontScaling?: boolean | null
-  message?: Types.MessageText
+  message?: Types.MessageText | Types.MessageAttachment
   styleOverride: StyleOverride
   styles: {[K in string]: StylesTextCrossPlatform}
 }
@@ -123,7 +123,11 @@ const ServiceDecoration = (props: Props) => {
   } catch (e) {
     return null
   }
-  if (parsed.typ === RPCChatTypes.UITextDecorationTyp.payment && props.message) {
+  if (
+    parsed.typ === RPCChatTypes.UITextDecorationTyp.payment &&
+    props.message &&
+    props.message.type === 'text'
+  ) {
     let paymentID: WalletTypes.PaymentID | undefined
     let error
     if (

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -922,7 +922,6 @@ const validUIMessagetoMessage = (
     }
     case RPCChatTypes.MessageType.attachmentuploaded: // fallthrough
     case RPCChatTypes.MessageType.attachment: {
-      console.warn(m)
       // The attachment flow is currently pretty complicated. We'll have core do more of this so it'll be simpler but for now
       // 1. On thread load we only get attachment type. It'll have full data
       // 2. On incoming we get attachment first (placeholder), then we get the full data (attachmentuploaded)

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -1103,7 +1103,6 @@ const outboxUIMessagetoMessage = (
         const baseMd = (o.preview && o.preview.baseMetadata) || null
         pre = previewSpecs(md, baseMd)
       }
-      // TODO: add decoratedText
       return makePendingAttachmentMessage(
         state,
         conversationIDKey,

--- a/shared/constants/types/chat2/message.tsx
+++ b/shared/constants/types/chat2/message.tsx
@@ -157,6 +157,7 @@ export type MessageAttachment = {
   attachmentType: AttachmentType
   audioAmps: Array<number>
   audioDuration: number
+  decoratedText: HiddenString | null
   showPlayButton: boolean
   fileURL: string
   fileURLCached: boolean
@@ -173,6 +174,9 @@ export type MessageAttachment = {
   // id: MessageID  that of first attachment message, not second attachment-uploaded message,
   inlineVideoPlayable: boolean
   isCollapsed: boolean
+  mentionsAt: MentionsAt
+  mentionsChannel: MentionsChannel
+  mentionsChannelName: MentionsChannelName
   previewHeight: number
   previewWidth: number
   previewTransferState: 'downloading' | null // only for preview,


### PR DESCRIPTION
Expands on #22220 by adding `decoratedText` and mentions fields to attachment messages and rendering them in chat. This also required changing what parts of attachment messages are clickable in order to make mentions behave as expected.