### PR TITLE
ipad: fix bug in deleting an email address on native

### DIFF
--- a/shared/common-adapters/confirm-modal/index.tsx
+++ b/shared/common-adapters/confirm-modal/index.tsx
@@ -106,7 +106,7 @@ const ConfirmModal = (props: Props) => (
       ) : (
         props.prompt
       )}
-      {props.description && (
+      {!!props.description && (
         <Text center={true} style={styles.text} type="Body">
           {props.description}
         </Text>


### PR DESCRIPTION
turns out this is also an issue on the iphone

if you try to delete an email address that's (1) not searchable and (2) not your last email address, the description in the modal is an empty string. and i guess this block will render as an empty string instead of nothing or a proper text node. 