### PR TITLE
kbfsops/simplefs: fix CI flakes

### DIFF
--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -3539,6 +3539,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 
 	// Create mallory's fake TLF using the same TLF ID as alice's.
 	config2 := ConfigAsUser(config1, "mallory")
+	defer func() { _ = config2.Shutdown(ctx) }()
 	config2.SetMode(modeNoHistory{config2.Mode()})
 	crypto2 := cryptoFixedTlf{config2.Crypto(), fb1.Tlf}
 	config2.SetCrypto(crypto2)

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -171,6 +171,10 @@ func testList(
 func TestStatNonExistent(t *testing.T) {
 	ctx := context.Background()
 	config := libkbfs.MakeTestConfigOrBust(t, "dog", "cat")
+	defer func() {
+		err := config.Shutdown(ctx)
+		require.NoError(t, err)
+	}()
 	sfs := newSimpleFS(env.EmptyAppStateUpdater{}, config)
 
 	t.Logf("/private/dog,cat should be writable for dog")
@@ -194,6 +198,7 @@ func TestSymlink(t *testing.T) {
 	ctx := context.Background()
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe")
 	sfs := newSimpleFS(env.EmptyAppStateUpdater{}, config)
+	defer closeSimpleFS(ctx, t, sfs)
 
 	t.Logf("Make a file and then symlink it")
 	p := keybase1.NewPathWithKbfsPath(`/private/jdoe`)


### PR DESCRIPTION
@maxtaco I think this covers the last tests you mentioned in chat (TestKBFSOps and TestSimpleFS).  Let me know if I missed any others.