### PR TITLE
display badge if menu item isBadged on desktop

### DIFF
--- a/shared/common-adapters/floating-menu/menu-layout/index.desktop.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.desktop.tsx
@@ -127,15 +127,6 @@ const styles = Styles.styleSheetCreate(
         marginTop: 8,
       },
       horizBox: {...Styles.globalStyles.flexBoxRow},
-      itemBodyText: {color: undefined},
-      itemContainer: {
-        ...Styles.globalStyles.flexBoxColumn,
-        paddingBottom: Styles.globalMargins.xtiny,
-        paddingLeft: Styles.globalMargins.small,
-        paddingRight: Styles.globalMargins.small,
-        paddingTop: Styles.globalMargins.xtiny,
-        position: 'relative',
-      },
       iconBadge: {
         backgroundColor: Styles.globalColors.blue,
         height: Styles.globalMargins.tiny,
@@ -145,6 +136,15 @@ const styles = Styles.styleSheetCreate(
         position: 'relative',
         right: Styles.globalMargins.xtiny,
         width: Styles.globalMargins.tiny,
+      },
+      itemBodyText: {color: undefined},
+      itemContainer: {
+        ...Styles.globalStyles.flexBoxColumn,
+        paddingBottom: Styles.globalMargins.xtiny,
+        paddingLeft: Styles.globalMargins.small,
+        paddingRight: Styles.globalMargins.small,
+        paddingTop: Styles.globalMargins.xtiny,
+        position: 'relative',
       },
       menuContainer: Styles.platformStyles({
         isElectron: {

--- a/shared/common-adapters/floating-menu/menu-layout/index.desktop.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.desktop.tsx
@@ -4,6 +4,7 @@ import Box from '../../box'
 import Divider from '../../divider'
 import Text from '../../text'
 import Meta from '../../meta'
+import Badge from '../../badge'
 import ProgressIndicator from '../../progress-indicator'
 import * as Styles from '../../../styles'
 
@@ -52,6 +53,7 @@ class MenuLayout extends Component<MenuLayoutProps> {
               />
             )}
             {item.decoration}
+            {item.isBadged && <Badge badgeStyle={Styles.collapseStyles([styles.badge, styles.iconBadge])} />}
           </Box>
         )}
         {!item.view && item.subTitle && (
@@ -133,6 +135,16 @@ const styles = Styles.styleSheetCreate(
         paddingRight: Styles.globalMargins.small,
         paddingTop: Styles.globalMargins.xtiny,
         position: 'relative',
+      },
+      iconBadge: {
+        backgroundColor: Styles.globalColors.blue,
+        height: Styles.globalMargins.tiny,
+        minWidth: 0,
+        paddingLeft: 0,
+        paddingRight: 0,
+        position: 'relative',
+        right: Styles.globalMargins.xtiny,
+        width: Styles.globalMargins.tiny,
       },
       menuContainer: Styles.platformStyles({
         isElectron: {


### PR DESCRIPTION
This PR fixes an issue where the "Subscribe to channels..." menu item would not be badged on desktop. Although it's badged correctly on mobile, the desktop menu item component didn't do anything with the `isBadged` prop, so adding a badge if `isBadged` resolved the issue.