### PR TITLE
iPad: Chat split inbox view

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -3604,7 +3604,7 @@ const refreshBotSettings = async (action: Chat2Gen.RefreshBotSettingsPayload, lo
 
 const onShowInfoPanel = (action: Chat2Gen.ShowInfoPanelPayload) => {
   const {conversationIDKey, show, tab} = action.payload
-  if (Container.isMobile) {
+  if (Container.isPhone) {
     const visibleScreen = Router2Constants.getVisibleScreen()
     if ((visibleScreen?.routeName === 'chatInfoPanel') !== show) {
       return show

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -91,7 +91,7 @@ const inboxRefresh = (
     actions.push(Chat2Gen.createClearMessages())
   }
   const reselectMode =
-    state.chat2.inboxHasLoaded || Container.isMobile
+    state.chat2.inboxHasLoaded || Container.isPhone
       ? RPCChatTypes.InboxLayoutReselectMode.default
       : RPCChatTypes.InboxLayoutReselectMode.force
   RPCChatTypes.localRequestInboxLayoutRpcPromise({reselectMode})
@@ -274,7 +274,7 @@ const maybeChangeSelectedConv = (
     !Constants.isValidConversationIDKey(selectedConversation) ||
     state.chat2.selectedConversation === reselectInfo.oldConvID
   ) {
-    if (Container.isMobile) {
+    if (Container.isPhone) {
       // on mobile just head back to the inbox if we have something selected
       if (Constants.isValidConversationIDKey(selectedConversation)) {
         logger.info(`maybeChangeSelectedConv: mobile: navigating up on conv change`)
@@ -2402,7 +2402,7 @@ const navigateToThreadRoute = (conversationIDKey: Types.ConversationIDKey, fromK
   let replace = false
   const visible = Router2Constants.getVisibleScreen()
 
-  if (!Container.isMobile && visible && visible.routeName === 'chatRoot') {
+  if (!Container.isPhone && visible && visible.routeName === 'chatRoot') {
     // Don't append; we don't want to increase the size of the stack on desktop
     return
   }
@@ -2418,7 +2418,7 @@ const navigateToThreadRoute = (conversationIDKey: Types.ConversationIDKey, fromK
 
   return RouteTreeGen.createNavigateAppend({
     fromKey,
-    path: [{props: {conversationIDKey}, selected: Container.isMobile ? 'chatConversation' : 'chatRoot'}],
+    path: [{props: {conversationIDKey}, selected: Container.isPhone ? 'chatConversation' : 'chatRoot'}],
     replace,
   })
 }
@@ -3624,9 +3624,10 @@ const onShowInfoPanel = (action: Chat2Gen.ShowInfoPanelPayload) => {
 
 function* chat2Saga() {
   // Platform specific actions
-  if (Container.isMobile) {
+  if (Container.isPhone) {
     // Push us into the conversation
     yield* Saga.chainAction2(Chat2Gen.selectConversation, mobileNavigateOnSelect)
+  } else if (Container.isMobile) {
     yield* Saga.chainGenerator<Chat2Gen.MessageAttachmentNativeSharePayload>(
       Chat2Gen.messageAttachmentNativeShare,
       mobileMessageAttachmentShare

--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -76,7 +76,7 @@ export class Conversation extends React.PureComponent<SwitchProps> {
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     let _storeConvoIDKey = Constants.getSelectedConversation(state)
-    const conversationIDKey = Container.isMobile
+    const conversationIDKey = Container.isPhone
       ? Container.getRouteProps(ownProps, 'conversationIDKey', Constants.noConversationIDKey)
       : _storeConvoIDKey
     let _meta = Constants.getMeta(state, conversationIDKey)

--- a/shared/chat/conversation/header-area/container.native.tsx
+++ b/shared/chat/conversation/header-area/container.native.tsx
@@ -28,9 +28,7 @@ const HeaderBranch = (props: Props) => {
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const conversationIDKey = Container.isPhone
-      ? ownProps.conversationIDKey
-      : Constants.getSelectedConversation(state)
+    const conversationIDKey = ownProps.conversationIDKey
     const meta = Constants.getMeta(state, conversationIDKey)
     const participantInfo = Constants.getParticipantInfo(state, conversationIDKey)
     const participants = meta.teamname ? null : participantInfo.name

--- a/shared/chat/conversation/header-area/container.native.tsx
+++ b/shared/chat/conversation/header-area/container.native.tsx
@@ -27,7 +27,10 @@ const HeaderBranch = (props: Props) => {
 }
 
 export default Container.connect(
-  (state, {conversationIDKey}: OwnProps) => {
+  (state, ownProps: OwnProps) => {
+    const conversationIDKey = Container.isPhone
+      ? ownProps.conversationIDKey
+      : Constants.getSelectedConversation(state)
     const meta = Constants.getMeta(state, conversationIDKey)
     const participantInfo = Constants.getParticipantInfo(state, conversationIDKey)
     const participants = meta.teamname ? null : participantInfo.name

--- a/shared/chat/conversation/header-area/index.native.tsx
+++ b/shared/chat/conversation/header-area/index.native.tsx
@@ -95,7 +95,11 @@ const ChannelHeader = (props: Props) => (
 
 const UsernameHeader = (props: Props) => (
   <Wrapper {...props}>
-    <Box2 direction={props.theirFullname ? 'vertical' : 'horizontal'} style={styles.usernameHeaderContainer}>
+    <Box2
+      direction={props.theirFullname ? 'vertical' : 'horizontal'}
+      fullWidth={true}
+      style={styles.usernameHeaderContainer}
+    >
       {!!props.theirFullname && (
         <Text lineClamp={1} type="BodyBig">
           {props.theirFullname}

--- a/shared/chat/conversation/normal/index.native.tsx
+++ b/shared/chat/conversation/normal/index.native.tsx
@@ -35,39 +35,55 @@ const Conversation = React.memo((props: Props) => {
   const onLayout = React.useCallback((e: LayoutEvent) => {
     setMaxInputArea(e.nativeEvent.layout.height)
   }, [])
+  const innerComponent = (
+    <Kb.BoxGrow onLayout={onLayout}>
+      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.innerContainer}>
+        <ThreadLoadStatus conversationIDKey={props.conversationIDKey} />
+        <PinnedMessage conversationIDKey={props.conversationIDKey} />
+        <ListArea
+          scrollListDownCounter={props.scrollListDownCounter}
+          scrollListToBottomCounter={props.scrollListToBottomCounter}
+          scrollListUpCounter={props.scrollListUpCounter}
+          onFocusInput={props.onFocusInput}
+          conversationIDKey={props.conversationIDKey}
+        />
+        {props.showLoader && <Kb.LoadingLine />}
+      </Kb.Box2>
+      <InvitationToBlock conversationID={props.conversationIDKey} />
+      <Banner conversationIDKey={props.conversationIDKey} />
+      <InputArea
+        focusInputCounter={props.focusInputCounter}
+        jumpToRecent={props.jumpToRecent}
+        onRequestScrollDown={props.onRequestScrollDown}
+        onRequestScrollToBottom={props.onRequestScrollToBottom}
+        onRequestScrollUp={props.onRequestScrollUp}
+        conversationIDKey={props.conversationIDKey}
+        maxInputArea={maxInputArea}
+      />
+    </Kb.BoxGrow>
+  )
   return (
-    <>
+    <Kb.Box style={styles.innerContainer}>
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
         {props.threadLoadedOffline && <Offline />}
-        <HeaderArea conversationIDKey={props.conversationIDKey} />
-        <Kb.BoxGrow onLayout={onLayout}>
-          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.innerContainer}>
-            <ThreadLoadStatus conversationIDKey={props.conversationIDKey} />
-            <PinnedMessage conversationIDKey={props.conversationIDKey} />
-            <ListArea
-              scrollListDownCounter={props.scrollListDownCounter}
-              scrollListToBottomCounter={props.scrollListToBottomCounter}
-              scrollListUpCounter={props.scrollListUpCounter}
-              onFocusInput={props.onFocusInput}
-              conversationIDKey={props.conversationIDKey}
-            />
-            {props.showLoader && <Kb.LoadingLine />}
-          </Kb.Box2>
-          <InvitationToBlock conversationID={props.conversationIDKey} />
-          <Banner conversationIDKey={props.conversationIDKey} />
-          <InputArea
-            focusInputCounter={props.focusInputCounter}
-            jumpToRecent={props.jumpToRecent}
-            onRequestScrollDown={props.onRequestScrollDown}
-            onRequestScrollToBottom={props.onRequestScrollToBottom}
-            onRequestScrollUp={props.onRequestScrollUp}
-            conversationIDKey={props.conversationIDKey}
-            maxInputArea={maxInputArea}
-          />
-        </Kb.BoxGrow>
+        {Styles.isTablet ? (
+          <Kb.KeyboardAvoidingView
+            style={Styles.globalStyles.fillAbsolute}
+            pointerEvents="box-none"
+            behavior="height"
+            keyboardVerticalOffset={80}
+          >
+            {innerComponent}
+          </Kb.KeyboardAvoidingView>
+        ) : (
+          <>
+            <HeaderArea conversationIDKey={props.conversationIDKey} />
+            {innerComponent}
+          </>
+        )}
       </Kb.Box2>
       <GatewayDest name="convOverlay" component={Kb.Box} />
-    </>
+    </Kb.Box>
   )
 })
 
@@ -78,6 +94,12 @@ const styles = Styles.styleSheetCreate(
         flex: 1,
         position: 'relative',
       },
+      outerContainer: Styles.platformStyles({
+        isTablet: {
+          flex: 1,
+          position: 'relative',
+        },
+      }),
     } as const)
 )
 

--- a/shared/chat/header.tsx
+++ b/shared/chat/header.tsx
@@ -29,7 +29,17 @@ type Props = {
   fullName?: string
 }
 
-const descStyle = {fontSize: 13, lineHeight: '16px', wordBreak: 'break-all'} as const // approximates BodySmall since markdown does not support text type
+const descStyleTablet = {
+  fontSize: 13,
+  lineHeight: 16,
+}
+const descStyleDesktop = {
+  fontSize: 13,
+  lineHeight: '16px',
+  wordBreak: 'break-all',
+} as const // approximates BodySmall since markdown does not support text type
+const descStyle = Container.isTablet ? descStyleTablet : descStyleDesktop
+
 const descStyleOverride = {
   del: descStyle,
   em: descStyle,
@@ -106,10 +116,7 @@ const Header = (p: Props) => {
         alignItems="flex-end"
         alignSelf="flex-end"
       >
-        <Kb.Box2
-          direction="vertical"
-          style={renderDescription ? styles.headerTitle : styles.headerTitleNoDesc}
-        >
+        <Kb.Box2 direction="vertical" style={styles.headerTitle}>
           <Kb.Box2 direction="horizontal" fullWidth={true}>
             {channel ? (
               <Kb.Text selectable={true} type="Header" lineClamp={1}>
@@ -231,11 +238,7 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       headerTitle: Styles.platformStyles({
-        common: {flexGrow: 1, paddingBottom: Styles.globalMargins.xtiny},
-        isElectron: Styles.desktopStyles.windowDraggingClickable,
-      }),
-      headerTitleNoDesc: Styles.platformStyles({
-        common: {flexGrow: 1, paddingBottom: Styles.globalMargins.tiny},
+        common: {flexGrow: Styles.isTablet ? 0 : 1, paddingBottom: Styles.globalMargins.xtiny},
         isElectron: Styles.desktopStyles.windowDraggingClickable,
       }),
       left: {minWidth: 260},

--- a/shared/chat/inbox-and-conversation-2.tsx
+++ b/shared/chat/inbox-and-conversation-2.tsx
@@ -1,10 +1,10 @@
-// Just for desktop, we show inbox and conversation side by side
+// Just for desktop and tablet, we show inbox and conversation side by side
 import * as React from 'react'
 import * as Kb from '../common-adapters'
 import Inbox from './inbox/container'
 import InboxSearch from './inbox-search/container'
 import Conversation from './conversation/container'
-import Header from './header.desktop'
+import Header from './header'
 import InfoPanel from './conversation/info-panel/container'
 import * as Container from '../util/container'
 

--- a/shared/chat/inbox-search/index.tsx
+++ b/shared/chat/inbox-search/index.tsx
@@ -276,7 +276,7 @@ class InboxSearch extends React.Component<Props, State> {
 
     return (
       <Kb.Box2 style={styles.container} direction="vertical" fullWidth={true}>
-        <Rover />
+        {!Styles.isTablet && <Rover />}
         <Kb.SectionList
           ListHeaderComponent={this.props.header}
           stickySectionHeadersEnabled={true}
@@ -395,6 +395,9 @@ const styles = Styles.styleSheetCreate(
         isMobile: {
           height: '100%',
           width: '100%',
+        },
+        isTablet: {
+          maxWidth: Styles.globalStyles.shortWidth,
         },
       }),
       errorText: {

--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -71,7 +71,7 @@ type Props = {
   _onInitialLoad: (array: Array<Types.ConversationIDKey>) => void
   _refreshInbox: () => void
   _canRefreshOnMount: boolean
-  _onMountedDesktop: () => void
+  _onMountedDesktopOrTablet: () => void
 } & _Props
 
 export class InboxWrapper extends React.PureComponent<Props> {
@@ -89,7 +89,7 @@ export class InboxWrapper extends React.PureComponent<Props> {
 
   componentDidMount() {
     if (!isPhone) {
-      this.props._onMountedDesktop()
+      this.props._onMountedDesktopOrTablet()
     }
     if (this.props._canRefreshOnMount) {
       this.props._refreshInbox()
@@ -113,7 +113,7 @@ export class InboxWrapper extends React.PureComponent<Props> {
       _refreshInbox,
       _onInitialLoad,
       _canRefreshOnMount,
-      _onMountedDesktop,
+      _onMountedDesktopOrTablet,
       ...rest
     } = this.props
     return <Inbox {...rest} />
@@ -149,7 +149,7 @@ const Connected = Container.namedConnect(
     // a hack to have it check for marked as read when we mount as the focus events don't fire always
     _onInitialLoad: (conversationIDKeys: Array<Types.ConversationIDKey>) =>
       dispatch(Chat2Gen.createMetaNeedsUpdating({conversationIDKeys, reason: 'initialTrustedLoad'})),
-    _onMountedDesktop: () => {
+    _onMountedDesktopOrTablet: () => {
       dispatch(Chat2Gen.createTabSelected())
     },
     _refreshInbox: () => dispatch(Chat2Gen.createInboxRefresh({reason: 'componentNeverLoaded'})),
@@ -218,7 +218,7 @@ const Connected = Container.namedConnect(
       _canRefreshOnMount: stateProps._canRefreshOnMount,
       _hasLoadedTrusted: stateProps._hasLoadedTrusted,
       _onInitialLoad: dispatchProps._onInitialLoad,
-      _onMountedDesktop: dispatchProps._onMountedDesktop,
+      _onMountedDesktopOrTablet: dispatchProps._onMountedDesktopOrTablet,
       _refreshInbox: dispatchProps._refreshInbox,
       allowShowFloatingButton: stateProps.allowShowFloatingButton,
       hasBigTeams,

--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -6,7 +6,7 @@ import * as Chat2Gen from '../../actions/chat2-gen'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 import {appendNewChatBuilder} from '../../actions/typed-routes'
 import Inbox from '.'
-import {isMobile} from '../../constants/platform'
+import {isPhone} from '../../constants/platform'
 import {
   Props as _Props,
   RowItemSmall,
@@ -88,7 +88,7 @@ export class InboxWrapper extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    if (!isMobile) {
+    if (!isPhone) {
       this.props._onMountedDesktop()
     }
     if (this.props._canRefreshOnMount) {
@@ -139,7 +139,7 @@ const Connected = Container.namedConnect(
       _selectedConversationIDKey: state.chat2.selectedConversation,
       allowShowFloatingButton,
       inboxNumSmallRows,
-      isLoading: isMobile ? Constants.anyChatWaitingKeys(state) : false, // desktop doesn't use isLoading so ignore it
+      isLoading: isPhone ? Constants.anyChatWaitingKeys(state) : false, // desktop doesn't use isLoading so ignore it
       isSearching: !!state.chat2.inboxSearch,
       neverLoaded,
       smallTeamsExpanded: state.chat2.smallTeamsExpanded,

--- a/shared/chat/inbox/filter-row/index.tsx
+++ b/shared/chat/inbox/filter-row/index.tsx
@@ -107,7 +107,7 @@ class ConversationFilterInput extends React.PureComponent<Props> {
       >
         {!Styles.isMobile && <Kb.HotKey hotKeys={this.hotKeys} onHotKey={this.onHotKeys} />}
         {searchInput}
-        {!this.props.isSearching && !!this.props.onNewChat && !Styles.isMobile && (
+        {!this.props.isSearching && !!this.props.onNewChat && !Styles.isPhone && (
           <Kb.Box style={styles.rainbowBorder}>
             <Kb.WithTooltip position="top center" tooltip={`(${Platforms.shortcutSymbol}N)`}>
               <Kb.Button

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -249,7 +249,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
             </Kb.Box2>
           ) : (
             <Kb.NativeFlatList
-              ListHeaderComponent={HeadComponent}
+              ListHeaderComponent={Styles.isTablet ? null : HeadComponent}
               data={this.props.rows}
               keyExtractor={this._keyExtractor}
               renderItem={this._renderItem}
@@ -278,12 +278,17 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       button: {width: '100%'},
-      container: {
-        ...Styles.globalStyles.flexBoxColumn,
-        backgroundColor: Styles.globalColors.fastBlank,
-        flex: 1,
-        position: 'relative',
-      },
+      container: Styles.platformStyles({
+        common: {
+          ...Styles.globalStyles.flexBoxColumn,
+          backgroundColor: Styles.globalColors.fastBlank,
+          flex: 1,
+          position: 'relative',
+        },
+        isTablet: {
+          maxWidth: Styles.globalStyles.shortWidth,
+        },
+      }),
       loadingContainer: {
         left: 0,
         position: 'absolute',

--- a/shared/chat/inbox/row/big-team-channel.tsx
+++ b/shared/chat/inbox/row/big-team-channel.tsx
@@ -23,7 +23,7 @@ const BigTeamChannel = (props: Props) => {
   const hasUnread = Container.useSelector(state => Constants.getHasUnread(state, conversationIDKey))
   const isMuted = Container.useSelector(state => Constants.isMuted(state, conversationIDKey))
   const isSelected = Container.useSelector(
-    state => !Container.isMobile && Constants.getSelectedConversation(state) === conversationIDKey
+    state => !Container.isPhone && Constants.getSelectedConversation(state) === conversationIDKey
   )
 
   const onSelectConversation = () =>

--- a/shared/chat/inbox/row/small-team/container.tsx
+++ b/shared/chat/inbox/row/small-team/container.tsx
@@ -40,7 +40,7 @@ export default Container.namedConnect(
       hasBadge: Constants.getHasBadge(state, _conversationIDKey),
       hasUnread: Constants.getHasUnread(state, _conversationIDKey),
       isMuted: Constants.isMuted(state, _conversationIDKey),
-      isSelected: !Container.isMobile && Constants.getSelectedConversation(state) === _conversationIDKey,
+      isSelected: !Container.isPhone && Constants.getSelectedConversation(state) === _conversationIDKey,
       isTypingSnippet,
       snippet,
       snippetDecoration,

--- a/shared/chat/inbox/row/small-team/index.tsx
+++ b/shared/chat/inbox/row/small-team/index.tsx
@@ -194,7 +194,7 @@ const styles = Styles.styleSheetCreate(() => ({
     paddingRight: 8,
   },
   fastBlank: Styles.platformStyles({
-    isMobile: {
+    isPhone: {
       backgroundColor: Styles.globalColors.fastBlank,
     },
   }),

--- a/shared/chat/inbox/row/small-team/top-line.tsx
+++ b/shared/chat/inbox/row/small-team/top-line.tsx
@@ -153,10 +153,15 @@ const styles = Styles.styleSheetCreate(
           whiteSpace: 'nowrap',
         },
       }),
-      timestamp: {
-        backgroundColor: Styles.globalColors.fastBlank,
-        color: Styles.globalColors.blueDark,
-      },
+      timestamp: Styles.platformStyles({
+        common: {
+          backgroundColor: Styles.globalColors.fastBlank,
+          color: Styles.globalColors.blueDark,
+        },
+        isTablet: {
+          backgroundColor: undefined,
+        },
+      }),
       unreadDotStyle: {
         backgroundColor: Styles.globalColors.orange,
         borderRadius: 6,

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -1,5 +1,4 @@
-import {isMobile} from '../constants/platform'
-
+import {isPhone} from '../constants/platform'
 import ChatConversation from './conversation/container'
 import ChatEnterPaperkey from './conversation/rekey/enter-paper-key'
 import ChatRoot from './inbox/container'
@@ -35,9 +34,7 @@ export const newRoutes = {
   },
   chatRoot: {
     getScreen: (): typeof ChatRoot =>
-      isMobile
-        ? require('./inbox/defer-loading').default
-        : require('./inbox-and-conversation-2.desktop').default,
+      isPhone ? require('./inbox/defer-loading').default : require('./inbox-and-conversation-2').default,
   },
 }
 

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -231,7 +231,6 @@ class FriendRow extends React.Component<FriendRowProps> {
   }
 
   render() {
-    console.warn('in render, usernames', this.props.usernames)
     return (
       <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.friendRow}>
         {this.props.usernames.map(u => (

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -68,6 +68,7 @@ export declare const globalStyles: {
   rounded: {
     borderRadius: 3
   }
+  shortWidth: number | string
 }
 
 export declare const desktopStyles: {

--- a/shared/styles/index.desktop.tsx
+++ b/shared/styles/index.desktop.tsx
@@ -67,6 +67,7 @@ const util = {
     marginTop: Shared.globalMargins.tiny,
   },
   mediumWidth: 400,
+  shortWidth: 240,
 }
 
 export const globalStyles = {

--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -40,6 +40,7 @@ const util = {
     height: 16,
   },
   mediumWidth: isTablet ? 460 : '100%',
+  shortWidth: isTablet ? 240 : '100%',
 }
 
 export const desktopStyles = {


### PR DESCRIPTION
@keybase/react-hackers 

Base PR for split inbox -- mainly converting `isMobile` to `isPhone` in sagas so that the desktop code gets used for navigation, and bringing `inbox-and-conversation` and `chat/header` over to tablet too.