### PR TITLE
libkb: save bandwidth on sig/get

### DIFF
--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -246,7 +246,7 @@ type ChainLink struct {
 func (c ChainLink) checkSpecialLinksTable(tab map[keybase1.LinkID]SpecialChainLink, uid keybase1.UID, why string) (found bool, reason string, err error) {
 	var scl SpecialChainLink
 
-	// The combination of hashVerified and chainVerified should ensure that this link
+	// The truthiness of hashVerified should ensure that this link
 	// is only considered here after all prevs have been successfully checked.
 	if !c.canTrustID() {
 		return false, "", ChainLinkError{fmt.Sprintf("cannot check if a link is %q without a verified link ID (linkID=%s, uid=%s, hash=%v, chain=%v, diskVersion=%d)", why, c.id, uid, c.hashVerified, c.chainVerified, c.diskVersion)}
@@ -823,7 +823,9 @@ func (c *ChainLink) Unpack(m MetaContext, trusted bool, selfUID keybase1.UID, pa
 	var payload []byte
 	switch tmp.sigVersion {
 	case KeybaseSignatureV1:
-		// use the payload from the signature here, since it's sent down.
+		// Use the payload from the signature here, since we always get the full signature with
+		// the attached payload for V1 signatures. Note that we redundantly check that the payload
+		// matches the sig in verifyPayloadV1() on the way out of this Unpack function.
 		payload, err = tmp.Payload()
 		if err != nil {
 			return err

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -427,6 +427,10 @@ func (c *ChainLink) Pack() (*jsonw.Wrapper, error) {
 		if err != nil {
 			return nil, err
 		}
+		err = p.SetKey("payload_verified", jsonw.NewBool(c.payloadVerified))
+		if err != nil {
+			return nil, err
+		}
 		err = p.SetKey("proof_text_full", jsonw.NewString(c.unpacked.proofText))
 		if err != nil {
 			return nil, err
@@ -934,6 +938,9 @@ func (c *ChainLink) Unpack(m MetaContext, trusted bool, selfUID keybase1.UID, pa
 		}
 		if b, err := jsonparserw.GetBoolean(packed, "chain_verified"); err == nil && b {
 			c.chainVerified = true
+		}
+		if b, err := jsonparserw.GetBoolean(packed, "payload_verified"); err == nil && b {
+			c.payloadVerified = true
 		}
 		if i, err := jsonparserw.GetInt(packed, "disk_version"); err == nil {
 			c.diskVersion = int(i)

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -244,6 +244,7 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 	readDeleted := m.G().Env.GetReadDeletedSigChain()
 
 	v2Compressed := (stubMode == StubModeStubbed)
+	nopj := true
 
 	resp, finisher, err := sc.G().API.GetResp(m, APIArg{
 		Endpoint:    "sig/get",
@@ -252,6 +253,7 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 			"uid":           UIDArg(sc.uid),
 			"low":           I{int(low)},
 			"v2_compressed": B{v2Compressed},
+			"nopj":          B{nopj},
 			"read_deleted":  B{readDeleted},
 		},
 	})


### PR DESCRIPTION
- tell the server not to send down payload_json if we can read them out of signatures