### PR TITLE
render resets in tracker2

### DIFF
--- a/shared/actions/json/tracker2.json
+++ b/shared/actions/json/tracker2.json
@@ -23,6 +23,9 @@
       "blocked": "boolean",
       "hidFromFollowers": "boolean"
     },
+    "updateUserReset": {
+      "guiID": "string"
+    },
     "updateResult": {
       "guiID": "string",
       "result": "Types.DetailsState",

--- a/shared/actions/tracker2-gen.tsx
+++ b/shared/actions/tracker2-gen.tsx
@@ -17,6 +17,7 @@ export const showUser = 'tracker2:showUser'
 export const updateAssertion = 'tracker2:updateAssertion'
 export const updateFollows = 'tracker2:updateFollows'
 export const updateResult = 'tracker2:updateResult'
+export const updateUserReset = 'tracker2:updateUserReset'
 export const updatedDetails = 'tracker2:updatedDetails'
 
 // Payload Types
@@ -62,6 +63,7 @@ type _UpdateResultPayload = {
   readonly result: Types.DetailsState
   readonly reason?: string
 }
+type _UpdateUserResetPayload = {readonly guiID: string}
 type _UpdatedDetailsPayload = {
   readonly guiID: string
   readonly bio: string
@@ -116,6 +118,10 @@ export const createUpdateResult = (payload: _UpdateResultPayload): UpdateResultP
   payload,
   type: updateResult,
 })
+export const createUpdateUserReset = (payload: _UpdateUserResetPayload): UpdateUserResetPayload => ({
+  payload,
+  type: updateUserReset,
+})
 export const createUpdatedDetails = (payload: _UpdatedDetailsPayload): UpdatedDetailsPayload => ({
   payload,
   type: updatedDetails,
@@ -152,6 +158,10 @@ export type UpdateFollowsPayload = {
   readonly type: typeof updateFollows
 }
 export type UpdateResultPayload = {readonly payload: _UpdateResultPayload; readonly type: typeof updateResult}
+export type UpdateUserResetPayload = {
+  readonly payload: _UpdateUserResetPayload
+  readonly type: typeof updateUserReset
+}
 export type UpdatedDetailsPayload = {
   readonly payload: _UpdatedDetailsPayload
   readonly type: typeof updatedDetails
@@ -172,5 +182,6 @@ export type Actions =
   | UpdateAssertionPayload
   | UpdateFollowsPayload
   | UpdateResultPayload
+  | UpdateUserResetPayload
   | UpdatedDetailsPayload
   | {type: 'common:resetStore', payload: {}}

--- a/shared/actions/tracker2.tsx
+++ b/shared/actions/tracker2.tsx
@@ -8,6 +8,11 @@ import * as Constants from '../constants/tracker2'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import logger from '../logger'
 
+const identify3UserReset = (action: EngineGen.Keybase1Identify3UiIdentify3UserResetPayload) =>
+  Tracker2Gen.createUpdateUserReset({
+    guiID: action.payload.params.guiID,
+  })
+
 const identify3Result = (action: EngineGen.Keybase1Identify3UiIdentify3ResultPayload) =>
   Tracker2Gen.createUpdateResult({
     guiID: action.payload.params.guiID,
@@ -319,6 +324,7 @@ function* tracker2Saga() {
 
   yield* Saga.chainAction2(EngineGen.keybase1NotifyTrackingTrackingChanged, refreshChanged)
   yield* Saga.chainAction(EngineGen.keybase1Identify3UiIdentify3Result, identify3Result)
+  yield* Saga.chainAction(EngineGen.keybase1Identify3UiIdentify3UserReset, identify3UserReset)
   yield* Saga.chainAction(EngineGen.keybase1Identify3UiIdentify3ShowTracker, identify3ShowTracker)
   yield* Saga.chainAction(EngineGen.keybase1Identify3UiIdentify3UpdateRow, identify3UpdateRow)
   yield* Saga.chainAction2(EngineGen.connected, connected)

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -959,6 +959,7 @@ export type TypedActionsMap = {
   'teams:showTeamByName': teams.ShowTeamByNamePayload
   'tracker2:load': tracker2.LoadPayload
   'tracker2:updatedDetails': tracker2.UpdatedDetailsPayload
+  'tracker2:updateUserReset': tracker2.UpdateUserResetPayload
   'tracker2:updateResult': tracker2.UpdateResultPayload
   'tracker2:closeTracker': tracker2.CloseTrackerPayload
   'tracker2:updateAssertion': tracker2.UpdateAssertionPayload

--- a/shared/common-adapters/proof-broken-banner.tsx
+++ b/shared/common-adapters/proof-broken-banner.tsx
@@ -30,7 +30,7 @@ const ProofBrokenBannerNonEmpty = (props: ProofBrokenBannerNonEmptyProps) => {
       ? [
           'Some of ',
           {onClick: () => onClickUsername(props.users[0]), text: props.users[0]},
-          "'s proofs have changed since you last followed them!",
+          "'s proofs have changed since you last followed them.",
         ]
       : [
           ...(props.users.length === 2

--- a/shared/common-adapters/proof-broken-banner.tsx
+++ b/shared/common-adapters/proof-broken-banner.tsx
@@ -30,7 +30,7 @@ const ProofBrokenBannerNonEmpty = (props: ProofBrokenBannerNonEmptyProps) => {
       ? [
           'Some of ',
           {onClick: () => onClickUsername(props.users[0]), text: props.users[0]},
-          "'s proofs have changed since you last followed them.",
+          "'s proofs have changed since you last followed them!",
         ]
       : [
           ...(props.users.length === 2

--- a/shared/constants/tracker2.tsx
+++ b/shared/constants/tracker2.tsx
@@ -22,6 +22,7 @@ export const noDetails = Object.freeze<Types.Details>({
   stellarHidden: false,
   teamShowcase: emptyArray,
   username: '',
+  resetBrokeTrack: false,
 })
 
 export const noNonUserDetails = Object.freeze<Types.NonUserDetails>({

--- a/shared/constants/tracker2.tsx
+++ b/shared/constants/tracker2.tsx
@@ -17,12 +17,12 @@ export const noDetails = Object.freeze<Types.Details>({
   guiID: '',
   hidFromFollowers: false,
   reason: '',
+  resetBrokeTrack: false,
   showTracker: false,
   state: 'error',
   stellarHidden: false,
   teamShowcase: emptyArray,
   username: '',
-  resetBrokeTrack: false,
 })
 
 export const noNonUserDetails = Object.freeze<Types.NonUserDetails>({

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -61,6 +61,7 @@ export type Details = {
   stellarHidden?: boolean
   teamShowcase?: Array<TeamShowcase>
   username: string
+  resetBrokeTrack: boolean
 }
 
 // Details for SBS profiles

--- a/shared/reducers/tracker2.tsx
+++ b/shared/reducers/tracker2.tsx
@@ -76,12 +76,12 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       (result === 'broken' && `Some of ${username}'s proofs have changed since you last followed them.`)
 
     const d = getDetails(draftState, username)
-    if (result === 'valid') {
-      d.resetBrokeTrack = false
-    }
     // Don't overwrite the old reason if the user reset.
     if (!d.resetBrokeTrack || d.reason.length === 0) {
       d.reason = newReason || d.reason
+    }
+    if (result === 'valid') {
+      d.resetBrokeTrack = false
     }
     d.state = result
   },

--- a/shared/reducers/tracker2.tsx
+++ b/shared/reducers/tracker2.tsx
@@ -59,6 +59,13 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     d.teamShowcase = action.payload.teamShowcase
     d.hidFromFollowers = action.payload.hidFromFollowers
   },
+  [Tracker2Gen.updateUserReset]: (draftState, action) => {
+    const username = actionToUsername(draftState, action)
+    if (!username) return
+    const d = getDetails(draftState, username)
+    d.resetBrokeTrack = true
+    d.reason = `${username} reset their account since you last followed them.`
+  },
   [Tracker2Gen.updateResult]: (draftState, action) => {
     const username = actionToUsername(draftState, action)
     if (!username) return
@@ -69,7 +76,13 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
       (result === 'broken' && `Some of ${username}'s proofs have changed since you last followed them.`)
 
     const d = getDetails(draftState, username)
-    d.reason = newReason || d.reason
+    if (result === 'valid') {
+      d.resetBrokeTrack = false
+    }
+    // Don't overwrite the old reason if the user reset.
+    if (!d.resetBrokeTrack || d.reason.length === 0) {
+      d.reason = newReason || d.reason
+    }
     d.state = result
   },
   [Tracker2Gen.closeTracker]: (draftState, action) => {

--- a/shared/tracker2/remote-container.desktop.tsx
+++ b/shared/tracker2/remote-container.desktop.tsx
@@ -15,6 +15,7 @@ const noDetails: Types.Details = {
   guiID: '',
   hidFromFollowers: false,
   reason: '',
+  resetBrokeTrack: false,
   showTracker: false,
   state: 'checking',
   username: '',

--- a/shared/tracker2/remote-proxy.desktop.tsx
+++ b/shared/tracker2/remote-proxy.desktop.tsx
@@ -45,6 +45,7 @@ const RemoteTracker = (props: {trackerUsername: string}) => {
     infoMap: mapFilterByKey(infoMap, trackerUsernames),
     location,
     reason,
+    resetBrokeTrack: false,
     showTracker: true,
     state: details.state,
     teamShowcase,

--- a/shared/tracker2/remote-serializer.desktop.tsx
+++ b/shared/tracker2/remote-serializer.desktop.tsx
@@ -151,6 +151,7 @@ export const deserialize = (
     hidFromFollowers: hidFromFollowers ?? oldDetails?.hidFromFollowers,
     location: location ?? oldDetails?.location,
     reason: reason ?? oldDetails?.reason,
+    resetBrokeTrack: false,
     showTracker: true,
     state: trackerState ?? oldDetails?.state,
     stellarHidden: stellarHidden ?? oldDetails?.stellarHidden,


### PR DESCRIPTION
Previously, when a user had reset and you hadn't tracked any of their proofs, the banner was red and said "Some of their proofs have changed", which isn't quite true. Now it will say that they have reset.