### PR TITLE
Web of Trust: basic profile vouch list UI

### DIFF
--- a/shared/__mocks__/feature-flags.tsx
+++ b/shared/__mocks__/feature-flags.tsx
@@ -23,6 +23,7 @@ const ff: FeatureFlags = {
   stellarExternalPartners: false,
   teamsRedesign: false,
   userBlocking: true,
+  webOfTrust: false,
 }
 
 console.warn('feature flag mock in effect')

--- a/shared/constants/types/profile.tsx
+++ b/shared/constants/types/profile.tsx
@@ -2,6 +2,8 @@ import * as RPCTypes from './rpc-gen'
 import {PlatformsExpandedType} from './more'
 import {SiteIconSet} from './tracker2'
 
+export type WebOfTrustVerificationType = 'none' | 'audio' | 'video' | 'email' | 'other_chat' | 'in_person'
+
 export type ProveGenericParams = {
   readonly logoBlack: SiteIconSet
   readonly logoFull: SiteIconSet

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -80,6 +80,10 @@ export type NonUserDetails = {
   siteURL: string // https://twitter.com/bob,
 }
 
+export type WebOfTrustEntry = {
+  attestingUser: string
+}
+
 export type State = {
   readonly usernameToDetails: Map<string, Details>
   readonly usernameToNonUserDetails: Map<string, NonUserDetails>

--- a/shared/profile/profile.stories.tsx
+++ b/shared/profile/profile.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Sb from '../stories/storybook'
 import proofsList from './generic/proofs-list/index.stories'
 import {BioTeamProofs, BackgroundColorType} from './user'
+import WebOfTrust from './user/weboftrust/index'
 
 const providerUser = (cfProps =>
   Sb.createPropProviderWithCommon({
@@ -153,12 +154,20 @@ const bioPropsSBS = {
   username: 'chris@twitter',
 }
 
+const webOfTrustProps = {
+  attestation:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  attestingUser: 'chris',
+  dateString: '2 months ago',
+}
+
 const load = () => {
   proofsList()
 
   Sb.storiesOf('Profile/Profile', module)
     .addDecorator(providerUser)
     .add('BioTeamProofs', () => <BioTeamProofs {...bioPropsUser} />)
+    .add('Web of Trust', () => <WebOfTrust {...webOfTrustProps} />)
 
   Sb.storiesOf('Profile/Profile', module)
     .addDecorator(providerSBS)

--- a/shared/profile/profile.stories.tsx
+++ b/shared/profile/profile.stories.tsx
@@ -154,11 +154,25 @@ const bioPropsSBS = {
   username: 'chris@twitter',
 }
 
-const webOfTrustProps = {
+const webOfTrustPending = {
   attestation:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
   attestingUser: 'chris',
   dateString: '2 months ago',
+  onAccept: Sb.action('onAccept'),
+  onReject: Sb.action('onReject'),
+  pending: true,
+  verificationType: 'video' as 'video',
+}
+
+const webOfTrustSent = {
+  ...webOfTrustPending,
+  attestingUser: 'max',
+  dateString: '2 months ago',
+  onAccept: undefined,
+  onHide: Sb.action('onHide'),
+  onReject: undefined,
+  pending: false,
 }
 
 const load = () => {
@@ -167,7 +181,9 @@ const load = () => {
   Sb.storiesOf('Profile/Profile', module)
     .addDecorator(providerUser)
     .add('BioTeamProofs', () => <BioTeamProofs {...bioPropsUser} />)
-    .add('Web of Trust', () => <WebOfTrust {...webOfTrustProps} />)
+    .add('Web of Trust - pending', () => <WebOfTrust {...webOfTrustPending} />)
+    .add('Web of Trust - you authored', () => <WebOfTrust {...webOfTrustSent} />)
+
 
   Sb.storiesOf('Profile/Profile', module)
     .addDecorator(providerSBS)

--- a/shared/profile/profile.stories.tsx
+++ b/shared/profile/profile.stories.tsx
@@ -184,7 +184,6 @@ const load = () => {
     .add('Web of Trust - pending', () => <WebOfTrust {...webOfTrustPending} />)
     .add('Web of Trust - you authored', () => <WebOfTrust {...webOfTrustSent} />)
 
-
   Sb.storiesOf('Profile/Profile', module)
     .addDecorator(providerSBS)
     .add('SBS Profile', () => <BioTeamProofs {...bioPropsSBS} />)

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -150,6 +150,7 @@ const connected = Container.namedConnect(
       onAddIdentity,
       onBack: dispatchProps.onBack,
       onEditAvatar: stateProps.userIsYou ? dispatchProps._onEditAvatar : undefined,
+      onIKnowThem: () => {},
       onReload: () => dispatchProps._onReload(stateProps.username, stateProps.userIsYou, stateProps.state),
       reason: stateProps.reason,
       sbsAvatarUrl: stateProps.sbsAvatarUrl,

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -162,6 +162,20 @@ const connected = Container.namedConnect(
       title: stateProps.title,
       userIsYou: stateProps.userIsYou,
       username: stateProps.username,
+      webOfTrustEntries: [
+        {
+          attestation:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+          attestingUser: 'chris',
+          dateString: '2 months ago',
+        },
+        {
+          attestation:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+          attestingUser: 'max',
+          dateString: '7 months ago',
+        },
+      ],
     }
   },
   'Profile2'

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -169,12 +169,16 @@ const connected = Container.namedConnect(
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
           attestingUser: 'chris',
           dateString: '2 months ago',
+          pending: false,
+          verificationType: 'audio',
         },
         {
           attestation:
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
           attestingUser: 'max',
           dateString: '7 months ago',
+          pending: false,
+          verificationType: 'video',
         },
       ],
     }

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -163,24 +163,8 @@ const connected = Container.namedConnect(
       title: stateProps.title,
       userIsYou: stateProps.userIsYou,
       username: stateProps.username,
-      webOfTrustEntries: [
-        {
-          attestation:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-          attestingUser: 'chris',
-          dateString: '2 months ago',
-          pending: false,
-          verificationType: 'audio',
-        },
-        {
-          attestation:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-          attestingUser: 'max',
-          dateString: '7 months ago',
-          pending: false,
-          verificationType: 'video',
-        },
-      ],
+      // Integrate webOfTrust here.
+      webOfTrustEntries: [],
     }
   },
   'Profile2'

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -205,7 +205,7 @@ class Tabs extends React.Component<TabsProps> {
       <Kb.Box2 direction="horizontal" style={styles.followTabContainer} fullWidth={true}>
         {flags.webOfTrust && this._tab('webOfTrust')}
         {this._tab('followers')}
-        {this._tab('following')}f
+        {this._tab('following')}
       </Kb.Box2>
     )
   }

--- a/shared/profile/user/weboftrust/container.tsx
+++ b/shared/profile/user/weboftrust/container.tsx
@@ -1,4 +1,5 @@
 import * as Container from '../../../util/container'
+import * as Types from '../../../constants/types/profile'
 import WebOfTrust from '.'
 
 type OwnProps = {
@@ -6,24 +7,38 @@ type OwnProps = {
     attestation: string
     attestingUser: string
     dateString: string
+    pending: boolean
+    verificationType: Types.WebOfTrustVerificationType
   }
 }
 
 const Connected = Container.connect(
-  (_, ownProps: OwnProps) => {
-    console.warn('ownProps', ownProps)
-    const {attestation, attestingUser, dateString} = ownProps.webOfTrustAttestation
+  (state, ownProps: OwnProps) => {
+    const {attestation, attestingUser, dateString, pending, verificationType} = ownProps.webOfTrustAttestation
     return {
       attestation,
       attestingUser,
       dateString,
+      pending,
+      username: state.config.username,
+      verificationType,
     }
   },
-  () => ({}),
-  stateProps => ({
+  () => ({
+    _onAccept: () => {},
+    _onHide: () => {},
+    _onReject: () => {},
+  }),
+  (stateProps, dispatchProps) => ({
     attestation: stateProps.attestation,
     attestingUser: stateProps.attestingUser,
     dateString: stateProps.dateString,
+    // Send these callback down based on what type of attestation it is.
+    onAccept: dispatchProps._onAccept,
+    onHide: dispatchProps._onHide,
+    onReject: dispatchProps._onReject,
+    pending: stateProps.pending,
+    verificationType: stateProps.verificationType,
   })
 )(WebOfTrust)
 

--- a/shared/profile/user/weboftrust/container.tsx
+++ b/shared/profile/user/weboftrust/container.tsx
@@ -1,0 +1,30 @@
+import * as Container from '../../../util/container'
+import WebOfTrust from '.'
+
+type OwnProps = {
+  webOfTrustAttestation: {
+    attestation: string
+    attestingUser: string
+    dateString: string
+  }
+}
+
+const Connected = Container.connect(
+  (_, ownProps: OwnProps) => {
+    console.warn('ownProps', ownProps)
+    const {attestation, attestingUser, dateString} = ownProps.webOfTrustAttestation
+    return {
+      attestation,
+      attestingUser,
+      dateString,
+    }
+  },
+  () => ({}),
+  stateProps => ({
+    attestation: stateProps.attestation,
+    attestingUser: stateProps.attestingUser,
+    dateString: stateProps.dateString,
+  })
+)(WebOfTrust)
+
+export default Connected

--- a/shared/profile/user/weboftrust/index.tsx
+++ b/shared/profile/user/weboftrust/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import * as Types from '../../../constants/types/profile'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 
@@ -6,9 +7,14 @@ type Props = {
   attestation: string
   attestingUser: string
   dateString: string
+  onAccept?: () => void
+  onHide?: () => void
+  onReject?: () => void
+  pending: boolean
+  verificationType: Types.WebOfTrustVerificationType
 }
 
-const WebOfTrust = (props: Props) => (
+const WebOfTrust = (props: Props) => <>
   <Kb.Box2 direction="horizontal" fullWidth={true}>
     <Kb.Box2 direction="vertical" style={styles.avatarContainer} centerChildren={true}>
       <Kb.Avatar size={96} username={props.attestingUser} style={styles.avatar} showFollowingStatus={false} />
@@ -33,7 +39,15 @@ const WebOfTrust = (props: Props) => (
       </Kb.Box2>
     </Kb.Box2>
   </Kb.Box2>
-)
+  {(props.onHide || props.onAccept || props.onReject) && <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={false} style={styles.buttonBar}>
+    <Kb.ButtonBar align="flex-start">
+      {props.onHide && <Kb.Button label="Hide" small={true} type="Danger" onClick={props.onHide} />}
+      {props.onAccept && <Kb.Button label="Accept" small={true} type="Success" onClick={props.onAccept} />}
+      {props.onReject && <Kb.Button label="Reject" small={true} type="Danger" onClick={props.onReject} />}
+    </Kb.ButtonBar>
+  </Kb.Box2>
+}
+</>
 
 const styles = Styles.styleSheetCreate(() => ({
   attestationText: {alignSelf: 'flex-start'},
@@ -41,6 +55,9 @@ const styles = Styles.styleSheetCreate(() => ({
   avatarContainer: {
     justifyContent: 'space-around',
     padding: Styles.globalMargins.small,
+  },
+  buttonBar: {
+    paddingLeft: Styles.globalMargins.small,
   },
   signatureBox: {alignSelf: 'flex-end'},
   textContainer: {

--- a/shared/profile/user/weboftrust/index.tsx
+++ b/shared/profile/user/weboftrust/index.tsx
@@ -8,7 +8,7 @@ type Props = {
   dateString: string
 }
 
-export default (props: Props) => (
+const WebOfTrust = (props: Props) => (
   <Kb.Box2 direction="horizontal" fullWidth={true}>
     <Kb.Box2 direction="vertical" style={styles.avatarContainer} centerChildren={true}>
       <Kb.Avatar size={96} username={props.attestingUser} style={styles.avatar} showFollowingStatus={false} />
@@ -52,3 +52,5 @@ const styles = Styles.styleSheetCreate(() => ({
     top: -1,
   },
 }))
+
+export default WebOfTrust

--- a/shared/profile/user/weboftrust/index.tsx
+++ b/shared/profile/user/weboftrust/index.tsx
@@ -14,40 +14,55 @@ type Props = {
   verificationType: Types.WebOfTrustVerificationType
 }
 
-const WebOfTrust = (props: Props) => <>
-  <Kb.Box2 direction="horizontal" fullWidth={true}>
-    <Kb.Box2 direction="vertical" style={styles.avatarContainer} centerChildren={true}>
-      <Kb.Avatar size={96} username={props.attestingUser} style={styles.avatar} showFollowingStatus={false} />
-    </Kb.Box2>
-    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.textContainer} centerChildren={false}>
-      <Kb.Text style={styles.attestationText} type="Body">
-        {props.attestation}
-      </Kb.Text>
-      <Kb.Box2 direction="vertical" style={styles.signatureBox} centerChildren={false} fullWidth={true}>
-        <Kb.Box2 direction="horizontal" gap="xxtiny" centerChildren={true} style={{alignSelf: 'flex-start'}}>
-          <Kb.Icon color={Styles.globalColors.blue} type="iconfont-proof-good" sizeType="Small" />
-          <Kb.Text type="BodySmall">signed by </Kb.Text>{' '}
-          <Kb.ConnectedUsernames
-            type={Styles.isMobile ? 'BodySmallSemibold' : 'BodySemibold'}
-            usernames={[props.attestingUser]}
-            colorBroken={true}
-            colorFollowing={true}
-            style={styles.username}
-          />{' '}
-          <Kb.Text type="BodySmall">{props.dateString}</Kb.Text>
+const WebOfTrust = (props: Props) => (
+  <>
+    <Kb.Box2 direction="horizontal" fullWidth={true}>
+      <Kb.Box2 direction="vertical" style={styles.avatarContainer} centerChildren={true}>
+        <Kb.Avatar
+          size={96}
+          username={props.attestingUser}
+          style={styles.avatar}
+          showFollowingStatus={false}
+        />
+      </Kb.Box2>
+      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.textContainer} centerChildren={false}>
+        <Kb.Text style={styles.attestationText} type="Body">
+          {props.attestation}
+        </Kb.Text>
+        <Kb.Box2 direction="vertical" style={styles.signatureBox} centerChildren={false} fullWidth={true}>
+          <Kb.Box2
+            direction="horizontal"
+            gap="xxtiny"
+            centerChildren={true}
+            style={{alignSelf: 'flex-start'}}
+          >
+            <Kb.Icon color={Styles.globalColors.blue} type="iconfont-proof-good" sizeType="Small" />
+            <Kb.Text type="BodySmall">signed by </Kb.Text>{' '}
+            <Kb.ConnectedUsernames
+              type={Styles.isMobile ? 'BodySmallSemibold' : 'BodySemibold'}
+              usernames={[props.attestingUser]}
+              colorBroken={true}
+              colorFollowing={true}
+              style={styles.username}
+            />{' '}
+            <Kb.Text type="BodySmall">{props.dateString}</Kb.Text>
+          </Kb.Box2>
         </Kb.Box2>
       </Kb.Box2>
     </Kb.Box2>
-  </Kb.Box2>
-  {(props.onHide || props.onAccept || props.onReject) && <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={false} style={styles.buttonBar}>
-    <Kb.ButtonBar align="flex-start">
-      {props.onHide && <Kb.Button label="Hide" small={true} type="Danger" onClick={props.onHide} />}
-      {props.onAccept && <Kb.Button label="Accept" small={true} type="Success" onClick={props.onAccept} />}
-      {props.onReject && <Kb.Button label="Reject" small={true} type="Danger" onClick={props.onReject} />}
-    </Kb.ButtonBar>
-  </Kb.Box2>
-}
-</>
+    {(props.onHide || props.onAccept || props.onReject) && (
+      <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={false} style={styles.buttonBar}>
+        <Kb.ButtonBar align="flex-start">
+          {props.onHide && <Kb.Button label="Hide" small={true} type="Danger" onClick={props.onHide} />}
+          {props.onAccept && (
+            <Kb.Button label="Accept" small={true} type="Success" onClick={props.onAccept} />
+          )}
+          {props.onReject && <Kb.Button label="Reject" small={true} type="Danger" onClick={props.onReject} />}
+        </Kb.ButtonBar>
+      </Kb.Box2>
+    )}
+  </>
+)
 
 const styles = Styles.styleSheetCreate(() => ({
   attestationText: {alignSelf: 'flex-start'},

--- a/shared/profile/user/weboftrust/index.tsx
+++ b/shared/profile/user/weboftrust/index.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import * as Kb from '../../../common-adapters'
+import * as Styles from '../../../styles'
+
+type Props = {
+  attestation: string
+  attestingUser: string
+  dateString: string
+}
+
+export default (props: Props) => (
+  <Kb.Box2 direction="horizontal" fullWidth={true}>
+    <Kb.Box2 direction="vertical" style={styles.avatarContainer} centerChildren={true}>
+      <Kb.Avatar size={96} username={props.attestingUser} style={styles.avatar} showFollowingStatus={false} />
+    </Kb.Box2>
+    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.textContainer} centerChildren={false}>
+      <Kb.Text style={styles.attestationText} type="Body">
+        {props.attestation}
+      </Kb.Text>
+      <Kb.Box2 direction="vertical" style={styles.signatureBox} centerChildren={false} fullWidth={true}>
+        <Kb.Box2 direction="horizontal" gap="xxtiny" centerChildren={true} style={{alignSelf: 'flex-start'}}>
+          <Kb.Icon color={Styles.globalColors.blue} type="iconfont-proof-good" sizeType="Small" />
+          <Kb.Text type="BodySmall">signed by </Kb.Text>{' '}
+          <Kb.ConnectedUsernames
+            type={Styles.isMobile ? 'BodySmallSemibold' : 'BodySemibold'}
+            usernames={[props.attestingUser]}
+            colorBroken={true}
+            colorFollowing={true}
+            style={styles.username}
+          />{' '}
+          <Kb.Text type="BodySmall">{props.dateString}</Kb.Text>
+        </Kb.Box2>
+      </Kb.Box2>
+    </Kb.Box2>
+  </Kb.Box2>
+)
+
+const styles = Styles.styleSheetCreate(() => ({
+  attestationText: {alignSelf: 'flex-start'},
+  avatar: {marginBottom: Styles.globalMargins.xxtiny},
+  avatarContainer: {
+    justifyContent: 'space-around',
+    padding: Styles.globalMargins.small,
+  },
+  signatureBox: {alignSelf: 'flex-end'},
+  textContainer: {
+    justifyContent: 'space-around',
+    padding: Styles.globalMargins.tiny,
+  },
+  username: {
+    position: 'relative',
+    top: -1,
+  },
+}))

--- a/shared/util/feature-flags.d.ts
+++ b/shared/util/feature-flags.d.ts
@@ -11,12 +11,13 @@ export type FeatureFlags = {
   lagRadar: boolean
   moveOrCopy: boolean
   newTeamBuildingForChatAllowMakeTeam: boolean
+  openTeamSearch: boolean
   outOfDateBanner: boolean
   proofProviders: boolean
   stellarExternalPartners: boolean
   teamsRedesign: boolean
   userBlocking: boolean
-  openTeamSearch: boolean
+  webOfTrust: boolean
 }
 
 declare const ff: FeatureFlags

--- a/shared/util/feature-flags.desktop.tsx
+++ b/shared/util/feature-flags.desktop.tsx
@@ -38,7 +38,7 @@ const inAdmin: {[K in keyof FeatureFlags]?: boolean} = {
   outOfDateBanner: true,
   proofProviders: true,
   userBlocking: false,
-  webOfTrust: true,
+  webOfTrust: false,
 }
 
 // load overrides

--- a/shared/util/feature-flags.desktop.tsx
+++ b/shared/util/feature-flags.desktop.tsx
@@ -24,6 +24,7 @@ const ff: FeatureFlags = {
   stellarExternalPartners: true,
   teamsRedesign: false,
   userBlocking: true,
+  webOfTrust: false,
 }
 
 const inAdmin: {[K in keyof FeatureFlags]?: boolean} = {
@@ -37,6 +38,7 @@ const inAdmin: {[K in keyof FeatureFlags]?: boolean} = {
   outOfDateBanner: true,
   proofProviders: true,
   userBlocking: false,
+  webOfTrust: true,
 }
 
 // load overrides

--- a/shared/util/feature-flags.native.tsx
+++ b/shared/util/feature-flags.native.tsx
@@ -24,6 +24,7 @@ const ff: FeatureFlags = {
   stellarExternalPartners: true,
   teamsRedesign: false,
   userBlocking: true,
+  webOfTrust: false,
 }
 
 // load overrides


### PR DESCRIPTION
@keybase/picnicsquad 

Here's a first shot at the web of trust form.  Rather than just doing stories, I integrated it into the profile view with mocked out data.  The profile view had to be refactored -- it only supported two tabs, whether you were on Following or Followers was just a bool.

Screenshots of different configurations:

<img width="1069" alt="Screen Shot 2020-02-04 at 11 03 28 PM" src="https://user-images.githubusercontent.com/21217/73820011-9b5d9980-47a5-11ea-8eff-f2081be8d793.png">

<img width="1025" alt="Screen Shot 2020-02-04 at 11 04 21 PM" src="https://user-images.githubusercontent.com/21217/73820021-a284a780-47a5-11ea-835a-34c4a666210d.png">

<img width="1025" alt="Screen Shot 2020-02-04 at 11 04 34 PM" src="https://user-images.githubusercontent.com/21217/73820037-ab757900-47a5-11ea-8d7c-86cc20fd6c17.png">
