### PR TITLE
folder_block_ops: block writes while copying dirty dir blocks

### DIFF
--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -232,6 +232,9 @@ type folderBlockOps struct {
 	// set to true if this write or truncate should be deferred
 	doDeferWrite bool
 
+	// While this channel is non-nil and non-closed, writes get blocked.
+	holdNewWritesCh <-chan struct{}
+
 	// nodeCache itself is goroutine-safe, but write/truncate must
 	// call PathFromNode() only under blockLock (see nodeCache
 	// comments in folder_branch_ops.go).
@@ -1679,10 +1682,16 @@ func (fbo *folderBlockOps) GetDirtyFileBlockRefs(
 	return dirtyRefs
 }
 
-// GetDirtyDirBlockRefs returns a list of references of all known dirty
-// directories.
+// GetDirtyDirBlockRefs returns a list of references of all known
+// dirty directories.  Also returns a channel that, while it is open,
+// all future writes will be blocked until it is closed -- this lets
+// the caller ensure that the directory entries will remain stable
+// (not updated with new file sizes by the writes) until all of the
+// directory blocks have been safely copied.  The caller *must* close
+// this channel once they are done processing the dirty directory
+// blocks.
 func (fbo *folderBlockOps) GetDirtyDirBlockRefs(
-	lState *kbfssync.LockState) []data.BlockRef {
+	lState *kbfssync.LockState) ([]data.BlockRef, chan<- struct{}) {
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
 	var dirtyRefs []data.BlockRef
@@ -1693,7 +1702,9 @@ func (fbo *folderBlockOps) GetDirtyDirBlockRefs(
 		panic("GetDirtyDirBlockRefs() called twice")
 	}
 	fbo.dirtyDirsSyncing = true
-	return dirtyRefs
+	ch := make(chan struct{})
+	fbo.holdNewWritesCh = ch
+	return dirtyRefs, ch
 }
 
 // GetDirtyDirBlockRefsDone is called to indicate the caller is done
@@ -1704,6 +1715,7 @@ func (fbo *folderBlockOps) GetDirtyDirBlockRefsDone(
 	defer fbo.blockLock.Unlock(lState)
 	fbo.dirtyDirsSyncing = false
 	fbo.deferredDirUpdates = nil
+	fbo.holdNewWritesCh = nil
 }
 
 // getDirtyDirUnrefsLocked returns a list of block infos that need to be
@@ -2089,7 +2101,8 @@ func (fbo *folderBlockOps) writeDataLocked(
 	}
 	if de.BlockPointer != file.TailPointer() {
 		fbo.log.CDebugf(ctx, "DirEntry and file tail pointer don't match: "+
-			"%v vs %v", de.BlockPointer, file.TailPointer())
+			"%v vs %v, parent=%s", de.BlockPointer, file.TailPointer(),
+			file.ParentPath().TailPointer())
 	}
 
 	si, err := fbo.getOrCreateSyncInfoLocked(lState, de)
@@ -2124,6 +2137,38 @@ func (fbo *folderBlockOps) writeDataLocked(
 	return latestWrite, dirtyPtrs, newlyDirtiedChildBytes, nil
 }
 
+func (fbo *folderBlockOps) holdWritesLocked(
+	ctx context.Context, lState *kbfssync.LockState) error {
+	fbo.blockLock.AssertLocked(lState)
+
+	// Loop until either the hold channel is nil, or it has been
+	// closed.  However, we can't hold the lock while we're waiting
+	// for it to close, as that will cause deadlocks.  So we need to
+	// verify that it's the _same_ channel that was closed after we
+	// re-take the lock; otherwise, we need to wait again on the new
+	// channel.
+	for fbo.holdNewWritesCh != nil {
+		ch := fbo.holdNewWritesCh
+		fbo.blockLock.Unlock(lState)
+		fbo.vlog.CLogf(ctx, libkb.VLog1, "Blocking write on hold channel")
+		select {
+		case <-ch:
+			fbo.blockLock.Lock(lState)
+			// If the channel hasn't changed since we checked it
+			// outside of the lock, we are good to proceed.
+			if ch == fbo.holdNewWritesCh {
+				fbo.vlog.CLogf(
+					ctx, libkb.VLog1, "Unblocking write on hold channel")
+				return nil
+			}
+		case <-ctx.Done():
+			fbo.blockLock.Lock(lState)
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
 // Write writes the given data to the given file. May block if there
 // is too much unflushed data; in that case, it will be unblocked by a
 // future sync.
@@ -2147,6 +2192,11 @@ func (fbo *folderBlockOps) Write(
 
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
+
+	err = fbo.holdWritesLocked(ctx, lState)
+	if err != nil {
+		return err
+	}
 
 	filePath, err := fbo.pathFromNodeForBlockWriteLocked(lState, file)
 	if err != nil {
@@ -2391,6 +2441,11 @@ func (fbo *folderBlockOps) Truncate(
 
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
+
+	err = fbo.holdWritesLocked(ctx, lState)
+	if err != nil {
+		return err
+	}
 
 	filePath, err := fbo.pathFromNodeForBlockWriteLocked(lState, file)
 	if err != nil {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -5795,9 +5795,17 @@ func (fbo *folderBranchOps) syncAllLocked(
 	ctx context.Context, lState *kbfssync.LockState, excl Excl) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
-	dirtyDirs := fbo.blocks.GetDirtyDirBlockRefs(lState)
+	dirtyDirs, holdNewWritesCh := fbo.blocks.GetDirtyDirBlockRefs(lState)
+	doCloseHoldNewWritesCh := true
+	defer func() {
+		if doCloseHoldNewWritesCh {
+			close(holdNewWritesCh)
+		}
+	}()
 	defer fbo.blocks.GetDirtyDirBlockRefsDone(lState)
+
+	dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
+
 	if len(dirtyFiles) == 0 && len(dirtyDirs) == 0 {
 		return nil
 	}
@@ -6120,6 +6128,11 @@ func (fbo *folderBranchOps) syncAllLocked(
 			}
 		}
 	}
+
+	// Now that we've copied all the directory blocks and marked dirty
+	// files for syncing, we can unblock new writes.
+	close(holdNewWritesCh)
+	doCloseHoldNewWritesCh = false
 
 	session, err := fbo.config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {


### PR DESCRIPTION
The following scenario was causing bugs when syncs and writes were happening concurrently:

* `SyncAll` starts.
* It gets the list of dirty dirs, which sets `folderBlockOps.dirtyDirsSyncing = true`.
* Then a write to a file sneaks in.  Because `SyncAll` hasn’t yet started syncing the file, the update to the directory is deferred, but not the write to the file itself.
* Then `SyncAll` starts syncing the file.
* By the end of `SyncAll`, the file has synced and so its dirty status is cleared.
* Then the deferred directory update is replayed, causing the directory to be dirty without any corresponding dirty file or directory operation.
* After that, the next `SyncAll` starts, but it doesn’t consist of any operations.  It’s is only one dirty directory, without any operations to support it.
* This confuses the `folderUpdatePrepper` code, which decides that the directory hasn’t actually been updated because it’s not connected to an operation, and it turns the directory pointer's update into just a single reference in the MD's list of operations.
* Because of that, we don't update the node cache's pointer, and the directory's node remains pinned at its old block ID.
* Then the next write to a file in that directory then results in an error because the expected block pointers don't match up between the directory's entry for the file and the file node itself.

This happens because we allow writes to happen during syncs, so we don't slow things down for the user very much.  But this makes things complicated, since directory entries can change during the sync.  So instead, this commit blocks writes just during the sensitive phase of sync that is copying the dirty directory blocks.  That way, in constrast to the above, the written file won't be included in the sync, and its write will be deferred along with the directory update. Then the next sync will correctly pick up both the file write and the directory update.

The cost of this is that writes will be slightly buffered during a sync, but during that block there shouldn't be any disk or network accesses, so it shouldn't affect performance too much overall.

Note that I couldn't figure out a good way to write a reliable unit test for this scenario; I think it would require to much test-specific scaffolding to be inserted into the production code, and it doesn't seem worth it to me.  I was able to reliably reproduce it using the new KBFS search code though, and I'm reasonable confident it's fixed now.

Issue: HOTPOT-1903