### PR TITLE
search: enable indexer with special mode, and add search devel CLI command

### DIFF
--- a/go/bind/keybase.go
+++ b/go/bind/keybase.go
@@ -264,9 +264,9 @@ func (s serviceCn) NewKeybaseService(config libkbfs.Config, params libkbfs.InitP
 	// TODO: plumb the func somewhere it can be called on shutdown?
 	gitrpc, _ := libgit.NewRPCHandlerWithCtx(
 		ctx, config, nil)
+	sfsIface, _ := simplefs.NewSimpleFS(ctx, config)
 	additionalProtocols := []rpc.Protocol{
-		keybase1.SimpleFSProtocol(
-			simplefs.NewSimpleFS(ctx, config)),
+		keybase1.SimpleFSProtocol(sfsIface),
 		keybase1.KBFSGitProtocol(gitrpc),
 		keybase1.FsProtocol(fsrpc.NewFS(config, log)),
 	}

--- a/go/client/cmd_simplefs_search.go
+++ b/go/client/cmd_simplefs_search.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+const (
+	defaultNumFSSearchResults = 10
+)
+
+// CmdSimpleFSSearch is the 'fs search' command.
+type CmdSimpleFSSearch struct {
+	libkb.Contextified
+
+	query        string
+	numResults   int
+	startingFrom int
+}
+
+// NewCmdSimpleFSSearch creates a new cli.Command.
+func NewCmdSimpleFSSearch(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "search",
+		Usage: "search [flags] <query>",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSSearch{
+				Contextified: libkb.NewContextified(g)}, "search", c)
+			cl.SetNoStandalone()
+		},
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "n, num-results",
+				Usage: "how many results to return",
+				Value: defaultNumFSSearchResults,
+			},
+			cli.IntFlag{
+				Name:  "s, start-from",
+				Usage: "what number result to start from (for paging)",
+				Value: 0,
+			},
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSSearch) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	arg := keybase1.SimpleFSSearchArg{
+		Query:        c.query,
+		NumResults:   c.numResults,
+		StartingFrom: c.startingFrom,
+	}
+	res, err := cli.SimpleFSSearch(context.TODO(), arg)
+	if err != nil {
+		return err
+	}
+
+	ui := c.G().UI.GetTerminalUI()
+	if len(res.Hits) == 0 {
+		ui.Printf("No results\n")
+		return nil
+	}
+
+	for _, hit := range res.Hits {
+		ui.Printf("%s\n", hit.Path)
+	}
+	if res.NextResult != -1 {
+		ui.Printf(
+			"(For more results, use `--start-from %d` next time.)\n",
+			res.NextResult)
+	}
+	return nil
+}
+
+// ParseArgv gets the optional flags and the query.
+func (c *CmdSimpleFSSearch) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return fmt.Errorf("wrong number of arguments")
+	}
+
+	c.query = ctx.Args().Get(0)
+	c.numResults = ctx.Int("num-results")
+	if c.numResults == 0 {
+		c.numResults = defaultNumFSSearchResults
+	}
+	c.startingFrom = ctx.Int("start-from")
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSSearch) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -76,6 +76,7 @@ func getBuildSpecificFSCommands(cl *libcmdline.CommandLine, g *libkb.GlobalConte
 	return []cli.Command{
 		NewCmdSimpleFSUpgrade(cl, g),
 		NewCmdSimpleFSForceConflict(cl, g),
+		NewCmdSimpleFSSearch(cl, g),
 	}
 }
 

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -380,6 +380,12 @@ func (s SimpleFSMock) SimpleFSSetSfmiBannerDismissed(ctx context.Context, dismis
 	return nil
 }
 
+func (s SimpleFSMock) SimpleFSSearch(
+	_ context.Context, _ keybase1.SimpleFSSearchArg) (
+	keybase1.SimpleFSSearchResults, error) {
+	return keybase1.SimpleFSSearchResults{}, nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/libfuse/start.go
+++ b/go/kbfs/libfuse/start.go
@@ -7,6 +7,7 @@
 package libfuse
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -90,10 +91,13 @@ func startMounting(ctx context.Context,
 // Start the filesystem
 func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// Hook simplefs implementation in.
+	shutdownSimpleFS := func(_ context.Context) error { return nil }
 	createSimpleFS := func(
 		libkbfsCtx libkbfs.Context, config libkbfs.Config) (rpc.Protocol, error) {
-		return keybase1.SimpleFSProtocol(
-			simplefs.NewSimpleFS(libkbfsCtx, config)), nil
+		var simplefsIface keybase1.SimpleFSInterface
+		simplefsIface, shutdownSimpleFS = simplefs.NewSimpleFS(
+			libkbfsCtx, config)
+		return keybase1.SimpleFSProtocol(simplefsIface), nil
 	}
 	// Hook git implementation in.
 	shutdownGit := func() {}
@@ -105,6 +109,10 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 		return keybase1.KBFSGitProtocol(handler), nil
 	}
 	defer func() {
+		err := shutdownSimpleFS(context.Background())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Couldn't shut down SimpleFS: %+v\n", err)
+		}
 		shutdownGit()
 	}()
 

--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -266,6 +266,9 @@ const (
 	// InitMemoryLimited is a mode where KBFS reads and writes data, but
 	// constrains its memory use even further.
 	InitMemoryLimited
+	// InitTestSearch is the same as the default mode, but with search
+	// enabled for synced TLFs.
+	InitTestSearch
 )
 
 func (im InitModeType) String() string {
@@ -280,6 +283,8 @@ func (im InitModeType) String() string {
 		return InitConstrainedString
 	case InitMemoryLimited:
 		return InitMemoryLimitedString
+	case InitTestSearch:
+		return InitTestSearchString
 	default:
 		return "unknown"
 	}

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -44,6 +44,8 @@ const (
 	// InitMemoryLimitedString is for when KBFS will use memory limited
 	// resources.
 	InitMemoryLimitedString = "memoryLimited"
+	// InitTestSearchString is for when KBFS will index synced TLFs.
+	InitTestSearchString = "testSearch"
 )
 
 // CtxInitTagKey is the type used for unique context tags for KBFS init.
@@ -653,6 +655,9 @@ func getInitMode(
 	case InitMemoryLimitedString:
 		log.CDebugf(ctx, "Initializing in memoryLimited mode")
 		mode = InitMemoryLimited
+	case InitTestSearchString:
+		log.CDebugf(ctx, "Initializing in testSearch mode")
+		mode = InitTestSearch
 	default:
 		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2020,6 +2020,9 @@ type InitMode interface {
 	// BackgroundWorkPeriod indicates how long to wait between
 	// non-critical background work tasks.
 	BackgroundWorkPeriod() time.Duration
+	// IndexingEnabled indicates whether or not synced TLFs are
+	// indexed and searchable.
+	IndexingEnabled() bool
 
 	ldbutils.DbWriteBufferSizeGetter
 }

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -29,6 +29,8 @@ func NewInitModeFromType(t InitModeType) InitMode {
 		return modeConstrained{modeDefault{}}
 	case InitMemoryLimited:
 		return modeMemoryLimited{modeConstrained{modeDefault{}}}
+	case InitTestSearch:
+		return modeTestSearch{modeDefault{}}
 	default:
 		panic(fmt.Sprintf("Unknown mode: %s", t))
 	}
@@ -185,6 +187,10 @@ func (md modeDefault) InitialDelayForBackgroundWork() time.Duration {
 
 func (md modeDefault) BackgroundWorkPeriod() time.Duration {
 	return 0
+}
+
+func (md modeDefault) IndexingEnabled() bool {
+	return false
 }
 
 func (md modeDefault) DbWriteBufferSize() int {
@@ -355,6 +361,10 @@ func (mm modeMinimal) InitialDelayForBackgroundWork() time.Duration {
 func (mm modeMinimal) BackgroundWorkPeriod() time.Duration {
 	// No background work
 	return math.MaxInt64
+}
+
+func (mm modeMinimal) IndexingEnabled() bool {
+	return false
 }
 
 func (mm modeMinimal) DbWriteBufferSize() int {
@@ -603,6 +613,14 @@ func (mml modeMemoryLimited) TLFEditHistoryEnabled() bool {
 
 func (mml modeMemoryLimited) DbWriteBufferSize() int {
 	return 1 * opt.KiB // 1 KB
+}
+
+type modeTestSearch struct {
+	InitMode
+}
+
+func (mts modeTestSearch) IndexingEnabled() bool {
+	return true
 }
 
 // Wrapper for tests.

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -482,7 +482,7 @@ func TestFullIndexSearch(t *testing.T) {
 	t.Log("Search!")
 	checkSearch := func(
 		query string, numResults, start int, expectedResults map[string]bool) {
-		results, err := i.Search(ctx, query, numResults, start)
+		results, _, err := i.Search(ctx, query, numResults, start)
 		require.NoError(t, err)
 		for _, r := range results {
 			_, ok := expectedResults[r.Path]
@@ -508,10 +508,12 @@ func TestFullIndexSearch(t *testing.T) {
 	})
 
 	t.Log("Try partial results")
-	results, err := i.Search(ctx, names[0], 2, 0)
+	results, nextResult, err := i.Search(ctx, names[0], 2, 0)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
-	results2, err := i.Search(ctx, names[0], 2, 2)
+	require.Equal(t, 2, nextResult)
+	results2, nextResult2, err := i.Search(ctx, names[0], 2, nextResult)
 	require.NoError(t, err)
 	require.Len(t, results2, 1)
+	require.Equal(t, -1, nextResult2)
 }

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/keybase/client/go/kbfs/libfs"
 	"github.com/keybase/client/go/kbfs/libhttpserver"
 	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/search"
 	"github.com/keybase/client/go/kbfs/tlf"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
 	"github.com/keybase/client/go/libkb"
@@ -105,6 +106,8 @@ type SimpleFS struct {
 	newFS newFSFunc
 	// For dumping debug info to the logs.
 	idd *libkbfs.ImpatientDebugDumper
+	// Indexes synced TLFs.
+	indexer *search.Indexer
 
 	// lock protects handles and inProgress
 	lock sync.RWMutex
@@ -190,6 +193,17 @@ func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *Si
 			log.Fatalf("initializing localHTTPServer error: %v", err)
 		}
 	}
+
+	var indexer *search.Indexer
+	if config.Mode().IndexingEnabled() {
+		newIndexer, err := search.NewIndexer(config)
+		if err != nil {
+			log.Warning("Couldn't make indexer: %+v", err)
+		} else {
+			indexer = newIndexer
+		}
+	}
+
 	k := &SimpleFS{
 		config: config,
 
@@ -199,6 +213,7 @@ func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *Si
 		vlog:                config.MakeVLogger(log),
 		newFS:               defaultNewFS,
 		idd:                 libkbfs.NewImpatientDebugDumperForForcedDumps(config),
+		indexer:             indexer,
 		localHTTPServer:     localHTTPServer,
 		subscriber:          config.SubscriptionManager().Subscriber(subscriptionNotifier{config}),
 		onlineStatusTracker: config.SubscriptionManager().OnlineStatusTracker(),
@@ -209,8 +224,12 @@ func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *Si
 }
 
 // NewSimpleFS creates a new SimpleFS instance.
-func NewSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) keybase1.SimpleFSInterface {
-	return newSimpleFS(appStateUpdater, config)
+func NewSimpleFS(
+	appStateUpdater env.AppStateUpdater, config libkbfs.Config) (
+	iface keybase1.SimpleFSInterface,
+	shutdownFn func(context.Context) error) {
+	simpleFS := newSimpleFS(appStateUpdater, config)
+	return simpleFS, simpleFS.Shutdown
 }
 
 func (k *SimpleFS) makeContext(ctx context.Context) context.Context {
@@ -3175,6 +3194,30 @@ func (k *SimpleFS) SimpleFSSetSfmiBannerDismissed(
 // SimpleFSSearch implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSSearch(
 	ctx context.Context, arg keybase1.SimpleFSSearchArg) (
-	keybase1.SimpleFSSearchResults, error) {
-	return keybase1.SimpleFSSearchResults{}, nil
+	res keybase1.SimpleFSSearchResults, err error) {
+	if k.indexer == nil {
+		return keybase1.SimpleFSSearchResults{},
+			errors.New("Indexing not enabled")
+	}
+
+	results, nextResult, err := k.indexer.Search(
+		ctx, arg.Query, arg.NumResults, arg.StartingFrom)
+	if err != nil {
+		return keybase1.SimpleFSSearchResults{}, err
+	}
+
+	res.Hits = make([]keybase1.SimpleFSSearchHit, len(results))
+	for i, result := range results {
+		res.Hits[i].Path = result.Path
+	}
+	res.NextResult = nextResult
+	return res, nil
+}
+
+// Shutdown shuts down SimpleFS.
+func (k *SimpleFS) Shutdown(ctx context.Context) error {
+	if k.indexer == nil {
+		return nil
+	}
+	return k.indexer.Shutdown(ctx)
 }

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -3171,3 +3171,10 @@ func (k *SimpleFS) SimpleFSSetSfmiBannerDismissed(
 	k.config.SubscriptionManagerPublisher().PublishChange(keybase1.SubscriptionTopic_SETTINGS)
 	return nil
 }
+
+// SimpleFSSearch implements the SimpleFSInterface.
+func (k *SimpleFS) SimpleFSSearch(
+	ctx context.Context, arg keybase1.SimpleFSSearchArg) (
+	keybase1.SimpleFSSearchResults, error) {
+	return keybase1.SimpleFSSearchResults{}, nil
+}

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -48,7 +48,9 @@ func closeSimpleFS(ctx context.Context, t *testing.T, fs *SimpleFS) {
 	// Sync in-memory data to disk before shutting down and flushing
 	// the journal.
 	syncFS(ctx, t, fs, "/private/jdoe")
-	err := fs.config.Shutdown(ctx)
+	err := fs.Shutdown(ctx)
+	require.NoError(t, err)
+	err = fs.config.Shutdown(ctx)
 	require.NoError(t, err)
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -757,3 +757,16 @@ func (s *SimpleFSHandler) SimpleFSSetSfmiBannerDismissed(ctx context.Context, di
 	defer cancel()
 	return cli.SimpleFSSetSfmiBannerDismissed(ctx, dismissed)
 }
+
+// SimpleFSSearch implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSSearch(
+	ctx context.Context, arg keybase1.SimpleFSSearchArg) (
+	keybase1.SimpleFSSearchResults, error) {
+	cli, err := s.client(ctx)
+	if err != nil {
+		return keybase1.SimpleFSSearchResults{}, err
+	}
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	return cli.SimpleFSSearch(ctx, arg)
+}

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -654,4 +654,15 @@ protocol SimpleFS {
 
   void simpleFSUserIn(string clientID);
   void simpleFSUserOut(string clientID);
+
+  record SimpleFSSearchHit {
+     string path;
+  }
+
+  record SimpleFSSearchResults {
+     array<SimpleFSSearchHit> hits;
+     int nextResult; // -1 if no more results
+  }
+
+  SimpleFSSearchResults simpleFSSearch(string query, int numResults, int startingFrom);
 }

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -939,6 +939,33 @@
           "name": "url"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "SimpleFSSearchHit",
+      "fields": [
+        {
+          "type": "string",
+          "name": "path"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SimpleFSSearchResults",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "SimpleFSSearchHit"
+          },
+          "name": "hits"
+        },
+        {
+          "type": "int",
+          "name": "nextResult"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1643,6 +1670,23 @@
         }
       ],
       "response": null
+    },
+    "simpleFSSearch": {
+      "request": [
+        {
+          "name": "query",
+          "type": "string"
+        },
+        {
+          "name": "numResults",
+          "type": "int"
+        },
+        {
+          "name": "startingFrom",
+          "type": "int"
+        }
+      ],
+      "response": "SimpleFSSearchResults"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3035,6 +3035,8 @@ export type Signer = {readonly e: Seqno; readonly k: KID; readonly u: UID}
 export type SignupRes = {readonly passphraseOk: Boolean; readonly postOk: Boolean; readonly writeOk: Boolean; readonly paperKey: String}
 export type SimpleFSListResult = {readonly entries?: Array<Dirent> | null; readonly progress: Progress}
 export type SimpleFSQuotaUsage = {readonly usageBytes: Int64; readonly archiveBytes: Int64; readonly limitBytes: Int64; readonly gitUsageBytes: Int64; readonly gitArchiveBytes: Int64; readonly gitLimitBytes: Int64}
+export type SimpleFSSearchHit = {readonly path: String}
+export type SimpleFSSearchResults = {readonly hits?: Array<SimpleFSSearchHit> | null; readonly nextResult: Int}
 export type SimpleFSStats = {readonly processStats: ProcessRuntimeStats; readonly blockCacheDbStats?: Array<String> | null; readonly syncCacheDbStats?: Array<String> | null; readonly runtimeDbStats?: Array<DbStats> | null}
 export type SizedImage = {readonly path: String; readonly width: Int}
 export type SocialAssertion = {readonly user: String; readonly service: SocialAssertionService}
@@ -4052,6 +4054,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.SimpleFS.simpleFSObfuscatePath'
 // 'keybase.1.SimpleFS.simpleFSDeobfuscatePath'
 // 'keybase.1.SimpleFS.simpleFSGetStats'
+// 'keybase.1.SimpleFS.simpleFSSearch'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
This is the first PR that actually enables the indexer in real builds.  It adds a new `testSearch` mode that you have to enable for it to happen. (I don't recommend doing that, as there are still lots of bugs with it.)  On top of that, it adds a `keybase fs search` command for devel builds (not prod), and the accompanying SimpleFS protocol changes needed for that.

Also it fixes a couple simple issues with the indexer that came up during testing:
* Support for ignoring symlinks while indexing (since they don't have BlockPointers, they are hard to track in our indexer DBs; we'll have to add a new way to track them in the future if they are important)
* Filtering out duplicate results.
* Returning a `nextResult` parameter from `Search` so that the caller can fetch the next page of results if desired.

Issue: HOTPOT-1497