### PR TITLE
folder_branch_ops: only one partial sync should happen at a time

### DIFF
--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3832,3 +3832,18 @@ func (c Confidence) ToJsonw() *jsonw.Wrapper {
 	}
 	return j
 }
+
+func (fsc FolderSyncConfig) Equal(other FolderSyncConfig) bool {
+	if fsc.Mode != other.Mode {
+		return false
+	}
+	if len(fsc.Paths) != len(other.Paths) {
+		return false
+	}
+	for i, p := range fsc.Paths {
+		if p != other.Paths[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Make sure that only one partial sync for the same revision, with the same sync configuration, can only happen at a time.  In user logs, I've seen many partial syncs being launched for the same revision (for recent file syncing, in particular), possibly launched by connection flapping.  This just makes that impossible, to avoid extraneous CPU usage and logging.

Issue: HOTPOT-1830