### PR TITLE
No systemd on nonstandard home

### DIFF
--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -2017,8 +2017,8 @@ func (e *Env) RunningInCI() bool {
 }
 
 func (e *Env) WantsSystemd() bool {
-	nonstandard, err := e.HomeFinder.IsLinuxNonstandardHome()
-	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && (err != nil || !nonstandard))
+	isNonstandard, isNonstandardErr := e.HomeFinder.IsNonstandardHome()
+	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && (isNonstandardErr != nil || !isNonstandard))
 }
 
 func (e *Env) ModelessWantsSystemd() bool {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -2017,7 +2017,7 @@ func (e *Env) RunningInCI() bool {
 }
 
 func (e *Env) WantsSystemd() bool {
-	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && e.cmd.GetHome() == "")
+	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && !e.HomeFinder.IsLinuxNonstandardHome())
 }
 
 func (e *Env) ModelessWantsSystemd() bool {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -2017,7 +2017,8 @@ func (e *Env) RunningInCI() bool {
 }
 
 func (e *Env) WantsSystemd() bool {
-	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && !e.HomeFinder.IsLinuxNonstandardHome())
+	nonstandard, err := e.HomeFinder.IsLinuxNonstandardHome()
+	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && (err != nil || !nonstandard))
 }
 
 func (e *Env) ModelessWantsSystemd() bool {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -2017,7 +2017,7 @@ func (e *Env) RunningInCI() bool {
 }
 
 func (e *Env) WantsSystemd() bool {
-	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd())
+	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && e.Cmd.GetHome() == "")
 }
 
 func (e *Env) ModelessWantsSystemd() bool {

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -2017,7 +2017,7 @@ func (e *Env) RunningInCI() bool {
 }
 
 func (e *Env) WantsSystemd() bool {
-	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && e.Cmd.GetHome() == "")
+	return (e.GetRunMode() == ProductionRunMode && e.ModelessWantsSystemd() && e.cmd.GetHome() == "")
 }
 
 func (e *Env) ModelessWantsSystemd() bool {

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -105,39 +105,37 @@ func (x XdgPosix) Home(emptyOk bool) string {
 // IsNonstandardHome is true if the home directory gleaned via cmdline,
 // env, or config is different from that in /etc/passwd.
 func (x XdgPosix) IsNonstandardHome() (bool, error) {
+	passed := x.Home(false)
+	if passed == "" {
+		return false, nil
+	}
 	passwd, err := user.Current()
 	if err != nil {
-		fmt.Println(err)
 		return false, err
 	}
 	passwdAbs, err := filepath.Abs(passwd.HomeDir)
 	if err != nil {
-		fmt.Println(err)
 		return false, err
 	}
-	passedAbs, err := filepath.Abs(x.Home(false))
+	passedAbs, err := filepath.Abs(passed)
 	if err != nil {
-		fmt.Println(err)
 		return false, err
 	}
-	fmt.Println(passedAbs, passwdAbs)
-	return passedAbs != "" && passedAbs != passwdAbs, nil
+	return passedAbs != passwdAbs, nil
 }
 
 func (x XdgPosix) MobileSharedHome(emptyOk bool) string {
 	return x.Home(emptyOk)
 }
 
-func (x XdgPosix) dirHelper(env string, prefixDirs ...string) string {
+func (x XdgPosix) dirHelper(xdgEnvVar string, prefixDirs ...string) string {
 	appName := x.appName
 	if x.getRunMode() != ProductionRunMode {
 		appName = appName + "." + string(x.getRunMode())
 	}
 
 	isNonstandard, isNonstandardErr := x.IsNonstandardHome()
-	xdgSpecified := x.getenv(env)
-
-	fmt.Println("isn", isNonstandardErr, isNonstandard, xdgSpecified)
+	xdgSpecified := x.getenv(xdgEnvVar)
 
 	// If the user specified a nonstandard home directory, or there's no XDG
 	// environment variable present, use the home directory from the

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -43,6 +43,7 @@ type HomeFinder interface {
 	ServiceSpawnDir() (string, error)
 	SandboxCacheDir() string // For macOS
 	InfoDir() string
+	IsLinuxNonstandardHome() bool
 }
 
 func (b Base) getHome() string {
@@ -60,6 +61,8 @@ func (b Base) getHome() string {
 	}
 	return ""
 }
+
+func (b Base) IsLinuxNonstandardHome() bool { return false }
 
 func (b Base) getenv(s string) string {
 	if b.getenvFunc != nil {
@@ -86,6 +89,10 @@ func (x XdgPosix) Home(emptyOk bool) string {
 		ret = x.getenv("HOME")
 	}
 	return ret
+}
+
+func (x XdgPosix) IsLinuxNonstandardHome() bool {
+	return x.Home(false) != ""
 }
 
 func (x XdgPosix) MobileSharedHome(emptyOk bool) string {

--- a/go/libkb/socket_nix.go
+++ b/go/libkb/socket_nix.go
@@ -144,7 +144,7 @@ func NewSocket(g *GlobalContext) (ret Socket, err error) {
 	if err != nil {
 		return
 	}
-	g.Log.Info("Connecting to socket with dialFiles=%s, bindFiles=%s", dialFiles, bindFile)
+	g.Log.Debug("Connecting to socket with dialFiles=%s, bindFiles=%s", dialFiles, bindFile)
 	log := g.Log
 	if log == nil {
 		log = logger.NewNull()

--- a/go/libkb/socket_nix.go
+++ b/go/libkb/socket_nix.go
@@ -144,6 +144,7 @@ func NewSocket(g *GlobalContext) (ret Socket, err error) {
 	if err != nil {
 		return
 	}
+	g.Log.Info("Connecting to socket with dialFiles=%s, bindFiles=%s", dialFiles, bindFile)
 	log := g.Log
 	if log == nil {
 		log = logger.NewNull()


### PR DESCRIPTION
Continued from https://github.com/keybase/client/pull/19897/files

Test cases
* Specified via cmdline, relative, different from real home
* Specified via cmdline, abs, different from real home
* Specified via envvar, relative, different from real home
* Specified via envvar, abs, different from real home
* Specified via cmdline, abs, same as real home (should connect to systemd if present)
  * This is a behavior change. Is it ok?
* Specified via envvar, abs, same as real home (should connect to systemd if present)