### PR TITLE
bump box auditor flag to turn it off for users without fix

### DIFF
--- a/go/libkb/features.go
+++ b/go/libkb/features.go
@@ -70,7 +70,7 @@ type FeatureFlagSet struct {
 
 const (
 	FeatureFTL                        = Feature("ftl")
-	FeatureBoxAuditor                 = Feature("box_auditor2")
+	FeatureBoxAuditor                 = Feature("box_auditor3")
 	ExperimentalGenericProofs         = Feature("experimental_generic_proofs")
 	FeatureCheckForHiddenChainSupport = Feature("check_for_hidden_chain_support")
 


### PR DESCRIPTION
I should've done this in the last release

cc @maxtaco 