### PR TITLE
Filter bots from members tab

### DIFF
--- a/shared/chat/conversation/bot/search.tsx
+++ b/shared/chat/conversation/bot/search.tsx
@@ -77,7 +77,7 @@ const SearchBotPopup = (props: Props) => {
   }
   const botSection = {
     data: botData,
-    renderItem: ({item}: {item: RPCTypes.FeaturedBot | string}) => {
+    renderItem: ({index, item}: {index: number; item: RPCTypes.FeaturedBot | string}) => {
       return item === resultEmptyPlaceholder ? (
         <Kb.Text
           style={{...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.tiny)}}
@@ -86,7 +86,7 @@ const SearchBotPopup = (props: Props) => {
           No results were found
         </Kb.Text>
       ) : typeof item !== 'string' ? (
-        <Bot {...item} onClick={onSelect} />
+        <Bot {...item} onClick={onSelect} firstItem={index === 0} />
       ) : null
     },
     title: 'Featured bots',

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -13,7 +13,7 @@ import * as Constants from '../../../constants/chat2'
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
   onClick: (username: string) => void
-  showInChannel: boolean
+  showInChannel?: boolean
 }
 
 export const Bot = (props: BotProps) => {

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -64,9 +64,9 @@ export const Bot = (props: BotProps) => {
       firstItem={!!firstItem}
       icon={<Kb.Avatar size={Styles.isMobile ? 48 : 32} style={styles.avatarStyle} username={botUsername} />}
       body={
-        <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
+        <Kb.Box2 direction="vertical" style={styles.container}>
           {usernameDisplay}
-          {lower}
+          {description ? lower : null}
         </Kb.Box2>
       }
     />

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -13,11 +13,11 @@ import * as Constants from '../../../constants/chat2'
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
   onClick: (username: string) => void
-  showInChannel?: boolean
+  showNotInChannel?: boolean
 }
 
 export const Bot = (props: BotProps) => {
-  const {botAlias, description, botUsername, onClick, showInChannel} = props
+  const {botAlias, description, botUsername, onClick, showNotInChannel} = props
   const {ownerTeam, ownerUser} = props
   const lower = (
     <Kb.Box2
@@ -66,9 +66,15 @@ export const Bot = (props: BotProps) => {
               {usernameDisplay}
               {lower}
             </Kb.Box2>
-            {showInChannel && (
-              <Kb.WithTooltip tooltip={`${botAlias || botUsername} can respond to messages in this channel.`}>
-                <Kb.Icon type="iconfont-bot" color={Styles.globalColors.black_35} onClick={() => null} />
+            {showNotInChannel && (
+              <Kb.WithTooltip
+                tooltip={`${botAlias || botUsername} can't respond to messages in this channel.`}
+              >
+                <Kb.Icon
+                  type="iconfont-exclamation"
+                  color={Styles.globalColors.black_35}
+                  onClick={() => null}
+                />
               </Kb.WithTooltip>
             )}
           </Kb.Box2>
@@ -288,7 +294,11 @@ export default (props: Props) => {
             <Bot
               {...item}
               onClick={onBotSelect}
-              showInChannel={teamType === 'big' && participantsAll.includes(item.botUsername)}
+              showNotInChannel={
+                teamType === 'big' &&
+                botUsernames.includes(item.botUsername) &&
+                !participantsAll.includes(item.botUsername)
+              }
             />
           )
         }

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -12,13 +12,14 @@ import * as Constants from '../../../constants/chat2'
 
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
+  firstItem?: boolean
   onClick: (username: string) => void
-  showNotInChannel?: boolean
 }
 
 export const Bot = (props: BotProps) => {
-  const {botAlias, description, botUsername, onClick, showNotInChannel} = props
+  const {botAlias, description, botUsername} = props
   const {ownerTeam, ownerUser} = props
+  const {onClick, firstItem} = props
   const lower = (
     <Kb.Box2
       direction="horizontal"
@@ -57,31 +58,18 @@ export const Bot = (props: BotProps) => {
     </Kb.Box2>
   )
   return (
-    <Kb.ClickableBox onClick={() => onClick(botUsername)}>
-      <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
-        <Kb.Box2 direction="vertical" fullWidth={true} style={styles.rowContainer}>
-          <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.row}>
-            <Kb.Avatar size={Styles.isMobile ? 48 : 32} style={styles.avatarStyle} username={botUsername} />
-            <Kb.Box2 direction="vertical" fullWidth={true} style={{flex: 1}}>
-              {usernameDisplay}
-              {lower}
-            </Kb.Box2>
-            {showNotInChannel && (
-              <Kb.WithTooltip
-                tooltip={`${botAlias || botUsername} can't respond to messages in this channel.`}
-              >
-                <Kb.Icon
-                  type="iconfont-exclamation"
-                  color={Styles.globalColors.black_35}
-                  onClick={() => null}
-                />
-              </Kb.WithTooltip>
-            )}
-          </Kb.Box2>
+    <Kb.ListItem2
+      onClick={() => onClick(botUsername)}
+      type="Large"
+      firstItem={!!firstItem}
+      icon={<Kb.Avatar size={Styles.isMobile ? 48 : 32} style={styles.avatarStyle} username={botUsername} />}
+      body={
+        <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
+          {usernameDisplay}
+          {lower}
         </Kb.Box2>
-        <Kb.Divider style={styles.divider} />
-      </Kb.Box2>
-    </Kb.ClickableBox>
+      }
+    />
   )
 }
 
@@ -145,6 +133,7 @@ type Props = {
 }
 
 const inThisChannelHeader = 'bots: in this channel'
+const inThisTeamHeader = 'bots: in this team'
 const featuredBotsHeader = 'bots: featured bots'
 const loadMoreBotsButton = 'bots: load more'
 const addBotButton = 'bots: add bot'
@@ -186,17 +175,19 @@ export default (props: Props) => {
   }
 
   const featuredBotsMap = Container.useSelector(state => state.chat2.featuredBotsMap)
-  const featuredBots = BotConstants.getFeaturedSorted(featuredBotsMap).filter(
-    k =>
-      !botUsernames.includes(k.botUsername) &&
-      !(!adhocTeam && TeamConstants.userInTeamNotBotWithInfo(teamMembers, k.botUsername))
-  )
+  const featuredBots = BotConstants.getFeaturedSorted(featuredBotsMap)
+    .filter(
+      k =>
+        !botUsernames.includes(k.botUsername) &&
+        !(!adhocTeam && TeamConstants.userInTeamNotBotWithInfo(teamMembers, k.botUsername))
+    )
+    .map((bot, index) => ({...bot, index}))
   const infoMap = Container.useSelector(state => state.users.infoMap)
   const loadedAllBots = Container.useSelector(state => state.chat2.featuredBotsLoaded)
 
-  const installedBots: Array<RPCTypes.FeaturedBot> = botUsernames.map(
-    b =>
-      featuredBotsMap.get(b) ?? {
+  const usernamesToFeaturedBots = (usernames: string[]) =>
+    usernames.map((b, index) => ({
+      ...(featuredBotsMap.get(b) ?? {
         botAlias: botAliases[b] ?? (infoMap.get(b) || {fullname: ''}).fullname,
         botUsername: b,
         description: infoMap.get(b)?.bio ?? '',
@@ -204,8 +195,14 @@ export default (props: Props) => {
         extendedDescriptionRaw: '',
         isPromoted: false,
         rank: 0,
-      }
-  )
+      }),
+      index,
+    }))
+
+  // bots in conv
+  const botsInConv = teamType === 'big' ? botUsernames.filter(b => participantsAll.includes(b)) : botUsernames
+
+  const botsInTeam = botUsernames.filter(b => !botsInConv.includes(b))
 
   const onBotAdd = () => {
     dispatch(
@@ -240,8 +237,10 @@ export default (props: Props) => {
     {
       data: [
         ...(canManageBots ? [addBotButton] : []),
-        ...(installedBots.length > 0 ? [inThisChannelHeader] : []),
-        ...installedBots,
+        ...(botsInConv.length > 0 ? [inThisChannelHeader] : []),
+        ...usernamesToFeaturedBots(botsInConv),
+        ...(botsInTeam.length > 0 ? [inThisTeamHeader] : []),
+        ...usernamesToFeaturedBots(botsInTeam),
         featuredBotsHeader,
         ...(featuredBots.length > 0 ? featuredBots : []),
         ...(!loadedAllBots && featuredBots.length > 0 ? [loadMoreBotsButton] : []),
@@ -262,7 +261,14 @@ export default (props: Props) => {
         if (item === inThisChannelHeader) {
           return (
             <Kb.Text type="Header" style={styles.botHeaders}>
-              {teamname ? 'Installed in this team' : 'In this conversation'}
+              In this conversation
+            </Kb.Text>
+          )
+        }
+        if (item === inThisTeamHeader) {
+          return (
+            <Kb.Text type="Header" style={styles.botHeaders}>
+              Installed in this team
             </Kb.Text>
           )
         }
@@ -290,17 +296,7 @@ export default (props: Props) => {
         if (!item.botUsername) {
           return null
         } else {
-          return (
-            <Bot
-              {...item}
-              onClick={onBotSelect}
-              showNotInChannel={
-                teamType === 'big' &&
-                botUsernames.includes(item.botUsername) &&
-                !participantsAll.includes(item.botUsername)
-              }
-            />
-          )
+          return <Bot {...item} firstItem={item.index === 0} onClick={onBotSelect} />
         }
       },
       renderSectionHeader: renderTabs,

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -13,10 +13,11 @@ import * as Constants from '../../../constants/chat2'
 type BotProps = RPCTypes.FeaturedBot & {
   description?: string
   onClick: (username: string) => void
+  showInChannel: boolean
 }
 
 export const Bot = (props: BotProps) => {
-  const {botAlias, description, botUsername, onClick} = props
+  const {botAlias, description, botUsername, onClick, showInChannel} = props
   const {ownerTeam, ownerUser} = props
   const lower = (
     <Kb.Box2
@@ -65,6 +66,11 @@ export const Bot = (props: BotProps) => {
               {usernameDisplay}
               {lower}
             </Kb.Box2>
+            {showInChannel && (
+              <Kb.WithTooltip tooltip={`${botAlias || botUsername} can respond to messages in this channel.`}>
+                <Kb.Icon type="iconfont-bot" color={Styles.globalColors.black_35} onClick={() => null} />
+              </Kb.WithTooltip>
+            )}
           </Kb.Box2>
         </Kb.Box2>
         <Kb.Divider style={styles.divider} />
@@ -278,7 +284,13 @@ export default (props: Props) => {
         if (!item.botUsername) {
           return null
         } else {
-          return <Bot {...item} onClick={onBotSelect} />
+          return (
+            <Bot
+              {...item}
+              onClick={onBotSelect}
+              showInChannel={teamType === 'big' && participantsAll.includes(item.botUsername)}
+            />
+          )
         }
       },
       renderSectionHeader: renderTabs,

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -87,7 +87,7 @@ export default (props: Props) => {
         ...props.commonSections,
         {
           data: [...(showAuditingBanner ? [auditingBannerItem] : []), ...participantsItems],
-          renderItem: ({item}: {item: any}) => {
+          renderItem: ({index, item}: {index: number; item: any}) => {
             if (item === auditingBannerItem) {
               return (
                 <Kb.Banner color="grey" small={true}>
@@ -100,12 +100,12 @@ export default (props: Props) => {
             }
             return (
               <Participant
-                botAlias={item.botAlias}
                 fullname={item.fullname}
                 isAdmin={item.isAdmin}
                 isOwner={item.isOwner}
                 username={item.username}
                 onShowProfile={onShowProfile}
+                firstItem={index === 0}
               />
             )
           },

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -29,9 +29,7 @@ export default (props: Props) => {
     Constants.getParticipantInfo(state, conversationIDKey)
   )
   let participants = participantInfo.all
-  const smallTeam = meta.teamType !== 'big'
   const adhocTeam = meta.teamType === 'adhoc'
-  const shouldFilterBots = smallTeam
 
   let botUsernames: Array<string> = []
   if (adhocTeam) {
@@ -53,12 +51,11 @@ export default (props: Props) => {
       return l
     }, [])
 
-    if (flags.botUI && shouldFilterBots) {
+    if (flags.botUI) {
       participants = participants.filter(p => !botUsernames.includes(p))
     }
   } else {
-    participants =
-      flags.botUI && shouldFilterBots ? participants.filter(p => !botUsernames.includes(p)) : participants
+    participants = flags.botUI ? participants.filter(p => !botUsernames.includes(p)) : participants
   }
 
   const participantsItems = participants

--- a/shared/chat/conversation/info-panel/participant.tsx
+++ b/shared/chat/conversation/info-panel/participant.tsx
@@ -3,15 +3,15 @@ import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 
 type Props = {
+  firstItem: boolean
   fullname: string
   isAdmin: boolean
   isOwner: boolean
   username: string
-  botAlias: string
   onShowProfile: (username: string) => void
 }
 
-const Participant = ({botAlias, fullname, isAdmin, isOwner, username, onShowProfile}: Props) => {
+const Participant = ({firstItem, fullname, isAdmin, isOwner, username, onShowProfile}: Props) => {
   const lower = (
     <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center" gap="xtiny">
       {fullname !== '' && <Kb.Text type="BodySmall">{fullname}</Kb.Text>}
@@ -30,49 +30,19 @@ const Participant = ({botAlias, fullname, isAdmin, isOwner, username, onShowProf
     </Kb.Box2>
   )
   return (
-    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
-      <Kb.ClickableBox key={username} onClick={() => onShowProfile(username)}>
-        <Kb.Box2 direction="vertical" fullWidth={true} style={styles.rowContainer}>
-          <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.row}>
-            <Kb.NameWithIcon
-              botAlias={botAlias}
-              horizontal={true}
-              colorFollowing={true}
-              username={username}
-              metaOne={lower}
-            />
-          </Kb.Box2>
+    <Kb.ListItem2
+      onClick={() => onShowProfile(username)}
+      firstItem={firstItem}
+      type="Large"
+      icon={<Kb.Avatar size={32} username={username} />}
+      body={
+        <Kb.Box2 direction="vertical" fullWidth={true}>
+          <Kb.ConnectedUsernames usernames={[username]} colorFollowing={true} type="BodySemibold" />
+          {lower}
         </Kb.Box2>
-      </Kb.ClickableBox>
-    </Kb.Box2>
+      }
+    />
   )
 }
-
-const styles = Styles.styleSheetCreate(
-  () =>
-    ({
-      container: {
-        paddingTop: Styles.globalMargins.tiny,
-      },
-      row: {
-        alignItems: 'center',
-        flex: 1,
-        marginRight: Styles.globalMargins.tiny,
-      },
-      rowContainer: Styles.platformStyles({
-        common: {
-          minHeight: 48,
-          paddingLeft: Styles.globalMargins.small,
-          paddingRight: Styles.globalMargins.small,
-        },
-        isElectron: {
-          ...Styles.desktopStyles.clickable,
-        },
-        isMobile: {
-          minHeight: 56,
-        },
-      }),
-    } as const)
-)
 
 export default Participant

--- a/shared/chat/conversation/info-panel/participant.tsx
+++ b/shared/chat/conversation/info-panel/participant.tsx
@@ -34,7 +34,7 @@ const Participant = ({firstItem, fullname, isAdmin, isOwner, username, onShowPro
       onClick={() => onShowProfile(username)}
       firstItem={firstItem}
       type="Large"
-      icon={<Kb.Avatar size={32} username={username} />}
+      icon={<Kb.Avatar size={Styles.isMobile ? 48 : 32} username={username} />}
       body={
         <Kb.Box2 direction="vertical">
           <Kb.ConnectedUsernames usernames={[username]} colorFollowing={true} type="BodySemibold" />

--- a/shared/chat/conversation/info-panel/participant.tsx
+++ b/shared/chat/conversation/info-panel/participant.tsx
@@ -36,7 +36,7 @@ const Participant = ({firstItem, fullname, isAdmin, isOwner, username, onShowPro
       type="Large"
       icon={<Kb.Avatar size={32} username={username} />}
       body={
-        <Kb.Box2 direction="vertical" fullWidth={true}>
+        <Kb.Box2 direction="vertical">
           <Kb.ConnectedUsernames usernames={[username]} colorFollowing={true} type="BodySemibold" />
           {lower}
         </Kb.Box2>


### PR DESCRIPTION
Removes bot users from the members tab and splits the bots tab into "in this conversation", "installed in this team", and "featured" sections. Also refactors the members and bots tabs to use ListItem2, as per design. 

cc @keybase/design 