### PR TITLE
align decorations on floating menu items so they look ok on ipad too

### DIFF
--- a/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
@@ -64,7 +64,6 @@ const MenuRow = (props: MenuRowProps) => (
         <Box2 direction="horizontal">
           <Box2 direction="vertical" fullHeight={true}>
             <Box2 direction="horizontal" fullWidth={true}>
-              {props.decoration && <Box style={styles.flexOne} />}
               <Text type="BodyBig" style={styleRowText(props)}>
                 {props.title}
               </Text>
@@ -76,7 +75,7 @@ const MenuRow = (props: MenuRowProps) => (
                   style={styles.badge}
                 />
               )}
-              {props.decoration && <Box style={styles.flexOne}>{props.decoration}</Box>}
+              {props.decoration && <Box style={styles.flexStart}>{props.decoration}</Box>}
             </Box2>
             {!!props.subTitle && (
               <Box2 direction="horizontal" fullWidth={true}>
@@ -179,8 +178,8 @@ const styles = Styles.styleSheetCreate(
       divider: {
         marginBottom: Styles.globalMargins.tiny,
       },
-      flexOne: {
-        flex: 1,
+      flexStart: {
+        justifyContent: 'flex-start',
       },
       iconBadge: {
         backgroundColor: Styles.globalColors.blue,


### PR DESCRIPTION
tweak an alignment case in a menu component. i couldn't find anywhere other than searchability/verifiedness of email/phone rows (i.e. see screenshots) that this is actually being used.

### Before
<img width="792" alt="Screen Shot 2020-02-06 at 4 37 28 PM" src="https://user-images.githubusercontent.com/1275828/74064785-66c62980-49c1-11ea-8363-5f2c43084b7a.png">


### After
ipad
<img width="789" alt="Screen Shot 2020-02-07 at 3 40 34 PM" src="https://user-images.githubusercontent.com/1275828/74064585-fae3c100-49c0-11ea-8fbc-d2569dd982fc.png">
iphone
<img width="396" alt="Screen Shot 2020-02-07 at 3 32 32 PM" src="https://user-images.githubusercontent.com/1275828/74064630-0fc05480-49c1-11ea-9788-b16805694332.png">
