### PR TITLE
alignment for whats new on an ipad

### DIFF
--- a/shared/whats-new/index.tsx
+++ b/shared/whats-new/index.tsx
@@ -26,15 +26,12 @@ type Props = {
 const Wrapper = ({children}: {children: React.ReactNode}) => (
   <Kb.Box2
     direction="vertical"
-    alignItems="flex-start"
-    alignSelf="flex-start"
     fullHeight={true}
     style={!Styles.isMobile && styles.popupContainer}
+    centerChildren={true}
   >
     <Kb.Box2
       direction="vertical"
-      alignItems="flex-start"
-      alignSelf="flex-start"
       fullHeight={true}
       fullWidth={!Styles.isMobile}
       style={styles.contentBackground}
@@ -131,6 +128,9 @@ const styles = Styles.styleSheetCreate(() => ({
     },
     isElectron: {
       ...Styles.padding(Styles.globalMargins.tiny),
+    },
+    isTablet: {
+      maxWidth: Styles.globalStyles.mediumWidth,
     },
   }),
   scrollViewInner: Styles.platformStyles({


### PR DESCRIPTION
whats new looks weird on ipad. this tightens it up. 
* i pulled in commits from https://github.com/keybase/client/pull/22472/files so i could use `mediumWidth` rather than hardcoding the same constant
* i checked on iphone and it looks the same before and after


## before
![image-20200206-150235](https://user-images.githubusercontent.com/1275828/74186696-0fba9180-4c19-11ea-8321-6eb692719d42.png)


## after
<img width="570" alt="ipad portrait after" src="https://user-images.githubusercontent.com/1275828/74186720-19dc9000-4c19-11ea-947b-cde7770ce64c.png">

<img width="799" alt="ipad landscape after" src="https://user-images.githubusercontent.com/1275828/74186734-219c3480-4c19-11ea-9c7d-fbad7383931b.png">

