### PR TITLE
Teams: use getAnnotatedTeam, reorganize store

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -2104,7 +2104,7 @@ type TeamChangeRow struct {
 	MembershipChanged   bool   `codec:"membershipChanged" json:"membership_changed"`
 	LatestSeqno         Seqno  `codec:"latestSeqno" json:"latest_seqno"`
 	LatestHiddenSeqno   Seqno  `codec:"latestHiddenSeqno" json:"latest_hidden_seqno"`
-	LatestOffchainSeqno Seqno  `codec:"latestOffchainSeqno" json:"latest_offchain_seqno"`
+	LatestOffchainSeqno Seqno  `codec:"latestOffchainSeqno" json:"latest_offchain_version"`
 	ImplicitTeam        bool   `codec:"implicitTeam" json:"implicit_team"`
 	Misc                bool   `codec:"misc" json:"misc"`
 	RemovedResetUsers   bool   `codec:"removedResetUsers" json:"removed_reset_users"`
@@ -3509,7 +3509,6 @@ type AnnotatedTeam struct {
 	Members                      []AnnotatedTeamMemberDetails `codec:"members" json:"members"`
 	Invites                      []AnnotatedTeamInvite        `codec:"invites" json:"invites"`
 	JoinRequests                 []TeamJoinRequest            `codec:"joinRequests" json:"joinRequests"`
-	UserIsShowcasing             bool                         `codec:"userIsShowcasing" json:"userIsShowcasing"`
 	TarsDisabled                 bool                         `codec:"tarsDisabled" json:"tarsDisabled"`
 	Settings                     TeamSettings                 `codec:"settings" json:"settings"`
 	Showcase                     TeamShowcase                 `codec:"showcase" json:"showcase"`
@@ -3553,10 +3552,9 @@ func (o AnnotatedTeam) DeepCopy() AnnotatedTeam {
 			}
 			return ret
 		})(o.JoinRequests),
-		UserIsShowcasing: o.UserIsShowcasing,
-		TarsDisabled:     o.TarsDisabled,
-		Settings:         o.Settings.DeepCopy(),
-		Showcase:         o.Showcase.DeepCopy(),
+		TarsDisabled: o.TarsDisabled,
+		Settings:     o.Settings.DeepCopy(),
+		Showcase:     o.Showcase.DeepCopy(),
 	}
 }
 

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -804,7 +804,7 @@ protocol teams {
     Seqno latestSeqno;
     @jsonkey("latest_hidden_seqno")
     Seqno latestHiddenSeqno;
-    @jsonkey("latest_offchain_seqno")
+    @jsonkey("latest_offchain_version")
     Seqno latestOffchainSeqno;
     @jsonkey("implicit_team")
     boolean implicitTeam;
@@ -1500,7 +1500,6 @@ protocol teams {
     array<AnnotatedTeamInvite> invites;
     array<TeamJoinRequest> joinRequests;
 
-    boolean userIsShowcasing;
     boolean tarsDisabled;
     TeamSettings settings;
     TeamShowcase showcase;

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -264,6 +264,7 @@
   "keybase.1.signup.getInvitationCode": {"promise": true},
   "keybase.1.signup.inviteRequest": {"promise": true},
   "keybase.1.signup.signup": {"engineSaga": true},
+  "keybase.1.teams.getAnnotatedTeam": {"promise": true},
   "keybase.1.teams.getTarsDisabled": {"promise": true},
   "keybase.1.teams.getTeamAndMemberShowcase": {"promise": true},
   "keybase.1.teams.getTeamRoleMap": {"promise": true},

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -1742,7 +1742,7 @@
         {
           "type": "Seqno",
           "name": "latestOffchainSeqno",
-          "jsonkey": "latest_offchain_seqno"
+          "jsonkey": "latest_offchain_version"
         },
         {
           "type": "boolean",
@@ -3130,10 +3130,6 @@
             "items": "TeamJoinRequest"
           },
           "name": "joinRequests"
-        },
-        {
-          "type": "boolean",
-          "name": "userIsShowcasing"
         },
         {
           "type": "boolean",

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -57,20 +57,22 @@
     "unsubscribeTeamList": {
       "_description": "Don't eagerly reload team list anymore."
     },
-    "getDetails": {
-      "_description": "Deprecated, use subscriptions or by ID in new code",
-      "teamname": "string",
-      "clearInviteLoadingKey?": "string"
-    },
-    "getDetailsByID": {
+    "loadTeam": {
       "_description": "Load team details if we are stale. _subscribe is for use by teams/subscriber only.",
       "_subscribe?": "boolean",
+      "teamID": "Types.TeamID"
+    },
+    "teamLoaded": {
       "teamID": "Types.TeamID",
-      "clearInviteLoadingKey?": "string"
+      "details": "Types.TeamDetails"
     },
     "unsubscribeTeamDetails": {
       "_description": "Stop listening for team details for this team",
       "teamID": "Types.TeamID"
+    },
+    "setTeamVersion": {
+      "teamID": "Types.TeamID",
+      "version": "Types.TeamVersion"
     },
     "getMembers": {
       "teamID": "Types.TeamID"
@@ -81,9 +83,6 @@
     },
     "getTeamProfileAddList": {
       "username": "string"
-    },
-    "getTeamPublicity": {
-      "teamID": "Types.TeamID"
     },
     "addTeamWithChosenChannels": {
       "teamID": "Types.TeamID"
@@ -231,10 +230,6 @@
       "teamID": "Types.TeamID",
       "teamOperation": "Types.TeamOperations"
     },
-    "setTeamPublicitySettings": {
-      "teamID": "Types.TeamID",
-      "publicity": "Types._PublicitySettings"
-    },
     "setTeamChannelInfo": {
       "teamID": "Types.TeamID",
       "conversationIDKey": "ChatTypes.ConversationIDKey",
@@ -247,7 +242,7 @@
     "setTeamInfo": {
       "teamnames": "Set<Types.Teamname>",
       "teamNameToID": "Map<Types.Teamname, string>",
-      "teamDetails": "Map<Types.TeamID, Types.TeamDetails>"
+      "teamMeta": "Map<Types.TeamID, Types.TeamMeta>"
     },
     "setTeamProfileAddList": {
       "teamlist": "Array<Types.TeamProfileAddList>"

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -25,11 +25,8 @@ export const editMembership = 'teams:editMembership'
 export const editTeamDescription = 'teams:editTeamDescription'
 export const getChannelInfo = 'teams:getChannelInfo'
 export const getChannels = 'teams:getChannels'
-export const getDetails = 'teams:getDetails'
-export const getDetailsByID = 'teams:getDetailsByID'
 export const getMembers = 'teams:getMembers'
 export const getTeamProfileAddList = 'teams:getTeamProfileAddList'
-export const getTeamPublicity = 'teams:getTeamPublicity'
 export const getTeamRetentionPolicy = 'teams:getTeamRetentionPolicy'
 export const getTeams = 'teams:getTeams'
 export const ignoreRequest = 'teams:ignoreRequest'
@@ -38,6 +35,7 @@ export const inviteToTeamByPhone = 'teams:inviteToTeamByPhone'
 export const joinTeam = 'teams:joinTeam'
 export const leaveTeam = 'teams:leaveTeam'
 export const leftTeam = 'teams:leftTeam'
+export const loadTeam = 'teams:loadTeam'
 export const reAddToTeam = 'teams:reAddToTeam'
 export const removeMember = 'teams:removeMember'
 export const removeParticipant = 'teams:removeParticipant'
@@ -65,17 +63,18 @@ export const setTeamJoinError = 'teams:setTeamJoinError'
 export const setTeamJoinSuccess = 'teams:setTeamJoinSuccess'
 export const setTeamLoadingInvites = 'teams:setTeamLoadingInvites'
 export const setTeamProfileAddList = 'teams:setTeamProfileAddList'
-export const setTeamPublicitySettings = 'teams:setTeamPublicitySettings'
 export const setTeamRetentionPolicy = 'teams:setTeamRetentionPolicy'
 export const setTeamRoleMap = 'teams:setTeamRoleMap'
 export const setTeamRoleMapLatestKnownVersion = 'teams:setTeamRoleMapLatestKnownVersion'
 export const setTeamSawChatBanner = 'teams:setTeamSawChatBanner'
 export const setTeamSawSubteamsBanner = 'teams:setTeamSawSubteamsBanner'
+export const setTeamVersion = 'teams:setTeamVersion'
 export const setTeamsWithChosenChannels = 'teams:setTeamsWithChosenChannels'
 export const setUpdatedChannelName = 'teams:setUpdatedChannelName'
 export const setUpdatedTopic = 'teams:setUpdatedTopic'
 export const settingsError = 'teams:settingsError'
 export const teamCreated = 'teams:teamCreated'
+export const teamLoaded = 'teams:teamLoaded'
 export const toggleInvitesCollapsed = 'teams:toggleInvitesCollapsed'
 export const unsubscribeTeamDetails = 'teams:unsubscribeTeamDetails'
 export const unsubscribeTeamList = 'teams:unsubscribeTeamList'
@@ -139,15 +138,8 @@ type _GetChannelInfoPayload = {
   readonly teamID: Types.TeamID
 }
 type _GetChannelsPayload = {readonly teamID: Types.TeamID}
-type _GetDetailsByIDPayload = {
-  readonly _subscribe?: boolean
-  readonly teamID: Types.TeamID
-  readonly clearInviteLoadingKey?: string
-}
-type _GetDetailsPayload = {readonly teamname: string; readonly clearInviteLoadingKey?: string}
 type _GetMembersPayload = {readonly teamID: Types.TeamID}
 type _GetTeamProfileAddListPayload = {readonly username: string}
-type _GetTeamPublicityPayload = {readonly teamID: Types.TeamID}
 type _GetTeamRetentionPolicyPayload = {readonly teamID: Types.TeamID}
 type _GetTeamsPayload = {readonly _subscribe?: boolean; readonly forceReload?: boolean}
 type _IgnoreRequestPayload = {readonly teamname: string; readonly username: string}
@@ -171,6 +163,7 @@ type _LeaveTeamPayload = {
   readonly context: 'teams' | 'chat'
 }
 type _LeftTeamPayload = {readonly teamname: string; readonly context: 'teams' | 'chat'}
+type _LoadTeamPayload = {readonly _subscribe?: boolean; readonly teamID: Types.TeamID}
 type _ReAddToTeamPayload = {readonly teamID: Types.TeamID; readonly username: string}
 type _RemoveMemberPayload = {readonly teamID: Types.TeamID; readonly username: string}
 type _RemoveParticipantPayload = {
@@ -232,7 +225,7 @@ type _SetTeamDetailsPayload = {
 type _SetTeamInfoPayload = {
   readonly teamnames: Set<Types.Teamname>
   readonly teamNameToID: Map<Types.Teamname, string>
-  readonly teamDetails: Map<Types.TeamID, Types.TeamDetails>
+  readonly teamMeta: Map<Types.TeamID, Types.TeamMeta>
 }
 type _SetTeamInviteErrorPayload = {readonly error: string}
 type _SetTeamJoinErrorPayload = {readonly error: string}
@@ -247,10 +240,6 @@ type _SetTeamLoadingInvitesPayload = {
   readonly isLoading: boolean
 }
 type _SetTeamProfileAddListPayload = {readonly teamlist: Array<Types.TeamProfileAddList>}
-type _SetTeamPublicitySettingsPayload = {
-  readonly teamID: Types.TeamID
-  readonly publicity: Types._PublicitySettings
-}
 type _SetTeamRetentionPolicyPayload = {
   readonly teamID: Types.TeamID
   readonly retentionPolicy: RetentionPolicy
@@ -259,6 +248,7 @@ type _SetTeamRoleMapLatestKnownVersionPayload = {readonly version: number}
 type _SetTeamRoleMapPayload = {readonly map: Types.TeamRoleMap}
 type _SetTeamSawChatBannerPayload = void
 type _SetTeamSawSubteamsBannerPayload = void
+type _SetTeamVersionPayload = {readonly teamID: Types.TeamID; readonly version: Types.TeamVersion}
 type _SetTeamsWithChosenChannelsPayload = {readonly teamsWithChosenChannels: Set<Types.TeamID>}
 type _SetUpdatedChannelNamePayload = {
   readonly teamID: Types.TeamID
@@ -276,6 +266,7 @@ type _TeamCreatedPayload = {
   readonly teamID: Types.TeamID
   readonly teamname: string
 }
+type _TeamLoadedPayload = {readonly teamID: Types.TeamID; readonly details: Types.TeamDetails}
 type _ToggleInvitesCollapsedPayload = {readonly teamID: Types.TeamID}
 type _UnsubscribeTeamDetailsPayload = {readonly teamID: Types.TeamID}
 type _UnsubscribeTeamListPayload = void
@@ -297,13 +288,6 @@ type _UploadTeamAvatarPayload = {
 }
 
 // Action Creators
-/**
- * Deprecated, use subscriptions or by ID in new code
- */
-export const createGetDetails = (payload: _GetDetailsPayload): GetDetailsPayload => ({
-  payload,
-  type: getDetails,
-})
 /**
  * Don't eagerly reload team list anymore.
  */
@@ -333,10 +317,7 @@ export const createGetTeamRetentionPolicy = (
 /**
  * Load team details if we are stale. _subscribe is for use by teams/subscriber only.
  */
-export const createGetDetailsByID = (payload: _GetDetailsByIDPayload): GetDetailsByIDPayload => ({
-  payload,
-  type: getDetailsByID,
-})
+export const createLoadTeam = (payload: _LoadTeamPayload): LoadTeamPayload => ({payload, type: loadTeam})
 /**
  * Load team list if we are stale. _subscribe is for use by teams/subscriber only.
  */
@@ -435,10 +416,6 @@ export const createGetMembers = (payload: _GetMembersPayload): GetMembersPayload
 export const createGetTeamProfileAddList = (
   payload: _GetTeamProfileAddListPayload
 ): GetTeamProfileAddListPayload => ({payload, type: getTeamProfileAddList})
-export const createGetTeamPublicity = (payload: _GetTeamPublicityPayload): GetTeamPublicityPayload => ({
-  payload,
-  type: getTeamPublicity,
-})
 export const createIgnoreRequest = (payload: _IgnoreRequestPayload): IgnoreRequestPayload => ({
   payload,
   type: ignoreRequest,
@@ -541,9 +518,6 @@ export const createSetTeamLoadingInvites = (
 export const createSetTeamProfileAddList = (
   payload: _SetTeamProfileAddListPayload
 ): SetTeamProfileAddListPayload => ({payload, type: setTeamProfileAddList})
-export const createSetTeamPublicitySettings = (
-  payload: _SetTeamPublicitySettingsPayload
-): SetTeamPublicitySettingsPayload => ({payload, type: setTeamPublicitySettings})
 export const createSetTeamRetentionPolicy = (
   payload: _SetTeamRetentionPolicyPayload
 ): SetTeamRetentionPolicyPayload => ({payload, type: setTeamRetentionPolicy})
@@ -560,6 +534,10 @@ export const createSetTeamSawChatBanner = (
 export const createSetTeamSawSubteamsBanner = (
   payload: _SetTeamSawSubteamsBannerPayload
 ): SetTeamSawSubteamsBannerPayload => ({payload, type: setTeamSawSubteamsBanner})
+export const createSetTeamVersion = (payload: _SetTeamVersionPayload): SetTeamVersionPayload => ({
+  payload,
+  type: setTeamVersion,
+})
 export const createSetTeamsWithChosenChannels = (
   payload: _SetTeamsWithChosenChannelsPayload
 ): SetTeamsWithChosenChannelsPayload => ({payload, type: setTeamsWithChosenChannels})
@@ -577,6 +555,10 @@ export const createSettingsError = (payload: _SettingsErrorPayload): SettingsErr
 export const createTeamCreated = (payload: _TeamCreatedPayload): TeamCreatedPayload => ({
   payload,
   type: teamCreated,
+})
+export const createTeamLoaded = (payload: _TeamLoadedPayload): TeamLoadedPayload => ({
+  payload,
+  type: teamLoaded,
 })
 export const createUpdateChannelName = (payload: _UpdateChannelNamePayload): UpdateChannelNamePayload => ({
   payload,
@@ -652,19 +634,10 @@ export type GetChannelInfoPayload = {
   readonly type: typeof getChannelInfo
 }
 export type GetChannelsPayload = {readonly payload: _GetChannelsPayload; readonly type: typeof getChannels}
-export type GetDetailsByIDPayload = {
-  readonly payload: _GetDetailsByIDPayload
-  readonly type: typeof getDetailsByID
-}
-export type GetDetailsPayload = {readonly payload: _GetDetailsPayload; readonly type: typeof getDetails}
 export type GetMembersPayload = {readonly payload: _GetMembersPayload; readonly type: typeof getMembers}
 export type GetTeamProfileAddListPayload = {
   readonly payload: _GetTeamProfileAddListPayload
   readonly type: typeof getTeamProfileAddList
-}
-export type GetTeamPublicityPayload = {
-  readonly payload: _GetTeamPublicityPayload
-  readonly type: typeof getTeamPublicity
 }
 export type GetTeamRetentionPolicyPayload = {
   readonly payload: _GetTeamRetentionPolicyPayload
@@ -686,6 +659,7 @@ export type InviteToTeamByPhonePayload = {
 export type JoinTeamPayload = {readonly payload: _JoinTeamPayload; readonly type: typeof joinTeam}
 export type LeaveTeamPayload = {readonly payload: _LeaveTeamPayload; readonly type: typeof leaveTeam}
 export type LeftTeamPayload = {readonly payload: _LeftTeamPayload; readonly type: typeof leftTeam}
+export type LoadTeamPayload = {readonly payload: _LoadTeamPayload; readonly type: typeof loadTeam}
 export type ReAddToTeamPayload = {readonly payload: _ReAddToTeamPayload; readonly type: typeof reAddToTeam}
 export type RemoveMemberPayload = {readonly payload: _RemoveMemberPayload; readonly type: typeof removeMember}
 export type RemoveParticipantPayload = {
@@ -776,10 +750,6 @@ export type SetTeamProfileAddListPayload = {
   readonly payload: _SetTeamProfileAddListPayload
   readonly type: typeof setTeamProfileAddList
 }
-export type SetTeamPublicitySettingsPayload = {
-  readonly payload: _SetTeamPublicitySettingsPayload
-  readonly type: typeof setTeamPublicitySettings
-}
 export type SetTeamRetentionPolicyPayload = {
   readonly payload: _SetTeamRetentionPolicyPayload
   readonly type: typeof setTeamRetentionPolicy
@@ -800,6 +770,10 @@ export type SetTeamSawSubteamsBannerPayload = {
   readonly payload: _SetTeamSawSubteamsBannerPayload
   readonly type: typeof setTeamSawSubteamsBanner
 }
+export type SetTeamVersionPayload = {
+  readonly payload: _SetTeamVersionPayload
+  readonly type: typeof setTeamVersion
+}
 export type SetTeamsWithChosenChannelsPayload = {
   readonly payload: _SetTeamsWithChosenChannelsPayload
   readonly type: typeof setTeamsWithChosenChannels
@@ -817,6 +791,7 @@ export type SettingsErrorPayload = {
   readonly type: typeof settingsError
 }
 export type TeamCreatedPayload = {readonly payload: _TeamCreatedPayload; readonly type: typeof teamCreated}
+export type TeamLoadedPayload = {readonly payload: _TeamLoadedPayload; readonly type: typeof teamLoaded}
 export type ToggleInvitesCollapsedPayload = {
   readonly payload: _ToggleInvitesCollapsedPayload
   readonly type: typeof toggleInvitesCollapsed
@@ -860,11 +835,8 @@ export type Actions =
   | EditTeamDescriptionPayload
   | GetChannelInfoPayload
   | GetChannelsPayload
-  | GetDetailsByIDPayload
-  | GetDetailsPayload
   | GetMembersPayload
   | GetTeamProfileAddListPayload
-  | GetTeamPublicityPayload
   | GetTeamRetentionPolicyPayload
   | GetTeamsPayload
   | IgnoreRequestPayload
@@ -873,6 +845,7 @@ export type Actions =
   | JoinTeamPayload
   | LeaveTeamPayload
   | LeftTeamPayload
+  | LoadTeamPayload
   | ReAddToTeamPayload
   | RemoveMemberPayload
   | RemoveParticipantPayload
@@ -900,17 +873,18 @@ export type Actions =
   | SetTeamJoinSuccessPayload
   | SetTeamLoadingInvitesPayload
   | SetTeamProfileAddListPayload
-  | SetTeamPublicitySettingsPayload
   | SetTeamRetentionPolicyPayload
   | SetTeamRoleMapLatestKnownVersionPayload
   | SetTeamRoleMapPayload
   | SetTeamSawChatBannerPayload
   | SetTeamSawSubteamsBannerPayload
+  | SetTeamVersionPayload
   | SetTeamsWithChosenChannelsPayload
   | SetUpdatedChannelNamePayload
   | SetUpdatedTopicPayload
   | SettingsErrorPayload
   | TeamCreatedPayload
+  | TeamLoadedPayload
   | ToggleInvitesCollapsedPayload
   | UnsubscribeTeamDetailsPayload
   | UnsubscribeTeamListPayload

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -250,11 +250,10 @@ function* inviteByEmail(_: TypedState, action: TeamsGen.InviteToTeamByEmailPaylo
         yield Saga.put(RouteTreeGen.createClearModals())
       }
     }
-    // TODO: make sure this works
-    // yield Saga.put(TeamsGen.createGetDetails({clearInviteLoadingKey: loadingKey, teamname}))
   } catch (err) {
     // other error. display messages and leave all emails in input box
     yield Saga.put(TeamsGen.createSetEmailInviteError({malformed: [], message: err.desc}))
+  } finally {
     if (loadingKey) {
       yield Saga.put(TeamsGen.createSetTeamLoadingInvites({isLoading: false, loadingKey, teamname}))
     }

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -484,10 +484,10 @@ const ignoreRequest = async (action: TeamsGen.IgnoreRequestPayload) => {
       {name: teamname, username},
       Constants.teamWaitingKey(teamname)
     )
-    return false
   } catch (_) {
     // TODO handle error
   }
+  return false
 }
 
 async function createNewTeamFromConversation(

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -250,8 +250,8 @@ function* inviteByEmail(_: TypedState, action: TeamsGen.InviteToTeamByEmailPaylo
         yield Saga.put(RouteTreeGen.createClearModals())
       }
     }
-    // TODO: refactor invite situation
-    yield Saga.put(TeamsGen.createGetDetails({clearInviteLoadingKey: loadingKey, teamname}))
+    // TODO: make sure this works
+    // yield Saga.put(TeamsGen.createGetDetails({clearInviteLoadingKey: loadingKey, teamname}))
   } catch (err) {
     // other error. display messages and leave all emails in input box
     yield Saga.put(TeamsGen.createSetEmailInviteError({malformed: [], message: err.desc}))
@@ -464,7 +464,10 @@ function* inviteToTeamByPhone(
     /* Open SMS */
     const bodyText = generateSMSBody(teamname, seitan)
     yield openSMS([phoneNumber], bodyText)
-    return TeamsGen.createGetDetails({clearInviteLoadingKey: loadingKey, teamname})
+    if (loadingKey) {
+      return TeamsGen.createSetTeamLoadingInvites({isLoading: false, loadingKey, teamname})
+    }
+    return false
   } catch (err) {
     logger.info('Error sending SMS', err)
     if (loadingKey) {
@@ -483,10 +486,7 @@ const ignoreRequest = async (action: TeamsGen.IgnoreRequestPayload) => {
     )
     return false
   } catch (_) {
-    // TODO handle error, but for now make sure loading is unset
-    // TODO get rid of this once core sends us a notification for this (CORE-7125)
-    // TODO just unset loading without calling this
-    return TeamsGen.createGetDetails({teamname}) // getDetails will unset loading
+    // TODO handle error
   }
 }
 
@@ -512,106 +512,15 @@ async function createNewTeamFromConversation(
   })
 }
 
-function* getDetailsByID(state: TypedState, action: TeamsGen.GetDetailsByIDPayload, logger: Saga.SagaLogger) {
-  const {teamID, _subscribe} = action.payload
-  let teamname = ''
+const loadTeam = async (_: TypedState, action: TeamsGen.LoadTeamPayload, logger: Saga.SagaLogger) => {
+  const {teamID} = action.payload
 
-  // If we're already subscribed to team details for this team ID, we're already up to date
-  const subscriptions = state.teams.teamDetailsSubscriptionCount.get(teamID) ?? 0
-  if (_subscribe && subscriptions > 1) {
+  if (!teamID || teamID === Types.noTeamID) {
+    logger.warn(`bail on invalid team ID ${teamID}`)
     return
   }
-
-  const waitingKeys = [Constants.teamWaitingKeyByID(teamID, state), Constants.teamGetWaitingKey(teamID)]
-
-  yield Saga.put(TeamsGen.createGetTeamPublicity({teamID}))
-
-  try {
-    const unsafeDetails: Saga.RPCPromiseType<typeof RPCTypes.teamsTeamGetByIDRpcPromise> = yield RPCTypes.teamsTeamGetByIDRpcPromise(
-      {id: teamID},
-      waitingKeys
-    )
-
-    // Don't allow the none default
-    const details: RPCTypes.TeamDetails = {
-      ...unsafeDetails,
-      settings: {
-        ...unsafeDetails.settings,
-        joinAs:
-          unsafeDetails.settings.joinAs === RPCTypes.TeamRole.none
-            ? RPCTypes.TeamRole.reader
-            : unsafeDetails.settings.joinAs,
-      },
-    }
-    teamname = unsafeDetails.name
-
-    // Get requests to join
-    let requests: Saga.RPCPromiseType<typeof RPCTypes.teamsTeamListRequestsRpcPromise> | undefined
-    const state: TypedState = yield* Saga.selectState()
-    if (Constants.getCanPerformByID(state, teamID).manageMembers) {
-      // TODO (DESKTOP-6478) move this somewhere else
-      requests = yield RPCTypes.teamsTeamListRequestsRpcPromise({teamName: teamname}, waitingKeys)
-    }
-
-    if (!requests) {
-      requests = []
-    }
-    requests.sort((a, b) => a.username.localeCompare(b.username))
-
-    const requestMap = new Map<string, Array<string>>()
-    requests.forEach(request => {
-      let arr = requestMap.get(request.name)
-      if (!arr) {
-        arr = []
-        requestMap.set(request.name, arr)
-      }
-      arr.push(request.username)
-    })
-
-    const invites = Constants.annotatedInvitesToInviteInfo(details.annotatedActiveInvites)
-
-    // Get the subteam map for this team.
-    const subTeam: Saga.RPCPromiseType<typeof RPCTypes.teamsTeamGetSubteamsRpcPromise> = yield RPCTypes.teamsTeamGetSubteamsRpcPromise(
-      {name: {parts: teamname.split('.')}},
-      waitingKeys
-    )
-    const {entries} = subTeam
-    const subteamIDs = new Set<Types.TeamID>()
-    const subteams = (entries || []).reduce<Array<string>>((arr, {name, teamID}) => {
-      name.parts && arr.push(name.parts.join('.'))
-      subteamIDs.add(teamID)
-      return arr
-    }, [])
-    yield Saga.put(
-      TeamsGen.createSetTeamDetails({
-        invites,
-        members: details.members,
-        requests: requestMap,
-        settings: details.settings,
-        subteamIDs,
-        subteams: subteams,
-        teamID,
-        teamname,
-      })
-    )
-  } catch (e) {
-    logger.warn(e)
-  } finally {
-    const loadingKey = action.payload.clearInviteLoadingKey
-    if (loadingKey) {
-      yield Saga.put(TeamsGen.createSetTeamLoadingInvites({isLoading: false, loadingKey, teamname}))
-    }
-  }
-}
-
-const getDetails = (state: TypedState, action: TeamsGen.GetDetailsPayload) => {
-  const {teamname, clearInviteLoadingKey} = action.payload
-  const teamID = Constants.getTeamID(state, teamname)
-  if (teamID) {
-    return TeamsGen.createGetDetailsByID({clearInviteLoadingKey, teamID})
-  } else {
-    throw new Error(`Could not get team ID in getDetails for team: ${teamname}`)
-  }
+  const team = await RPCTypes.teamsGetAnnotatedTeamRpcPromise({teamID})
+  return TeamsGen.createTeamLoaded({details: Constants.annotatedTeamToDetails(team), teamID})
 }
 
 function* addUserToTeams(state: TypedState, action: TeamsGen.AddUserToTeamsPayload, logger: Saga.SagaLogger) {
@@ -675,42 +584,6 @@ function* addUserToTeams(state: TypedState, action: TeamsGen.AddUserToTeamsPaylo
       results: result,
     })
   )
-}
-
-function* getTeamPublicity(
-  state: TypedState,
-  action: TeamsGen.GetTeamPublicityPayload,
-  logger: Saga.SagaLogger
-) {
-  try {
-    const teamID = action.payload.teamID
-    // Get publicity settings for this team.
-    const publicity: Saga.RPCPromiseType<typeof RPCTypes.teamsGetTeamAndMemberShowcaseRpcPromise> = yield RPCTypes.teamsGetTeamAndMemberShowcaseRpcPromise(
-      {teamID},
-      Constants.teamWaitingKeyByID(teamID, state)
-    )
-
-    let tarsDisabled: Saga.RPCPromiseType<typeof RPCTypes.teamsGetTarsDisabledRpcPromise> = false
-    // can throw if you're not an admin
-    try {
-      tarsDisabled = yield RPCTypes.teamsGetTarsDisabledRpcPromise(
-        {teamID},
-        Constants.teamTarsWaitingKey(teamID)
-      )
-    } catch (_) {}
-
-    const publicityMap = {
-      anyMemberShowcase: publicity.teamShowcase.anyMemberShowcase,
-      description: publicity.teamShowcase.description || '',
-      ignoreAccessRequests: tarsDisabled,
-      member: publicity.isMemberShowcased,
-      team: publicity.teamShowcase.isShowcased,
-    }
-
-    yield Saga.put(TeamsGen.createSetTeamPublicitySettings({publicity: publicityMap, teamID}))
-  } catch (e) {
-    logger.info(e.message)
-  }
 }
 
 const getChannelInfo = async (
@@ -803,7 +676,7 @@ function* getTeams(
   }
   if (action.type === TeamsGen.getTeams) {
     const {forceReload} = action.payload
-    if (!forceReload && !state.teams.teamDetailsMetaStale) {
+    if (!forceReload && !state.teams.teamMetaStale) {
       // bail
       return
     }
@@ -825,7 +698,7 @@ function* getTeams(
 
     yield Saga.put(
       TeamsGen.createSetTeamInfo({
-        teamDetails: Constants.teamListToDetails(teams),
+        teamMeta: Constants.teamListToMeta(teams),
         teamNameToID,
         teamnames: teamNameSet,
       })
@@ -990,16 +863,15 @@ function* setPublicity(state: TypedState, action: TeamsGen.SetPublicityPayload) 
 
   const waitingKey = Constants.settingsWaitingKey(teamID)
 
-  const teamSettings = state.teams.teamDetails.get(teamID)?.settings || Constants.initialTeamSettings
+  const teamMeta = Constants.getTeamMeta(state, teamID)
+  const teamSettings = Constants.getTeamDetails(state, teamID).settings
 
-  const teamPublicitySettings = Constants.getTeamPublicitySettings(state, teamID)
-
-  const ignoreAccessRequests = teamPublicitySettings.ignoreAccessRequests
+  const ignoreAccessRequests = teamSettings.tarsDisabled
   const openTeam = teamSettings.open
-  const openTeamRole = Constants.teamRoleByEnum[teamSettings.joinAs]
-  const publicityAnyMember = teamPublicitySettings.anyMemberShowcase
-  const publicityMember = teamPublicitySettings.member
-  const publicityTeam = teamPublicitySettings.team
+  const openTeamRole = teamSettings.openJoinAs
+  const publicityAnyMember = teamMeta.allowPromote
+  const publicityMember = teamMeta.showcasing
+  const publicityTeam = teamSettings.teamShowcased
 
   const calls: Array<any> = []
   if (openTeam !== settings.openTeam || (settings.openTeam && openTeamRole !== settings.openTeamRole)) {
@@ -1095,12 +967,20 @@ function* setPublicity(state: TypedState, action: TeamsGen.SetPublicityPayload) 
 }
 
 const teamChangedByID = (state: TypedState, action: EngineGen.Keybase1NotifyTeamTeamChangedByIDPayload) => {
-  const {teamID} = action.payload.params
-  if (state.teams.teamDetailsSubscriptionCount.get(teamID)) {
-    // only reload if that team is selected or subscribed to
-    return TeamsGen.createGetDetailsByID({teamID})
+  const {teamID, latestHiddenSeqno, latestOffchainSeqno, latestSeqno} = action.payload.params
+  const version = state.teams.teamVersion.get(teamID)
+  let versionChanged = true
+  if (version) {
+    versionChanged =
+      latestHiddenSeqno > version.latestHiddenSeqno ||
+      latestOffchainSeqno > version.latestOffchainSeqno ||
+      latestSeqno > version.latestSeqno
   }
-  return []
+  const shouldLoad = versionChanged && !!state.teams.teamDetailsSubscriptionCount.get(teamID)
+  return [
+    TeamsGen.createSetTeamVersion({teamID, version: {latestHiddenSeqno, latestOffchainSeqno, latestSeqno}}),
+    shouldLoad && TeamsGen.createLoadTeam({teamID}),
+  ]
 }
 
 const teamRoleMapChangedUpdateLatestKnownVersion = (
@@ -1138,13 +1018,13 @@ const teamDeletedOrExit = (
   const {teamID} = action.payload.params
   const selectedTeams = Constants.getSelectedTeams()
   if (selectedTeams.includes(teamID)) {
-    return [RouteTreeGen.createNavUpToScreen({routeName: 'teamsRoot'})]
+    return RouteTreeGen.createNavUpToScreen({routeName: 'teamsRoot'})
   }
-  return []
+  return false
 }
 
 const reloadTeamListIfSubscribed = (state: TypedState, _: unknown, logger: Saga.SagaLogger) => {
-  if (state.teams.teamDetailsMetaSubscribeCount > 0) {
+  if (state.teams.teamMetaSubscribeCount > 0) {
     logger.info('eagerly reloading')
     return TeamsGen.createGetTeams()
   } else {
@@ -1410,10 +1290,8 @@ const teamsSaga = function*() {
   yield* Saga.chainAction(TeamsGen.createNewTeam, createNewTeam)
   yield* Saga.chainAction(TeamsGen.teamCreated, showTeamAfterCreation)
   yield* Saga.chainGenerator<TeamsGen.JoinTeamPayload>(TeamsGen.joinTeam, joinTeam)
-  yield* Saga.chainAction2(TeamsGen.getDetails, getDetails)
-  yield* Saga.chainGenerator<TeamsGen.GetDetailsByIDPayload>(TeamsGen.getDetailsByID, getDetailsByID)
+  yield* Saga.chainAction2(TeamsGen.loadTeam, loadTeam)
   yield* Saga.chainAction(TeamsGen.getMembers, getMembers)
-  yield* Saga.chainGenerator<TeamsGen.GetTeamPublicityPayload>(TeamsGen.getTeamPublicity, getTeamPublicity)
   yield* Saga.chainAction2(TeamsGen.createNewTeamFromConversation, createNewTeamFromConversation)
   yield* Saga.chainAction2(TeamsGen.getChannelInfo, getChannelInfo)
   yield* Saga.chainAction2(TeamsGen.getChannels, getChannels)

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -897,13 +897,13 @@ export type TypedActionsMap = {
   'teams:getChannels': teams.GetChannelsPayload
   'teams:getTeams': teams.GetTeamsPayload
   'teams:unsubscribeTeamList': teams.UnsubscribeTeamListPayload
-  'teams:getDetails': teams.GetDetailsPayload
-  'teams:getDetailsByID': teams.GetDetailsByIDPayload
+  'teams:loadTeam': teams.LoadTeamPayload
+  'teams:teamLoaded': teams.TeamLoadedPayload
   'teams:unsubscribeTeamDetails': teams.UnsubscribeTeamDetailsPayload
+  'teams:setTeamVersion': teams.SetTeamVersionPayload
   'teams:getMembers': teams.GetMembersPayload
   'teams:setMembers': teams.SetMembersPayload
   'teams:getTeamProfileAddList': teams.GetTeamProfileAddListPayload
-  'teams:getTeamPublicity': teams.GetTeamPublicityPayload
   'teams:addTeamWithChosenChannels': teams.AddTeamWithChosenChannelsPayload
   'teams:saveChannelMembership': teams.SaveChannelMembershipPayload
   'teams:addParticipant': teams.AddParticipantPayload
@@ -937,7 +937,6 @@ export type TypedActionsMap = {
   'teams:setTeamLoadingInvites': teams.SetTeamLoadingInvitesPayload
   'teams:setTeamDetails': teams.SetTeamDetailsPayload
   'teams:setTeamCanPerform': teams.SetTeamCanPerformPayload
-  'teams:setTeamPublicitySettings': teams.SetTeamPublicitySettingsPayload
   'teams:setTeamChannelInfo': teams.SetTeamChannelInfoPayload
   'teams:setTeamChannels': teams.SetTeamChannelsPayload
   'teams:setTeamInfo': teams.SetTeamInfoPayload

--- a/shared/chat/conversation/info-panel/menu/container.tsx
+++ b/shared/chat/conversation/info-panel/menu/container.tsx
@@ -55,7 +55,7 @@ export default Container.namedConnect(
     let _convPropsTeamType: ConvProps['teamType'] | undefined
     let _convPropsTeamname: ConvProps['teamname'] | undefined
 
-    let teamDetails: TeamTypes.TeamDetails | undefined
+    let teamMeta: TeamTypes.TeamMeta | undefined
     let teamname: string = ''
     let teamID: TeamTypes.TeamID = TeamTypes.noTeamID
     if (conversationIDKey && conversationIDKey !== ChatConstants.noConversationIDKey) {
@@ -68,7 +68,7 @@ export default Container.namedConnect(
           (state.users.infoMap.get(participants[0]) || {fullname: ''}).fullname) ||
         ''
       const isTeam = meta.teamType === 'big' || meta.teamType === 'small'
-      teamDetails = isTeam ? TeamConstants.getTeamDetails(state, meta.teamID) : undefined
+      teamMeta = isTeam ? TeamConstants.getTeamMeta(state, meta.teamID) : undefined
       teamname = meta.teamname
       teamID = meta.teamID ?? TeamTypes.noTeamID
       _convPropsFullname = fullname
@@ -80,8 +80,8 @@ export default Container.namedConnect(
       _convPropsTeamname = teamname
     } else if (_teamID) {
       teamID = _teamID
-      teamDetails = TeamConstants.getTeamDetails(state, teamID)
-      teamname = teamDetails.teamname
+      teamMeta = TeamConstants.getTeamMeta(state, teamID)
+      teamname = teamMeta.teamname
     }
     // skip a bunch of stuff for menus that aren't visible
     if (!visible) {
@@ -127,7 +127,7 @@ export default Container.namedConnect(
       isSmallTeam,
       manageChannelsSubtitle,
       manageChannelsTitle,
-      memberCount: teamDetails ? teamDetails.memberCount : 0,
+      memberCount: teamMeta?.memberCount ?? 0,
       teamname,
     }
   },

--- a/shared/common-adapters/team-with-popup/container.tsx
+++ b/shared/common-adapters/team-with-popup/container.tsx
@@ -18,12 +18,12 @@ type OwnProps = {
 const ConnectedTeamWithPopup = Container.connect(
   (state, {teamName}: OwnProps) => {
     const teamID = TeamsConstants.getTeamID(state, teamName)
-    const details: TeamsTypes.TeamDetails = TeamsConstants.getTeamDetails(state, teamID)
+    const meta = TeamsConstants.getTeamMeta(state, teamID)
     return {
-      description: TeamsConstants.getTeamPublicitySettings(state, teamID).description,
-      isMember: details.isMember,
-      isOpen: details.isOpen,
-      memberCount: details.memberCount,
+      description: TeamsConstants.getTeamDetails(state, teamID).description,
+      isMember: meta.isMember,
+      isOpen: meta.isOpen,
+      memberCount: meta.memberCount,
       teamID,
     }
   },

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -711,7 +711,7 @@ export const annotatedInvitesToInviteInfo = (
     return arr
   }, [])
 
-const emptyTeamDetails = Object.freeze<Types.TeamDetails>({
+export const emptyTeamDetails = Object.freeze<Types.TeamDetails>({
   description: '',
   invites: new Set(),
   members: new Map(),

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1307,6 +1307,10 @@ export type MessageTypes = {
     inParam: {readonly s: Stream; readonly buf: Bytes}
     outParam: Int
   }
+  'keybase.1.teams.getAnnotatedTeam': {
+    inParam: {readonly teamID: TeamID}
+    outParam: AnnotatedTeam
+  }
   'keybase.1.teams.getTarsDisabled': {
     inParam: {readonly teamID: TeamID}
     outParam: Boolean
@@ -2633,7 +2637,7 @@ export type APIUserServiceSummary = {readonly serviceName: APIUserServiceID; rea
 export type AirdropDetails = {readonly uid: UID; readonly kid: BinaryKID; readonly vid: VID; readonly vers: String; readonly time: Time}
 export type AllProvisionedUsernames = {readonly defaultUsername: String; readonly provisionedUsernames?: Array<String> | null; readonly hasProvisionedUser: Boolean}
 export type AnnotatedMemberInfo = {readonly userID: UID; readonly teamID: TeamID; readonly username: String; readonly fullName: String; readonly fqName: String; readonly isImplicitTeam: Boolean; readonly impTeamDisplayName: String; readonly isOpenTeam: Boolean; readonly role: TeamRole; readonly implicit?: ImplicitRole | null; readonly needsPUK: Boolean; readonly memberCount: Int; readonly eldestSeqno: Seqno; readonly allowProfilePromote: Boolean; readonly isMemberShowcased: Boolean; readonly status: TeamMemberStatus}
-export type AnnotatedTeam = {readonly teamID: TeamID; readonly name: String; readonly transitiveSubteamsUnverified: SubteamListResult; readonly members?: Array<AnnotatedTeamMemberDetails> | null; readonly invites?: Array<AnnotatedTeamInvite> | null; readonly joinRequests?: Array<TeamJoinRequest> | null; readonly userIsShowcasing: Boolean; readonly tarsDisabled: Boolean; readonly settings: TeamSettings; readonly showcase: TeamShowcase}
+export type AnnotatedTeam = {readonly teamID: TeamID; readonly name: String; readonly transitiveSubteamsUnverified: SubteamListResult; readonly members?: Array<AnnotatedTeamMemberDetails> | null; readonly invites?: Array<AnnotatedTeamInvite> | null; readonly joinRequests?: Array<TeamJoinRequest> | null; readonly tarsDisabled: Boolean; readonly settings: TeamSettings; readonly showcase: TeamShowcase}
 export type AnnotatedTeamInvite = {readonly role: TeamRole; readonly id: TeamInviteID; readonly type: TeamInviteType; readonly name: TeamInviteName; readonly uv: UserVersion; readonly inviter: UserVersion; readonly inviterUsername: String; readonly teamName: String; readonly status: TeamMemberStatus}
 export type AnnotatedTeamList = {readonly teams?: Array<AnnotatedMemberInfo> | null; readonly annotatedActiveInvites: {[key: string]: AnnotatedTeamInvite}}
 export type AnnotatedTeamMemberDetails = {readonly details: TeamMemberDetails; readonly role: TeamRole}
@@ -3643,6 +3647,7 @@ export const signupCheckUsernameAvailableRpcPromise = (params: MessageTypes['key
 export const signupGetInvitationCodeRpcPromise = (params: MessageTypes['keybase.1.signup.getInvitationCode']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.signup.getInvitationCode']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.signup.getInvitationCode', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const signupInviteRequestRpcPromise = (params: MessageTypes['keybase.1.signup.inviteRequest']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.signup.inviteRequest']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.signup.inviteRequest', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const signupSignupRpcSaga = (p: {params: MessageTypes['keybase.1.signup.signup']['inParam']; incomingCallMap: IncomingCallMapType; customResponseIncomingCallMap?: CustomResponseIncomingCallMap; waitingKey?: WaitingKey}) => call(getEngineSaga(), {method: 'keybase.1.signup.signup', params: p.params, incomingCallMap: p.incomingCallMap, customResponseIncomingCallMap: p.customResponseIncomingCallMap, waitingKey: p.waitingKey})
+export const teamsGetAnnotatedTeamRpcPromise = (params: MessageTypes['keybase.1.teams.getAnnotatedTeam']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getAnnotatedTeam']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getAnnotatedTeam', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.getTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamAndMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamAndMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamRoleMapRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamRoleMap']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamRoleMap']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamRoleMap', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -4078,7 +4083,6 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.teams.getTeamID'
 // 'keybase.1.teams.getTeamName'
 // 'keybase.1.teams.ftl'
-// 'keybase.1.teams.getAnnotatedTeam'
 // 'keybase.1.teamsUi.confirmRootTeamDelete'
 // 'keybase.1.teamsUi.confirmSubteamDelete'
 // 'keybase.1.teamSearch.teamSearch'

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -80,21 +80,31 @@ export type EmailInviteError = {
 
 export type AddUserToTeamsState = 'notStarted' | 'pending' | 'succeeded' | 'failed'
 
-export type TeamDetails = {
-  allowPromote: boolean
+export type TeamMeta = {
+  allowPromote: boolean // if members other than admins can showcase
   id: TeamID
   isMember: boolean
   isOpen: boolean
   memberCount: number
   role: MaybeTeamRoleType
-  showcasing: boolean
+  showcasing: boolean // if this team is showcased on your profile
   teamname: string
+}
 
-  members?: Map<string, MemberInfo>
-  settings?: TeamSettings
-  invites?: Set<InviteInfo>
-  subteams?: Set<TeamID>
-  requests?: Set<string>
+export type TeamDetails = {
+  members: Map<string, MemberInfo>
+  settings: TeamSettings2
+  invites: Set<InviteInfo>
+  subteams: Set<TeamID>
+  requests: Set<string>
+  description: string
+}
+
+export type TeamSettings2 = {
+  open: boolean
+  openJoinAs: TeamRoleType
+  tarsDisabled: boolean
+  teamShowcased: boolean // showcased on "popular teams"
 }
 
 export type TeamRoleAndDetails = {
@@ -106,6 +116,12 @@ export type TeamRoleMap = {
   latestKnownVersion: number
   loadedVersion: number
   roles: Map<TeamID, TeamRoleAndDetails>
+}
+
+export type TeamVersion = {
+  latestSeqno: number
+  latestHiddenSeqno: number
+  latestOffchainSeqno: number
 }
 
 export type State = {
@@ -129,13 +145,14 @@ export type State = {
   readonly teamJoinSuccess: boolean
   readonly teamJoinSuccessOpen: boolean
   readonly teamJoinSuccessTeamName: string
+  readonly teamMeta: Map<TeamID, TeamMeta>
+  readonly teamMetaStale: boolean // if we've received an update since we last loaded team list
+  readonly teamMetaSubscribeCount: number // if >0 we are eagerly reloading team list
   readonly teamDetails: Map<TeamID, TeamDetails>
   readonly teamDetailsSubscriptionCount: Map<TeamID, number> // >0 if we are eagerly reloading a team
-  readonly teamDetailsMetaStale: boolean // if we've received an update since we last loaded team list
-  readonly teamDetailsMetaSubscribeCount: number // if >0 we are eagerly reloading team list
   readonly teamIDToChannelInfos: Map<TeamID, Map<ConversationIDKey, ChannelInfo>>
   readonly teamIDToMembers: Map<TeamID, Map<string, MemberInfo>> // Used by chat sidebar until team loading gets easier
-  readonly teamIDToPublicitySettings: Map<TeamID, _PublicitySettings>
+  readonly teamVersion: Map<TeamID, TeamVersion>
   readonly teamIDToResetUsers: Map<TeamID, Set<string>>
   readonly teamIDToRetentionPolicy: Map<TeamID, RetentionPolicy>
   readonly teamNameToID: Map<Teamname, string>

--- a/shared/profile/add-to-team/container.tsx
+++ b/shared/profile/add-to-team/container.tsx
@@ -112,7 +112,7 @@ class AddToTeamStateWrapper extends React.Component<ExtraProps & AddToTeamProps,
 export default Container.connect(
   (state, ownProps: OwnProps) => ({
     _roles: state.teams.teamRoleMap.roles,
-    _teams: state.teams.teamDetails,
+    _teams: state.teams.teamMeta,
     _them: Container.getRouteProps(ownProps, 'username', ''),
     addUserToTeamsResults: state.teams.addUserToTeamsResults,
     addUserToTeamsState: state.teams.addUserToTeamsState,

--- a/shared/profile/showcase-team-offer/container.tsx
+++ b/shared/profile/showcase-team-offer/container.tsx
@@ -14,7 +14,7 @@ export default Container.connect(
   (state: Container.TypedState) => ({
     _waiting: state.waiting.counts,
     _you: state.config.username,
-    teamDetails: state.teams.teamDetails,
+    teamMeta: state.teams.teamMeta,
   }),
   (dispatch: Container.TypedDispatch) => ({
     onCancel: (you: string) => {
@@ -40,7 +40,7 @@ export default Container.connect(
       ...dispatchProps,
       customCancelText: 'Close',
       onCancel: () => dispatchProps.onCancel(stateProps._you),
-      teams: Constants.sortTeamsByName(stateProps.teamDetails),
+      teams: Constants.sortTeamsByName(stateProps.teamMeta),
       title: 'Feature your teams',
       waiting: stateProps._waiting,
     }

--- a/shared/profile/showcase-team-offer/index.tsx
+++ b/shared/profile/showcase-team-offer/index.tsx
@@ -22,7 +22,7 @@ export type Props = {
   headerStyle?: Object | null
   onCancel: () => void
   onPromote: (teamID: Types.TeamID, promote: boolean) => void
-  teams: ReadonlyArray<Types.TeamDetails>
+  teams: ReadonlyArray<Types.TeamMeta>
   waiting: Map<string, number>
 }
 
@@ -98,17 +98,17 @@ const ShowcaseTeamOffer = (props: Props) => {
       {!Styles.isMobile && <ShowcaseTeamOfferHeader />}
       <Kb.ScrollView>
         {Styles.isMobile && <ShowcaseTeamOfferHeader />}
-        {props.teams.map(teamDetails => (
+        {props.teams.map(teamMeta => (
           <TeamRow
-            key={teamDetails.id}
-            canShowcase={teamDetails.allowPromote}
-            isExplicitMember={teamDetails.isMember}
-            name={teamDetails.teamname}
-            isOpen={teamDetails.isOpen}
-            membercount={teamDetails.memberCount}
-            onPromote={promoted => props.onPromote(teamDetails.id, promoted)}
-            showcased={teamDetails.showcasing}
-            waiting={!!props.waiting[teamWaitingKey(teamDetails.teamname)]}
+            key={teamMeta.id}
+            canShowcase={teamMeta.allowPromote || ['admin', 'owner'].includes(teamMeta.role)}
+            isExplicitMember={teamMeta.isMember}
+            name={teamMeta.teamname}
+            isOpen={teamMeta.isOpen}
+            membercount={teamMeta.memberCount}
+            onPromote={promoted => props.onPromote(teamMeta.id, promoted)}
+            showcased={teamMeta.showcasing}
+            waiting={!!props.waiting[teamWaitingKey(teamMeta.teamname)]}
           />
         ))}
       </Kb.ScrollView>

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -79,25 +79,19 @@ export default Container.makeReducer<
     oldLoadingInvites.set(loadingKey, isLoading)
     draftState.teamNameToLoadingInvites.set(teamname, oldLoadingInvites)
   },
-  [TeamsGen.setTeamDetails]: (draftState, action) => {
-    const {teamname, teamID} = action.payload
-    const members = Constants.rpcDetailsToMemberInfos(action.payload.members)
-    const details = mapGetEnsureValue(
-      draftState.teamDetails,
+  [TeamsGen.teamLoaded]: (draftState, action) => {
+    const {teamID, details} = action.payload
+    draftState.teamDetails.set(teamID, details)
+  },
+  [TeamsGen.setTeamVersion]: (draftState, action) => {
+    const {teamID, version} = action.payload
+    draftState.teamVersion.set(
       teamID,
-      Constants.makeTeamDetails({id: teamID, teamname})
+      Constants.ratchetTeamVersion(version, draftState.teamVersion.get(teamID))
     )
-    details.members = members
-    details.settings = action.payload.settings
-    details.invites = new Set(action.payload.invites)
-    details.subteams = action.payload.subteamIDs
-    details.requests = new Set(action.payload.requests.get(teamname))
   },
   [TeamsGen.setTeamCanPerform]: (draftState, action) => {
     draftState.canPerform.set(action.payload.teamID, action.payload.teamOperation)
-  },
-  [TeamsGen.setTeamPublicitySettings]: (draftState, action) => {
-    draftState.teamIDToPublicitySettings.set(action.payload.teamID, action.payload.publicity)
   },
   [TeamsGen.setTeamChannelInfo]: (draftState, action) => {
     const {conversationIDKey, channelInfo, teamID} = action.payload
@@ -122,10 +116,10 @@ export default Container.makeReducer<
   },
   [TeamsGen.getTeams]: (draftState, action) => {
     if (action.payload._subscribe) {
-      draftState.teamDetailsMetaSubscribeCount++
+      draftState.teamMetaSubscribeCount++
     }
   },
-  [TeamsGen.getDetailsByID]: (draftState, action) => {
+  [TeamsGen.loadTeam]: (draftState, action) => {
     if (action.payload._subscribe) {
       const {teamID} = action.payload
       draftState.teamDetailsSubscriptionCount.set(
@@ -142,18 +136,18 @@ export default Container.makeReducer<
     )
   },
   [TeamsGen.unsubscribeTeamList]: draftState => {
-    if (draftState.teamDetailsMetaSubscribeCount > 0) {
-      draftState.teamDetailsMetaSubscribeCount--
+    if (draftState.teamMetaSubscribeCount > 0) {
+      draftState.teamMetaSubscribeCount--
     }
   },
   [TeamsGen.setTeamInfo]: (draftState, action) => {
     draftState.teamNameToID = action.payload.teamNameToID
     draftState.teamnames = action.payload.teamnames
-    draftState.teamDetails = Constants.mergeTeamDetails(draftState.teamDetails, action.payload.teamDetails)
-    draftState.teamDetailsMetaStale = false
+    draftState.teamMeta = Constants.mergeTeamMeta(draftState.teamMeta, action.payload.teamMeta)
+    draftState.teamMetaStale = false
   },
   [EngineGen.keybase1NotifyTeamTeamMetadataUpdate]: draftState => {
-    draftState.teamDetailsMetaStale = true
+    draftState.teamMetaStale = true
   },
   [TeamsGen.setTeamAccessRequestsPending]: (draftState, action) => {
     draftState.teamAccessRequestsPending = action.payload.accessRequestsPending

--- a/shared/settings/chat/container.tsx
+++ b/shared/settings/chat/container.tsx
@@ -29,7 +29,7 @@ export default Container.namedConnect(
       contactSettingsIndirectFollowees,
       contactSettingsTeams,
       contactSettingsTeamsEnabled,
-      teamDetails: state.teams.teamDetails,
+      teamMeta: state.teams.teamMeta,
       title: 'Chat',
       unfurlError: state.settings.chat.unfurl.unfurlError,
       unfurlMode: state.settings.chat.unfurl.unfurlMode,
@@ -57,12 +57,12 @@ export default Container.namedConnect(
     },
   }),
   (stateProps, dispatchProps, ownProps: OwnProps) => {
-    const teamDetails = TeamConstants.sortTeamsByName(stateProps.teamDetails)
+    const teamMeta = TeamConstants.sortTeamsByName(stateProps.teamMeta)
     const serverSelectedTeams = new Map(
       stateProps.contactSettingsTeams?.map(t => [t.teamID, {enabled: t.enabled}])
     )
     const selectedTeams: {[K in TeamTypes.TeamID]: boolean} = {}
-    teamDetails.forEach(t => {
+    teamMeta.forEach(t => {
       // If there's a server-provided previous choice, use that.
       if (serverSelectedTeams.has(t.id)) {
         selectedTeams[t.id] = !!serverSelectedTeams.get(t.id)?.enabled
@@ -75,7 +75,7 @@ export default Container.namedConnect(
       ...stateProps,
       ...dispatchProps,
       contactSettingsSelectedTeams: selectedTeams,
-      teamDetails,
+      teamMeta,
     }
   },
   'Chat'

--- a/shared/settings/chat/index.stories.tsx
+++ b/shared/settings/chat/index.stories.tsx
@@ -13,22 +13,22 @@ const actions = {
   },
 }
 
-const teamDetails = [
-  Constants.makeTeamDetails({
+const teamMeta = [
+  Constants.makeTeamMeta({
     id: 'openteam1',
     isMember: true,
     isOpen: true,
     teamname: 'openteam1',
   }),
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     id: 'closedteam1',
     teamname: 'closedteam1',
   }),
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     id: 'closedteam2',
     teamname: 'closedteam2',
   }),
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     id: 'closedteam3',
     teamname: 'closedteam3',
   }),
@@ -45,7 +45,7 @@ const props = {
     openteam1: false,
   },
   contactSettingsTeamsEnabled: false,
-  teamDetails,
+  teamMeta,
   unfurlMode: RPCChatTypes.UnfurlMode.whitelisted,
   unfurlWhitelist: [
     'amazon.com',
@@ -72,7 +72,7 @@ const loadErrorProps = {
   contactSettingsIndirectFollowees: false,
   contactSettingsSelectedTeams: {},
   contactSettingsTeamsEnabled: false,
-  teamDetails: [],
+  teamMeta: [],
   unfurlError: 'Unable to load link preview settings, please try again.',
   ...actions,
 }

--- a/shared/settings/chat/index.tsx
+++ b/shared/settings/chat/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 import * as Constants from '../../constants/settings'
-import {TeamDetails, TeamID} from '../../constants/types/teams'
+import {TeamMeta, TeamID} from '../../constants/types/teams'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 
@@ -22,7 +22,7 @@ export type Props = {
   ) => void
   onUnfurlSave: (mode: RPCChatTypes.UnfurlMode, whitelist: Array<string>) => void
   onRefresh: () => void
-  teamDetails: Array<TeamDetails>
+  teamMeta: Array<TeamMeta>
 }
 
 type State = {
@@ -184,17 +184,17 @@ class Chat extends React.Component<Props, State> {
                       gapStart={false}
                       gapEnd={true}
                     >
-                      {this.props.teamDetails.map(teamDetails => (
+                      {this.props.teamMeta.map(teamMeta => (
                         <TeamRow
-                          checked={this.state.contactSettingsSelectedTeams[teamDetails.id]}
-                          key={teamDetails.id}
-                          isOpen={teamDetails.isOpen}
-                          name={teamDetails.teamname}
+                          checked={this.state.contactSettingsSelectedTeams[teamMeta.id]}
+                          key={teamMeta.id}
+                          isOpen={teamMeta.isOpen}
+                          name={teamMeta.teamname}
                           onCheck={(checked: boolean) =>
                             this.setState(prevState => ({
                               contactSettingsSelectedTeams: {
                                 ...prevState.contactSettingsSelectedTeams,
-                                [teamDetails.id]: checked,
+                                [teamMeta.id]: checked,
                               },
                             }))
                           }

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -23,7 +23,7 @@ import * as TeamTypes from '../constants/types/teams'
 import {requestIdleCallback} from '../util/idle-callback'
 import {HeaderHoc, PopupDialogHoc, Button} from '../common-adapters'
 import {memoizeShallow, memoize} from '../util/memoize'
-import {getDisabledReasonsForRolePicker, getTeamDetails} from '../constants/teams'
+import {getDisabledReasonsForRolePicker, getTeamDetails, getTeamMeta} from '../constants/teams'
 import {nextRoleDown, nextRoleUp} from '../teams/role-picker'
 import {Props as HeaderHocProps} from '../common-adapters/header-hoc/types'
 import {HocExtractProps as PopupHocProps} from '../common-adapters/popup-dialog-hoc'
@@ -159,6 +159,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
     .get(trim(ownProps.searchString))
     ?.get(ownProps.selectedService)
 
+  const maybeTeamMeta = ownProps.teamID ? getTeamMeta(state, ownProps.teamID) : undefined
   const maybeTeamDetails = ownProps.teamID ? getTeamDetails(state, ownProps.teamID) : undefined
   const preExistingTeamMembers: TeamTypes.TeamDetails['members'] = maybeTeamDetails?.members ?? emptyMap
   const disabledRoles = ownProps.teamID
@@ -197,7 +198,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
     showServiceResultCount: !isMobile && deriveShowResults(ownProps.searchString),
     teamBuildingSearchResults,
     teamSoFar: deriveTeamSoFar(teamBuildingState.teamSoFar),
-    teamname: maybeTeamDetails?.teamname,
+    teamname: maybeTeamMeta?.teamname,
     userFromUserId: deriveUserFromUserIdFn(userResults, teamBuildingState.userRecs),
     waitingForCreate: WaitingConstants.anyWaiting(state, ChatConstants.waitingKeyCreating),
   }

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -40,9 +40,9 @@ const useHeaderActions = (): HeaderActionProps => {
 }
 
 const orderTeamsImpl = (
-  teams: Map<string, Types.TeamDetails>,
+  teams: Map<string, Types.TeamMeta>,
   newRequests: Map<Types.TeamID, number>
-): Array<Types.TeamDetails> =>
+): Array<Types.TeamMeta> =>
   [...teams.values()].sort((a, b) => {
     const sizeDiff = (newRequests.get(b.id) || 0) - (newRequests.get(a.id) || 0)
     if (sizeDiff != 0) return sizeDiff
@@ -95,7 +95,7 @@ Reloadable.navigationOptions = {
 const Connected = Container.connect(
   (state: Container.TypedState) => ({
     _teamresetusers: state.teams.teamIDToResetUsers || new Map(),
-    _teams: state.teams.teamDetails,
+    _teams: state.teams.teamMeta,
     deletedTeams: state.teams.deletedTeams,
     loaded: !WaitingConstants.anyWaiting(state, Constants.teamsLoadedWaitingKey),
     newTeamRequests: state.teams.newTeamRequests,

--- a/shared/teams/delete-team/container.tsx
+++ b/shared/teams/delete-team/container.tsx
@@ -11,7 +11,7 @@ type OwnProps = Container.RouteProps<{teamID: Types.TeamID}>
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const teamID = Container.getRouteProps(ownProps, 'teamID', Types.noTeamID)
-    const {teamname} = Constants.getTeamDetails(state, teamID)
+    const {teamname} = Constants.getTeamMeta(state, teamID)
     return {
       deleteWaiting: anyWaiting(state, Constants.deleteTeamWaitingKey(teamID)),
       teamID,

--- a/shared/teams/edit-team-description/index.stories.tsx
+++ b/shared/teams/edit-team-description/index.stories.tsx
@@ -11,13 +11,18 @@ const makeStore = (withErr: boolean) =>
     draftState.teams = {
       ...Constants.makeState(),
       errorInEditDescription: withErr ? 'Something has gone horribly wrong!!!' : '',
-      teamDetails: new Map([[fakeTeamID, {...Constants.emptyTeamDetails, teamname: 'description_changers'}]]),
-      teamIDToPublicitySettings: new Map([
+      teamDetails: new Map([
+        [
+          fakeTeamID,
+          {...Constants.emptyTeamDetails, description: 'A team for people who change team descriptions'},
+        ],
+      ]),
+      teamMeta: new Map([
         [
           fakeTeamID,
           {
-            ...Constants.initialPublicitySettings,
-            description: 'A team for people who change team descriptions',
+            ...Constants.emptyTeamMeta,
+            teamname: 'description changers',
           },
         ],
       ]),

--- a/shared/teams/edit-team-description/index.stories.tsx
+++ b/shared/teams/edit-team-description/index.stories.tsx
@@ -22,7 +22,7 @@ const makeStore = (withErr: boolean) =>
           fakeTeamID,
           {
             ...Constants.emptyTeamMeta,
-            teamname: 'description changers',
+            teamname: 'description_changers',
           },
         ],
       ]),

--- a/shared/teams/edit-team-description/index.tsx
+++ b/shared/teams/edit-team-description/index.tsx
@@ -15,9 +15,7 @@ const EditTeamDescription = (props: Props) => {
   const waitingKey = Container.useSelector(state => Constants.teamWaitingKeyByID(teamID, state))
   const waiting = Container.useAnyWaiting(waitingKey)
   const error = Container.useSelector(state => state.teams.errorInEditDescription)
-  const origDescription = Container.useSelector(
-    state => Constants.getTeamPublicitySettings(state, teamID).description
-  )
+  const origDescription = Container.useSelector(state => Constants.getTeamDetails(state, teamID).description)
 
   if (teamID === Types.noTeamID || teamname === null) {
     throw new Error(

--- a/shared/teams/invite-by-contact/team-invite-by-contacts.native.tsx
+++ b/shared/teams/invite-by-contact/team-invite-by-contacts.native.tsx
@@ -48,8 +48,8 @@ type TeamInviteByContactProps = {
 
 const TeamInviteByContact = (props: TeamInviteByContactProps) => {
   const {teamID, contacts, region, errorMessage} = props
-  const teamDetails = Container.useSelector(state => Constants.getTeamDetails(state, teamID))
-  const {teamname, invites} = teamDetails
+  const {teamname} = Container.useSelector(state => Constants.getTeamMeta(state, teamID))
+  const {invites} = Container.useSelector(state => Constants.getTeamDetails(state, teamID))
 
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()

--- a/shared/teams/invite-by-email/container.tsx
+++ b/shared/teams/invite-by-email/container.tsx
@@ -10,7 +10,7 @@ type OwnProps = Container.RouteProps<{teamID: string}>
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const teamID = Container.getRouteProps(ownProps, 'teamID', '')
-    const {teamname} = Constants.getTeamDetails(state, teamID)
+    const {teamname} = Constants.getTeamMeta(state, teamID)
     const inviteError = Constants.getEmailInviteError(state)
     return {
       errorMessage: inviteError.message,

--- a/shared/teams/main/index.stories.tsx
+++ b/shared/teams/main/index.stories.tsx
@@ -7,26 +7,26 @@ import TeamList from '.'
 import {Box} from '../../common-adapters'
 
 const teams = [
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     isMember: true,
     isOpen: true,
     memberCount: 5,
     teamname: 'stripe',
   }),
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     isMember: false,
     isOpen: false,
     memberCount: 1,
     teamname: 'stripe.usa',
   }),
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     id: 'techtonica_id',
     isMember: true,
     isOpen: true,
     memberCount: 1,
     teamname: 'techtonica',
   }),
-  Constants.makeTeamDetails({
+  Constants.makeTeamMeta({
     id: 'ted_talks_inc_id',
     isMember: true,
     isOpen: false,

--- a/shared/teams/main/index.tsx
+++ b/shared/teams/main/index.tsx
@@ -25,7 +25,7 @@ export type OwnProps = {
   sawChatBanner: boolean
   teamresetusers: Map<Types.TeamID, Set<string>>
   newTeamRequests: Map<Types.TeamID, number>
-  teams: Array<Types.TeamDetails>
+  teams: Array<Types.TeamMeta>
 }
 
 export type Props = OwnProps & {
@@ -114,7 +114,7 @@ type Row =
     }
   | {
       key: string
-      team: Types.TeamDetails
+      team: Types.TeamMeta
       type: 'team'
     }
   | {

--- a/shared/teams/new-team/container.tsx
+++ b/shared/teams/new-team/container.tsx
@@ -11,7 +11,7 @@ type OwnProps = Container.RouteProps<{subteamOf?: Types.TeamID}>
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const subteamOf = Container.getRouteProps(ownProps, 'subteamOf', undefined) || Types.noTeamID
-    const baseTeam = Constants.getTeamDetails(state, subteamOf).teamname
+    const baseTeam = Constants.getTeamMeta(state, subteamOf).teamname
     return {
       baseTeam,
       errorText: upperFirst(state.teams.errorInTeamCreation),

--- a/shared/teams/really-leave-team/container.tsx
+++ b/shared/teams/really-leave-team/container.tsx
@@ -30,7 +30,8 @@ const RenderLastOwner = (p: Props & ExtraProps) => {
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const teamID = Container.getRouteProps(ownProps, 'teamID', Types.noTeamID)
-    const {teamname, settings, members} = Constants.getTeamDetails(state, teamID)
+    const {teamname} = Constants.getTeamMeta(state, teamID)
+    const {settings, members} = Constants.getTeamDetails(state, teamID)
     const lastOwner = Constants.isLastOwner(state, teamID)
     const stillLoadingTeam = !members
     return {

--- a/shared/teams/subscriber.tsx
+++ b/shared/teams/subscriber.tsx
@@ -47,7 +47,7 @@ const useTeamDetailsSubscribeMobile = (teamID: Types.TeamID) => {
   const dispatch = Container.useDispatch()
   const callback: NavigationEventCallback = e => {
     if (e.type === 'didFocus') {
-      dispatch(TeamsGen.createGetDetailsByID({_subscribe: true, teamID}))
+      dispatch(TeamsGen.createLoadTeam({_subscribe: true, teamID}))
     } else if (e.type === 'willBlur') {
       dispatch(TeamsGen.createUnsubscribeTeamDetails({teamID}))
     }
@@ -60,7 +60,7 @@ const useTeamDetailsSubscribeMobile = (teamID: Types.TeamID) => {
 const useTeamDetailsSubscribeDesktop = (teamID: Types.TeamID) => {
   const dispatch = Container.useDispatch()
   React.useEffect(() => {
-    dispatch(TeamsGen.createGetDetailsByID({_subscribe: true, teamID}))
+    dispatch(TeamsGen.createLoadTeam({_subscribe: true, teamID}))
     return () => dispatch(TeamsGen.createUnsubscribeTeamDetails({teamID}))
   }, [dispatch, teamID])
 }

--- a/shared/teams/team/container.tsx
+++ b/shared/teams/team/container.tsx
@@ -31,6 +31,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
     selectedTab,
     teamDetails: Constants.getTeamDetails(state, teamID),
     teamID,
+    teamMeta: Constants.getTeamMeta(state, teamID),
     yourOperations: Constants.getCanPerformByID(state, teamID),
     yourUsername: state.config.username,
   }
@@ -43,6 +44,7 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
 const Connected = Container.compose(
   Container.connect(mapStateToProps, mapDispatchToProps, (stateProps, dispatchProps, ownProps: OwnProps) => {
     const rows = makeRows(
+      stateProps.teamMeta,
       stateProps.teamDetails,
       stateProps.selectedTab,
       stateProps.yourUsername,

--- a/shared/teams/team/custom-title/container.tsx
+++ b/shared/teams/team/custom-title/container.tsx
@@ -11,7 +11,7 @@ type OwnProps = {
 
 export default connect(
   (state, {teamID}: OwnProps) => {
-    const {teamname} = Constants.getTeamDetails(state, teamID)
+    const {teamname} = Constants.getTeamMeta(state, teamID)
     const yourOperations = Constants.getCanPerformByID(state, teamID)
     return {
       canChat: !yourOperations.joinTeam,

--- a/shared/teams/team/header/container.tsx
+++ b/shared/teams/team/header/container.tsx
@@ -17,7 +17,7 @@ export type OwnProps = {
 export default Container.connect(
   (state, {teamID}: OwnProps) => {
     const yourOperations = Constants.getCanPerformByID(state, teamID)
-    const {teamname, isOpen, memberCount} = Constants.getTeamDetails(state, teamID)
+    const {teamname, isOpen, memberCount} = Constants.getTeamMeta(state, teamID)
     return {
       _canRenameTeam: yourOperations.renameTeam,
       _you: state.config.username,
@@ -25,7 +25,7 @@ export default Container.connect(
       canEditDescription: yourOperations.editTeamDescription,
       canJoinTeam: yourOperations.joinTeam,
       canManageMembers: yourOperations.manageMembers,
-      description: Constants.getTeamPublicitySettings(state, teamID).description,
+      description: Constants.getTeamDetails(state, teamID).description,
       memberCount,
       openTeam: isOpen,
       role: Constants.getRole(state, teamID),

--- a/shared/teams/team/index.tsx
+++ b/shared/teams/team/index.tsx
@@ -5,7 +5,7 @@ import * as Styles from '../../styles'
 import TeamTabs from './tabs/container'
 import {Row} from './rows'
 import renderRow from './rows/render'
-import {TeamDetailsSubscriber} from '../subscriber'
+import {TeamDetailsSubscriber, TeamsSubscriber} from '../subscriber'
 
 export type Sections = Array<{data: Array<Row>; header?: Row; key: string}>
 
@@ -55,6 +55,7 @@ class Team extends React.Component<Props> {
   render() {
     return (
       <Kb.Box style={styles.container}>
+        <TeamsSubscriber />
         <TeamDetailsSubscriber teamID={this.props.teamID} />
         <Kb.SectionList
           alwaysVounceVertical={false}

--- a/shared/teams/team/member/container.tsx
+++ b/shared/teams/team/member/container.tsx
@@ -16,7 +16,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   const username = Container.getRouteProps(ownProps, 'username', '')
   const teamID = Container.getRouteProps(ownProps, 'teamID', Types.noTeamID)
   const teamDetails = Constants.getTeamDetails(state, teamID)
-  const {teamname} = teamDetails
+  const {teamname} = Constants.getTeamMeta(state, teamID)
   const disabledReasonsForRolePicker = Constants.getDisabledReasonsForRolePicker(state, teamID, username)
 
   return {
@@ -114,7 +114,7 @@ export default Container.connect(
     }
     // If they're an owner, you need to be an owner to edit them
     // otherwise you just need to be an admin
-    let admin = user.type === 'owner' ? you.type === 'owner' : stateProps.yourOperations.manageMembers
+    const admin = user.type === 'owner' ? you.type === 'owner' : stateProps.yourOperations.manageMembers
 
     return {
       admin,

--- a/shared/teams/team/menu-container.tsx
+++ b/shared/teams/team/menu-container.tsx
@@ -25,7 +25,7 @@ const mapStateToProps = (state: Container.TypedState, {teamID}: OwnProps) => {
     canManageChat: yourOperations.renameChannel,
     canViewFolder: !yourOperations.joinTeam,
     isBigTeam,
-    teamname: teamname,
+    teamname,
   }
 }
 

--- a/shared/teams/team/menu-container.tsx
+++ b/shared/teams/team/menu-container.tsx
@@ -16,15 +16,16 @@ type OwnProps = {
 
 const mapStateToProps = (state: Container.TypedState, {teamID}: OwnProps) => {
   const teamDetails = Constants.getTeamDetails(state, teamID)
+  const {teamname} = Constants.getTeamMeta(state, teamID)
   const yourOperations = Constants.getCanPerformByID(state, teamID)
-  const isBigTeam = Constants.isBigTeam(state, teamDetails.teamname)
+  const isBigTeam = Constants.isBigTeam(state, teamname)
   return {
     canCreateSubteam: yourOperations.manageSubteams,
     canDeleteTeam: yourOperations.deleteTeam && teamDetails.subteams?.size === 0,
     canManageChat: yourOperations.renameChannel,
     canViewFolder: !yourOperations.joinTeam,
     isBigTeam,
-    teamname: teamDetails.teamname,
+    teamname: teamname,
   }
 }
 

--- a/shared/teams/team/nav-header/container.tsx
+++ b/shared/teams/team/nav-header/container.tsx
@@ -20,7 +20,7 @@ type OwnProps = {
 export const HeaderRightActions = Container.connect(
   (state, {teamID}: OwnProps) => {
     const yourOperations = Constants.getCanPerformByID(state, teamID)
-    const {teamname} = Constants.getTeamDetails(state, teamID)
+    const {teamname} = Constants.getTeamMeta(state, teamID)
     return {
       canAddPeople: yourOperations.manageMembers,
       canChat: !yourOperations.joinTeam,
@@ -44,13 +44,13 @@ export const HeaderRightActions = Container.connect(
 
 export const HeaderTitle = Container.connect(
   (state, {teamID}: OwnProps) => {
-    const details = Constants.getTeamDetails(state, teamID)
-    const {role, memberCount, teamname} = details
+    const meta = Constants.getTeamMeta(state, teamID)
+    const {role, memberCount, teamname} = meta
     const yourOperations = Constants.getCanPerformByID(state, teamID)
     return {
       _canEditDescAvatar: yourOperations.editTeamDescription,
       _canRenameTeam: yourOperations.renameTeam,
-      description: Constants.getTeamPublicitySettings(state, teamID).description,
+      description: Constants.getTeamDetails(state, teamID).description,
       members: memberCount,
       role,
       teamname,
@@ -88,7 +88,6 @@ export const HeaderTitle = Container.connect(
 export const SubHeader = Container.namedConnect(
   (state, {teamID}: OwnProps) => ({
     _canAddSelf: Constants.getCanPerformByID(state, teamID).joinTeam,
-    _teamname: Constants.getTeamDetails(state, teamID).teamname,
     _you: state.config.username,
   }),
   (dispatch, {teamID}) => ({

--- a/shared/teams/team/rows/bot-row/bot/container.tsx
+++ b/shared/teams/team/rows/bot-row/bot/container.tsx
@@ -17,9 +17,10 @@ const blankInfo = Constants.initialMemberInfo
 
 export default connect(
   (state, {teamID, username}: OwnProps) => {
+    const {teamname} = Constants.getTeamMeta(state, teamID)
     const teamDetails = Constants.getTeamDetails(state, teamID)
     const canManageBots = Constants.getCanPerformByID(state, teamID).manageBots
-    const {members: map = new Map<string, Types.MemberInfo>(), teamname} = teamDetails
+    const {members: map = new Map<string, Types.MemberInfo>()} = teamDetails
     const info: Types.MemberInfo = map.get(username) || blankInfo
     const bot: RPCTypes.FeaturedBot = state.chat2.featuredBotsMap.get(username) ?? {
       botAlias: info.fullName,

--- a/shared/teams/team/rows/index.tsx
+++ b/shared/teams/team/rows/index.tsx
@@ -100,7 +100,7 @@ const makeRows = (
           username: user.username,
         }))
       )
-      if (meta.memberCount > 0 && !details.members) {
+      if (meta.memberCount > 0 && !details.members.size) {
         // loading
         rows.push({key: 'loading', type: 'loading'})
       }

--- a/shared/teams/team/rows/index.tsx
+++ b/shared/teams/team/rows/index.tsx
@@ -37,6 +37,7 @@ export type Row =
   | LoadingRow
 
 const makeRows = (
+  meta: Types.TeamMeta,
   details: Types.TeamDetails,
   selectedTab: Types.TabKey,
   yourUsername: string,
@@ -75,7 +76,7 @@ const makeRows = (
             key: 'member-divider:invites',
             type: 'divider',
           })
-          if (!invitesCollapsed.has(details.id)) {
+          if (!invitesCollapsed.has(meta.id)) {
             rows.push(
               ...[...details.invites]
                 .sort(sortInvites)
@@ -86,7 +87,7 @@ const makeRows = (
       }
       if (flags.teamsRedesign) {
         rows.push({
-          count: details.memberCount,
+          count: meta.memberCount,
           dividerType: 'members',
           key: 'member-divider:members',
           type: 'divider',
@@ -99,7 +100,7 @@ const makeRows = (
           username: user.username,
         }))
       )
-      if (details.memberCount > 0 && !details.members) {
+      if (meta.memberCount > 0 && !details.members) {
         // loading
         rows.push({key: 'loading', type: 'loading'})
       }
@@ -113,7 +114,7 @@ const makeRows = (
           username: bot.username,
         }))
       )
-      if (details.memberCount > 0 && !details.members) {
+      if (meta.memberCount > 0 && !details.members) {
         // loading
         rows.push({key: 'loading', type: 'loading'})
       }

--- a/shared/teams/team/rows/invite-row/request/container.tsx
+++ b/shared/teams/team/rows/invite-row/request/container.tsx
@@ -14,7 +14,7 @@ type OwnProps = {
 }
 
 const mapStateToProps = (state, {username, teamID}) => {
-  const {teamname} = Constants.getTeamDetails(state, teamID)
+  const {teamname} = Constants.getTeamMeta(state, teamID)
   return {
     _notifLabel:
       Constants.getTeamType(state, teamname) === 'big'

--- a/shared/teams/team/rows/member-row/container.tsx
+++ b/shared/teams/team/rows/member-row/container.tsx
@@ -18,9 +18,9 @@ const blankInfo = Constants.initialMemberInfo
 
 export default connect(
   (state, {teamID, username}: OwnProps) => {
-    const teamDetails = Constants.getTeamDetails(state, teamID)
-    const {members: map = new Map(), teamname} = teamDetails
-    const info = map.get(username) || blankInfo
+    const {members} = Constants.getTeamDetails(state, teamID)
+    const {teamname} = Constants.getTeamMeta(state, teamID)
+    const info = members.get(username) || blankInfo
 
     return {
       following: state.config.following.has(username),

--- a/shared/teams/team/rows/subteam-row/intro.tsx
+++ b/shared/teams/team/rows/subteam-row/intro.tsx
@@ -11,7 +11,7 @@ export type Props = {
 }
 
 const Banner = ({teamID}: Props) => {
-  const {teamname} = Container.useSelector(state => Constants.getTeamDetails(state, teamID))
+  const {teamname} = Container.useSelector(state => Constants.getTeamMeta(state, teamID))
   const shouldRender = Container.useSelector(state => !state.teams.sawSubteamsBanner)
   const dispatch = Container.useDispatch()
   const onHide = React.useCallback(

--- a/shared/teams/team/rows/subteam-row/team.tsx
+++ b/shared/teams/team/rows/subteam-row/team.tsx
@@ -12,7 +12,7 @@ type OwnProps = {
 
 export default Container.connect(
   (state, {teamID}: OwnProps) => {
-    const {isMember, isOpen, memberCount, teamname} = Constants.getTeamDetails(state, teamID)
+    const {isMember, isOpen, memberCount, teamname} = Constants.getTeamMeta(state, teamID)
     return {
       _isMember: isMember,
       _newTeamRequests: state.teams.newTeamRequests,

--- a/shared/teams/team/settings-tab/container.tsx
+++ b/shared/teams/team/settings-tab/container.tsx
@@ -13,22 +13,20 @@ export type OwnProps = {
 
 export default Container.connect(
   (state, {teamID}: OwnProps) => {
+    const teamMeta = Constants.getTeamMeta(state, teamID)
     const teamDetails = Constants.getTeamDetails(state, teamID)
-    const {teamname} = teamDetails
-    const publicitySettings = Constants.getTeamPublicitySettings(state, teamID)
-    const publicityAnyMember = publicitySettings.anyMemberShowcase
-    const publicityMember = publicitySettings.member
-    const publicityTeam = publicitySettings.team
+    const publicityAnyMember = teamMeta.allowPromote
+    const publicityMember = teamMeta.showcasing
+    const publicityTeam = teamDetails.settings.teamShowcased
     const settings = teamDetails.settings || Constants.initialTeamSettings
-    const openTeamRole: Types.MaybeTeamRoleType = Constants.teamRoleByEnum[settings.joinAs] || 'none'
     return {
-      canShowcase: teamDetails.allowPromote || teamDetails.role === 'admin' || teamDetails.role === 'owner',
+      canShowcase: teamMeta.allowPromote || teamMeta.role === 'admin' || teamMeta.role === 'owner',
       error: state.teams.errorInSettings,
-      ignoreAccessRequests: publicitySettings.ignoreAccessRequests,
-      isBigTeam: Constants.isBigTeam(state, teamname),
+      ignoreAccessRequests: teamDetails.settings.tarsDisabled,
+      isBigTeam: Constants.isBigTeam(state, teamMeta.teamname),
       openTeam: settings.open,
       // Cast to TeamRoleType
-      openTeamRole: openTeamRole === 'none' ? 'reader' : openTeamRole,
+      openTeamRole: teamDetails.settings.openJoinAs,
       publicityAnyMember,
       publicityMember,
       publicityTeam,

--- a/shared/teams/team/tabs/container.tsx
+++ b/shared/teams/team/tabs/container.tsx
@@ -13,6 +13,7 @@ type OwnProps = {
 
 export default Container.connect(
   (state, {teamID, selectedTab, setSelectedTab}: OwnProps) => {
+    const teamMeta = Constants.getTeamMeta(state, teamID)
     const teamDetails = Constants.getTeamDetails(state, teamID)
     const yourOperations = Constants.getCanPerformByID(state, teamID)
 
@@ -25,18 +26,18 @@ export default Container.connect(
       error: state.teams.errorInAddToTeam,
       loading: anyWaiting(
         state,
-        Constants.teamWaitingKey(teamDetails.teamname),
-        Constants.teamTarsWaitingKey(teamDetails.teamname)
+        Constants.teamWaitingKey(teamMeta.teamname),
+        Constants.teamTarsWaitingKey(teamMeta.teamname)
       ),
       newTeamRequests: state.teams.newTeamRequests,
       numInvites: teamDetails.invites?.size ?? 0,
       numRequests: teamDetails.requests?.size ?? 0,
       numSubteams: teamDetails.subteams?.size ?? 0,
-      resetUserCount: Constants.getTeamResetUsers(state, teamDetails.teamname).size,
+      resetUserCount: Constants.getTeamResetUsers(state, teamMeta.teamname).size,
       selectedTab,
       setSelectedTab,
       showSubteams: yourOperations.manageSubteams,
-      teamname: teamDetails.teamname,
+      teamname: teamMeta.teamname,
     }
   },
   dispatch => ({


### PR DESCRIPTION
- Remove `getDetails*` actions, replace by `loadTeam` which calls `getAnnotatedTeam`
- Split `TeamMeta` off from `TeamDetails`, with `TeamMeta` driving the team list and `TeamDetails` driving the team page
- Update views

Lots of this is lifted from #21580 

cc @keybase/y2ksquad 