### PR TITLE
webview: avoid stopLoading() race by using onShouldStartLoadWithRequest

### DIFF
--- a/shared/chat/pdf/index.native.tsx
+++ b/shared/chat/pdf/index.native.tsx
@@ -28,6 +28,7 @@ const ChatPDF = (props: Props) => {
             </Kb.Box2>
           )}
           url={url}
+          pinnedURLMode={true}
           onError={err => setError(err)}
           style={styles.webViewContainer}
         />

--- a/shared/common-adapters/web-view.d.ts
+++ b/shared/common-adapters/web-view.d.ts
@@ -12,6 +12,7 @@ export type WebViewProps = {
   originWhitelist?: Array<string>
   renderLoading?: () => React.ReactElement<any>
   url: string
+  pinnedURLMode: boolean // only tested on iOS
   injections?: WebViewInjections
   style?: Object
   onLoadingStateChange?: (isLoading: boolean) => void

--- a/shared/common-adapters/web-view.native.tsx
+++ b/shared/common-adapters/web-view.native.tsx
@@ -53,7 +53,7 @@ const KBWebView = (props: WebViewProps) => {
                 return true
               }
               // With links from the Files tab, URL can change because of the
-              // token. So only open the URL when navigateionType is 'click'.
+              // token. So only open the URL when navigationType is 'click'.
               request.navigationType === 'click' && openURL(request.url)
               return false
             }

--- a/shared/common-adapters/web-view.native.tsx
+++ b/shared/common-adapters/web-view.native.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import {WebView as NativeWebView} from 'react-native-webview'
 import {WebViewInjections, WebViewProps} from './web-view'
 import memoize from 'lodash/memoize'
-import * as Container from '../util/container'
 import openURL from '../util/open-url'
 
 const escape = (str?: string): string => (str ? str.replace(/\\/g, '\\\\').replace(/`/g, '\\`') : '')
@@ -32,13 +31,8 @@ const KBWebView = (props: WebViewProps) => {
     renderLoading,
     url,
   } = props
-  const ref = React.useRef<NativeWebView>(null)
-  const previousUrl = Container.usePrevious(url)
-  const [key, setKey] = React.useState(0)
   return (
     <NativeWebView
-      key={`nativewebview-${key}`}
-      ref={ref}
       allowUniversalAccessFromFileURLs={allowUniversalAccessFromFileURLs}
       originWhitelist={originWhitelist}
       allowFileAccess={allowFileAccess}
@@ -52,33 +46,19 @@ const KBWebView = (props: WebViewProps) => {
       onError={onError && (syntheticEvent => onError(syntheticEvent.nativeEvent.description))}
       startInLoadingState={!!renderLoading}
       renderLoading={renderLoading}
-      onNavigationStateChange={navState => {
-        // This prevents navigating away from a link on a PDF, which protects
-        // us from an attack where someone could make a webpage that looks like
-        // the app and trick user into entering sensitive information on a
-        // webform.
-        //
-        // This means for local PDF files, we should prepend the 'file://'
-        // prefix to props.url before passing it in. Otherwise webview
-        // automatically does that, and it triggers onNavigationStateChange
-        // with the new address and we'd call stoploading().
-        //
-        // If url change comes from the props, this event can trigger too, with
-        // the `url` field being different from what's in the props. So compare
-        // with both old and new props.url.
-        //
-        // This didn't work in a real build:
-        //   navState.url !== url && navState.url !== previousUrl && ref?.current?.stopLoading()
-        //
-        // Assuming it was `stopLoading()`'s problem, let's try something
-        // different: if url every changes, force re-mounting NativeWebView by
-        // giving it a different key, so it loads the original URL again.
-        if (navState.url !== url && navState.url !== previousUrl) {
-          setKey(key => key + 1)
-          // At the same time, open the link in browser.
-          openURL(navState.url)
-        }
-      }}
+      onShouldStartLoadWithRequest={
+        props.pinnedURLMode
+          ? request => {
+              if (request.url === url) {
+                return true
+              }
+              // With links from the Files tab, URL can change because of the
+              // token. So only open the URL when navigateionType is 'click'.
+              request.navigationType === 'click' && openURL(request.url)
+              return false
+            }
+          : undefined
+      }
     />
   )
 }

--- a/shared/common-adapters/web-view.native.tsx
+++ b/shared/common-adapters/web-view.native.tsx
@@ -53,7 +53,6 @@ const KBWebView = (props: WebViewProps) => {
       startInLoadingState={!!renderLoading}
       renderLoading={renderLoading}
       onNavigationStateChange={navState => {
-        console.log({songgao: 'onNavigationStateChange', navState, url: navState.url})
         // This prevents navigating away from a link on a PDF, which protects
         // us from an attack where someone could make a webpage that looks like
         // the app and trick user into entering sensitive information on a

--- a/shared/fs/filepreview/pdf-view.tsx
+++ b/shared/fs/filepreview/pdf-view.tsx
@@ -8,10 +8,11 @@ type Props = {
   onUrlError?: (err: string) => void
 }
 
-const TextView = (props: Props) => (
+const PdfView = (props: Props) => (
   <Kb.Box2 fullHeight={true} fullWidth={true} direction="vertical">
     <Kb.WebView
       url={props.url}
+      pinnedURLMode={true}
       style={styles.webview}
       onError={props.onUrlError}
       renderLoading={() => (
@@ -37,5 +38,5 @@ const styles = Styles.styleSheetCreate(
     } as const)
 )
 
-// Only supported on iOS for now. Should try to prevent link navigation when adding support for other platforms.
-export default Platform.isIOS ? TextView : () => null
+// Only supported on iOS for now.
+export default Platform.isIOS ? PdfView : () => null

--- a/shared/fs/filepreview/text-view.native.tsx
+++ b/shared/fs/filepreview/text-view.native.tsx
@@ -7,6 +7,7 @@ const TextView = (props: Props) => (
   <Kb.Box2 fullHeight={true} fullWidth={true} direction="vertical">
     <Kb.WebView
       url={props.url}
+      pinnedURLMode={true}
       style={styles.webview}
       injections={injections}
       onError={props.onUrlError}


### PR DESCRIPTION
I couldn't repro the issue in either simulator or on a real device using a dev build, but from a testflight build it indeed navigated to the different address after several taps on a link. So do something different where we force remounting the webview if url changes. Also open the link in browser if user taps on one.