### PR TITLE
citogo - a Go test wrapper that solves a bunch of CI problems

### DIFF
--- a/go/citogo/main.go
+++ b/go/citogo/main.go
@@ -81,6 +81,10 @@ func (r *runner) parseArgs() (err error) {
 }
 
 func (r *runner) compile() error {
+	if r.opts.NoCompile {
+		return nil
+	}
+	fmt.Printf("CMPL: %s\n", r.testerName())
 	cmd := exec.Command("go", "test", "-c")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -260,11 +264,9 @@ func (r *runner) run() error {
 		return err
 	}
 	r.debugStartup()
-	if !r.opts.NoCompile {
-		err = r.compile()
-		if err != nil {
-			return err
-		}
+	err = r.compile()
+	if err != nil {
+		return err
 	}
 	err = r.listTests()
 	if err != nil {

--- a/go/citogo/main.go
+++ b/go/citogo/main.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type opts struct {
+	Flakes      int
+	Fails       int
+	Prefix      string
+	S3Bucket    string
+	DirBasename string
+	BuildID     string
+	Preserve    bool
+	BuildURL    string
+	GetLogCmd   string
+	NoCompile   bool
+	TestBinary  string
+}
+
+func logError(f string, args ...interface{}) {
+	s := fmt.Sprintf(f, args...)
+	if s[len(s)-1] != '\n' {
+		s += "\n"
+	}
+	fmt.Fprintf(os.Stderr, "%s", s)
+}
+
+func reportTestOutcome(outcome string, test string, where string) {
+	fmt.Printf("%s: %s", outcome, test)
+	if where != "" {
+		fmt.Printf(" %s", where)
+	}
+	fmt.Printf("\n")
+}
+
+type runner struct {
+	opts   opts
+	flakes int
+	fails  int
+	tests  []string
+}
+
+func convertPrefix(p string) string {
+	s := fmt.Sprintf("%c", os.PathSeparator)
+	return strings.ReplaceAll(p, s, "_")
+}
+
+func (r *runner) parseArgs() (err error) {
+	flag.IntVar(&r.opts.Flakes, "flakes", 3, "number of allowed flakes")
+	flag.IntVar(&r.opts.Fails, "fails", -1, "number of fails allowed before quitting")
+	var prfx string
+	flag.StringVar(&prfx, "prefix", "", "test set prefix")
+	flag.StringVar(&r.opts.S3Bucket, "s3bucket", "", "AWS S3 bucket to write failures to")
+	flag.StringVar(&r.opts.BuildID, "build", "", "build ID of the current build")
+	flag.BoolVar(&r.opts.Preserve, "preserve", false, "preserve test binary after done")
+	flag.StringVar(&r.opts.BuildURL, "build-url", "", "URL for this build (in CI mainly)")
+	flag.StringVar(&r.opts.GetLogCmd, "get-log-cmd", "", "Command to get logs from S3")
+	flag.BoolVar(&r.opts.NoCompile, "no-compile", false, "specify flag if you've pre-compiled the test")
+	flag.StringVar(&r.opts.TestBinary, "test-binary", "", "specify the test binary to run")
+	flag.Parse()
+	r.opts.Prefix = convertPrefix(prfx)
+	var d string
+	d, err = os.Getwd()
+	if err != nil {
+		return err
+	}
+	r.opts.DirBasename = filepath.Base(d)
+	return nil
+}
+
+func (r *runner) compile() error {
+	cmd := exec.Command("go", "test", "-c")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func filter(v []string) []string {
+	var ret []string
+	for _, s := range v {
+		if s != "" {
+			ret = append(ret, s)
+		}
+	}
+	return ret
+}
+
+func (r *runner) testerName() string {
+	if r.opts.TestBinary != "" {
+		return r.opts.TestBinary
+	}
+	return fmt.Sprintf(".%c%s.test", os.PathSeparator, r.opts.DirBasename)
+}
+
+func (r *runner) listTests() error {
+	cmd := exec.Command(r.testerName(), "-test.list", ".")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	r.tests = filter(strings.Split(out.String(), "\n"))
+	return nil
+}
+
+func (r *runner) flushTestLogs(test string, log bytes.Buffer) (string, error) {
+	buildID := strings.ReplaceAll(r.opts.BuildID, "-", "_")
+	logName := fmt.Sprintf("citogo-%s-%s-%s", buildID, r.opts.Prefix, test)
+	if r.opts.S3Bucket != "" {
+		return r.flushLogsToS3(logName, log)
+	}
+	return r.flushTestLogsToTemp(logName, log)
+}
+
+func (r *runner) flushLogsToS3(logName string, log bytes.Buffer) (string, error) {
+	return s3put(&log, r.opts.S3Bucket, logName, r.opts.GetLogCmd)
+}
+
+func (r *runner) flushTestLogsToTemp(logName string, log bytes.Buffer) (string, error) {
+	tmpfile, err := ioutil.TempFile("", fmt.Sprintf("%s-", logName))
+	if err != nil {
+		return "", err
+	}
+	_, err = tmpfile.Write(log.Bytes())
+	if err != nil {
+		return "", err
+	}
+	err = tmpfile.Close()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("see log: %s", tmpfile.Name()), nil
+}
+
+func (r *runner) reportFlake(test string, logs string) {
+	hook := os.Getenv("CITOGO_FLAKE_WEBHOOK")
+	if hook == "" {
+		return
+	}
+	hook += url.QueryEscape(fmt.Sprintf("❄️ _client_ %s %s *%s* %s [%s]", r.opts.BuildID, r.opts.Prefix, test, logs, r.opts.BuildURL))
+	_, err := http.Get(hook)
+	if err != nil {
+		logError("error reporting flake: %s", err.Error())
+	}
+}
+
+func (r *runner) runTest(test string) error {
+	canRerun := r.flakes < r.opts.Flakes
+	logs, err := r.runTestOnce(test, canRerun, false)
+	if err == errTestFailed && canRerun {
+		_, err = r.runTestOnce(test, false, true)
+		if err == nil {
+			r.reportFlake(test, logs)
+			r.flakes++
+		}
+	}
+	return err
+}
+
+var errTestFailed = errors.New("test failed")
+
+func (r *runner) runTestOnce(test string, canRerun bool, isRerun bool) (string, error) {
+	cmd := exec.Command(r.testerName(), "-test.run", "^"+test+"$")
+	var combined bytes.Buffer
+	if isRerun {
+		cmd.Env = append(os.Environ(), "CITOGO_FLAKE_RERUN=1")
+	}
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+	err := cmd.Run()
+	if err != nil {
+		err = errTestFailed
+	}
+	var where string
+	var status string
+	if err != nil {
+		var flushErr error
+		where, flushErr = r.flushTestLogs(test, combined)
+		if flushErr != nil {
+			return "", flushErr
+		}
+		if canRerun {
+			status = "FLK?"
+		} else {
+			status = "FAIL"
+		}
+	} else {
+		status = "PASS"
+	}
+	reportTestOutcome(status, test, where)
+	return where, err
+}
+
+func (r *runner) runTestFixError(t string) error {
+	err := r.runTest(t)
+	if err == nil {
+		return nil
+	}
+	if err != errTestFailed {
+		return err
+	}
+	r.fails++
+	if r.opts.Fails < 0 {
+		// We have an infinite fail budget, so keep plowing through
+		// failed tests. This test run is still going to fail.
+		return nil
+	}
+	if r.opts.Fails >= r.fails {
+		// We've failed less than our budget, so we can still keep going.
+		// This test run is still going to fail.
+		return nil
+	}
+	// We ate up our fail budget.
+	return err
+}
+
+func (r *runner) runTests() error {
+	for _, f := range r.tests {
+		err := r.runTestFixError(f)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *runner) cleanup() {
+	if r.opts.Preserve || r.opts.NoCompile {
+		return
+	}
+	n := r.testerName()
+	err := os.Remove(n)
+	if err != nil {
+		logError("could not remove %s: %s", n, err.Error())
+	}
+}
+
+func (r *runner) debugStartup() {
+	dir, _ := os.Getwd()
+	fmt.Printf("WDIR: %s\n", dir)
+}
+
+func (r *runner) run() error {
+	start := time.Now()
+	err := r.parseArgs()
+	if err != nil {
+		return err
+	}
+	r.debugStartup()
+	if !r.opts.NoCompile {
+		err = r.compile()
+		if err != nil {
+			return err
+		}
+	}
+	err = r.listTests()
+	if err != nil {
+		return err
+	}
+	err = r.runTests()
+	r.cleanup()
+	end := time.Now()
+	diff := end.Sub(start)
+	fmt.Printf("DONE: in %s\n", diff)
+	if err != nil {
+		return err
+	}
+	if r.fails > 0 {
+		return fmt.Errorf("RED!: %d total tests failed", r.fails)
+	}
+	return nil
+}
+
+func main2() error {
+	runner := runner{}
+	return runner.run()
+}
+
+func main() {
+	err := main2()
+	if err != nil {
+		logError(err.Error())
+		fmt.Printf("EXIT: 2\n")
+		os.Exit(2)
+	}
+	fmt.Printf("EXIT: 0\n")
+	os.Exit(0)
+}

--- a/go/citogo/s3.go
+++ b/go/citogo/s3.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base32"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func gzipSource(src io.Reader) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	gzipIn := gzip.NewWriter(buf)
+	_, err := io.Copy(gzipIn, src)
+	if err != nil {
+		return nil, err
+	}
+	err = gzipIn.Close()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func hashToHex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+func randString() (string, error) {
+	c := 20
+	b := make([]byte, c)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b)), nil
+}
+
+func awsStringSign4(key string, date string, region string, service string, toSign string) string {
+	mac := func(key, payload []byte) []byte {
+		f := hmac.New(sha256.New, key)
+		_, _ = f.Write(payload)
+		ret := f.Sum(nil)
+		return ret
+	}
+	kSecret := []byte("AWS4" + key)
+	kDate := mac(kSecret, []byte(date))
+	kRegion := mac(kDate, []byte(region))
+	kService := mac(kRegion, []byte(service))
+	kSigning := mac(kService, []byte("aws4_request"))
+	signedString := mac(kSigning, []byte(toSign))
+	return hex.EncodeToString(signedString)
+
+}
+
+// s3 put without the dependencies, adopted from this shell script:
+//
+//  https://superuser.com/questions/279986/uploading-files-to-s3-account-from-linux-command-line
+//
+func s3put(src io.Reader, bucket string, name string, getLogCmd string) (string, error) {
+	buf, err := gzipSource(src)
+	if err != nil {
+		return "", err
+	}
+
+	randSuffix, err := randString()
+	if err != nil {
+		return "", err
+	}
+	name += "-" + randSuffix + ".gz"
+
+	payloadHash := hashToHex(buf)
+	now := time.Now().UTC()
+	dateLong := now.Format("20060102T150405Z")
+	dateShort := now.Format("20060102")
+	contentType := "application/gzip"
+	host := bucket + ".s3.amazonaws.com"
+	storageClass := "STANDARD"
+	headerList := "content-type;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class"
+	canonicalRequest := strings.Join([]string{
+		"PUT",
+		"/" + name,
+		"",
+		"content-type:" + contentType,
+		"host:" + host,
+		"x-amz-content-sha256:" + payloadHash,
+		"x-amz-date:" + dateLong,
+		"x-amz-storage-class:" + storageClass,
+		"",
+		headerList,
+		payloadHash,
+	}, "\n")
+
+	canonicalRequestHash := hashToHex([]byte(canonicalRequest))
+	authType := "AWS4-HMAC-SHA256"
+	region := "us-east-1"
+	service := "s3"
+	req2 := strings.Join([]string{dateShort, region, service, "aws4_request"}, "/")
+	stringToSign := strings.Join([]string{
+		authType,
+		dateLong,
+		req2,
+		canonicalRequestHash,
+	}, "\n")
+
+	keyID := os.Getenv("CITOGO_AWS_ACCESS_KEY_ID")
+	key := os.Getenv("CITOGO_AWS_SECRET_ACCESS_KEY")
+	if keyID == "" || key == "" {
+		return "", errors.New("need CITOGO_AWS_ACCESS_KEY_ID and CITOGO_AWS_SECRET_ACCESS_KEY environment variables")
+	}
+	sig := awsStringSign4(key, dateShort, region, service, stringToSign)
+	authorization := authType + " " + strings.Join([]string{
+		"Credential=" + strings.Join([]string{keyID, dateShort, region, service, "aws4_request"}, "/"),
+		"SignedHeaders=" + headerList,
+		"Signature=" + sig,
+	}, ", ")
+
+	client := &http.Client{}
+	url := "https://" + host + "/" + name
+	req, err := http.NewRequest("PUT", url, bytes.NewReader(buf))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-type", contentType)
+	req.Header.Set("Host", host)
+	req.Header.Set("X-Amz-Content-SHA256", payloadHash)
+	req.Header.Set("X-Amz-Date", dateLong)
+	req.Header.Set("X-Amz-Storage-Class", storageClass)
+	req.Header.Set("Authorization", authorization)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	resource := "/" + bucket + "/" + name
+	var where string
+	if getLogCmd != "" {
+		where = fmt.Sprintf("(fetch with: `%s s3:/%s`)", getLogCmd, resource)
+	} else {
+		where = fmt.Sprintf("(`%s`)", resource)
+	}
+
+	return where, nil
+}

--- a/go/kex2/rpc_test.go
+++ b/go/kex2/rpc_test.go
@@ -165,12 +165,15 @@ func testProtocolXWithBehavior(t *testing.T, provisioneeBehavior int) (results [
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
+	testLogCtx, cleanup := newTestLogCtx(t)
+	defer cleanup()
+
 	// Run the provisioner
 	go func() {
 		err := RunProvisioner(ProvisionerArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           ctx,
-				LogCtx:        testLogCtx{t},
+				LogCtx:        testLogCtx,
 				Mr:            router,
 				Secret:        genSecret(t),
 				DeviceID:      genKeybase1DeviceID(t),
@@ -187,7 +190,7 @@ func testProtocolXWithBehavior(t *testing.T, provisioneeBehavior int) (results [
 		err := RunProvisionee(ProvisioneeArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           context.Background(),
-				LogCtx:        testLogCtx{t},
+				LogCtx:        testLogCtx,
 				Mr:            router,
 				Secret:        s2,
 				DeviceID:      genKeybase1DeviceID(t),
@@ -289,13 +292,15 @@ func TestFullProtocolY(t *testing.T) {
 	ch := make(chan error, 3)
 
 	secretCh := make(chan Secret)
+	testLogCtx, cleanup := newTestLogCtx(t)
+	defer cleanup()
 
 	// Run the provisioner
 	go func() {
 		err := RunProvisioner(ProvisionerArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           context.TODO(),
-				LogCtx:        testLogCtx{t},
+				LogCtx:        testLogCtx,
 				Mr:            router,
 				Secret:        s1,
 				DeviceID:      genKeybase1DeviceID(t),
@@ -312,7 +317,7 @@ func TestFullProtocolY(t *testing.T) {
 		err := RunProvisionee(ProvisioneeArg{
 			KexBaseArg: KexBaseArg{
 				Ctx:           context.TODO(),
-				LogCtx:        testLogCtx{t},
+				LogCtx:        testLogCtx,
 				Mr:            router,
 				Secret:        genSecret(t),
 				DeviceID:      genKeybase1DeviceID(t),

--- a/go/test/run_tests.sh
+++ b/go/test/run_tests.sh
@@ -10,8 +10,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-FLAGS="-timeout 50m"
-
 for i
 do
     case "$1" in
@@ -21,6 +19,8 @@ do
     esac
     shift
 done
+
+(cd citogo && go install)
 
 # Log the Go version.
 echo "Running tests on commit $(git rev-parse --short HEAD) with $(go version)."
@@ -35,9 +35,11 @@ go get "github.com/stretchr/testify/assert"
 
 failures=()
 
+PID=$$
+
 for i in $DIRS; do
   echo -n "$i......."
-  if ! (cd $i && go test $FLAGS ) ; then
+  if ! (cd $i && citogo --flakes 4 --fails 5 --build pid-$PID --prefix $i) ; then
     failures+=("$i")
   fi
 done


### PR DESCRIPTION
- run one test in a process, so they don't leak threads and memory
- output failed logs to files, so the logs don't become insane                                
- in CI, output logs to S3, for the above reason                                   
- allow a certain number of flakes (3)                                            
- after 3 failures, don't keep running, just bail early.  