### PR TITLE
Add environment variable for the keybase bin path

### DIFF
--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -106,8 +106,13 @@ function* checkRPCOwnership(_: Container.TypedState, action: ConfigGen.DaemonHan
   try {
     logger.info('Checking RPC ownership')
 
-    const localAppData = String(env.LOCALAPPDATA)
-    var binPath = localAppData ? resolve(localAppData, 'Keybase', 'keybase.exe') : 'keybase.exe'
+    const kbCli = env.KEYBASE_BIN_PATH
+    const localAppData = env.LOCALAPPDATA
+    var binPath = kbCli
+      ? resolve(String(kbCli), 'keybase.exe')
+      : localAppData
+      ? resolve(String(localAppData), 'Keybase', 'keybase.exe')
+      : 'keybase.exe'
     const args = ['pipeowner', socketPath]
     yield Saga.callUntyped(
       () =>

--- a/shared/desktop/app/paths.desktop.tsx
+++ b/shared/desktop/app/paths.desktop.tsx
@@ -4,9 +4,14 @@ const {appPath} = KB.electron.app
 const {resolve} = KB.path
 const {env} = KB.process
 
-// Path to keybase executable (darwin only), null if not available
+// Path to keybase executable, null if not available
 export function keybaseBinPath() {
+  const kbCli = env.KEYBASE_BIN_PATH
+
   if (os.platform() === 'win32') {
+    if (kbCli) {
+      return resolve(String(kbCli), 'keybase.exe')
+    }
     var kbPath = SafeElectron.getApp()
       .getPath('appData')
       .replace('Roaming', 'Local')
@@ -19,7 +24,11 @@ export function keybaseBinPath() {
     }
     return resolve(String(kbPath), 'Keybase', 'keybase.exe')
   }
-  if (os.platform() === 'darwin') {
+
+  // Platform is NOT Windows
+  if (kbCli) {
+    return resolve(String(kbCli), 'keybase')
+  } else if (os.platform() === 'darwin') {
     return resolve(appPath, '..', '..', '..', 'Contents', 'SharedSupport', 'bin', 'keybase')
   } else {
     return null


### PR DESCRIPTION
**Closes #22039**

The client will now look for the CLI program in this variable, and in case of failure, fallback to current platform-specific methods (e.g. `%localappdata%` in Windows)

The variable should work cross-platform and (probably) doesn't affect current ways of looking for said executable (`keybase.exe` or `keybase`), which are now fallback.

Current name is `KEYBASE_BIN_PATH` but any other may be used instead. ¯\\\_(ツ)_/¯