### PR TITLE
fix width of feedback page

### DIFF
--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -183,8 +183,8 @@ const styles = Styles.styleSheetCreate(
       mainBox: Styles.platformStyles({
         isElectron: {
           maxWidth: 550,
-          width: '100%',
           padding: Styles.globalMargins.small,
+          width: '100%',
         },
         isTablet: {
           maxWidth: Styles.globalStyles.mediumWidth,

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -182,13 +182,13 @@ const styles = Styles.styleSheetCreate(
       }),
       mainBox: Styles.platformStyles({
         isElectron: {
-          padding: Styles.globalMargins.small,
-          width: '100%',
           maxWidth: 550,
+          width: '100%',
+          padding: Styles.globalMargins.small,
         },
         isTablet: {
-          width: '100%',
           maxWidth: Styles.globalStyles.mediumWidth,
+          width: '100%',
         },
       }),
       outerStyle: {backgroundColor: Styles.globalColors.white},

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -193,9 +193,15 @@ const styles = Styles.styleSheetCreate(
         isMobile: {...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small)},
       }),
       mainBox: Styles.platformStyles({
-        common: {padding: Styles.globalMargins.small},
-        isElectron: {width: 550},
-        isTablet: {width: 460},
+        isElectron: {
+          padding: Styles.globalMargins.small,
+          width: '100%',
+          maxWidth: 550,
+        },
+        isTablet: {
+          width: '100%',
+          maxWidth: Styles.globalStyles.mediumWidth,
+        },
       }),
       outerStyle: {backgroundColor: Styles.globalColors.white},
       smallLabel: {color: Styles.globalColors.black},

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -90,8 +90,8 @@ class Feedback extends React.Component<Props, State> {
   render() {
     const {sending, sendError} = this.props
     return (
-      <Kb.Box2 direction="vertical" fullWidth={true} alignItems="center">
-        <Kb.ScrollView alwaysBounceVertical={false}>
+      <Kb.ScrollView alwaysBounceVertical={false}>
+        <Kb.Box2 direction="vertical" fullWidth={true} alignItems="center">
           {this.state.showSuccessBanner && (
             <Kb.Banner color="green">
               <Kb.BannerParagraph bannerColor="green" content="Thanks! Your feedback was sent." />
@@ -157,8 +157,8 @@ class Feedback extends React.Component<Props, State> {
               </Kb.Box2>
             )}
           </Kb.Box2>
-        </Kb.ScrollView>
-      </Kb.Box2>
+        </Kb.Box2>
+      </Kb.ScrollView>
     )
   }
 }

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -137,9 +137,13 @@ class Feedback extends React.Component<Props, State> {
                 />
               </Kb.Box2>
             )}
-            <Kb.Box2 alignSelf={this.props.loggedOut ? 'center' : 'flex-start'} direction="horizontal" gap="tiny">
-              <Kb.ButtonBar >
-                <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true}/>
+            <Kb.Box2
+              alignSelf={this.props.loggedOut ? 'center' : 'flex-start'}
+              direction="horizontal"
+              gap="tiny"
+            >
+              <Kb.ButtonBar>
+                <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true} />
               </Kb.ButtonBar>
             </Kb.Box2>
             {sendError && (

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -137,9 +137,20 @@ class Feedback extends React.Component<Props, State> {
                 />
               </Kb.Box2>
             )}
-            <Kb.ButtonBar>
-              <Kb.Button fullWidth={true} label="Send" onClick={this._onSendFeedback} waiting={sending} />
-            </Kb.ButtonBar>
+            {!this.props.loggedOut && (
+            <Kb.Box2 style={styles.btnContainer} direction="horizontal" gap="tiny">
+              <Kb.ButtonBar >
+                <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true}/>
+              </Kb.ButtonBar>
+            </Kb.Box2>
+            )}
+            {this.props.loggedOut && (
+            <Kb.Box2 direction="horizontal" gap="tiny">
+              <Kb.ButtonBar >
+                <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true}/>
+              </Kb.ButtonBar>
+            </Kb.Box2>
+            )}
             {sendError && (
               <Kb.Box2 direction="vertical" gap="small">
                 <Kb.Text type="BodySmallError">Could not send log</Kb.Text>
@@ -171,6 +182,9 @@ const styles = Styles.styleSheetCreate(
       container: Styles.platformStyles({
         common: {flex: 1},
       }),
+      btnContainer: {
+        alignSelf: 'flex-start',
+      },
       includeLogs: {
         ...Styles.globalStyles.fullWidth,
       },
@@ -180,7 +194,8 @@ const styles = Styles.styleSheetCreate(
       }),
       mainBox: Styles.platformStyles({
         common: {padding: Styles.globalMargins.small},
-        isElectron: {width: 368},
+        isElectron: {width: 550},
+        isTablet: {width: 460},
       }),
       outerStyle: {backgroundColor: Styles.globalColors.white},
       smallLabel: {color: Styles.globalColors.black},

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -137,20 +137,11 @@ class Feedback extends React.Component<Props, State> {
                 />
               </Kb.Box2>
             )}
-            {!this.props.loggedOut && (
-            <Kb.Box2 style={styles.btnContainer} direction="horizontal" gap="tiny">
+            <Kb.Box2 alignSelf={this.props.loggedOut ? 'center' : 'flex-start'} direction="horizontal" gap="tiny">
               <Kb.ButtonBar >
                 <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true}/>
               </Kb.ButtonBar>
             </Kb.Box2>
-            )}
-            {this.props.loggedOut && (
-            <Kb.Box2 direction="horizontal" gap="tiny">
-              <Kb.ButtonBar >
-                <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true}/>
-              </Kb.ButtonBar>
-            </Kb.Box2>
-            )}
             {sendError && (
               <Kb.Box2 direction="vertical" gap="small">
                 <Kb.Text type="BodySmallError">Could not send log</Kb.Text>
@@ -182,9 +173,6 @@ const styles = Styles.styleSheetCreate(
       container: Styles.platformStyles({
         common: {flex: 1},
       }),
-      btnContainer: {
-        alignSelf: 'flex-start',
-      },
       includeLogs: {
         ...Styles.globalStyles.fullWidth,
       },


### PR DESCRIPTION
DESKTOP:
<img width="1186" alt="Screen Shot 2020-02-10 at 11 04 03 AM" src="https://user-images.githubusercontent.com/1981254/74181368-08ce5780-4bf6-11ea-8689-9a958d601e87.png">
<img width="1197" alt="Screen Shot 2020-02-10 at 11 04 34 AM" src="https://user-images.githubusercontent.com/1981254/74181371-0a981b00-4bf6-11ea-8538-ca9a15526e5e.png">

IPHONE:
<img width="377" alt="Screen Shot 2020-02-10 at 11 05 08 AM" src="https://user-images.githubusercontent.com/1981254/74181375-0bc94800-4bf6-11ea-8347-6c0abccc5499.png">

IPAD:
<img width="916" alt="Screen Shot 2020-02-10 at 11 06 49 AM" src="https://user-images.githubusercontent.com/1981254/74181377-0c61de80-4bf6-11ea-9645-88de01dfe49f.png">
<img width="923" alt="Screen Shot 2020-02-10 at 11 07 11 AM" src="https://user-images.githubusercontent.com/1981254/74181378-0cfa7500-4bf6-11ea-98c4-5482bf9710a0.png">