### PR TITLE
subteam filter plumbing

### DIFF
--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -183,7 +183,7 @@ const emptyState: Types.State = {
   sawChatBanner: false,
   sawSubteamsBanner: false,
   subteamFilter: '',
-  subteamsFiltered: new Set(),
+  subteamsFiltered: undefined,
   teamAccessRequestsPending: new Set(),
   teamBuilding: TeamBuildingConstants.makeSubState(),
   teamDetails: new Map(),

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -142,7 +142,7 @@ export type State = {
   readonly sawChatBanner: boolean
   readonly sawSubteamsBanner: boolean
   readonly subteamFilter: string
-  readonly subteamsFiltered: Set<TeamID>
+  readonly subteamsFiltered: Set<TeamID> | undefined
   readonly teamAccessRequestsPending: Set<Teamname>
   readonly teamJoinSuccess: boolean
   readonly teamJoinSuccessOpen: boolean

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -248,7 +248,7 @@ export default Container.makeReducer<
         )
       )
     } else {
-      draftState.subteamsFiltered = new Set()
+      draftState.subteamsFiltered = undefined
     }
   },
   [TeamBuildingGen.tbResetStore]: handleTeamBuilding,

--- a/shared/teams/team/container.tsx
+++ b/shared/teams/team/container.tsx
@@ -30,6 +30,7 @@ const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
   return {
     invitesCollapsed: state.teams.invitesCollapsed,
     selectedTab,
+    subteamsFiltered: state.teams.subteamsFiltered,
     teamDetails: Constants.getTeamDetails(state, teamID),
     teamID,
     teamMeta: Constants.getTeamMeta(state, teamID),
@@ -50,7 +51,8 @@ const Connected = Container.compose(
       stateProps.selectedTab,
       stateProps.yourUsername,
       stateProps.yourOperations,
-      stateProps.invitesCollapsed
+      stateProps.invitesCollapsed,
+      stateProps.subteamsFiltered
     )
     const sections: Sections = [
       ...(Container.isMobile && !flags.teamsRedesign


### PR DESCRIPTION
Was removed accidentally in #22405. Previous code checked if `subteamFilter` existed in container to decide whether to use this. Change it so `subteamsFiltered` is undefined if there is no filter. cc @keybase/y2ksquad 