### PR TITLE
iPad: Chat header styling tweaks

### DIFF
--- a/shared/chat/header.tsx
+++ b/shared/chat/header.tsx
@@ -107,7 +107,7 @@ const Header = (p: Props) => {
   return (
     <Kb.Box2 direction="horizontal" style={styles.container} fullWidth={true}>
       <Kb.Box2 direction="vertical" style={styles.left}>
-        <ChatInboxHeader />
+        <ChatInboxHeader showNewChat={true} showSearch={!Styles.isTablet} />
       </Kb.Box2>
       <Kb.Box2
         direction="horizontal"
@@ -216,9 +216,16 @@ const Header = (p: Props) => {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      actionIcons: {
-        paddingBottom: Styles.globalMargins.tiny,
-      },
+      actionIcons: Styles.platformStyles({
+        common: {
+          paddingBottom: Styles.globalMargins.tiny,
+        },
+        isTablet: {
+          flexGrow: 0,
+          flexShrink: 0,
+          minWidth: 200,
+        },
+      }),
       clickable: Styles.platformStyles({isElectron: Styles.desktopStyles.windowDraggingClickable}),
       container: {
         flexGrow: 1,
@@ -238,10 +245,19 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       headerTitle: Styles.platformStyles({
-        common: {flexGrow: Styles.isTablet ? 0 : 1, paddingBottom: Styles.globalMargins.xtiny},
+        common: {
+          flexGrow: 1,
+          paddingBottom: Styles.globalMargins.xtiny,
+        },
         isElectron: Styles.desktopStyles.windowDraggingClickable,
+        isTablet: {
+          flex: 1,
+        },
       }),
-      left: {minWidth: 260},
+      left: Styles.platformStyles({
+        isElectron: {minWidth: 260},
+        isTablet: {minWidth: 180},
+      }),
       right: {
         flexGrow: 1,
         paddingLeft: Styles.globalMargins.xsmall,

--- a/shared/chat/inbox-and-conversation-2.tsx
+++ b/shared/chat/inbox-and-conversation-2.tsx
@@ -19,7 +19,7 @@ const InboxAndConversation = (props: Props) => {
 
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
-      {inboxSearch ? <InboxSearch /> : <Inbox navKey={navKey} />}
+      {!Container.isTablet && inboxSearch ? <InboxSearch /> : <Inbox navKey={navKey} />}
       <Conversation navigation={props.navigation} />
       {infoPanelShowing && <InfoPanel />}
     </Kb.Box2>

--- a/shared/chat/inbox/filter-row/container.tsx
+++ b/shared/chat/inbox/filter-row/container.tsx
@@ -11,6 +11,8 @@ type OwnProps = {
   onSelectUp: () => void
   onQueryChanged: (arg0: string) => void
   query: string
+  showNewChat: boolean
+  showSearch: boolean
 }
 
 export default Container.namedConnect(
@@ -30,12 +32,14 @@ export default Container.namedConnect(
     isSearching: stateProps.isSearching,
     onBack: dispatchProps.onBack,
     onEnsureSelection: ownProps.onEnsureSelection,
-    onNewChat: ownProps.onNewChat,
+    onNewChat: ownProps.showNewChat ? ownProps.onNewChat : null,
     onSelectDown: ownProps.onSelectDown,
     onSelectUp: ownProps.onSelectUp,
     onSetFilter: ownProps.onQueryChanged,
     onStartSearch: dispatchProps.onStartSearch,
     onStopSearch: dispatchProps.onStopSearch,
+    showNewChat: ownProps.showNewChat,
+    showSearch: ownProps.showSearch,
   }),
   'ChatFilterRow'
 )(ConversationFilterInput)

--- a/shared/chat/inbox/filter-row/index.tsx
+++ b/shared/chat/inbox/filter-row/index.tsx
@@ -9,12 +9,14 @@ export type Props = {
   isSearching: boolean
   onBack: () => void
   onEnsureSelection: () => void
-  onNewChat?: () => void
+  onNewChat?: (() => void) | null
   onSelectDown: () => void
   onSelectUp: () => void
   onSetFilter: (filter: string) => void
   onStartSearch: () => void
   onStopSearch: () => void
+  showNewChat: boolean
+  showSearch: boolean
   style?: Styles.StylesCrossPlatform
 }
 
@@ -94,20 +96,20 @@ class ConversationFilterInput extends React.PureComponent<Props> {
     return (
       <Kb.Box2
         direction="horizontal"
-        centerChildren={true}
+        centerChildren={!Styles.isTablet}
         gap={Styles.isMobile ? 'small' : 'tiny'}
         style={Styles.collapseStyles([
           styles.containerNotFiltering,
           !Styles.isMobile && styles.whiteBg,
           this.props.style,
         ])}
-        gapStart={true}
+        gapStart={this.props.showSearch}
         gapEnd={true}
         fullWidth={true}
       >
         {!Styles.isMobile && <Kb.HotKey hotKeys={this.hotKeys} onHotKey={this.onHotKeys} />}
-        {searchInput}
-        {!this.props.isSearching && !!this.props.onNewChat && !Styles.isPhone && (
+        {this.props.showSearch && searchInput}
+        {!!this.props.onNewChat && !Styles.isPhone && (Styles.isTablet || !this.props.isSearching) && (
           <Kb.Box style={styles.rainbowBorder}>
             <Kb.WithTooltip position="top center" tooltip={`(${Platforms.shortcutSymbol}N)`}>
               <Kb.Button

--- a/shared/chat/inbox/header/container.tsx
+++ b/shared/chat/inbox/header/container.tsx
@@ -1,9 +1,14 @@
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import {namedConnect, isMobile} from '../../../util/container'
+import {namedConnect, isPhone} from '../../../util/container'
 import ChatInboxHeader from '.'
 import HiddenString from '../../../util/hidden-string'
 import {appendNewChatBuilder} from '../../../actions/typed-routes'
+
+type OwnProps = {
+  showNewChat: boolean
+  showSearch: boolean
+}
 
 export default namedConnect(
   state => {
@@ -13,10 +18,11 @@ export default namedConnect(
       (state.chat2.inboxLayout.smallTeams || []).length === 0 &&
       (state.chat2.inboxLayout.bigTeams || []).length === 0
     const showEmptyInbox = !state.chat2.inboxSearch && hasLoadedEmptyInbox
+    const showNewChat = !isPhone && showEmptyInbox
     return {
       isSearching: !!state.chat2.inboxSearch,
       showFilter: !showEmptyInbox,
-      showNewChat: !isMobile && showEmptyInbox,
+      showNewChat,
     }
   },
   dispatch => ({
@@ -27,7 +33,7 @@ export default namedConnect(
     onSelectDown: () => dispatch(Chat2Gen.createInboxSearchMoveSelectedIndex({increment: true})),
     onSelectUp: () => dispatch(Chat2Gen.createInboxSearchMoveSelectedIndex({increment: false})),
   }),
-  (stateProps, dispatchProps) => ({
+  (stateProps, dispatchProps, ownProps: OwnProps) => ({
     isSearching: stateProps.isSearching,
     onBack: dispatchProps.onBack,
     onEnsureSelection: dispatchProps.onEnsureSelection,
@@ -36,7 +42,9 @@ export default namedConnect(
     onSelectDown: dispatchProps.onSelectDown,
     onSelectUp: dispatchProps.onSelectUp,
     showFilter: stateProps.showFilter,
-    showNewChat: stateProps.showNewChat,
+    showNewChat: ownProps.showNewChat,
+    showSearch: ownProps.showSearch,
+    showStartNewChat: stateProps.showNewChat,
   }),
   'ChatInboxHeaderContainer'
 )(ChatInboxHeader)

--- a/shared/chat/inbox/header/index.tsx
+++ b/shared/chat/inbox/header/index.tsx
@@ -8,6 +8,8 @@ type Props = {
   onNewChat: () => void
   showFilter: boolean
   showNewChat: boolean
+  showSearch: boolean
+  showStartNewChat: boolean
   onSelectUp: () => void
   onSelectDown: () => void
   onEnsureSelection: () => void
@@ -34,7 +36,7 @@ class ChatInboxHeader extends React.Component<Props, State> {
   render() {
     return (
       <>
-        {!!this.props.showNewChat && (
+        {!!this.props.showStartNewChat && (
           <StartNewChat onBack={this.props.onBack} onNewChat={this.props.onNewChat} />
         )}
         {!!this.props.showFilter && (
@@ -45,6 +47,8 @@ class ChatInboxHeader extends React.Component<Props, State> {
             onEnsureSelection={this.props.onEnsureSelection}
             onQueryChanged={this._setQuery}
             query={this.state.query}
+            showNewChat={this.props.showNewChat}
+            showSearch={this.props.showSearch}
           />
         )}
       </>

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -234,7 +234,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
     const floatingDivider = this.state.showFloating &&
       !this.props.isSearching &&
       this.props.allowShowFloatingButton && <BigTeamsDivider toggle={this.props.toggleSmallTeamsExpanded} />
-    const HeadComponent = <ChatInboxHeader />
+    const HeadComponent = <ChatInboxHeader showNewChat={false} showSearch={Styles.isMobile} />
     return (
       <Kb.ErrorBoundary>
         <Kb.Box style={styles.container}>
@@ -249,7 +249,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
             </Kb.Box2>
           ) : (
             <Kb.NativeFlatList
-              ListHeaderComponent={Styles.isTablet ? null : HeadComponent}
+              ListHeaderComponent={HeadComponent}
               data={this.props.rows}
               keyExtractor={this._keyExtractor}
               renderItem={this._renderItem}


### PR DESCRIPTION
@keybase/react-hackers 

Screenshots:

![Screen Shot 2020-02-12 at 11 29 08 AM](https://user-images.githubusercontent.com/21217/74369845-f174a300-4d8a-11ea-8e54-ee60f4d0f038.png)

![Screen Shot 2020-02-12 at 11 29 19 AM](https://user-images.githubusercontent.com/21217/74369891-02251900-4d8b-11ea-8920-bc95630e982b.png)

On desktop we combine Search and New Chat into the header, which I don't think we have horizontal space for here on older iPads.  So this PR makes tablets look more like mobile, with a lone New chat button above the inbox, and the Search as the first row of the inbox.