### PR TITLE
Drop personalization of device name suggestion

### DIFF
--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -8,16 +8,12 @@ export const usernameHint =
 export const noEmail = 'NOEMAIL'
 export const waitingKey = 'signup:waiting'
 
-// Remove parens from the device name. Keybase device names cannot have parens.
-const cleanupDeviceName = (name: string) => name.replace(/[()]/g, '')
-
 export const defaultDevicename =
-  (Platforms.realDeviceName && cleanupDeviceName(Platforms.realDeviceName)) ||
-  (Platforms.isAndroid && 'My Android Device') ||
-  (Platforms.isIOS && 'My iOS Device') ||
-  (Platforms.isDarwin && 'My Mac Device') ||
-  (Platforms.isWindows && 'My Windows Device') ||
-  (Platforms.isLinux && 'My Linux Device') ||
+  (Platforms.isAndroid && 'Android Device') ||
+  (Platforms.isIOS && 'iOS Device') ||
+  (Platforms.isDarwin && 'Mac Device') ||
+  (Platforms.isWindows && 'Windows Device') ||
+  (Platforms.isLinux && 'Linux Device') ||
   (Platforms.isMobile ? 'Mobile Device' : 'Home Computer')
 
 export const makeState = (): Types.State => ({

--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -9,7 +9,7 @@ export const noEmail = 'NOEMAIL'
 export const waitingKey = 'signup:waiting'
 
 // Remove parens from the device name. Keybase device names cannot have parens.
-const cleanupDeviceName = (name: string) => name.replace(/[\(\)]/g, '')
+const cleanupDeviceName = (name: string) => name.replace(/[()]/g, '')
 
 export const defaultDevicename =
   cleanupDeviceName(Platforms.realDeviceName) ||

--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -8,8 +8,11 @@ export const usernameHint =
 export const noEmail = 'NOEMAIL'
 export const waitingKey = 'signup:waiting'
 
-const defaultDevicename =
-  Platforms.realDeviceName ||
+// Remove parens from the device name. Keybase device names cannot have parens.
+const cleanupDeviceName = (name: string) => name.replace(/[\(\)]/g, '')
+
+export const defaultDevicename =
+  cleanupDeviceName(Platforms.realDeviceName) ||
   (Platforms.isAndroid && 'My Android Device') ||
   (Platforms.isIOS && 'My iOS Device') ||
   (Platforms.isDarwin && 'My Mac Device') ||

--- a/shared/constants/signup.tsx
+++ b/shared/constants/signup.tsx
@@ -12,7 +12,7 @@ export const waitingKey = 'signup:waiting'
 const cleanupDeviceName = (name: string) => name.replace(/[()]/g, '')
 
 export const defaultDevicename =
-  cleanupDeviceName(Platforms.realDeviceName) ||
+  (Platforms.realDeviceName && cleanupDeviceName(Platforms.realDeviceName)) ||
   (Platforms.isAndroid && 'My Android Device') ||
   (Platforms.isIOS && 'My iOS Device') ||
   (Platforms.isDarwin && 'My Mac Device') ||

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -3,6 +3,7 @@ import * as Kb from '../../common-adapters'
 import * as Constants from '../../constants/provision'
 import * as Styles from '../../styles'
 import * as Platform from '../../constants/platform'
+import {defaultDevicename} from '../../constants/signup'
 
 import {SignupScreen, errorBanner} from '../../signup/common'
 
@@ -15,7 +16,7 @@ type Props = {
 }
 
 const SetPublicName = (props: Props) => {
-  const [deviceName, setDeviceName] = React.useState(Platform.realDeviceName ?? '')
+  const [deviceName, setDeviceName] = React.useState(defaultDevicename)
   const cleanDeviceName = Constants.cleanDeviceName(deviceName)
   const _onSubmit = props.onSubmit
   const onSubmit = React.useCallback(() => {


### PR DESCRIPTION
iPad simulator was presenting as "iPad Pro (11-inch)" which is not a valid keybase device name. ~Drop the parens so it's "iPad Pro 11-inch" which is a valid device name.~