### PR TITLE
folder_branch_ops: update pointers for new files correctly

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1168,6 +1168,9 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 
 // CheckStateOnShutdown implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) CheckStateOnShutdown() bool {
+	if !c.IsTestMode() {
+		return false
+	}
 	if md, ok := c.MDServer().(mdServerLocal); ok {
 		return !md.isShutdown()
 	}

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -1521,6 +1521,7 @@ func (fbo *folderBlockOps) updateEntryLocked(ctx context.Context,
 		fbo.deferredDirUpdates = append(
 			fbo.deferredDirUpdates, func(lState *kbfssync.LockState) error {
 				file := fbo.nodeCache.PathFromNode(n)
+				de.BlockPointer = file.TailPointer()
 				return fbo.updateEntryLocked(
 					ctx, lState, kmd, file, de, includeDeleted)
 			})


### PR DESCRIPTION
[This covers a couple issues I uncovered while trying to test indexing and search on a real binary.]

Previously, we were updating the pointers for newly-created files _after_ all the other pointers were updated, and the deferred writes were replayed.  This is wrong, because those deferred writes need to operate on the new pointer, and if there were deferred writes for the new file, they would get lost due to trying to write to the old pointer.

Instead, make sure the pointers are updated first, during the same phase as the other pointer updates, and make sure deferred writes refer to the new pointer.

Also, never check state on shutdown when not in test mode.