### PR TITLE
back in buttonbar tablet change

### DIFF
--- a/shared/common-adapters/button-bar.tsx
+++ b/shared/common-adapters/button-bar.tsx
@@ -51,9 +51,9 @@ class ButtonBar extends React.PureComponent<Props> {
     }
 
     const style = collapseStyles([
+      this.props.direction === 'column' ? {width: '100%'} : isTablet ? undefined : {width: '100%'},
       {
         alignItems: this.props.fullWidth ? 'stretch' : 'center',
-        width: '100%',
         ...(this.props.direction === 'column'
           ? {...globalStyles.flexBoxColumn}
           : {

--- a/shared/common-adapters/button-bar.tsx
+++ b/shared/common-adapters/button-bar.tsx
@@ -51,9 +51,9 @@ class ButtonBar extends React.PureComponent<Props> {
     }
 
     const style = collapseStyles([
-      isTablet ? null : {width: '100%'},
       {
         alignItems: this.props.fullWidth ? 'stretch' : 'center',
+        width: '100%',
         ...(this.props.direction === 'column'
           ? {...globalStyles.flexBoxColumn}
           : {


### PR DESCRIPTION
Better than https://github.com/keybase/client/pull/22527 @cjb since it leaves the buttons on the retention warning centered.

![image](https://user-images.githubusercontent.com/705646/74375002-91432880-4dad-11ea-9790-b995a106dcd8.png)
![image](https://user-images.githubusercontent.com/705646/74375054-ab7d0680-4dad-11ea-8dbb-8ac6592e7094.png)
![image](https://user-images.githubusercontent.com/705646/74375110-bd5ea980-4dad-11ea-92ec-4ac9e4a8aeb2.png)
