### PR TITLE
Restore feedback screen padding

### DIFF
--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -185,9 +185,11 @@ const styles = Styles.styleSheetCreate(
         isMobile: {...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small)},
       }),
       mainBox: Styles.platformStyles({
+        common: {
+          padding: Styles.globalMargins.small,
+        },
         isElectron: {
           maxWidth: 550,
-          padding: Styles.globalMargins.small,
           width: '100%',
         },
         isTablet: {

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -194,7 +194,6 @@ const styles = Styles.styleSheetCreate(
         },
         isTablet: {
           maxWidth: Styles.globalStyles.mediumWidth,
-          padding: Styles.globalMargins.small,
           width: '100%',
         },
       }),


### PR DESCRIPTION
Mobile padding was lost in https://github.com/keybase/client/pull/22450

<img width="442" alt="image" src="https://user-images.githubusercontent.com/705646/74447375-40800e00-4e47-11ea-9381-46a406519bab.png">

