### PR TITLE
just ignore errors from stellar1NotifyAccountDetailsUpdate

### DIFF
--- a/shared/actions/wallets.tsx
+++ b/shared/actions/wallets.tsx
@@ -469,9 +469,11 @@ const handleSelectAccountError = (
     (action.payload.reason === 'user-selected' || action.payload.reason === 'auto-selected')
   ) {
     // No need to throw black bars -- handled by Reloadable.
-    _logger.warn(errMsg)
+    _logger.warn('selectAccountError', action.type, action.payload.reason, errMsg)
+  } else if (action.type === WalletsGen.accountUpdateReceived) {
+    _logger.warn('selectAccountError', action.type, errMsg)
   } else {
-    _logger.error(errMsg)
+    _logger.error('selectAccountError', action.type, errMsg)
     throw err
   }
 }
@@ -512,6 +514,7 @@ const loadAssets = async (state: TypedState, action: LoadAssetsActions, logger: 
 
   // should be impossible
   if (!accountID) {
+    logger.error('loadAssets unexpected empty accountID', action.type)
     return
   }
 
@@ -1699,7 +1702,6 @@ function* walletsSaga() {
   yield* Saga.chainAction(WalletsGen.changeMobileOnlyMode, changeMobileOnlyMode)
   yield* Saga.chainAction2(WalletsGen.setLastSentXLM, writeLastSentXLM)
   yield* Saga.chainAction(ConfigGen.daemonHandshakeDone, readLastSentXLM)
-  yield* Saga.chainAction(EngineGen.stellar1NotifyAccountDetailsUpdate, accountDetailsUpdate)
   yield* Saga.chainAction(EngineGen.stellar1NotifyAccountsUpdate, accountsUpdate)
   yield* Saga.chainAction(EngineGen.stellar1NotifyPendingPaymentsUpdate, pendingPaymentsUpdate)
   yield* Saga.chainAction(EngineGen.stellar1NotifyRecentPaymentsUpdate, recentPaymentsUpdate)

--- a/shared/reducers/wallets.tsx
+++ b/shared/reducers/wallets.tsx
@@ -55,7 +55,6 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     // this is because we get the sort order from the full accounts load,
     // and can't figure it out from these notifications alone.
     if (account) {
-      // } && state.accountMap.get(account.accountID)) {
       const {accountID} = account
       const old = draftState.accountMap.get(accountID)
       if (old) {


### PR DESCRIPTION
When going offline right after confirming a wallet send the client was liable to throw a global error. It was from `stellar1NotifyAccountDetailsUpdate -> accountDetailsUpdate -> createAccountUpdateReceived -> loadAssets -> localGetAccountAssetsLocalRpcPromise -> handleSelectAccountError -> throw`.

This patch ignores that path. The reducer for `accountUpdateReceived` blanks out `state.accountMap` so hopefully that means that this won't result in unmarked stale data.