### PR TITLE
Don't show "digging ancient messages" on new convo

### DIFF
--- a/shared/chat/conversation/messages/special-top-message.tsx
+++ b/shared/chat/conversation/messages/special-top-message.tsx
@@ -159,9 +159,6 @@ const styles = Styles.styleSheetCreate(
       errorText: {
         padding: Styles.globalMargins.small,
       },
-      loading: {
-        marginLeft: Styles.globalMargins.small,
-      },
       more: {
         ...Styles.globalStyles.flexBoxColumn,
         alignItems: 'center',

--- a/shared/chat/conversation/messages/special-top-message.tsx
+++ b/shared/chat/conversation/messages/special-top-message.tsx
@@ -56,9 +56,9 @@ class SpecialTopMessage extends React.PureComponent<Props> {
           <ProfileResetNotice conversationIDKey={this.props.conversationIDKey} />
         )}
         {this.props.pendingState === 'waiting' && (
-          <Kb.Text type="BodySmallSemibold" style={styles.loading}>
-            Loading...
-          </Kb.Text>
+          <Kb.Box style={styles.more}>
+            <Kb.Text type="BodySmallSemibold">Loading...</Kb.Text>
+          </Kb.Box>
         )}
         {this.props.pendingState === 'error' && (
           <Kb.Box2
@@ -137,7 +137,7 @@ class SpecialTopMessage extends React.PureComponent<Props> {
             <MakeTeamCard conversationIDKey={this.props.conversationIDKey} />
           </Kb.Box>
         )}
-        {this.props.loadMoreType === 'moreToLoad' && this.props.pendingState !== 'error' && (
+        {this.props.loadMoreType === 'moreToLoad' && this.props.pendingState === 'done' && (
           <Kb.Box style={styles.more}>
             <Kb.Text type="BodyBig">
               <Kb.Emoji size={16} emojiName=":moyai:" />


### PR DESCRIPTION
Prevents the "digging ancient messages" box from appearing on a new conversation by only showing that text when `pendingState` is done (rather than also including the waiting state where "loading..." would be shown). Also centers the loading text for consistency.