### PR TITLE
anchor the rover to the right edge so it works on tablet too

### DIFF
--- a/shared/chat/inbox-search/background.native.tsx
+++ b/shared/chat/inbox-search/background.native.tsx
@@ -10,24 +10,34 @@ const Rover = () => (
   </Kb.Box2>
 )
 
-const common = {
-  bottom: 0,
-  right: 0,
-  position: 'absolute',
-} as const
-
-const styles = Styles.styleSheetCreate(
-  () =>
-    ({
-      background: {...common, bottom: 10},
-      container: common,
-      foreground: common,
-      rover: {
-        ...common,
-        bottom: 80,
-        right: 50,
-      },
+const shared = Styles.isTablet
+  ? ({
+      bottom: 0,
+      right: 0,
+      position: 'absolute',
     } as const)
-)
+  : ({
+      bottom: 0,
+      left: 0,
+      position: 'absolute',
+    } as const)
+
+const styles = Styles.styleSheetCreate(() => ({
+  background: {...shared, bottom: 10},
+  container: shared,
+  foreground: shared,
+  rover: Styles.platformStyles({
+    common: {
+      ...shared,
+      bottom: 80,
+    },
+    isTablet: {
+      right: 50,
+    },
+    isPhone: {
+      left: Styles.dimensionWidth - 50,
+    },
+  }),
+}))
 
 export default Rover

--- a/shared/chat/inbox-search/background.native.tsx
+++ b/shared/chat/inbox-search/background.native.tsx
@@ -12,7 +12,7 @@ const Rover = () => (
 
 const common = {
   bottom: 0,
-  left: 0,
+  right: 0,
   position: 'absolute',
 } as const
 
@@ -25,7 +25,7 @@ const styles = Styles.styleSheetCreate(
       rover: {
         ...common,
         bottom: 80,
-        left: Styles.dimensionWidth - 50,
+        right: 50,
       },
     } as const)
 )

--- a/shared/chat/inbox-search/background.native.tsx
+++ b/shared/chat/inbox-search/background.native.tsx
@@ -13,8 +13,8 @@ const Rover = () => (
 const shared = Styles.isTablet
   ? ({
       bottom: 0,
-      right: 0,
       position: 'absolute',
+      right: 0,
     } as const)
   : ({
       bottom: 0,
@@ -31,11 +31,11 @@ const styles = Styles.styleSheetCreate(() => ({
       ...shared,
       bottom: 80,
     },
-    isTablet: {
-      right: 50,
-    },
     isPhone: {
       left: Styles.dimensionWidth - 50,
+    },
+    isTablet: {
+      right: 50,
     },
   }),
 }))

--- a/shared/chat/inbox-search/index.tsx
+++ b/shared/chat/inbox-search/index.tsx
@@ -276,7 +276,7 @@ class InboxSearch extends React.Component<Props, State> {
 
     return (
       <Kb.Box2 style={styles.container} direction="vertical" fullWidth={true}>
-        {!Styles.isTablet && <Rover />}
+        <Rover />
         <Kb.SectionList
           ListHeaderComponent={this.props.header}
           stickySectionHeadersEnabled={true}


### PR DESCRIPTION
banged my head against this for a while, and then discovered that anchoring to the right edge instead of the left is a very easy fix that (i think) looks indistinguishably great.

<img width="400" alt="Screen Shot 2020-02-11 at 2 01 14 PM" src="https://user-images.githubusercontent.com/1275828/74270572-71423500-4cd9-11ea-87aa-4aec234801bb.png">

phone should be unchanged
<img width="200" alt="Screen Shot 2020-02-11 at 2 54 47 PM" src="https://user-images.githubusercontent.com/1275828/74278204-da7c7500-4ce6-11ea-977e-05c6badcf56f.png">
