### PR TITLE
iPad: basic support

### DIFF
--- a/shared/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/ios/Keybase.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7s arm7";
 			};
 			name = Debug;
@@ -791,7 +791,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "arm64 armv7s arm7";
 			};
 			name = Release;

--- a/shared/ios/Keybase/Info.plist
+++ b/shared/ios/Keybase/Info.plist
@@ -100,10 +100,17 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
@keybase/react-hackers 

Note: this enables non-landscape orientations for us to use while exploring, but that doesn't mean we're committing to releasing with them enabled, we might remove them in a followup PR.

(Verified that this PR doesn't break iPhone or make it rotatable.)