### PR TITLE
style markdown wrapper box for mobile

### DIFF
--- a/shared/chat/conversation/messages/attachment/image/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image/index.tsx
@@ -173,14 +173,19 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                       </Kb.Box2>
                     </Kb.ClickableBox>
                     {this.props.title.length > 0 && (
-                      <Kb.Markdown
+                      <Kb.Box2
+                        direction="vertical"
                         style={Styles.collapseStyles([styles.title])}
-                        meta={{message: this.props.message}}
-                        selectable={true}
-                        allowFontScaling={true}
+                        alignItems="flex-start"
                       >
-                        {this.props.title}
-                      </Kb.Markdown>
+                        <Kb.Markdown
+                          meta={{message: this.props.message}}
+                          selectable={true}
+                          allowFontScaling={true}
+                        >
+                          {this.props.title}
+                        </Kb.Markdown>
+                      </Kb.Box2>
                     )}
                   </Kb.Box2>
                 )}


### PR DESCRIPTION
This PR fixes an issue where attachment captions were centered on mobile instead of left-aligned. The issue was that the `Kb.Markdown` component doesn't have a wrapper on mobile (intentionally), and so didn't pick up the styles passed to the component, so setting those styles on a wrapper `Box2` fixed the issue.