### PR TITLE
teams/hidden: still persist racthets from visible->hidden on parent FTL

### DIFF
--- a/go/teams/ftl.go
+++ b/go/teams/ftl.go
@@ -721,7 +721,7 @@ func (a fastLoadArg) toHTTPArgs(m libkb.MetaContext, s shoppingList, hp *hidden.
 		ret["read_subteam_id"] = libkb.S{Val: a.readSubteamID.String()}
 	}
 
-	if hp.Enabled() {
+	if hp.HiddenChainDataEnabled() {
 		ret["ftl_hidden_low"] = libkb.I{Val: int(s.hiddenLinksSince)}
 	}
 	return ret
@@ -1329,11 +1329,11 @@ func (f *FastTeamChainLoader) hiddenPackage(m libkb.MetaContext, arg fastLoadArg
 	}
 	if !arg.readSubteamID.IsNil() {
 		m.Debug("hiddenPackage: disabling checks since we a subteam reader looking for parent chain")
-		hp.Disable()
+		hp.DisableHiddenChainData()
 	}
 	if tmp := hidden.CheckFeatureGateForSupport(m, arg.ID, false /* isWrite */); tmp != nil {
 		m.Debug("hiddenPackage: disabling checks since we are feature-flagged off")
-		hp.Disable()
+		hp.DisableHiddenChainData()
 	}
 	return hp, nil
 }
@@ -1348,13 +1348,6 @@ func (f *FastTeamChainLoader) consumeRatchets(m libkb.MetaContext, newLinks []*C
 }
 
 func (f *FastTeamChainLoader) processHidden(m libkb.MetaContext, arg fastLoadArg, state *keybase1.FastTeamData, groceries *groceries, hp *hidden.LoaderPackage) (err error) {
-
-	// Hidden Package is disabled if we're checking parent teams for subteam readers or if we
-	// are feature flagged off. TODO: we should still consume the ratchets and commit them,
-	// in case we later get added to the parent team.
-	if !hp.Enabled() {
-		return nil
-	}
 
 	err = f.consumeRatchets(m, groceries.newLinks, hp)
 	if err != nil {

--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -17,18 +17,18 @@ const (
 // It additionally can have new chain links loaded from the server, since it might need to be queried
 // in the process of loading the team as if the new links were already committed to the data store.
 type LoaderPackage struct {
-	id                 keybase1.TeamID
-	encKID             keybase1.KID
-	encKIDGen          keybase1.PerTeamKeyGeneration
-	data               *keybase1.HiddenTeamChain
-	newData            *keybase1.HiddenTeamChain
-	expectedPrev       *keybase1.LinkTriple
-	rbks               *RatchetBlindingKeySet
-	allNewRatchets     map[keybase1.Seqno]keybase1.LinkTripleAndTime
-	newRatchetSet      keybase1.HiddenTeamChainRatchetSet
-	role               keybase1.TeamRole
-	lastCommittedSeqno keybase1.Seqno
-	disabled           bool
+	id                     keybase1.TeamID
+	encKID                 keybase1.KID
+	encKIDGen              keybase1.PerTeamKeyGeneration
+	data                   *keybase1.HiddenTeamChain
+	newData                *keybase1.HiddenTeamChain
+	expectedPrev           *keybase1.LinkTriple
+	rbks                   *RatchetBlindingKeySet
+	allNewRatchets         map[keybase1.Seqno]keybase1.LinkTripleAndTime
+	newRatchetSet          keybase1.HiddenTeamChainRatchetSet
+	role                   keybase1.TeamRole
+	lastCommittedSeqno     keybase1.Seqno
+	disableHiddenChainData bool
 }
 
 // NewLoaderPackage creates a loader package that can work in the FTL of slow team loading settings. As a preliminary,
@@ -137,6 +137,10 @@ func (l *LoaderPackage) checkPrev(mctx libkb.MetaContext, first sig3.Generic) (e
 // merkle/path api call. We look at both the loaded and the received downloaded
 // ratchets for this check.
 func (l *LoaderPackage) checkExpectedHighSeqno(mctx libkb.MetaContext, links []sig3.Generic, maxUncommittedSeqnoPromised keybase1.Seqno) (err error) {
+	if !l.HiddenChainDataEnabled() {
+		mctx.Debug("skipping checkExpectedHighSeqno, since we didn't ask for any data")
+		return nil
+	}
 	last := l.LastSeqno()
 	max := l.MaxRatchet()
 	if max < maxUncommittedSeqnoPromised {
@@ -277,7 +281,7 @@ func (l *LoaderPackage) checkNewLinksAgainstNewRatchets(mctx libkb.MetaContext, 
 	return nil
 }
 
-// This function checks that uncommitted links which we previously got from the
+// VerifyOldChainLinksAreCommitted checks that uncommitted links which we previously got from the
 // server have indeed been included in the blind tree (the server has a short
 // grace period to do this to account for potential downtime)
 func (l *LoaderPackage) VerifyOldChainLinksAreCommitted(mctx libkb.MetaContext, newCommittedSeqno keybase1.Seqno) error {
@@ -743,13 +747,14 @@ func (l *LoaderPackage) CheckParentPointersOnFastLoad(mctx libkb.MetaContext, te
 	return nil
 }
 
-// Disable the LoaderPackage if we are a subteam reader, or if we are feature-flagged off
-func (l *LoaderPackage) Disable() {
-	l.disabled = true
+// DisableHiddenChainData tells the LoaderPackage to disable reading and consuming
+// of hidden chain data. On if we are a subteam reader, or if we are feature-flagged off
+func (l *LoaderPackage) DisableHiddenChainData() {
+	l.disableHiddenChainData = true
 }
 
-// Enabled is true if we are doing a full hidden chain load (and off if we're skipping
+// HiddenChainDataEnabled is true if we are doing a full hidden chain load (and off if we're skipping
 // due to the above).
-func (l *LoaderPackage) Enabled() bool {
-	return !l.disabled
+func (l *LoaderPackage) HiddenChainDataEnabled() bool {
+	return !l.disableHiddenChainData
 }

--- a/go/teams/hidden_loader_test.go
+++ b/go/teams/hidden_loader_test.go
@@ -793,7 +793,7 @@ func TestSubteamReaderFTL(t *testing.T) {
 	defer cleanup()
 
 	t.Logf("create team")
-	teamName, _ := createTeam2(*tcs[0])
+	teamName, teamID := createTeam2(*tcs[0])
 	for i := 0; i < 4; i++ {
 		makeHiddenRotation(t, tcs[0].G, teamName)
 	}
@@ -801,11 +801,19 @@ func TestSubteamReaderFTL(t *testing.T) {
 	subteamName, subteamID := createSubteam(tcs[0], teamName, "sub")
 	_, err := AddMember(context.TODO(), tcs[0].G, subteamName.String(), fus[1].Username, keybase1.TeamRole_WRITER, nil)
 	require.NoError(t, err)
-	_, err = tcs[1].G.GetFastTeamLoader().Load(libkb.NewMetaContextForTest(*tcs[1]), keybase1.FastTeamLoadArg{
+	mctx := libkb.NewMetaContextForTest(*tcs[1])
+	_, err = mctx.G().GetFastTeamLoader().Load(mctx, keybase1.FastTeamLoadArg{
 		ID:                   subteamID,
 		ForceRefresh:         true,
 		Applications:         []keybase1.TeamApplication{keybase1.TeamApplication_CHAT},
 		KeyGenerationsNeeded: []keybase1.PerTeamKeyGeneration{keybase1.PerTeamKeyGeneration(1)},
 	})
 	require.NoError(t, err)
+	var htc *keybase1.HiddenTeamChain
+	htc, err = mctx.G().GetHiddenTeamChainManager().Load(mctx, teamID)
+	require.NoError(t, err)
+	require.NotNil(t, htc)
+	ratchet, ok := htc.RatchetSet.Ratchets[keybase1.RatchetType_MAIN]
+	require.True(t, ok)
+	require.Equal(t, ratchet.Triple.Seqno, keybase1.Seqno(4))
 }

--- a/go/teams/hidden_loader_test.go
+++ b/go/teams/hidden_loader_test.go
@@ -809,6 +809,9 @@ func TestSubteamReaderFTL(t *testing.T) {
 		KeyGenerationsNeeded: []keybase1.PerTeamKeyGeneration{keybase1.PerTeamKeyGeneration(1)},
 	})
 	require.NoError(t, err)
+
+	// Check that U1's hidden team data for the parent team is still stored, and that
+	// the ratchets persist (even though there's no other data there).
 	var htc *keybase1.HiddenTeamChain
 	htc, err = mctx.G().GetHiddenTeamChainManager().Load(mctx, teamID)
 	require.NoError(t, err)
@@ -816,4 +819,6 @@ func TestSubteamReaderFTL(t *testing.T) {
 	ratchet, ok := htc.RatchetSet.Ratchets[keybase1.RatchetType_MAIN]
 	require.True(t, ok)
 	require.Equal(t, ratchet.Triple.Seqno, keybase1.Seqno(4))
+	require.Equal(t, htc.Last, keybase1.Seqno(0))
+	require.Equal(t, len(htc.Outer), 0)
 }


### PR DESCRIPTION
- we can't load the data or the seeds in all cases, since we might not have
  privileges to if we're loading a parent team in FTL.
- similarly, we might be feature-flagged off
- still, we should note and record if the main chain is ratcheting the hidden chain forward
- since if we do become members of the parent, we don't want a rollback