### PR TITLE
log server error when erasing device ek

### DIFF
--- a/go/ephemeral/common_test.go
+++ b/go/ephemeral/common_test.go
@@ -70,7 +70,7 @@ func TestEphemeralCloneError(t *testing.T) {
 	allDevicEKs, err := s.GetAll(mctx)
 	require.NoError(t, err)
 	for _, dek := range allDevicEKs {
-		err = s.Delete(mctx, dek.Metadata.Generation)
+		err = s.Delete(mctx, dek.Metadata.Generation, "")
 		require.NoError(t, err)
 	}
 	_, err = g.GetTeamEKBoxStorage().Get(mctx, teamID, teamEK1.Generation(), nil)
@@ -97,7 +97,7 @@ func TestEphemeralDeviceProvisionedAfterContent(t *testing.T) {
 	allDevicEKs, err := s.GetAll(mctx)
 	require.NoError(t, err)
 	for _, dek := range allDevicEKs {
-		err = s.Delete(mctx, dek.Metadata.Generation)
+		err = s.Delete(mctx, dek.Metadata.Generation, "")
 		require.NoError(t, err)
 	}
 

--- a/go/ephemeral/device_ek.go
+++ b/go/ephemeral/device_ek.go
@@ -125,7 +125,7 @@ func signAndPostDeviceEK(mctx libkb.MetaContext, generation keybase1.EkGeneratio
 	err = postNewDeviceEK(mctx, signedStatement)
 	if err != nil {
 		storage.ClearCache()
-		serr := NewDeviceEKStorage(mctx).Delete(mctx, generation)
+		serr := NewDeviceEKStorage(mctx).Delete(mctx, generation, "unable to post deviceEK: %v", err)
 		if serr != nil {
 			mctx.Debug("DeviceEK deletion failed %v", err)
 		}

--- a/go/ephemeral/device_ek_storage.go
+++ b/go/ephemeral/device_ek_storage.go
@@ -293,14 +293,16 @@ func (s *DeviceEKStorage) get(mctx libkb.MetaContext, generation keybase1.EkGene
 	return deviceEK, nil
 }
 
-func (s *DeviceEKStorage) Delete(mctx libkb.MetaContext, generation keybase1.EkGeneration) (err error) {
+func (s *DeviceEKStorage) Delete(mctx libkb.MetaContext, generation keybase1.EkGeneration,
+	reason string, args ...interface{}) (err error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.delete(mctx, generation)
+	return s.delete(mctx, generation, reason, args...)
 }
 
-func (s *DeviceEKStorage) delete(mctx libkb.MetaContext, generation keybase1.EkGeneration) (err error) {
-	defer s.ekLogCTraceTimed(mctx, fmt.Sprintf("DeviceEKStorage#delete: generation:%v", generation), func() error { return err })()
+func (s *DeviceEKStorage) delete(mctx libkb.MetaContext, generation keybase1.EkGeneration,
+	reason string, args ...interface{}) (err error) {
+	defer s.ekLogCTraceTimed(mctx, fmt.Sprintf("DeviceEKStorage#delete: generation:%v reason: %s", generation, fmt.Sprintf(reason, args...)), func() error { return err })()
 
 	// clear the cache
 	cache, err := s.getCache(mctx)
@@ -499,7 +501,7 @@ func (s *DeviceEKStorage) DeleteExpired(mctx libkb.MetaContext, merkleRoot libkb
 	expired = s.getExpiredGenerations(mctx, keyMap, now)
 	epick := libkb.FirstErrorPicker{}
 	for _, generation := range expired {
-		epick.Push(s.delete(mctx, generation))
+		epick.Push(s.delete(mctx, generation, "generation expired"))
 	}
 
 	epick.Push(s.deletedWrongEldestSeqno(mctx))

--- a/go/ephemeral/device_ek_storage_test.go
+++ b/go/ephemeral/device_ek_storage_test.go
@@ -105,7 +105,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	}
 
 	// Test Delete
-	require.NoError(t, s.Delete(mctx, 2))
+	require.NoError(t, s.Delete(mctx, 2, ""))
 
 	deviceEK, err := s.Get(mctx, 2)
 	require.Error(t, err)
@@ -129,7 +129,7 @@ func TestDeviceEKStorage(t *testing.T) {
 	require.EqualValues(t, 3, maxGeneration)
 	s.ClearCache()
 
-	require.NoError(t, s.Delete(mctx, 3))
+	require.NoError(t, s.Delete(mctx, 3, ""))
 
 	maxGeneration, err = s.MaxGeneration(mctx, false)
 	require.NoError(t, err)

--- a/go/ephemeral/device_ek_test.go
+++ b/go/ephemeral/device_ek_test.go
@@ -46,7 +46,7 @@ func TestNewDeviceEK(t *testing.T) {
 
 	rawStorage := NewDeviceEKStorage(mctx)
 	// Put our storage in a bad state by deleting the maxGeneration
-	err = rawStorage.Delete(mctx, maxGeneration+1)
+	err = rawStorage.Delete(mctx, maxGeneration+1, "")
 	require.NoError(t, err)
 
 	// If we publish in a bad local state, we can successfully get the

--- a/go/ephemeral/lib_test.go
+++ b/go/ephemeral/lib_test.go
@@ -215,7 +215,7 @@ func TestNewTeamEKNeeded(t *testing.T) {
 	assertKeyGenerations(expectedDeviceEKGen, expectedUserEKGen, expectedTeamEKGen, false /*created*/, false /* teamEKCreationInProgress */)
 
 	// Now let's kill our deviceEK as well, and we should generate all new keys
-	err = rawDeviceEKStorage.Delete(mctx, expectedDeviceEKGen)
+	err = rawDeviceEKStorage.Delete(mctx, expectedDeviceEKGen, "")
 	require.NoError(t, err)
 	tc.G.GetDeviceEKStorage().ClearCache()
 	expectedDeviceEKGen++

--- a/go/ephemeral/team_ek_box_storage_test.go
+++ b/go/ephemeral/team_ek_box_storage_test.go
@@ -113,7 +113,7 @@ func TestTeamEKBoxStorage(t *testing.T) {
 
 	// No let's the deviceEK which we can't recover from
 	rawDeviceEKStorage := NewDeviceEKStorage(mctx)
-	err = rawDeviceEKStorage.Delete(mctx, deviceEKMaxGen)
+	err = rawDeviceEKStorage.Delete(mctx, deviceEKMaxGen, "")
 	require.NoError(t, err)
 
 	deviceEKStorage.ClearCache()

--- a/go/ephemeral/user_ek_box_storage_test.go
+++ b/go/ephemeral/user_ek_box_storage_test.go
@@ -72,7 +72,7 @@ func TestUserEKBoxStorage(t *testing.T) {
 
 	// Let's delete our deviceEK and verify we can't unbox the userEK
 	rawDeviceEKStorage := NewDeviceEKStorage(mctx)
-	err = rawDeviceEKStorage.Delete(mctx, deviceEKMaxGen)
+	err = rawDeviceEKStorage.Delete(mctx, deviceEKMaxGen, "")
 	require.NoError(t, err)
 
 	deviceEKStorage.ClearCache()


### PR DESCRIPTION
had a device ek go missing yesterday, ek log says the generation was deleted but i don't have any context as to why (assuming it was a server error which caused it) hoping this extra logging will help if the problem surfaces again