### PR TITLE
Squeeze git-create screens and modals in general

### DIFF
--- a/shared/common-adapters/modal/index.tsx
+++ b/shared/common-adapters/modal/index.tsx
@@ -275,7 +275,17 @@ const styles = Styles.styleSheetCreate(() => {
     scroll: Styles.platformStyles({
       isElectron: {...Styles.globalStyles.flexBoxColumn, flex: 1, position: 'relative'},
     }),
-    scrollContentContainer: {...Styles.globalStyles.flexBoxColumn, flexGrow: 1, width: '100%'},
+    scrollContentContainer: Styles.platformStyles({
+      common: {
+        ...Styles.globalStyles.flexBoxColumn,
+        flexGrow: 1,
+        width: '100%',
+      },
+      isTablet: {
+        alignSelf: 'center',
+        maxWidth: 600,
+      },
+    }),
   }
 })
 

--- a/shared/git/new-repo/index.tsx
+++ b/shared/git/new-repo/index.tsx
@@ -193,6 +193,11 @@ const styles = Styles.styleSheetCreate(() => ({
       padding: Styles.isMobile ? Styles.globalMargins.tiny : Styles.globalMargins.large,
     },
     isElectron: {maxWidth: 400},
+    isTablet: {
+      alignSelf: 'center',
+      marginTop: Styles.globalMargins.xsmall,
+      width: 500,
+    },
   }),
   dropdown: {
     marginBottom: Styles.globalMargins.small,

--- a/shared/settings/notifications/push-prompt.native.tsx
+++ b/shared/settings/notifications/push-prompt.native.tsx
@@ -48,7 +48,7 @@ const PushPrompt = () => {
         hideBorder: true,
         style: styles.footer,
       }}
-      mobileStyle={{backgroundColor: Styles.globalColors.blue}}
+      mobileStyle={styles.background}
     >
       <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} gap="small" style={styles.container}>
         <Kb.Icon type="illustration-turn-on-notifications" style={styles.image} />
@@ -68,6 +68,9 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       button: {maxHeight: 40},
+      background: {
+        backgroundColor: Styles.globalColors.blue,
+      },
       container: {
         ...Styles.globalStyles.fillAbsolute,
         backgroundColor: Styles.globalColors.blue,

--- a/shared/settings/notifications/push-prompt.native.tsx
+++ b/shared/settings/notifications/push-prompt.native.tsx
@@ -48,6 +48,7 @@ const PushPrompt = () => {
         hideBorder: true,
         style: styles.footer,
       }}
+      mobileStyle={{backgroundColor: Styles.globalColors.blue}}
     >
       <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} gap="small" style={styles.container}>
         <Kb.Icon type="illustration-turn-on-notifications" style={styles.image} />

--- a/shared/settings/notifications/push-prompt.native.tsx
+++ b/shared/settings/notifications/push-prompt.native.tsx
@@ -67,10 +67,8 @@ const PushPrompt = () => {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      background: {backgroundColor: Styles.globalColors.blue},
       button: {maxHeight: 40},
-      background: {
-        backgroundColor: Styles.globalColors.blue,
-      },
       container: {
         ...Styles.globalStyles.fillAbsolute,
         backgroundColor: Styles.globalColors.blue,


### PR DESCRIPTION
I think most modals designed primarily for phones will look better with a limited width on tablets. For modals that are tablet-optimized and look good wide, I imagine a future Kb.Modal prop `wideEvenOnTablet: boolean`.

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/705646/74187576-da16a800-4c1a-11ea-84b9-006fdce9e1e1.png">
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/705646/74187606-eb5fb480-4c1a-11ea-814e-bf7089ad424f.png">

cc @keybase/picnicsquad 