### PR TITLE
SetPublicName new icons, autofill device name

### DIFF
--- a/shared/constants/platform.d.ts
+++ b/shared/constants/platform.d.ts
@@ -23,4 +23,5 @@ export declare const version: string
 export declare const pprofDir: string
 export declare const serverConfigFileName: string
 export declare const shortcutSymbol: string
+export declare const deviceName: string
 export const appColorSchemeChanged: (pref: DarkModePreference) => void

--- a/shared/constants/platform.d.ts
+++ b/shared/constants/platform.d.ts
@@ -23,5 +23,5 @@ export declare const version: string
 export declare const pprofDir: string
 export declare const serverConfigFileName: string
 export declare const shortcutSymbol: string
-export declare const deviceName: string
+export declare const realDeviceName: string
 export const appColorSchemeChanged: (pref: DarkModePreference) => void

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -14,7 +14,7 @@ export const isLinux = platform === 'linux'
 export const isAndroidNewerThanN = false
 export const isMac = isDarwin && !isIOS
 export const shortcutSymbol = isDarwin ? '⌘' : 'Ctrl-'
-export const deviceName = ''
+export const realDeviceName = ''
 
 export const defaultUseNativeFrame = isDarwin || isLinux
 

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -14,6 +14,7 @@ export const isLinux = platform === 'linux'
 export const isAndroidNewerThanN = false
 export const isMac = isDarwin && !isIOS
 export const shortcutSymbol = isDarwin ? '⌘' : 'Ctrl-'
+export const deviceName = ''
 
 export const defaultUseNativeFrame = isDarwin || isLinux
 

--- a/shared/constants/platform.native.tsx
+++ b/shared/constants/platform.native.tsx
@@ -37,7 +37,7 @@ const mobileOsVersionNumber = typeof mobileOsVersion === 'string' ? parseInt(mob
 export const isAndroidNewerThanM = isAndroid && mobileOsVersionNumber > 22
 export const isAndroidNewerThanN = isAndroid && mobileOsVersionNumber >= 26
 export const shortcutSymbol = ''
-export const deviceName = Constants.deviceName ?? ''
+export const realDeviceName = Constants.deviceName ?? ''
 
 export const isIPhoneX = iPhoneXHelper.isIphoneX()
 

--- a/shared/constants/platform.native.tsx
+++ b/shared/constants/platform.native.tsx
@@ -1,6 +1,7 @@
 import {Dimensions, Platform, NativeModules} from 'react-native'
 import RNFB from 'rn-fetch-blob'
 import * as iPhoneXHelper from 'react-native-iphone-x-helper'
+import Constants from 'expo-constants'
 
 const nativeBridge = NativeModules.KeybaseEngine || {
   isDeviceSecure: 'fallback',
@@ -36,6 +37,7 @@ const mobileOsVersionNumber = typeof mobileOsVersion === 'string' ? parseInt(mob
 export const isAndroidNewerThanM = isAndroid && mobileOsVersionNumber > 22
 export const isAndroidNewerThanN = isAndroid && mobileOsVersionNumber >= 26
 export const shortcutSymbol = ''
+export const deviceName = Constants.deviceName ?? ''
 
 export const isIPhoneX = iPhoneXHelper.isIphoneX()
 

--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -9,6 +9,7 @@ export const noEmail = 'NOEMAIL'
 export const waitingKey = 'signup:waiting'
 
 const defaultDevicename =
+  Platforms.deviceName ||
   (Platforms.isAndroid && 'My Android Device') ||
   (Platforms.isIOS && 'My iOS Device') ||
   (Platforms.isDarwin && 'My Mac Device') ||

--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -9,7 +9,7 @@ export const noEmail = 'NOEMAIL'
 export const waitingKey = 'signup:waiting'
 
 const defaultDevicename =
-  Platforms.deviceName ||
+  Platforms.realDeviceName ||
   (Platforms.isAndroid && 'My Android Device') ||
   (Platforms.isIOS && 'My iOS Device') ||
   (Platforms.isDarwin && 'My Mac Device') ||

--- a/shared/provision/set-public-name/container.tsx
+++ b/shared/provision/set-public-name/container.tsx
@@ -1,11 +1,14 @@
 import * as ProvisionGen from '../../actions/provision-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/provision'
+import * as Platform from '../../constants/platform'
+import * as Devices from '../../constants/devices'
 import SetPublicName from '.'
 import * as Container from '../../util/container'
 
 export default Container.connect(
   (state: Container.TypedState) => ({
+    devices: state.provision.devices,
     error: state.provision.error.stringValue(),
     waiting: Container.anyWaiting(state, Constants.waitingKey),
   }),
@@ -13,10 +16,17 @@ export default Container.connect(
     onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
     onSubmit: (name: string) => dispatch(ProvisionGen.createSubmitDeviceName({name})),
   }),
-  (stateProps, dispatchProps) => ({
-    error: stateProps.error,
-    onBack: dispatchProps.onBack,
-    onSubmit: (name: string) => !stateProps.waiting && dispatchProps.onSubmit(name),
-    waiting: stateProps.waiting,
-  })
+  (stateProps, dispatchProps) => {
+    const deviceNumbers = stateProps.devices
+      .filter(d => d.type === (Platform.isMobile ? 'mobile' : 'desktop'))
+      .map(d => d.deviceNumberOfType)
+    const maxDeviceNumber = deviceNumbers.length > 0 ? Math.max(...deviceNumbers) : -1
+    return {
+      deviceIconNumber: ((maxDeviceNumber + 1) % Devices.numBackgrounds) + 1,
+      error: stateProps.error,
+      onBack: dispatchProps.onBack,
+      onSubmit: (name: string) => !stateProps.waiting && dispatchProps.onSubmit(name),
+      waiting: stateProps.waiting,
+    }
+  }
 )(Container.safeSubmit(['onSubmit', 'onBack'], ['error'])(SetPublicName))

--- a/shared/provision/set-public-name/index.stories.tsx
+++ b/shared/provision/set-public-name/index.stories.tsx
@@ -3,6 +3,7 @@ import * as Sb from '../../stories/storybook'
 import SetPublicName from '.'
 
 const props = {
+  deviceIconNumber: 1,
   deviceName: '',
   error: '',
   onBack: Sb.action('onBack'),

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -3,8 +3,6 @@ import * as Kb from '../../common-adapters'
 import * as Constants from '../../constants/provision'
 import * as Styles from '../../styles'
 import * as Platform from '../../constants/platform'
-import * as Devices from '../../constants/devices'
-import * as Container from '../../util/container'
 
 import {SignupScreen, errorBanner} from '../../signup/common'
 

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Constants from '../../constants/provision'
-import {globalMargins, styleSheetCreate, isMobile, platformStyles} from '../../styles'
+import * as Styles from '../../styles'
+import * as Platform from '../../constants/platform'
 import {SignupScreen, errorBanner} from '../../signup/common'
 
 type Props = {
@@ -32,10 +33,18 @@ const SetPublicName = (props: Props) => {
         },
       ]}
       onBack={props.onBack}
-      title={`Name this ${isMobile ? 'phone' : 'computer'}`}
+      title={`Name this ${Styles.isMobile ? 'phone' : 'computer'}`}
     >
       <Kb.Box2 direction="vertical" style={styles.contents} centerChildren={true} gap="medium">
-        <Kb.Icon type={isMobile ? 'icon-phone-96' : 'icon-computer-96'} />
+        <Kb.Icon
+          type={
+            Styles.isMobile
+              ? Platform.isLargeScreen
+                ? 'icon-phone-background-1-96'
+                : 'icon-phone-background-1-64'
+              : 'icon-computer-background-1-96'
+          }
+        />
         <Kb.Box2 direction="vertical" style={styles.wrapper} gap="xsmall">
           <Kb.NewInput
             autoFocus={true}
@@ -52,11 +61,11 @@ const SetPublicName = (props: Props) => {
   )
 }
 
-const styles = styleSheetCreate(() => ({
-  backButton: platformStyles({
+const styles = Styles.styleSheetCreate(() => ({
+  backButton: Styles.platformStyles({
     isElectron: {
-      marginLeft: globalMargins.medium,
-      marginTop: globalMargins.medium,
+      marginLeft: Styles.globalMargins.medium,
+      marginTop: Styles.globalMargins.medium,
     },
     isMobile: {
       marginLeft: 0,
@@ -66,15 +75,15 @@ const styles = styleSheetCreate(() => ({
   contents: {
     width: '100%',
   },
-  nameInput: platformStyles({
+  nameInput: Styles.platformStyles({
     common: {
-      padding: globalMargins.tiny,
+      padding: Styles.globalMargins.tiny,
     },
     isMobile: {
       minHeight: 48,
     },
   }),
-  wrapper: platformStyles({
+  wrapper: Styles.platformStyles({
     isElectron: {
       width: 400,
     },

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 
 const SetPublicName = (props: Props) => {
-  const [deviceName, setDeviceName] = React.useState('')
+  const [deviceName, setDeviceName] = React.useState(Platform.deviceName)
   const cleanDeviceName = Constants.cleanDeviceName(deviceName)
   const _onSubmit = props.onSubmit
   const onSubmit = React.useCallback(() => {

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -3,22 +3,38 @@ import * as Kb from '../../common-adapters'
 import * as Constants from '../../constants/provision'
 import * as Styles from '../../styles'
 import * as Platform from '../../constants/platform'
+import * as Devices from '../../constants/devices'
+import * as Container from '../../util/container'
+
 import {SignupScreen, errorBanner} from '../../signup/common'
 
 type Props = {
   onBack: () => void
   onSubmit: (name: string) => void
+  deviceIconNumber: number
   error: string
   waiting: boolean
 }
 
 const SetPublicName = (props: Props) => {
-  const [deviceName, setDeviceName] = React.useState(Platform.deviceName)
+  const [deviceName, setDeviceName] = React.useState(Platform.realDeviceName ?? '')
   const cleanDeviceName = Constants.cleanDeviceName(deviceName)
   const _onSubmit = props.onSubmit
   const onSubmit = React.useCallback(() => {
     _onSubmit(Constants.cleanDeviceName(cleanDeviceName))
   }, [cleanDeviceName, _onSubmit])
+
+  const maybeIcon = Styles.isMobile
+    ? Platform.isLargeScreen
+      ? `icon-phone-background-${props.deviceIconNumber}-96`
+      : `icon-phone-background-${props.deviceIconNumber}-64`
+    : `icon-computer-background-${props.deviceIconNumber}-96`
+
+  const defaultIcon = Styles.isMobile
+    ? Platform.isLargeScreen
+      ? `icon-phone-96`
+      : `icon-phone-64`
+    : `icon-computer-96`
 
   return (
     <SignupScreen
@@ -36,15 +52,7 @@ const SetPublicName = (props: Props) => {
       title={`Name this ${Styles.isMobile ? 'phone' : 'computer'}`}
     >
       <Kb.Box2 direction="vertical" style={styles.contents} centerChildren={true} gap="medium">
-        <Kb.Icon
-          type={
-            Styles.isMobile
-              ? Platform.isLargeScreen
-                ? 'icon-phone-background-1-96'
-                : 'icon-phone-background-1-64'
-              : 'icon-computer-background-1-96'
-          }
-        />
+        <Kb.Icon type={Kb.isValidIconType(maybeIcon) ? maybeIcon : defaultIcon} />
         <Kb.Box2 direction="vertical" style={styles.wrapper} gap="xsmall">
           <Kb.NewInput
             autoFocus={true}


### PR DESCRIPTION
Updates the "name this phone" screen in provisioning to use the new backgrounded device icons, and uses `expo-constants` to get the device name on mobile and autofill the name input with that.