### PR TITLE
Tablet fixes for info-panel

### DIFF
--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -94,7 +94,7 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
     {
       data: ['header'],
       renderItem: () => (
-        <Kb.Box2 direction="vertical" gap="tiny" gapStart={true} fullWidth={true}>
+        <Kb.Box2 direction="vertical" gap="tiny" gapStart={true} fullWidth={true} style={styles.header}>
           {this.props.teamname && this.props.channelname ? (
             <TeamHeader conversationIDKey={this.props.selectedConversationIDKey} />
           ) : (
@@ -179,7 +179,9 @@ const styles = Styles.styleSheetCreate(
           borderLeft: `1px solid ${Styles.globalColors.black_10}`,
           width: 320,
         },
+        isTablet: {marginTop: Styles.globalMargins.small},
       }),
+      header: Styles.platformStyles({isTablet: {marginBottom: Styles.globalMargins.small}}),
       tabContainerStyle: Styles.platformStyles({
         common: {
           backgroundColor: Styles.globalColors.white,
@@ -188,6 +190,9 @@ const styles = Styles.styleSheetCreate(
         isElectron: {
           overflowX: 'hidden',
           overflowY: 'hidden',
+        },
+        isTablet: {
+          justifyContent: 'center',
         },
       }),
       tabStyle: {

--- a/shared/chat/conversation/info-panel/settings/index.tsx
+++ b/shared/chat/conversation/info-panel/settings/index.tsx
@@ -169,11 +169,14 @@ const styles = Styles.styleSheetCreate(
         },
         isMobile: {width: '100%'},
       }),
-      settingsContainer: {
-        flex: 1,
-        height: '100%',
-        paddingTop: Styles.globalMargins.small,
-      },
+      settingsContainer: Styles.platformStyles({
+        common: {
+          flex: 1,
+          height: '100%',
+          paddingTop: Styles.globalMargins.small,
+        },
+        isTablet: {alignSelf: 'center', maxWidth: 600},
+      }),
     } as const)
 )
 

--- a/shared/common-adapters/button-bar.tsx
+++ b/shared/common-adapters/button-bar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import Box from './box'
-import {globalStyles, isMobile, collapseStyles} from '../styles'
+import {globalStyles, isMobile, collapseStyles, isTablet} from '../styles'
 
 type Props = {
   direction: 'row' | 'column'
@@ -51,9 +51,11 @@ class ButtonBar extends React.PureComponent<Props> {
     }
 
     const style = collapseStyles([
+      // This {width: 100%} should probably be removed.
+      // But for the sake of not making a big splash, it is only removed for tablet.
+      isTablet ? null : {width: '100%'},
       {
         alignItems: this.props.fullWidth ? 'stretch' : 'center',
-        width: '100%',
         ...(this.props.direction === 'column'
           ? {...globalStyles.flexBoxColumn}
           : {

--- a/shared/common-adapters/button-bar.tsx
+++ b/shared/common-adapters/button-bar.tsx
@@ -51,8 +51,6 @@ class ButtonBar extends React.PureComponent<Props> {
     }
 
     const style = collapseStyles([
-      // This {width: 100%} should probably be removed.
-      // But for the sake of not making a big splash, it is only removed for tablet.
       isTablet ? null : {width: '100%'},
       {
         alignItems: this.props.fullWidth ? 'stretch' : 'center',

--- a/shared/teams/team/settings-tab/retention/warning/index.tsx
+++ b/shared/teams/team/settings-tab/retention/warning/index.tsx
@@ -18,6 +18,7 @@ const Wrapper = ({children, onBack}: {children: React.ReactNode; onBack: () => v
   Styles.isMobile ? (
     <Kb.ScrollView
       style={{...Styles.globalStyles.fillAbsolute, ...Styles.globalStyles.flexBoxColumn}}
+      contentContainerStyle={styles.scrollContainer}
       children={children}
     />
   ) : (
@@ -52,7 +53,7 @@ const RetentionWarning = (props: Props) => {
           style={styles.checkboxStyle}
           label=""
           labelComponent={
-            <Kb.Box2 direction="vertical" alignItems="flex-start" style={styles.flexOne}>
+            <Kb.Box2 direction="vertical" alignItems="flex-start">
               <Kb.Text type="Body">
                 I understand that messages older than {props.timePeriod} will be deleted for everyone.
               </Kb.Text>
@@ -106,14 +107,12 @@ const styles = Styles.styleSheetCreate(() => ({
     },
     isMobile: {
       marginBottom: Styles.globalMargins.small,
-      width: '100%',
     },
   }),
   container: Styles.platformStyles({
     common: {
       ...Styles.globalStyles.flexBoxColumn,
       alignItems: 'center',
-      maxWidth: 560,
       paddingBottom: Styles.globalMargins.large,
     },
     isElectron: {
@@ -127,9 +126,12 @@ const styles = Styles.styleSheetCreate(() => ({
       paddingTop: Styles.globalMargins.small,
     },
   }),
-  flexOne: {flex: 1},
   headerStyle: {marginBottom: Styles.globalMargins.small},
   iconStyle: {marginBottom: 20},
+  scrollContainer: {
+    ...Styles.globalStyles.flexBoxCenter,
+    flex: 1,
+  },
 }))
 
 export default Kb.HeaderOnMobile(RetentionWarning)


### PR DESCRIPTION
Some fixes for info-panel.

Inside-out dropdowns coming in a later PR hopefully.

<img width="1136" alt="retention" src="https://user-images.githubusercontent.com/705646/74285659-54ffc180-4cf4-11ea-854a-f5fb4fb80ec8.png">
<img width="1138" alt="splode" src="https://user-images.githubusercontent.com/705646/74285664-57621b80-4cf4-11ea-94a5-5065ab223946.png">
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/705646/74285676-592bdf00-4cf4-11ea-8baa-c9ecf5d8fdc6.png">

