### PR TITLE
Filter bots from info panel members

### DIFF
--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -13,7 +13,7 @@ import * as Constants from '../../../constants/chat2'
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
   onClick: (username: string) => void
-  showInChannel: boolean
+  showInChannel?: boolean
 }
 
 export const Bot = (props: BotProps) => {

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -13,11 +13,11 @@ import * as Constants from '../../../constants/chat2'
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
   onClick: (username: string) => void
-  showInChannel?: boolean
+  showNotInChannel?: boolean
 }
 
 export const Bot = (props: BotProps) => {
-  const {botAlias, description, botUsername, onClick, showInChannel} = props
+  const {botAlias, description, botUsername, onClick, showNotInChannel} = props
   const {ownerTeam, ownerUser} = props
   const lower = (
     <Kb.Box2
@@ -66,9 +66,15 @@ export const Bot = (props: BotProps) => {
               {usernameDisplay}
               {lower}
             </Kb.Box2>
-            {showInChannel && (
-              <Kb.WithTooltip tooltip={`${botAlias || botUsername} can respond to messages in this channel.`}>
-                <Kb.Icon type="iconfont-bot" color={Styles.globalColors.black_35} onClick={() => null} />
+            {showNotInChannel && (
+              <Kb.WithTooltip
+                tooltip={`${botAlias || botUsername} can't respond to messages in this channel.`}
+              >
+                <Kb.Icon
+                  type="iconfont-exclamation"
+                  color={Styles.globalColors.black_35}
+                  onClick={() => null}
+                />
               </Kb.WithTooltip>
             )}
           </Kb.Box2>
@@ -288,7 +294,11 @@ export default (props: Props) => {
             <Bot
               {...item}
               onClick={onBotSelect}
-              showInChannel={teamType === 'big' && participantsAll.includes(item.botUsername)}
+              showNotInChannel={
+                teamType === 'big' &&
+                botUsernames.includes(item.botUsername) &&
+                !participantsAll.includes(item.botUsername)
+              }
             />
           )
         }

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -13,10 +13,11 @@ import * as Constants from '../../../constants/chat2'
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
   onClick: (username: string) => void
+  showInChannel: boolean
 }
 
 export const Bot = (props: BotProps) => {
-  const {botAlias, description, botUsername, onClick} = props
+  const {botAlias, description, botUsername, onClick, showInChannel} = props
   const {ownerTeam, ownerUser} = props
   const lower = (
     <Kb.Box2
@@ -65,6 +66,11 @@ export const Bot = (props: BotProps) => {
               {usernameDisplay}
               {lower}
             </Kb.Box2>
+            {showInChannel && (
+              <Kb.WithTooltip tooltip={`${botAlias || botUsername} can respond to messages in this channel.`}>
+                <Kb.Icon type="iconfont-bot" color={Styles.globalColors.black_35} onClick={() => null} />
+              </Kb.WithTooltip>
+            )}
           </Kb.Box2>
         </Kb.Box2>
         <Kb.Divider style={styles.divider} />
@@ -278,7 +284,13 @@ export default (props: Props) => {
         if (!item.botUsername) {
           return null
         } else {
-          return <Bot {...item} onClick={onBotSelect} />
+          return (
+            <Bot
+              {...item}
+              onClick={onBotSelect}
+              showInChannel={teamType === 'big' && participantsAll.includes(item.botUsername)}
+            />
+          )
         }
       },
       renderSectionHeader: renderTabs,

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -29,9 +29,7 @@ export default (props: Props) => {
     Constants.getParticipantInfo(state, conversationIDKey)
   )
   let participants = participantInfo.all
-  const smallTeam = meta.teamType !== 'big'
   const adhocTeam = meta.teamType === 'adhoc'
-  const shouldFilterBots = smallTeam
 
   let botUsernames: Array<string> = []
   if (adhocTeam) {
@@ -53,12 +51,11 @@ export default (props: Props) => {
       return l
     }, [])
 
-    if (flags.botUI && shouldFilterBots) {
+    if (flags.botUI) {
       participants = participants.filter(p => !botUsernames.includes(p))
     }
   } else {
-    participants =
-      flags.botUI && shouldFilterBots ? participants.filter(p => !botUsernames.includes(p)) : participants
+    participants = flags.botUI ? participants.filter(p => !botUsernames.includes(p)) : participants
   }
 
   const participantsItems = participants


### PR DESCRIPTION
Filters bot usernames from the "Members" tab in the info panel for all teams, and adds an icon with a tooltip if a bot is in a channel in a big team. 
