### PR TITLE
file_block_map: don't leak plaintext filenames in errors

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -2359,7 +2359,7 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 		}
 	}
 
-	err = blocks.putTopBlock(ctx, mergedMostRecent, name.Plaintext(), fblock)
+	err = blocks.putTopBlock(ctx, mergedMostRecent, name, fblock)
 	if err != nil {
 		return data.BlockPointer{}, err
 	}

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -1496,7 +1496,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 			mergedRootPath.TailPointer())
 	} else if len(blocks) != 1 {
 		t.Errorf("Unexpected number of blocks")
-	} else if fblock, ok := blocks[mergedName]; !ok {
+	} else if fblock, ok := blocks[data.NewPathPartString(mergedName, nil)]; !ok {
 		t.Errorf("No block for name %s", mergedName)
 	} else if fblock.IsInd {
 		t.Errorf("Unexpected indirect block")

--- a/go/kbfs/libkbfs/file_block_map_memory.go
+++ b/go/kbfs/libkbfs/file_block_map_memory.go
@@ -14,21 +14,23 @@ import (
 // fileBlockMapMemory is an internal structure to track file block
 // data in memory when putting blocks.
 type fileBlockMapMemory struct {
-	blocks map[data.BlockPointer]map[string]*data.FileBlock
+	blocks map[data.BlockPointer]map[data.PathPartString]*data.FileBlock
 }
 
 var _ fileBlockMap = (*fileBlockMapMemory)(nil)
 
 func newFileBlockMapMemory() *fileBlockMapMemory {
-	return &fileBlockMapMemory{make(map[data.BlockPointer]map[string]*data.FileBlock)}
+	return &fileBlockMapMemory{
+		blocks: make(map[data.BlockPointer]map[data.PathPartString]*data.FileBlock),
+	}
 }
 
 func (fbmm *fileBlockMapMemory) putTopBlock(
-	_ context.Context, parentPtr data.BlockPointer, childName string,
-	topBlock *data.FileBlock) error {
+	_ context.Context, parentPtr data.BlockPointer,
+	childName data.PathPartString, topBlock *data.FileBlock) error {
 	nameMap, ok := fbmm.blocks[parentPtr]
 	if !ok {
-		nameMap = make(map[string]*data.FileBlock)
+		nameMap = make(map[data.PathPartString]*data.FileBlock)
 		fbmm.blocks[parentPtr] = nameMap
 	}
 	nameMap[childName] = topBlock
@@ -36,8 +38,8 @@ func (fbmm *fileBlockMapMemory) putTopBlock(
 }
 
 func (fbmm *fileBlockMapMemory) GetTopBlock(
-	_ context.Context, parentPtr data.BlockPointer, childName string) (
-	*data.FileBlock, error) {
+	_ context.Context, parentPtr data.BlockPointer,
+	childName data.PathPartString) (*data.FileBlock, error) {
 	nameMap, ok := fbmm.blocks[parentPtr]
 	if !ok {
 		return nil, errors.Errorf("No such parent %s", parentPtr)
@@ -51,12 +53,13 @@ func (fbmm *fileBlockMapMemory) GetTopBlock(
 }
 
 func (fbmm *fileBlockMapMemory) getFilenames(
-	_ context.Context, parentPtr data.BlockPointer) (names []string, err error) {
+	_ context.Context, parentPtr data.BlockPointer) (
+	names []data.PathPartString, err error) {
 	nameMap, ok := fbmm.blocks[parentPtr]
 	if !ok {
 		return nil, nil
 	}
-	names = make([]string, 0, len(nameMap))
+	names = make([]data.PathPartString, 0, len(nameMap))
 	for name := range nameMap {
 		names = append(names, name)
 	}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -6083,8 +6083,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 		}
 		resolvedPaths[file.TailPointer()] = file
 		parent := file.ParentPath().TailPointer()
-		err = fileBlocks.putTopBlock(
-			ctx, parent, file.TailName().Plaintext(), fblock)
+		err = fileBlocks.putTopBlock(ctx, parent, file.TailName(), fblock)
 		if err != nil {
 			return err
 		}

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -474,7 +474,7 @@ func (fup *folderUpdatePrepper) prepTree(
 
 			var err error
 			fblock, err = newFileBlocks.GetTopBlock(
-				ctx, node.parent.ptr, node.mergedPath.TailName().Plaintext())
+				ctx, node.parent.ptr, node.mergedPath.TailName())
 			if err != nil {
 				return err
 			}
@@ -955,13 +955,14 @@ func (fup *folderUpdatePrepper) updateResolutionUsageAndPointersLockedCache(
 func (fup *folderUpdatePrepper) setChildrenNodes(
 	ctx context.Context, lState *kbfssync.LockState, kmd libkey.KeyMetadata,
 	p data.Path, indexInPath int, dbm dirBlockMap, nextNode *pathTreeNode,
-	currPath data.Path, names []string) {
+	currPath data.Path, names []data.PathPartString) {
 	dd, cleanupFn := fup.blocks.newDirDataWithDBM(
 		lState, currPath, keybase1.UserOrTeamID(""), kmd, dbm)
 	defer cleanupFn()
 
 	pnode := p.Path[indexInPath]
-	for _, namePlain := range names {
+	for _, name := range names {
+		namePlain := name.Plaintext()
 		if _, ok := nextNode.children[namePlain]; ok {
 			continue
 		}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2554,12 +2554,14 @@ type blockPutStateCopiable interface {
 
 type fileBlockMap interface {
 	putTopBlock(
-		ctx context.Context, parentPtr data.BlockPointer, childName string,
-		topBlock *data.FileBlock) error
+		ctx context.Context, parentPtr data.BlockPointer,
+		childName data.PathPartString, topBlock *data.FileBlock) error
 	GetTopBlock(
-		ctx context.Context, parentPtr data.BlockPointer, childName string) (
-		*data.FileBlock, error)
-	getFilenames(ctx context.Context, parentPtr data.BlockPointer) ([]string, error)
+		ctx context.Context, parentPtr data.BlockPointer,
+		childName data.PathPartString) (*data.FileBlock, error)
+	getFilenames(
+		ctx context.Context, parentPtr data.BlockPointer) (
+		[]data.PathPartString, error)
 }
 
 type dirBlockMap interface {


### PR DESCRIPTION
These errors should be rare, but they still shouldn't print the plaintext name.  No reason not to pass around `PathPartString`s here.

Issue: HOTPOT-1859