### PR TITLE
few small windows installer processes

### DIFF
--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -32,12 +32,10 @@
       <InstallValidate Suppress="yes">FAKE_PROPERTY</InstallValidate>
       <Custom Action="LogoutUser" Before="StopMainApp"><![CDATA[REMOVE ~= "ALL" AND NOT (UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED)]]></Custom>
       <Custom Action="StopMainApp" Before="StopUpdater"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
-      <Custom Action="StopUpdater" Before="StopGUI"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
+      <Custom Action="StopUpdater" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RemoveBrowserExtension" Before="InstallValidate"><![CDATA[Installed]]></Custom>
       <Custom Action="RemoveLegacyBundle" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RemoveGUIStartupShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT (UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED)]]></Custom>
-      <!-- StopGUI is legacy and to be removed after enough people are updated -->
-      <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
     </InstallExecuteSequence>
@@ -214,13 +212,6 @@
               Directory="GuiDir"
               ExeCommand="[INSTALLFOLDER]keybaserq.exe &quot;[GuiDir]Keybase.exe&quot;"
               Execute="commit"
-              Return="ignore"/>
-  </Fragment>
-  <Fragment>
-    <CustomAction Id="StopGUI"
-              Directory="INSTALLFOLDER"
-              ExeCommand="[INSTALLFOLDER]keybaserq.exe -wait [WindowsFolder]\System32\taskkill.exe /F /IM Keybase.exe"
-              Execute="immediate"
               Return="ignore"/>
   </Fragment>
   <Fragment>

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -38,7 +38,6 @@
       <Custom Action="RemoveGUIStartupShortcut" Before="InstallValidate"><![CDATA[REMOVE ~= "ALL" AND NOT (UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED)]]></Custom>
       <!-- StopGUI is legacy and to be removed after enough people are updated -->
       <Custom Action="StopGUI" Before="InstallValidate"><![CDATA[Installed OR UPGRADINGPRODUCTCODE OR WIX_UPGRADE_DETECTED]]></Custom>
-      <Custom Action="RunMainApp" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="RunGUI" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
       <Custom Action="AddBrowserExtension" Before="InstallFinalize"><![CDATA[NOT (RESTART_PENDING >< "Dokan") AND NOT (REMOVE ~= "ALL")]]></Custom>
     </InstallExecuteSequence>
@@ -195,13 +194,6 @@
     </Component>
   </Fragment>
 
-  <Fragment>
-    <CustomAction Id="RunMainApp"
-              Directory="INSTALLFOLDER"
-              ExeCommand="[INSTALLFOLDER]keybaserq.exe &quot;[INSTALLFOLDER]keybase.exe&quot; --log-format=file --log-prefix=&quot;[INSTALLFOLDER]watchdog.&quot; ctl watchdog"
-              Execute="commit"
-              Return="ignore"/>
-  </Fragment>
   <Fragment>
     <CustomAction Id="StopMainApp"
               Directory="INSTALLFOLDER"

--- a/packaging/windows/readme.md
+++ b/packaging/windows/readme.md
@@ -126,8 +126,8 @@ The installer places/updates all the files and adds:
 
 The service is invoked by the GUI with this command:
 `[INSTALLFOLDER]\keybaserq.exe keybase.exe --log-format=file --log-prefix="[INSTALLFOLDER]watchdog." ctl watchdog`
-This starts a copy of keybase.exe in watchdog mode, which in turn runs the service and kbfs processes, restarting them if they die or are killed.
-If the service is closed with `keybase ctl stop`, which the GUI does when the widtget menu is used, the watchdog will see a different exit code and not restart the processes.
+This starts a copy of keybase.exe in watchdog mode, which in turn runs the service and updater and kbfs processes, restarting them if they die or are killed.
+If the service is closed with `keybase ctl stop`, which the GUI does when the widtget menu is used, the watchdog will see a different exit code and shut down all everything it's watching.
 
 `keybaserq.exe` has 2 main jobs: de-elevating permissions to run as current user, and running Keybase invisibly, without the CMD window appearing, since it is a console program.
 
@@ -137,7 +137,7 @@ Notable executables
 `kbfsdokan.exe` - kbfs
 `kbnm.exe` - browser extension
 `keybase.exe` - service
-`keybase.rq.exe` - quiet launcher and de-elevator
+`keybaserq.exe` - quiet launcher and de-elevator
 `prompter.exe` - updater GUI
 `upd.exe` - updater
 `Gui\Keybase.exe` - GUI


### PR DESCRIPTION
the main change here is what happens when the installer is done installing and starts the app. before this change, it started the gui and the watchdog at around the same time. but the gui ALSO tries to start the watchdog. which means every time this happens, there are two watchdogs and one of them winds up killing the other. 
after this change, the installer starts the gui, and then the gui starts the watchdog. this is how it works when you start the app from the shortcut normally. 