### PR TITLE
tablet: shrink image attachment caption

### DIFF
--- a/shared/chat/conversation/attachment-get-titles/index.tsx
+++ b/shared/chat/conversation/attachment-get-titles/index.tsx
@@ -211,6 +211,10 @@ const styles = Styles.styleSheetCreate(
           width: '100%',
         },
         isElectron: {maxHeight: 100},
+        isTablet: {
+          alignSelf: 'center',
+          maxWidth: 460,
+        },
       }),
       inputContainer: Styles.platformStyles({
         isElectron: {


### PR DESCRIPTION
There's a lot of `width: 100%` on this screen, so doing it the easy way.

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/705646/74348211-55459e80-4d80-11ea-9e4f-d1a06475f6b7.png">
