### PR TITLE
engine: fix race in finishing ID2

### DIFF
--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -384,7 +384,6 @@ func (e *Identify2WithUID) notifyChat(m libkb.MetaContext, inErr error) error {
 
 func (e *Identify2WithUID) run(m libkb.MetaContext) {
 	err := e.runReturnError(m)
-	e.unblock(m /* isFinal */, true, err)
 
 	if notifyChatErr := e.notifyChat(m, err); notifyChatErr != nil {
 		m.Warning("failed to notify chat of identify result: %s", notifyChatErr)
@@ -399,6 +398,7 @@ func (e *Identify2WithUID) run(m libkb.MetaContext) {
 			m.Debug("| error during cancel: %+v", err)
 		}
 	}
+	e.unblock(m, true /* isFinal */, err)
 }
 
 func (e *Identify2WithUID) hitFastCache(m libkb.MetaContext) bool {
@@ -1321,6 +1321,7 @@ func (e *Identify2WithUID) maybeNotify(mctx libkb.MetaContext, explanation strin
 		// This check is needed because ActLoggedOut causes the untracked fast path
 		// to succeed even when the true active user is tracking the identifyee.
 		mctx.Debug("Identify2WithUID.maybeNotify(%v, %v) nope missing ME", target, explanation)
+		return
 	}
 	if target.IsNil() {
 		mctx.Debug("Identify2WithUID.maybeNotify(%v, %v) nope missing UID", target, explanation)


### PR DESCRIPTION
- when ID2 is called for the CLI, and tested via TestDelegateUI, the UI is finished when the engine calls Cancel
- we previously weren't waiting on that RPC to happen before exiting, so we could sometimes hit this very unlikely race
- just do the RPC before we unblock the caller, there are maybe other fixes, but this is simplest
- i hope it doesn't break anything, it does have the potential to, so let's let it bake
- also fix a bug in @mlsteele's earlier PR, that we discussed via chat