### PR TITLE
Add RPC for getting channel memberships

### DIFF
--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1708,7 +1708,7 @@ func (h *Server) GetChannelMembershipsLocal(ctx context.Context, arg chat1.GetCh
 	}
 
 	for _, conv := range convs {
-		isInConv, err := h.G().InboxSource.IsMember(ctx, arg.Uid.ToBytes(), chat1.ConversationID(conv.GetConvID()))
+		isInConv, err := h.G().InboxSource.IsMember(ctx, arg.Uid.ToBytes(), conv.GetConvID())
 		if err != nil {
 			return res, err
 		}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1690,10 +1690,6 @@ func (h *Server) GetChannelMembershipsLocal(ctx context.Context, arg chat1.GetCh
 			h.Debug(ctx, "GetTLFConversationsLocal: result obtained offline")
 		}
 	}()
-	uid, err := utils.AssertLoggedInUID(ctx, h.G())
-	if err != nil {
-		return res, err
-	}
 
 	// Fetch the TLF ID from specified name
 	nameInfo, err := CreateNameInfoSource(ctx, h.G(), arg.MembersType).LookupID(ctx, arg.TlfName, false)
@@ -1703,7 +1699,7 @@ func (h *Server) GetChannelMembershipsLocal(ctx context.Context, arg chat1.GetCh
 	}
 
 	var convs []chat1.ConversationLocal
-	convs, err = h.G().TeamChannelSource.GetChannelsFull(ctx, uid, nameInfo.ID, arg.TopicType)
+	convs, err = h.G().TeamChannelSource.GetChannelsFull(ctx, arg.Uid.ToBytes(), nameInfo.ID, arg.TopicType)
 	if err != nil {
 		return res, err
 	}
@@ -1712,7 +1708,7 @@ func (h *Server) GetChannelMembershipsLocal(ctx context.Context, arg chat1.GetCh
 	}
 
 	for _, conv := range convs {
-		isInConv, err := h.G().InboxSource.IsMember(ctx, arg.Uid, chat1.ConversationID(conv.GetConvID()))
+		isInConv, err := h.G().InboxSource.IsMember(ctx, arg.Uid.ToBytes(), chat1.ConversationID(conv.GetConvID()))
 		if err != nil {
 			return res, err
 		}

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1710,7 +1711,7 @@ func (h *Server) GetChannelMembershipsLocal(ctx context.Context, arg chat1.GetCh
 	var memberConvs []types.RemoteConversation
 	for _, conv := range inbox.ConvsUnverified {
 		for _, uid := range conv.Conv.Metadata.AllList {
-			if keybase1.UID(uid.String()) == arg.Uid {
+			if bytes.Equal(uid, arg.Uid) {
 				memberConvs = append(memberConvs, conv)
 				break
 			}

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4703,7 +4703,7 @@ func TestChatSrvChatMembershipsLocal(t *testing.T) {
 		getChannelsRes, err := ctc.as(t, users[1]).chatLocalHandler().GetChannelMembershipsLocal(ctx1,
 			chat1.GetChannelMembershipsLocalArg{
 				TlfName:     conv.TlfName,
-				Uid:         users[1].GetUID().ToBytes(),
+				Uid:         users[1].GetUID(),
 				TopicType:   chat1.TopicType_CHAT,
 				MembersType: chat1.ConversationMembersType_TEAM,
 			})
@@ -4722,7 +4722,7 @@ func TestChatSrvChatMembershipsLocal(t *testing.T) {
 		for i, user := range users {
 			getChannelsRes, err = ctc.as(t, user).chatLocalHandler().GetChannelMembershipsLocal(ctc.as(t, user).startCtx,
 				chat1.GetChannelMembershipsLocalArg{
-					Uid:         user.GetUID().ToBytes(),
+					Uid:         user.GetUID(),
 					TlfName:     conv.TlfName,
 					TopicType:   chat1.TopicType_CHAT,
 					MembersType: chat1.ConversationMembersType_TEAM,
@@ -4752,7 +4752,7 @@ func TestChatSrvChatMembershipsLocal(t *testing.T) {
 			getChannelsRes, err = ctc.as(t, user).chatLocalHandler().GetChannelMembershipsLocal(ctc.as(t, user).startCtx,
 				chat1.GetChannelMembershipsLocalArg{
 					TlfName:     conv.TlfName,
-					Uid:         user.GetUID().ToBytes(),
+					Uid:         user.GetUID(),
 					TopicType:   chat1.TopicType_CHAT,
 					MembersType: chat1.ConversationMembersType_TEAM,
 				})

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4709,7 +4709,7 @@ func TestChatSrvChatMembershipsLocal(t *testing.T) {
 		getChannelsRes, err := ctc.as(t, users[1]).chatLocalHandler().GetChannelMembershipsLocal(ctx1,
 			chat1.GetChannelMembershipsLocalArg{
 				TeamID: teamID,
-				Uid:    users[1].GetUID(),
+				Uid:    users[1].GetUID().ToBytes(),
 			})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(getChannelsRes.Channels))
@@ -4730,7 +4730,7 @@ func TestChatSrvChatMembershipsLocal(t *testing.T) {
 			getChannelsRes, err = ctc.as(t, user).chatLocalHandler().GetChannelMembershipsLocal(ctc.as(t, user).startCtx,
 				chat1.GetChannelMembershipsLocalArg{
 					TeamID: teamID,
-					Uid:    user.GetUID(),
+					Uid:    user.GetUID().ToBytes(),
 				})
 			require.NoError(t, err)
 			if i == 1 {
@@ -4757,7 +4757,7 @@ func TestChatSrvChatMembershipsLocal(t *testing.T) {
 			getChannelsRes, err = ctc.as(t, user).chatLocalHandler().GetChannelMembershipsLocal(ctc.as(t, user).startCtx,
 				chat1.GetChannelMembershipsLocalArg{
 					TeamID: teamID,
-					Uid:    user.GetUID(),
+					Uid:    user.GetUID().ToBytes(),
 				})
 			require.NoError(t, err)
 			require.Equal(t, 1, len(getChannelsRes.Channels))

--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -4656,6 +4656,113 @@ func TestChatSrvTLFConversationsLocal(t *testing.T) {
 	})
 }
 
+func TestChatSrvChatMembershipsLocal(t *testing.T) {
+	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
+		ctc := makeChatTestContext(t, "TestChatSrvChatMembershipsLocal", 2)
+		defer ctc.cleanup()
+		users := ctc.users()
+
+		// Only run this test for teams
+		switch mt {
+		case chat1.ConversationMembersType_TEAM:
+		default:
+			return
+		}
+
+		ctx := ctc.as(t, users[0]).startCtx
+		ctx1 := ctc.as(t, users[1]).startCtx
+
+		listener0 := newServerChatListener()
+		ctc.as(t, users[0]).h.G().NotifyRouter.AddListener(listener0)
+		ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
+
+		listener1 := newServerChatListener()
+		ctc.as(t, users[1]).h.G().NotifyRouter.AddListener(listener1)
+		ctc.world.Tcs[users[1].Username].ChatG.Syncer.(*Syncer).isConnected = true
+
+		conv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			mt, ctc.as(t, users[1]).user())
+		t.Logf("first conv: %s", conv.Id)
+		t.Logf("create a conversation, and join user 1 into by sending a message")
+		topicName := "zjoinonsend"
+		ncres, err := ctc.as(t, users[0]).chatLocalHandler().NewConversationLocal(ctx,
+			chat1.NewConversationLocalArg{
+				TlfName:       conv.TlfName,
+				TopicName:     &topicName,
+				TopicType:     chat1.TopicType_CHAT,
+				TlfVisibility: keybase1.TLFVisibility_PRIVATE,
+				MembersType:   chat1.ConversationMembersType_TEAM,
+			})
+		require.NoError(t, err)
+
+		_, err = postLocalForTest(t, ctc, users[1], ncres.Conv.Info, chat1.NewMessageBodyWithText(chat1.MessageText{
+			Body: fmt.Sprintf("JOINME"),
+		}))
+		require.NoError(t, err)
+
+		getChannelsRes, err := ctc.as(t, users[1]).chatLocalHandler().GetChannelMembershipsLocal(ctx1,
+			chat1.GetChannelMembershipsLocalArg{
+				TlfName:     conv.TlfName,
+				Uid:         users[1].GetUID().ToBytes(),
+				TopicType:   chat1.TopicType_CHAT,
+				MembersType: chat1.ConversationMembersType_TEAM,
+			})
+		require.NoError(t, err)
+		require.Equal(t, 2, len(getChannelsRes.Channels))
+		require.Equal(t, globals.DefaultTeamTopic, getChannelsRes.Channels[0].TopicName)
+
+		// users[1] leaves the new convo
+		_, err = ctc.as(t, users[1]).chatLocalHandler().LeaveConversationLocal(ctx1,
+			ncres.Conv.GetConvID())
+		require.NoError(t, err)
+		ignoreTypes := []chat1.MessageType{chat1.MessageType_SYSTEM, chat1.MessageType_JOIN, chat1.MessageType_TEXT}
+		consumeNewMsgWhileIgnoring(t, listener0, chat1.MessageType_LEAVE, ignoreTypes, chat1.ChatActivitySource_REMOTE)
+
+		// make sure users processed leave correctly
+		for i, user := range users {
+			getChannelsRes, err = ctc.as(t, user).chatLocalHandler().GetChannelMembershipsLocal(ctc.as(t, user).startCtx,
+				chat1.GetChannelMembershipsLocalArg{
+					Uid:         user.GetUID().ToBytes(),
+					TlfName:     conv.TlfName,
+					TopicType:   chat1.TopicType_CHAT,
+					MembersType: chat1.ConversationMembersType_TEAM,
+				})
+			require.NoError(t, err)
+			if i == 1 {
+				require.Equal(t, 1, len(getChannelsRes.Channels))
+				require.Equal(t, globals.DefaultTeamTopic, getChannelsRes.Channels[0].TopicName)
+			} else {
+				require.Equal(t, 2, len(getChannelsRes.Channels))
+			}
+		}
+
+		// delete the channel make sure it's gone from both inboxes
+		_, err = ctc.as(t, users[0]).chatLocalHandler().DeleteConversationLocal(ctx,
+			chat1.DeleteConversationLocalArg{
+				ConvID:    ncres.Conv.GetConvID(),
+				Confirmed: true,
+			})
+		require.NoError(t, err)
+		consumeLeaveConv(t, listener0)
+		consumeTeamType(t, listener0)
+		consumeLeaveConv(t, listener1)
+		consumeTeamType(t, listener1)
+
+		for _, user := range users {
+			getChannelsRes, err = ctc.as(t, user).chatLocalHandler().GetChannelMembershipsLocal(ctc.as(t, user).startCtx,
+				chat1.GetChannelMembershipsLocalArg{
+					TlfName:     conv.TlfName,
+					Uid:         user.GetUID().ToBytes(),
+					TopicType:   chat1.TopicType_CHAT,
+					MembersType: chat1.ConversationMembersType_TEAM,
+				})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(getChannelsRes.Channels))
+			require.Equal(t, globals.DefaultTeamTopic, getChannelsRes.Channels[0].TopicName)
+		}
+	})
+}
+
 func TestChatSrvSetAppNotificationSettings(t *testing.T) {
 	runWithMemberTypes(t, func(mt chat1.ConversationMembersType) {
 		ctc := makeChatTestContext(t, "TestChatSrvSetAppNotificationSettings", 2)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -1726,6 +1726,10 @@ func (r *GetTLFConversationsLocalRes) SetOffline() {
 	r.Offline = true
 }
 
+func (r *GetChannelMembershipsLocalRes) SetOffline() {
+	r.Offline = true
+}
+
 func (r *SetAppNotificationSettingsLocalRes) SetOffline() {
 	r.Offline = true
 }
@@ -2120,6 +2124,14 @@ func (r *GetTLFConversationsLocalRes) GetRateLimit() []RateLimit {
 }
 
 func (r *GetTLFConversationsLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *GetChannelMembershipsLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *GetChannelMembershipsLocalRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimits = rl
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -5191,6 +5191,40 @@ func (o GetTLFConversationsLocalRes) DeepCopy() GetTLFConversationsLocalRes {
 	}
 }
 
+type GetChannelMembershipsLocalRes struct {
+	Channels   []ChannelNameMention `codec:"channels" json:"channels"`
+	Offline    bool                 `codec:"offline" json:"offline"`
+	RateLimits []RateLimit          `codec:"rateLimits" json:"rateLimits"`
+}
+
+func (o GetChannelMembershipsLocalRes) DeepCopy() GetChannelMembershipsLocalRes {
+	return GetChannelMembershipsLocalRes{
+		Channels: (func(x []ChannelNameMention) []ChannelNameMention {
+			if x == nil {
+				return nil
+			}
+			ret := make([]ChannelNameMention, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Channels),
+		Offline: o.Offline,
+		RateLimits: (func(x []RateLimit) []RateLimit {
+			if x == nil {
+				return nil
+			}
+			ret := make([]RateLimit, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.RateLimits),
+	}
+}
+
 type SetAppNotificationSettingsLocalRes struct {
 	Offline    bool        `codec:"offline" json:"offline"`
 	RateLimits []RateLimit `codec:"rateLimits" json:"rateLimits"`
@@ -6400,6 +6434,13 @@ type GetTLFConversationsLocalArg struct {
 	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
 }
 
+type GetChannelMembershipsLocalArg struct {
+	TlfName     string                  `codec:"tlfName" json:"tlfName"`
+	Uid         gregor1.UID             `codec:"uid" json:"uid"`
+	TopicType   TopicType               `codec:"topicType" json:"topicType"`
+	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+}
+
 type SetAppNotificationSettingsLocalArg struct {
 	ConvID      ConversationID                `codec:"convID" json:"convID"`
 	ChannelWide bool                          `codec:"channelWide" json:"channelWide"`
@@ -6695,6 +6736,7 @@ type LocalInterface interface {
 	PreviewConversationByIDLocal(context.Context, ConversationID) (PreviewConversationLocalRes, error)
 	DeleteConversationLocal(context.Context, DeleteConversationLocalArg) (DeleteConversationLocalRes, error)
 	GetTLFConversationsLocal(context.Context, GetTLFConversationsLocalArg) (GetTLFConversationsLocalRes, error)
+	GetChannelMembershipsLocal(context.Context, GetChannelMembershipsLocalArg) (GetChannelMembershipsLocalRes, error)
 	SetAppNotificationSettingsLocal(context.Context, SetAppNotificationSettingsLocalArg) (SetAppNotificationSettingsLocalRes, error)
 	SetGlobalAppNotificationSettingsLocal(context.Context, map[string]bool) error
 	GetGlobalAppNotificationSettingsLocal(context.Context) (GlobalAppNotificationSettings, error)
@@ -7542,6 +7584,21 @@ func LocalProtocol(i LocalInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.GetTLFConversationsLocal(ctx, typedArgs[0])
+					return
+				},
+			},
+			"getChannelMembershipsLocal": {
+				MakeArg: func() interface{} {
+					var ret [1]GetChannelMembershipsLocalArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]GetChannelMembershipsLocalArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]GetChannelMembershipsLocalArg)(nil), args)
+						return
+					}
+					ret, err = i.GetChannelMembershipsLocal(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -8530,6 +8587,11 @@ func (c LocalClient) DeleteConversationLocal(ctx context.Context, __arg DeleteCo
 
 func (c LocalClient) GetTLFConversationsLocal(ctx context.Context, __arg GetTLFConversationsLocalArg) (res GetTLFConversationsLocalRes, err error) {
 	err = c.Cli.Call(ctx, "chat.1.local.getTLFConversationsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c LocalClient) GetChannelMembershipsLocal(ctx context.Context, __arg GetChannelMembershipsLocalArg) (res GetChannelMembershipsLocalRes, err error) {
+	err = c.Cli.Call(ctx, "chat.1.local.getChannelMembershipsLocal", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -6436,7 +6436,7 @@ type GetTLFConversationsLocalArg struct {
 
 type GetChannelMembershipsLocalArg struct {
 	TeamID keybase1.TeamID `codec:"teamID" json:"teamID"`
-	Uid    keybase1.UID    `codec:"uid" json:"uid"`
+	Uid    gregor1.UID     `codec:"uid" json:"uid"`
 }
 
 type SetAppNotificationSettingsLocalArg struct {

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -6436,7 +6436,7 @@ type GetTLFConversationsLocalArg struct {
 
 type GetChannelMembershipsLocalArg struct {
 	TlfName     string                  `codec:"tlfName" json:"tlfName"`
-	Uid         gregor1.UID             `codec:"uid" json:"uid"`
+	Uid         keybase1.UID            `codec:"uid" json:"uid"`
 	TopicType   TopicType               `codec:"topicType" json:"topicType"`
 	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
 }

--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -6435,10 +6435,8 @@ type GetTLFConversationsLocalArg struct {
 }
 
 type GetChannelMembershipsLocalArg struct {
-	TlfName     string                  `codec:"tlfName" json:"tlfName"`
-	Uid         keybase1.UID            `codec:"uid" json:"uid"`
-	TopicType   TopicType               `codec:"topicType" json:"topicType"`
-	MembersType ConversationMembersType `codec:"membersType" json:"membersType"`
+	TeamID keybase1.TeamID `codec:"teamID" json:"teamID"`
+	Uid    keybase1.UID    `codec:"uid" json:"uid"`
 }
 
 type SetAppNotificationSettingsLocalArg struct {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -1068,7 +1068,7 @@ protocol local {
     boolean offline;
     array<RateLimit> rateLimits;
   }
-  GetChannelMembershipsLocalRes getChannelMembershipsLocal(string tlfName, keybase1.UID uid, TopicType topicType, ConversationMembersType membersType);
+  GetChannelMembershipsLocalRes getChannelMembershipsLocal(keybase1.TeamID teamID, keybase1.UID uid);
 
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -1068,7 +1068,7 @@ protocol local {
     boolean offline;
     array<RateLimit> rateLimits;
   }
-  GetChannelMembershipsLocalRes getChannelMembershipsLocal(string tlfName, gregor1.UID uid, TopicType topicType, ConversationMembersType membersType);
+  GetChannelMembershipsLocalRes getChannelMembershipsLocal(string tlfName, keybase1.UID uid, TopicType topicType, ConversationMembersType membersType);
 
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -1063,6 +1063,13 @@ protocol local {
   }
   GetTLFConversationsLocalRes getTLFConversationsLocal(string tlfName, TopicType topicType, ConversationMembersType membersType);
 
+  record GetChannelMembershipsLocalRes {
+    array<ChannelNameMention> channels;
+    boolean offline;
+    array<RateLimit> rateLimits;
+  }
+  GetChannelMembershipsLocalRes getChannelMembershipsLocal(string tlfName, gregor1.UID uid, TopicType topicType, ConversationMembersType membersType);
+
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.
   record SetAppNotificationSettingsLocalRes {

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -1068,7 +1068,7 @@ protocol local {
     boolean offline;
     array<RateLimit> rateLimits;
   }
-  GetChannelMembershipsLocalRes getChannelMembershipsLocal(keybase1.TeamID teamID, keybase1.UID uid);
+  GetChannelMembershipsLocalRes getChannelMembershipsLocal(keybase1.TeamID teamID, gregor1.UID uid);
 
   // Chat notification configuration endpoint. Does not need to be complete, just a delta on the
   // currently configured settings.

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -18,6 +18,7 @@
   "chat.1.local.findConversationsLocal": {"promise": true},
   "chat.1.local.findGeneralConvFromTeamID": {"promise": true},
   "chat.1.local.getBotMemberSettings": {"promise": true},
+  "chat.1.local.getChannelMembershipsLocal": {"promise": true},
   "chat.1.local.getGlobalAppNotificationSettingsLocal": {"promise": true},
   "chat.1.local.getInboxAndUnboxUILocal": {"promise": true},
   "chat.1.local.getInboxNonblockLocal": {"engineSaga": true},

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -5008,7 +5008,7 @@
         },
         {
           "name": "uid",
-          "type": "gregor1.UID"
+          "type": "keybase1.UID"
         },
         {
           "name": "topicType",

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -5003,20 +5003,12 @@
     "getChannelMembershipsLocal": {
       "request": [
         {
-          "name": "tlfName",
-          "type": "string"
+          "name": "teamID",
+          "type": "keybase1.TeamID"
         },
         {
           "name": "uid",
           "type": "keybase1.UID"
-        },
-        {
-          "name": "topicType",
-          "type": "TopicType"
-        },
-        {
-          "name": "membersType",
-          "type": "ConversationMembersType"
         }
       ],
       "response": "GetChannelMembershipsLocalRes"

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -3200,6 +3200,30 @@
     },
     {
       "type": "record",
+      "name": "GetChannelMembershipsLocalRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "ChannelNameMention"
+          },
+          "name": "channels"
+        },
+        {
+          "type": "boolean",
+          "name": "offline"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "RateLimit"
+          },
+          "name": "rateLimits"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "SetAppNotificationSettingsLocalRes",
       "fields": [
         {
@@ -4975,6 +4999,27 @@
         }
       ],
       "response": "GetTLFConversationsLocalRes"
+    },
+    "getChannelMembershipsLocal": {
+      "request": [
+        {
+          "name": "tlfName",
+          "type": "string"
+        },
+        {
+          "name": "uid",
+          "type": "gregor1.UID"
+        },
+        {
+          "name": "topicType",
+          "type": "TopicType"
+        },
+        {
+          "name": "membersType",
+          "type": "ConversationMembersType"
+        }
+      ],
+      "response": "GetChannelMembershipsLocalRes"
     },
     "setAppNotificationSettingsLocal": {
       "request": [

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -5008,7 +5008,7 @@
         },
         {
           "name": "uid",
-          "type": "keybase1.UID"
+          "type": "gregor1.UID"
         }
       ],
       "response": "GetChannelMembershipsLocalRes"

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -348,7 +348,7 @@ export type MessageTypes = {
     outParam: Keybase1.TeamBotSettings
   }
   'chat.1.local.getChannelMembershipsLocal': {
-    inParam: {readonly tlfName: String; readonly uid: Keybase1.UID; readonly topicType: TopicType; readonly membersType: ConversationMembersType}
+    inParam: {readonly teamID: Keybase1.TeamID; readonly uid: Keybase1.UID}
     outParam: GetChannelMembershipsLocalRes
   }
   'chat.1.local.getGlobalAppNotificationSettingsLocal': {

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -347,6 +347,10 @@ export type MessageTypes = {
     inParam: {readonly convID: ConversationID; readonly username: String}
     outParam: Keybase1.TeamBotSettings
   }
+  'chat.1.local.getChannelMembershipsLocal': {
+    inParam: {readonly tlfName: String; readonly uid: Gregor1.UID; readonly topicType: TopicType; readonly membersType: ConversationMembersType}
+    outParam: GetChannelMembershipsLocalRes
+  }
   'chat.1.local.getGlobalAppNotificationSettingsLocal': {
     inParam: void
     outParam: GlobalAppNotificationSettings
@@ -1139,6 +1143,7 @@ export type FlipGameIDStr = String
 export type GenericPayload = {readonly Action: String; readonly inboxVers: InboxVers; readonly convID: ConversationID; readonly topicType: TopicType; readonly unreadUpdate?: UnreadUpdate | null}
 export type GetAllResetConvMembersRes = {readonly members?: Array<ResetConvMember> | null; readonly rateLimits?: Array<RateLimit> | null}
 export type GetBotInfoRes = {readonly response: BotInfoResponse; readonly rateLimit?: RateLimit | null}
+export type GetChannelMembershipsLocalRes = {readonly channels?: Array<ChannelNameMention> | null; readonly offline: Boolean; readonly rateLimits?: Array<RateLimit> | null}
 export type GetConversationForCLILocalQuery = {readonly markAsRead: Boolean; readonly MessageTypes?: Array<MessageType> | null; readonly Since?: String | null; readonly limit: UnreadFirstNumLimit; readonly conv: ConversationLocal}
 export type GetConversationForCLILocalRes = {readonly conversation: ConversationLocal; readonly messages?: Array<MessageUnboxed> | null; readonly offline: Boolean; readonly rateLimits?: Array<RateLimit> | null}
 export type GetConversationMetadataRemoteRes = {readonly conv: Conversation; readonly rateLimit?: RateLimit | null}
@@ -1545,6 +1550,7 @@ export const localEditBotMemberRpcPromise = (params: MessageTypes['chat.1.local.
 export const localFindConversationsLocalRpcPromise = (params: MessageTypes['chat.1.local.findConversationsLocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.findConversationsLocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.findConversationsLocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localFindGeneralConvFromTeamIDRpcPromise = (params: MessageTypes['chat.1.local.findGeneralConvFromTeamID']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.findGeneralConvFromTeamID']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.findGeneralConvFromTeamID', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localGetBotMemberSettingsRpcPromise = (params: MessageTypes['chat.1.local.getBotMemberSettings']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.getBotMemberSettings']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.getBotMemberSettings', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const localGetChannelMembershipsLocalRpcPromise = (params: MessageTypes['chat.1.local.getChannelMembershipsLocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.getChannelMembershipsLocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.getChannelMembershipsLocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localGetGlobalAppNotificationSettingsLocalRpcPromise = (params: MessageTypes['chat.1.local.getGlobalAppNotificationSettingsLocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.getGlobalAppNotificationSettingsLocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.getGlobalAppNotificationSettingsLocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localGetInboxAndUnboxUILocalRpcPromise = (params: MessageTypes['chat.1.local.getInboxAndUnboxUILocal']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['chat.1.local.getInboxAndUnboxUILocal']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'chat.1.local.getInboxAndUnboxUILocal', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const localGetInboxNonblockLocalRpcSaga = (p: {params: MessageTypes['chat.1.local.getInboxNonblockLocal']['inParam']; incomingCallMap: IncomingCallMapType; customResponseIncomingCallMap?: CustomResponseIncomingCallMap; waitingKey?: WaitingKey}) => call(getEngineSaga(), {method: 'chat.1.local.getInboxNonblockLocal', params: p.params, incomingCallMap: p.incomingCallMap, customResponseIncomingCallMap: p.customResponseIncomingCallMap, waitingKey: p.waitingKey})

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -348,7 +348,7 @@ export type MessageTypes = {
     outParam: Keybase1.TeamBotSettings
   }
   'chat.1.local.getChannelMembershipsLocal': {
-    inParam: {readonly tlfName: String; readonly uid: Gregor1.UID; readonly topicType: TopicType; readonly membersType: ConversationMembersType}
+    inParam: {readonly tlfName: String; readonly uid: Keybase1.UID; readonly topicType: TopicType; readonly membersType: ConversationMembersType}
     outParam: GetChannelMembershipsLocalRes
   }
   'chat.1.local.getGlobalAppNotificationSettingsLocal': {

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -348,7 +348,7 @@ export type MessageTypes = {
     outParam: Keybase1.TeamBotSettings
   }
   'chat.1.local.getChannelMembershipsLocal': {
-    inParam: {readonly teamID: Keybase1.TeamID; readonly uid: Keybase1.UID}
+    inParam: {readonly teamID: Keybase1.TeamID; readonly uid: Gregor1.UID}
     outParam: GetChannelMembershipsLocalRes
   }
   'chat.1.local.getGlobalAppNotificationSettingsLocal': {


### PR DESCRIPTION
Adds `GetChannelMembershipsLocal` which takes a UID and a tlf name and returns a list of channels that the provided user is a member of.