### PR TITLE
fix reset banner (connected usernames) bad underline

### DIFF
--- a/shared/common-adapters/text.d.ts
+++ b/shared/common-adapters/text.d.ts
@@ -69,6 +69,7 @@ type Props = {
   title?: string | null
   type: TextType
   underline?: boolean
+  underlineNever?: boolean
 }
 
 type MetaType = {

--- a/shared/common-adapters/text.desktop.tsx
+++ b/shared/common-adapters/text.desktop.tsx
@@ -40,6 +40,7 @@ class Text extends React.Component<Props> {
     const meta = metaData()[props.type]
     return Styles.classNames(`text_${props.type}`, props.className, {
       underline: props.underline,
+      'underline-never': props.underlineNever,
       // eslint-disable-next-line sort-keys
       'hover-underline': meta.isLink && !props.negative,
       text_center: props.center,

--- a/shared/common-adapters/usernames/index.tsx
+++ b/shared/common-adapters/usernames/index.tsx
@@ -86,9 +86,9 @@ const UsernameText = (props: Props) => {
         const _onUsernameClicked = props.onUsernameClicked
         const isNegative = backgroundModeIsNegative(props.backgroundMode || null)
         const renderText = (onLongPress?: () => void) => (
-          <Text type={props.type} key={u.username}>
+          <Text type="Body" key={u.username}>
             {i !== 0 && i === props.users.length - 1 && props.showAnd && (
-              <Text type={props.type} negative={isNegative} style={derivedJoinerStyle}>
+              <Text type={props.type} negative={isNegative} style={derivedJoinerStyle} underlineNever={true}>
                 {'and '}
               </Text>
             )}

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -333,6 +333,9 @@ body {
 .hover-underline-container:hover .hover-underline-child {
   text-decoration: underline;
 }
+.underline-never {
+  text-decoration: none !important;
+}
 
 .hover-opacity {
   opacity: 0.8;


### PR DESCRIPTION
the usernames component injects 'and' between usernames, yet uses the same text type. This is fine unless its a link type, if you use a link type then the whole container gets linkified and you get hovers and etc on it which looks weird. Instead of making assumptions i'm just adding a new flag where you can override if you want to never get hover underlines. also the parent text container gets a generic 'body' type (doesn't change any thing since all its children are wrapped texts anyways)