### PR TITLE
Truncate replies to 3 lines

### DIFF
--- a/shared/chat/conversation/messages/text/index.tsx
+++ b/shared/chat/conversation/messages/text/index.tsx
@@ -65,6 +65,7 @@ const Reply = (props: ReplyProps) => {
                 <Kb.Text
                   type="BodySmall"
                   style={Styles.collapseStyles([props.isParentHighlighted && styles.textHighlighted])}
+                  lineClamp={3}
                 >
                   {props.text}
                 </Kb.Text>


### PR DESCRIPTION
Clamps replies to 3 lines since you can just click through and see the (very long) original message.

![Screen Shot 2020-02-12 at 5 55 29 PM](https://user-images.githubusercontent.com/54032873/74385258-269be800-4dc1-11ea-8de4-84719542f90e.png)

cc @keybase/design 