### PR TITLE
newconversationslocal

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -7693,3 +7693,81 @@ func TestTeamBotChannelMembership(t *testing.T) {
 		}
 	})
 }
+
+func TestChatSrvNewConversationsLocal(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		switch mt {
+		case chat1.ConversationMembersType_TEAM:
+		default:
+			return
+		}
+
+		ctc := makeChatTestContext(t, "NewConversationsLocal", 3)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		key := teamKey(users)
+		name := createTeamWithWriters(ctc.world.Tcs[users[0].Username].TestContext, users[1:])
+		ctc.teamCache[key] = name
+		tlfName := strings.ToLower(name)
+
+		type L struct {
+			tlfName     string
+			channelName *string
+			ok          bool
+		}
+		sp := func(x string) *string { return &x }
+		argument := func(ll []L) (arg chat1.NewConversationsLocalArg) {
+			arg.IdentifyBehavior = keybase1.TLFIdentifyBehavior_CHAT_CLI
+			for _, l := range ll {
+				arg.NewConversationLocalArguments = append(arg.NewConversationLocalArguments, chat1.NewConversationLocalArgument{
+					TlfName:       name,
+					TopicType:     chat1.TopicType_CHAT,
+					TopicName:     l.channelName,
+					TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+					MembersType:   chat1.ConversationMembersType_TEAM,
+				})
+			}
+			return arg
+		}
+
+		t.Logf("creating many channels, some with bad names")
+		ll := []L{
+			{tlfName: tlfName, channelName: nil, ok: true},
+			{tlfName: tlfName, channelName: sp("now"), ok: true},
+			{tlfName: tlfName, channelName: sp("i"), ok: true},
+			{tlfName: tlfName, channelName: sp("am"), ok: true},
+			{tlfName: tlfName, channelName: sp("#become"), ok: false},
+			{tlfName: tlfName, channelName: sp("death"), ok: true},
+			{tlfName: tlfName, channelName: sp("destroyer.of"), ok: false},
+			{tlfName: tlfName, channelName: sp("worlds/"), ok: false},
+			{tlfName: tlfName, channelName: sp("!"), ok: false},
+		}
+		tc := ctc.as(t, users[0])
+		res, err := tc.chatLocalHandler().NewConversationsLocal(tc.startCtx, argument(ll))
+		require.Error(t, err)
+		require.Equal(t, len(ll), len(res.Results))
+		for idx, l := range ll {
+			result := res.Results[idx]
+			if l.ok {
+				require.NotNil(t, result.Result)
+				require.Equal(t, strings.ToLower(l.tlfName), result.Result.Conv.Info.TlfName)
+				if n := l.channelName; n != nil {
+					require.Equal(t, *n, result.Result.Conv.Info.TopicName)
+				}
+			} else {
+				require.NotNil(t, result.Err)
+				require.Nil(t, result.Result)
+			}
+		}
+
+		t.Logf("testing idempotency")
+		ll[4].channelName = sp("become")
+		ll[6].channelName = sp("destroyerof")
+		ll[7].channelName = sp("worlds")
+		ll[8].channelName = sp("exclam")
+		res, err = tc.chatLocalHandler().NewConversationsLocal(tc.startCtx, argument(ll))
+		require.NoError(t, err)
+		require.Equal(t, len(ll), len(res.Results))
+	})
+}

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -2375,6 +2375,14 @@ func (r *GetBotInfoRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimit = &rl[0]
 }
 
+func (r *NewConversationsLocalRes) GetRateLimit() (res []RateLimit) {
+	return r.RateLimits
+}
+
+func (r *NewConversationsLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
 func (i EphemeralPurgeInfo) String() string {
 	return fmt.Sprintf("EphemeralPurgeInfo{ ConvID: %v, IsActive: %v, NextPurgeTime: %v, MinUnexplodedID: %v }",
 		i.ConvID, i.IsActive, i.NextPurgeTime.Time(), i.MinUnexplodedID)

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -4344,6 +4344,98 @@ func (o SetConversationStatusLocalRes) DeepCopy() SetConversationStatusLocalRes 
 	}
 }
 
+type NewConversationsLocalRes struct {
+	Results          []NewConversationsLocalResult `codec:"results" json:"results"`
+	RateLimits       []RateLimit                   `codec:"rateLimits" json:"rateLimits"`
+	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`
+}
+
+func (o NewConversationsLocalRes) DeepCopy() NewConversationsLocalRes {
+	return NewConversationsLocalRes{
+		Results: (func(x []NewConversationsLocalResult) []NewConversationsLocalResult {
+			if x == nil {
+				return nil
+			}
+			ret := make([]NewConversationsLocalResult, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Results),
+		RateLimits: (func(x []RateLimit) []RateLimit {
+			if x == nil {
+				return nil
+			}
+			ret := make([]RateLimit, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.RateLimits),
+		IdentifyFailures: (func(x []keybase1.TLFIdentifyFailure) []keybase1.TLFIdentifyFailure {
+			if x == nil {
+				return nil
+			}
+			ret := make([]keybase1.TLFIdentifyFailure, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.IdentifyFailures),
+	}
+}
+
+type NewConversationsLocalResult struct {
+	Result *NewConversationLocalRes `codec:"result,omitempty" json:"result,omitempty"`
+	Err    *string                  `codec:"err,omitempty" json:"err,omitempty"`
+}
+
+func (o NewConversationsLocalResult) DeepCopy() NewConversationsLocalResult {
+	return NewConversationsLocalResult{
+		Result: (func(x *NewConversationLocalRes) *NewConversationLocalRes {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Result),
+		Err: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.Err),
+	}
+}
+
+type NewConversationLocalArgument struct {
+	TlfName       string                  `codec:"tlfName" json:"tlfName"`
+	TopicType     TopicType               `codec:"topicType" json:"topicType"`
+	TlfVisibility keybase1.TLFVisibility  `codec:"tlfVisibility" json:"tlfVisibility"`
+	TopicName     *string                 `codec:"topicName,omitempty" json:"topicName,omitempty"`
+	MembersType   ConversationMembersType `codec:"membersType" json:"membersType"`
+}
+
+func (o NewConversationLocalArgument) DeepCopy() NewConversationLocalArgument {
+	return NewConversationLocalArgument{
+		TlfName:       o.TlfName,
+		TopicType:     o.TopicType.DeepCopy(),
+		TlfVisibility: o.TlfVisibility.DeepCopy(),
+		TopicName: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.TopicName),
+		MembersType: o.MembersType.DeepCopy(),
+	}
+}
+
 type NewConversationLocalRes struct {
 	Conv             ConversationLocal             `codec:"conv" json:"conv"`
 	UiConv           InboxUIItem                   `codec:"uiConv" json:"uiConv"`
@@ -6055,6 +6147,11 @@ type SetConversationStatusLocalArg struct {
 	IdentifyBehavior keybase1.TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
+type NewConversationsLocalArg struct {
+	NewConversationLocalArguments []NewConversationLocalArgument `codec:"newConversationLocalArguments" json:"newConversationLocalArguments"`
+	IdentifyBehavior              keybase1.TLFIdentifyBehavior   `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
 type NewConversationLocalArg struct {
 	TlfName          string                       `codec:"tlfName" json:"tlfName"`
 	TopicType        TopicType                    `codec:"topicType" json:"topicType"`
@@ -6458,6 +6555,7 @@ type LocalInterface interface {
 	PostDeleteHistoryThrough(context.Context, PostDeleteHistoryThroughArg) (PostLocalRes, error)
 	PostDeleteHistoryByAge(context.Context, PostDeleteHistoryByAgeArg) (PostLocalRes, error)
 	SetConversationStatusLocal(context.Context, SetConversationStatusLocalArg) (SetConversationStatusLocalRes, error)
+	NewConversationsLocal(context.Context, NewConversationsLocalArg) (NewConversationsLocalRes, error)
 	NewConversationLocal(context.Context, NewConversationLocalArg) (NewConversationLocalRes, error)
 	GetInboxSummaryForCLILocal(context.Context, GetInboxSummaryForCLILocalQuery) (GetInboxSummaryForCLILocalRes, error)
 	GetConversationForCLILocal(context.Context, GetConversationForCLILocalQuery) (GetConversationForCLILocalRes, error)
@@ -6892,6 +6990,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.SetConversationStatusLocal(ctx, typedArgs[0])
+					return
+				},
+			},
+			"newConversationsLocal": {
+				MakeArg: func() interface{} {
+					var ret [1]NewConversationsLocalArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]NewConversationsLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]NewConversationsLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.NewConversationsLocal(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -8057,6 +8170,11 @@ func (c LocalClient) PostDeleteHistoryByAge(ctx context.Context, __arg PostDelet
 
 func (c LocalClient) SetConversationStatusLocal(ctx context.Context, __arg SetConversationStatusLocalArg) (res SetConversationStatusLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.SetConversationStatusLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c LocalClient) NewConversationsLocal(ctx context.Context, __arg NewConversationsLocalArg) (res NewConversationsLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.newConversationsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -854,6 +854,26 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
+  // newConversationsLocal tries to make many conversations at once. If the conversation triple already exists,
+  // it is not considered an error. Any errors are returned in the results.
+  NewConversationsLocalRes newConversationsLocal(array<NewConversationLocalArgument> newConversationLocalArguments, keybase1.TLFIdentifyBehavior identifyBehavior);
+  record NewConversationsLocalRes {
+    array<NewConversationsLocalResult> results;
+    array<RateLimit> rateLimits;
+    array<keybase1.TLFIdentifyFailure> identifyFailures;
+  }
+  record NewConversationsLocalResult {
+    union { null, NewConversationLocalRes } result;
+    union { null, string } err;
+  }
+  record NewConversationLocalArgument {
+    string tlfName;
+    TopicType topicType;
+    keybase1.TLFVisibility tlfVisibility;
+    union { null, string } topicName;
+    ConversationMembersType membersType;
+  }
+
   NewConversationLocalRes newConversationLocal(string tlfName, TopicType topicType, keybase1.TLFVisibility tlfVisibility, union { null, string } topicName, ConversationMembersType membersType, keybase1.TLFIdentifyBehavior identifyBehavior);
   record NewConversationLocalRes {
     ConversationLocal conv;
@@ -861,7 +881,6 @@ protocol local {
     array<RateLimit> rateLimits;
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
-
 
   // if since is given, limit is ignored
   GetInboxSummaryForCLILocalRes getInboxSummaryForCLILocal(GetInboxSummaryForCLILocalQuery query);

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -2588,6 +2588,82 @@
     },
     {
       "type": "record",
+      "name": "NewConversationsLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "NewConversationsLocalResult"
+          },
+          "name": "results"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "keybase1.TLFIdentifyFailure"
+          },
+          "name": "identifyFailures"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "NewConversationsLocalResult",
+      "fields": [
+        {
+          "type": [
+            null,
+            "NewConversationLocalRes"
+          ],
+          "name": "result"
+        },
+        {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "err"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "NewConversationLocalArgument",
+      "fields": [
+        {
+          "type": "string",
+          "name": "tlfName"
+        },
+        {
+          "type": "TopicType",
+          "name": "topicType"
+        },
+        {
+          "type": "keybase1.TLFVisibility",
+          "name": "tlfVisibility"
+        },
+        {
+          "type": [
+            null,
+            "string"
+          ],
+          "name": "topicName"
+        },
+        {
+          "type": "ConversationMembersType",
+          "name": "membersType"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "NewConversationLocalRes",
       "fields": [
         {
@@ -4320,6 +4396,22 @@
       ],
       "response": "SetConversationStatusLocalRes",
       "lint": "ignore"
+    },
+    "newConversationsLocal": {
+      "request": [
+        {
+          "name": "newConversationLocalArguments",
+          "type": {
+            "type": "array",
+            "items": "NewConversationLocalArgument"
+          }
+        },
+        {
+          "name": "identifyBehavior",
+          "type": "keybase1.TLFIdentifyBehavior"
+        }
+      ],
+      "response": "NewConversationsLocalRes"
     },
     "newConversationLocal": {
       "request": [

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -1242,9 +1242,12 @@ export type MsgSummary = {readonly id: MessageID; readonly convID: ConvIDStr; re
 export type NameQuery = {readonly name: String; readonly tlfID?: TLFID | null; readonly membersType: ConversationMembersType}
 export type NewConvRes = {readonly id: ConvIDStr; readonly identifyFailures?: Array<Keybase1.TLFIdentifyFailure> | null; readonly rateLimits?: Array<RateLimitRes> | null}
 export type NewConversationInfo = {readonly convID: ConversationID; readonly conv?: InboxUIItem | null}
+export type NewConversationLocalArgument = {readonly tlfName: String; readonly topicType: TopicType; readonly tlfVisibility: Keybase1.TLFVisibility; readonly topicName?: String | null; readonly membersType: ConversationMembersType}
 export type NewConversationLocalRes = {readonly conv: ConversationLocal; readonly uiConv: InboxUIItem; readonly rateLimits?: Array<RateLimit> | null; readonly identifyFailures?: Array<Keybase1.TLFIdentifyFailure> | null}
 export type NewConversationPayload = {readonly Action: String; readonly convID: ConversationID; readonly inboxVers: InboxVers; readonly topicType: TopicType; readonly unreadUpdate?: UnreadUpdate | null}
 export type NewConversationRemoteRes = {readonly convID: ConversationID; readonly createdComplexTeam: Boolean; readonly rateLimit?: RateLimit | null}
+export type NewConversationsLocalRes = {readonly results?: Array<NewConversationsLocalResult> | null; readonly rateLimits?: Array<RateLimit> | null; readonly identifyFailures?: Array<Keybase1.TLFIdentifyFailure> | null}
+export type NewConversationsLocalResult = {readonly result?: NewConversationLocalRes | null; readonly err?: String | null}
 export type NewMessagePayload = {readonly Action: String; readonly convID: ConversationID; readonly message: MessageBoxed; readonly inboxVers: InboxVers; readonly topicType: TopicType; readonly unreadUpdate?: UnreadUpdate | null; readonly untrustedTeamRole: Keybase1.TeamRole; readonly maxMsgs?: Array<MessageSummary> | null}
 export type NonblockFetchRes = {readonly offline: Boolean; readonly rateLimits?: Array<RateLimit> | null; readonly identifyFailures?: Array<Keybase1.TLFIdentifyFailure> | null}
 export type OutboxID = Bytes
@@ -1625,6 +1628,7 @@ export const localUpdateUnsentTextRpcPromise = (params: MessageTypes['chat.1.loc
 // 'chat.1.local.postMetadataNonblock'
 // 'chat.1.local.postDeleteHistoryUpto'
 // 'chat.1.local.postDeleteHistoryThrough'
+// 'chat.1.local.newConversationsLocal'
 // 'chat.1.local.getInboxSummaryForCLILocal'
 // 'chat.1.local.getConversationForCLILocal'
 // 'chat.1.local.GetMessagesLocal'


### PR DESCRIPTION
If preferred, I can leave the existing AVDL alone and just duplicate the argument types for NewConversations rather than factoring the common types out, which would make the diff a lot smaller. But it may lead to inconsistencies further down the road.