### PR TITLE
add fetching pending web-of-trust vouches from the server

### DIFF
--- a/go/client/cmd_wot_vouch.go
+++ b/go/client/cmd_wot_vouch.go
@@ -67,15 +67,20 @@ func (c *cmdWotVouch) ParseArgv(ctx *cli.Context) error {
 	}
 	via := ctx.String("verified-via")
 	if via != "" {
-		viaType, ok := keybase1.UsernameVerificationTypeMap[strings.ToUpper(via)]
+		viaType, ok := keybase1.UsernameVerificationTypeMap[strings.ToLower(via)]
 		if !ok {
 			return errors.New("invalid verified-via option")
 		}
 		c.confidence.UsernameVerifiedVia = viaType
 	}
-	c.confidence.VouchedBy = strings.Split(ctx.String("vouched-by"), ",")
+	vouchingUsernames := strings.Split(ctx.String("vouched-by"), ",")
+	var vouchers []keybase1.UID
+	for _, username := range vouchingUsernames {
+		uid := libkb.UsernameToUID(username)
+		vouchers = append(vouchers, uid)
+	}
+	c.confidence.VouchedBy = vouchers
 	c.confidence.Other = ctx.String("other")
-
 	return nil
 }
 

--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -81,7 +81,7 @@ func TestWebOfTrustVouch(t *testing.T) {
 		VouchTexts: []string{"charlie rocks"},
 		Confidence: keybase1.Confidence{
 			UsernameVerifiedVia: keybase1.UsernameVerificationType_VIDEO,
-			VouchedBy:           []string{"t_doug"},
+			VouchedBy:           []keybase1.UID{keybase1.UID("c4c565570e7e87cafd077509abf5f619")}, // t_doug
 			KnownOnKeybaseDays:  78,
 		},
 	}
@@ -137,7 +137,7 @@ func TestWebOfTrustPending(t *testing.T) {
 	bobVouch := pending[0]
 	require.Equal(t, bob.User.GetUID(), bobVouch.Voucher.Uid)
 	require.Equal(t, vouchTexts, bobVouch.VouchTexts)
-	require.Empty(t, bobVouch.Confidence)
+	require.Nil(t, bobVouch.Confidence)
 	t.Log("alice sees one pending vouch")
 
 	tcCharlie := SetupEngineTest(t, "wot")
@@ -155,7 +155,7 @@ func TestWebOfTrustPending(t *testing.T) {
 	vouchTexts = []string{"alice is wondibar and doug agrees"}
 	confidence := keybase1.Confidence{
 		UsernameVerifiedVia: keybase1.UsernameVerificationType_VIDEO,
-		VouchedBy:           []string{"t_doug"},
+		VouchedBy:           []keybase1.UID{keybase1.UID("c4c565570e7e87cafd077509abf5f619")}, // t_doug
 		KnownOnKeybaseDays:  78,
 	}
 	arg = &WotVouchArg{
@@ -175,6 +175,6 @@ func TestWebOfTrustPending(t *testing.T) {
 	charlieVouch := pending[1]
 	require.Equal(t, charlie.User.GetUID(), charlieVouch.Voucher.Uid)
 	require.Equal(t, vouchTexts, charlieVouch.VouchTexts)
-	require.Equal(t, confidence, charlieVouch.Confidence)
+	require.Equal(t, confidence, *charlieVouch.Confidence)
 	t.Log("alice sees two pending vouches that look right")
 }

--- a/go/engine/wot_vouch.go
+++ b/go/engine/wot_vouch.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"strings"
 
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -74,7 +73,7 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 	if err := statement.SetKey("vouch_text", libkb.JsonwStringArray(e.arg.VouchTexts)); err != nil {
 		return err
 	}
-	if err := statement.SetKey("confidence", e.confidence()); err != nil {
+	if err := statement.SetKey("confidence", e.arg.Confidence.ToJsonw()); err != nil {
 		return err
 	}
 
@@ -168,26 +167,4 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 		JSONPayload: payload,
 	})
 	return err
-}
-
-func (e *WotVouch) confidence() *jsonw.Wrapper {
-	c := jsonw.NewDictionary()
-	if e.arg.Confidence.UsernameVerifiedVia != keybase1.UsernameVerificationType_NONE {
-		_ = c.SetKey("username_verified_via", jsonw.NewString(strings.ToLower(e.arg.Confidence.UsernameVerifiedVia.String())))
-	}
-	if len(e.arg.Confidence.VouchedBy) > 0 {
-		vb := jsonw.NewArray(len(e.arg.Confidence.VouchedBy))
-		for i, username := range e.arg.Confidence.VouchedBy {
-			_ = vb.SetIndex(i, jsonw.NewString(libkb.GetUIDByUsername(e.G(), username).String()))
-		}
-		_ = c.SetKey("vouched_by", vb)
-	}
-	if e.arg.Confidence.KnownOnKeybaseDays > 0 {
-		_ = c.SetKey("known_on_keybase_days", jsonw.NewInt(e.arg.Confidence.KnownOnKeybaseDays))
-	}
-	if e.arg.Confidence.Other != "" {
-		_ = c.SetKey("other", jsonw.NewString(e.arg.Confidence.Other))
-	}
-
-	return c
 }

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -171,7 +171,13 @@ func ExtractExpansionObj(expansionID string, expansionJSON string) (expansionObj
 
 	// verify the hash of the expansion object payload matches the expension id
 	objBytes, err := json.Marshal(expansion.Obj)
+	if err != nil {
+		return nil, err
+	}
 	hmacKey, err := hex.DecodeString(expansion.Key)
+	if err != nil {
+		return nil, err
+	}
 	mac := hmac.New(sha256.New, hmacKey)
 	if _, err := mac.Write(objBytes); err != nil {
 		return nil, err

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -4,6 +4,10 @@
 package libkb
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -122,6 +126,63 @@ func CanonicalProofName(t TypedChainLink) string {
 
 //
 //=========================================================================
+
+//=========================================================================
+// Web of Trust
+
+type WotVouchChainLink struct {
+	GenericChainLink
+	ExpansionID string
+}
+
+func (cl *WotVouchChainLink) DoOwnNewLinkFromServerNotifications(g *GlobalContext) {}
+
+var _ TypedChainLink = (*WotVouchChainLink)(nil)
+
+func ParseWotVouch(base GenericChainLink) (ret *WotVouchChainLink, err error) {
+	body := base.UnmarshalPayloadJSON()
+	expansionID, err := body.AtPath("body.wot_vouch").GetString()
+	if err != nil {
+		return nil, err
+	}
+	return &WotVouchChainLink{
+		GenericChainLink: base,
+		ExpansionID:      expansionID,
+	}, nil
+}
+
+type sigExpansion struct {
+	Key string      `json:"key"`
+	Obj interface{} `json:"obj"`
+}
+
+// ExtractExpansionObj extracts the `obj` field from a sig expansion and verifies the
+// hash of the content matches the expected id. This is reusable beyond WotVouchChainLink.
+func ExtractExpansionObj(expansionID string, expansionJSON string) (expansionObj []byte, err error) {
+	var expansions map[string]sigExpansion
+	err = json.Unmarshal([]byte(expansionJSON), &expansions)
+	if err != nil {
+		return nil, err
+	}
+	expansion, ok := expansions[expansionID]
+	if !ok {
+		return nil, fmt.Errorf("expansion %s does not exist", expansionID)
+	}
+
+	// verify the hash of the expansion object payload matches the expension id
+	objBytes, err := json.Marshal(expansion.Obj)
+	hmacKey, err := hex.DecodeString(expansion.Key)
+	mac := hmac.New(sha256.New, hmacKey)
+	if _, err := mac.Write(objBytes); err != nil {
+		return nil, err
+	}
+	sum := mac.Sum(nil)
+	expectedID := hex.EncodeToString(sum)
+	if expectedID != expansionID {
+		return nil, fmt.Errorf("expansion id doesn't match expected value %s != %s", expansionID, expectedID)
+	}
+	return objBytes, nil
+}
 
 //=========================================================================
 // Remote, Web and Social
@@ -1318,6 +1379,8 @@ func NewTypedChainLink(cl *ChainLink) (ret TypedChainLink, w Warning) {
 			ret, err = ParseDeviceChainLink(base)
 		case string(LinkTypeWalletStellar):
 			ret, err = ParseWalletStellarChainLink(base)
+		case string(LinkTypeWotVouch):
+			ret, err = ParseWotVouch(base)
 		default:
 			err = fmt.Errorf("Unknown signature type %s @%s", s, base.ToDebugString())
 		}

--- a/go/libkb/wot.go
+++ b/go/libkb/wot.go
@@ -1,0 +1,191 @@
+package libkb
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+func getWotVouchChainLink(mctx MetaContext, uid keybase1.UID, sigID keybase1.SigID) (cl *WotVouchChainLink, voucher *User, err error) {
+	user, err := LoadUser(NewLoadUserArgWithMetaContext(mctx).WithUID(uid))
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error loading user: %v", err)
+	}
+	link := user.LinkFromSigID(sigID)
+	if link == nil {
+		return nil, nil, fmt.Errorf("Could not find link from sigID")
+	}
+	if link.revoked {
+		return nil, nil, fmt.Errorf("Link is revoked")
+	}
+
+	tlink, w := NewTypedChainLink(link)
+	if w != nil {
+		return nil, nil, fmt.Errorf("Could not get typed chain link: %v", w.Warning())
+	}
+
+	vlink, ok := tlink.(*WotVouchChainLink)
+	if !ok {
+		return nil, nil, fmt.Errorf("Link is not a WotVouchChainLink: %v", tlink)
+	}
+	return vlink, user, nil
+}
+
+func assertVouchIsForMe(mctx MetaContext, vouchedUser wotExpansionUser) (err error) {
+	me, err := LoadMe(NewLoadUserArgWithMetaContext(mctx))
+	if err != nil {
+		return fmt.Errorf("error loading myself: %s", err.Error())
+	}
+	if me.GetName() != vouchedUser.Username {
+		return fmt.Errorf("wot username isn't me %s != %s", me.GetName(), vouchedUser.Username)
+	}
+	if me.GetUID() != vouchedUser.UID {
+		return fmt.Errorf("wot uid isn't me %s != %s", me.GetUID(), vouchedUser.UID)
+	}
+	if me.GetEldestKID() != vouchedUser.Eldest.KID {
+		return fmt.Errorf("wot eldest kid isn't me %s != %s", me.GetEldestKID(), vouchedUser.Eldest.KID)
+	}
+	return nil
+}
+
+type wotExpansionUser struct {
+	Eldest struct {
+		KID   keybase1.KID
+		Seqno keybase1.Seqno
+	}
+	SeqTail struct {
+		PayloadHash string
+		Seqno       keybase1.Seqno
+		SigID       string
+	}
+	UID      keybase1.UID
+	Username string
+}
+
+// standardizeConfidence converts the confidence blob that's in the sig expansion into
+// the keybase1.Confidence type
+func standardizeConfidence(mctx MetaContext, expansionConfidence map[string]interface{}) (*keybase1.Confidence, error) {
+	var confidence keybase1.Confidence
+	// reach into expansionConfidence and change username_verified_via if present
+	if verificationRaw, ok := expansionConfidence["username_verified_via"]; ok {
+		// replace "video" -> "VIDEO" -> 2
+		verification, ok := verificationRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %v into UsernameVerifiedVia", verificationRaw)
+		}
+		expansionConfidence["username_verified_via"] = keybase1.UsernameVerificationTypeMap[strings.ToUpper(verification)]
+	}
+	// reach into expansionConfidence and change vouched_by if present
+	if vouchedByRaw, ok := expansionConfidence["vouched_by"]; ok {
+		// replace user []uids -> []username
+		vouchedByUIDs, ok := vouchedByRaw.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannot convert %v into list of uids", vouchedByUIDs)
+		}
+		var vouchedByUsernames []string
+		for _, vuid := range vouchedByUIDs {
+			uid, ok := vuid.(string)
+			if !ok {
+				return nil, fmt.Errorf("cannot convert %v into uid", vuid)
+			}
+			username, err := mctx.G().GetUPAKLoader().LookupUsername(mctx.Ctx(), keybase1.UID(uid))
+			if err != nil {
+				return nil, err
+			}
+			vouchedByUsernames = append(vouchedByUsernames, username.String())
+		}
+		expansionConfidence["vouched_by"] = vouchedByUsernames
+	}
+	// now expansionConfidence should match keybase1.Confidence, so serialize and deserialize
+	// to do the recursive type conversion
+	asJsonBytes, err := json.Marshal(expansionConfidence)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(asJsonBytes, &confidence)
+	if err != nil {
+		return nil, err
+	}
+	return &confidence, nil
+}
+
+type wotExpansionDetails struct {
+	User                wotExpansionUser       `json:"user"`
+	ExpansionConfidence map[string]interface{} `json:"confidence"`
+	VouchTexts          []string               `json:"vouch_text"`
+}
+
+func transformPending(mctx MetaContext, serverPending apiPendingWot) (res keybase1.PendingVouch, err error) {
+	// load the voucher and fetch the relevant chain link
+	wotVouchLink, voucher, err := getWotVouchChainLink(mctx, serverPending.UID, serverPending.SigID)
+	if err != nil {
+		return res, fmt.Errorf("error finding the pending vouch in the voucher's sigchain: %s", err.Error())
+	}
+	// extract the sig expansion
+	expansionObject, err := ExtractExpansionObj(wotVouchLink.ExpansionID, serverPending.ExpansionJSON)
+	if err != nil {
+		return res, fmt.Errorf("error extracting and validating the expansion: %s", err.Error())
+	}
+	// load it into the right type for web-of-trust vouching
+	var wotObj wotExpansionDetails
+	err = json.Unmarshal(expansionObject, &wotObj)
+	if err != nil {
+		return res, fmt.Errorf("error casting expansion object to expected web-of-trust schema: %s", err.Error())
+	}
+	err = assertVouchIsForMe(mctx, wotObj.User)
+	if err != nil {
+		mctx.Debug("web-of-trust pending vouch user-section doesn't look right: %+v", wotObj.User)
+		return res, fmt.Errorf("error verifying user section of web-of-trust expansion: %s", err.Error())
+	}
+	// convert the confidence object that's in the expansion to the standard type in keybase1
+	confidence, err := standardizeConfidence(mctx, wotObj.ExpansionConfidence)
+	if err != nil {
+		return res, fmt.Errorf("error standardizing confidence: %s", err.Error())
+	}
+	// build a PendingVouch
+	vouch := keybase1.PendingVouch{
+		Voucher:    voucher.ToUserVersion(),
+		Proof:      serverPending.SigID,
+		VouchTexts: wotObj.VouchTexts,
+		Confidence: *confidence,
+	}
+	return vouch, nil
+}
+
+type apiPendingWot struct {
+	UID           keybase1.UID   `json:"voucher"`
+	EldestSeqno   keybase1.Seqno `json:"voucher_eldest_seqno"`
+	SigID         keybase1.SigID `json:"sig_id"`
+	ExpansionJSON string         `json:"expansion_json"`
+}
+
+type GetPendingWotVouches struct {
+	AppStatusEmbed
+	Pending []apiPendingWot `json:"pending"`
+}
+
+func FetchPendingWotVouches(mctx MetaContext) (res []keybase1.PendingVouch, err error) {
+	defer mctx.Trace("FetchPendingWotVouches", func() error { return err })()
+	apiArg := APIArg{
+		Endpoint:    "wot/pending",
+		SessionType: APISessionTypeREQUIRED,
+	}
+	var response GetPendingWotVouches
+	err = mctx.G().API.GetDecode(mctx, apiArg, &response)
+	if err != nil {
+		mctx.Debug("error fetching pending web-of-trust vouches: %s", err.Error())
+		return nil, err
+	}
+	for _, apiPending := range response.Pending {
+		newPending, err := transformPending(mctx, apiPending)
+		if err != nil {
+			mctx.Debug("error validating server-reported pending web-of-trust vouches: %s", err.Error())
+			return nil, err
+		}
+		res = append(res, newPending)
+	}
+	mctx.Debug("found %d pending web-of-trust vouches", len(res))
+	return res, nil
+}

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3802,6 +3802,16 @@ const (
 	UsernameVerificationType_IN_PERSON  = "in_person"
 )
 
+var UsernameVerificationTypeMap = map[string]UsernameVerificationType{
+	"":           UsernameVerificationType_NONE,
+	"none":       UsernameVerificationType_NONE,
+	"audio":      UsernameVerificationType_AUDIO,
+	"video":      UsernameVerificationType_VIDEO,
+	"email":      UsernameVerificationType_EMAIL,
+	"other_chat": UsernameVerificationType_OTHER_CHAT,
+	"in_person":  UsernameVerificationType_IN_PERSON,
+}
+
 func (c Confidence) ToJsonw() *jsonw.Wrapper {
 	j := jsonw.NewDictionary()
 	if c.UsernameVerifiedVia != UsernameVerificationType_NONE {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -3791,3 +3791,34 @@ func (e TeamSearchExport) Hash() string {
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
 }
+
+// web-of-trust
+const (
+	UsernameVerificationType_NONE       = ""
+	UsernameVerificationType_AUDIO      = "audio"
+	UsernameVerificationType_VIDEO      = "video"
+	UsernameVerificationType_EMAIL      = "email"
+	UsernameVerificationType_OTHER_CHAT = "other_chat"
+	UsernameVerificationType_IN_PERSON  = "in_person"
+)
+
+func (c Confidence) ToJsonw() *jsonw.Wrapper {
+	j := jsonw.NewDictionary()
+	if c.UsernameVerifiedVia != UsernameVerificationType_NONE {
+		_ = j.SetKey("username_verified_via", jsonw.NewString(string(c.UsernameVerifiedVia)))
+	}
+	if len(c.VouchedBy) > 0 {
+		vb := jsonw.NewArray(len(c.VouchedBy))
+		for i, uid := range c.VouchedBy {
+			_ = vb.SetIndex(i, jsonw.NewString(uid.String()))
+		}
+		_ = j.SetKey("vouched_by", vb)
+	}
+	if c.KnownOnKeybaseDays > 0 {
+		_ = j.SetKey("known_on_keybase_days", jsonw.NewInt(c.KnownOnKeybaseDays))
+	}
+	if c.Other != "" {
+		_ = j.SetKey("other", jsonw.NewString(c.Other))
+	}
+	return j
+}

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -4,52 +4,19 @@
 package keybase1
 
 import (
-	"fmt"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 	"time"
 )
 
-type UsernameVerificationType int
+type UsernameVerificationType string
 
-const (
-	UsernameVerificationType_NONE       UsernameVerificationType = 0
-	UsernameVerificationType_AUDIO      UsernameVerificationType = 1
-	UsernameVerificationType_VIDEO      UsernameVerificationType = 2
-	UsernameVerificationType_EMAIL      UsernameVerificationType = 3
-	UsernameVerificationType_OTHER_CHAT UsernameVerificationType = 4
-	UsernameVerificationType_IN_PERSON  UsernameVerificationType = 5
-)
-
-func (o UsernameVerificationType) DeepCopy() UsernameVerificationType { return o }
-
-var UsernameVerificationTypeMap = map[string]UsernameVerificationType{
-	"NONE":       0,
-	"AUDIO":      1,
-	"VIDEO":      2,
-	"EMAIL":      3,
-	"OTHER_CHAT": 4,
-	"IN_PERSON":  5,
-}
-
-var UsernameVerificationTypeRevMap = map[UsernameVerificationType]string{
-	0: "NONE",
-	1: "AUDIO",
-	2: "VIDEO",
-	3: "EMAIL",
-	4: "OTHER_CHAT",
-	5: "IN_PERSON",
-}
-
-func (e UsernameVerificationType) String() string {
-	if v, ok := UsernameVerificationTypeRevMap[e]; ok {
-		return v
-	}
-	return fmt.Sprintf("%v", int(e))
+func (o UsernameVerificationType) DeepCopy() UsernameVerificationType {
+	return o
 }
 
 type Confidence struct {
-	VouchedBy           []string                 `codec:"vouchedBy" json:"vouched_by,omitempty"`
+	VouchedBy           []UID                    `codec:"vouchedBy" json:"vouched_by,omitempty"`
 	Proofs              []SigID                  `codec:"proofs" json:"proofs"`
 	UsernameVerifiedVia UsernameVerificationType `codec:"usernameVerifiedVia" json:"username_verified_via,omitempty"`
 	Other               string                   `codec:"other" json:"other"`
@@ -58,13 +25,13 @@ type Confidence struct {
 
 func (o Confidence) DeepCopy() Confidence {
 	return Confidence{
-		VouchedBy: (func(x []string) []string {
+		VouchedBy: (func(x []UID) []UID {
 			if x == nil {
 				return nil
 			}
-			ret := make([]string, len(x))
+			ret := make([]UID, len(x))
 			for i, v := range x {
-				vCopy := v
+				vCopy := v.DeepCopy()
 				ret[i] = vCopy
 			}
 			return ret
@@ -90,7 +57,7 @@ type PendingVouch struct {
 	Voucher    UserVersion `codec:"voucher" json:"voucher"`
 	Proof      SigID       `codec:"proof" json:"proof"`
 	VouchTexts []string    `codec:"vouchTexts" json:"vouchTexts"`
-	Confidence Confidence  `codec:"confidence" json:"confidence"`
+	Confidence *Confidence `codec:"confidence,omitempty" json:"confidence,omitempty"`
 }
 
 func (o PendingVouch) DeepCopy() PendingVouch {
@@ -108,7 +75,13 @@ func (o PendingVouch) DeepCopy() PendingVouch {
 			}
 			return ret
 		})(o.VouchTexts),
-		Confidence: o.Confidence.DeepCopy(),
+		Confidence: (func(x *Confidence) *Confidence {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Confidence),
 	}
 }
 

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -52,3 +52,9 @@ func (h *WebOfTrustHandler) WotVouchCLI(ctx context.Context, arg keybase1.WotVou
 	eng := engine.NewWotVouch(h.G(), earg)
 	return engine.RunEngine2(mctx, eng)
 }
+
+func (h *WebOfTrustHandler) WotPending(ctx context.Context, sessionID int) (res []keybase1.PendingVouch, err error) {
+	ctx = libkb.WithLogTag(ctx, "WOT")
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	return libkb.FetchPendingWotVouches(mctx)
+}

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -23,6 +23,15 @@ protocol wot {
     int knownOnKeybaseDays;
   }
 
+  record PendingVouch {
+    UserVersion voucher;
+    SigID proof;
+    array<string> vouchTexts;
+    Confidence confidence;
+  }
+
+  array<PendingVouch> wotPending(int sessionID);
+
   void wotVouch(int sessionID, UserVersion uv, array<string> vouchTexts, Confidence confidence);
 
   void wotVouchCLI(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -3,18 +3,13 @@
 protocol wot {
   import idl "common.avdl";
 
-  enum UsernameVerificationType {
-    NONE_0,
-    AUDIO_1,
-    VIDEO_2,
-    EMAIL_3,
-    OTHER_CHAT_4,
-    IN_PERSON_5
-  }
+  // none (""), audio, video, email, other_chat, in_person
+  @typedef("string")
+  record UsernameVerificationType {}
 
   record Confidence {
     @jsonkey("vouched_by,omitempty")
-    array<string> vouchedBy; // usernames
+    array<UID> vouchedBy;
     array<SigID> proofs;
     @jsonkey("username_verified_via,omitempty")
     UsernameVerificationType usernameVerifiedVia;
@@ -27,7 +22,7 @@ protocol wot {
     UserVersion voucher;
     SigID proof;
     array<string> vouchTexts;
-    Confidence confidence;
+    union { null, Confidence } confidence;
   }
 
   array<PendingVouch> wotPending(int sessionID);

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -53,9 +53,46 @@
           "jsonkey": "known_on_keybase_days,omitempty"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "PendingVouch",
+      "fields": [
+        {
+          "type": "UserVersion",
+          "name": "voucher"
+        },
+        {
+          "type": "SigID",
+          "name": "proof"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "vouchTexts"
+        },
+        {
+          "type": "Confidence",
+          "name": "confidence"
+        }
+      ]
     }
   ],
   "messages": {
+    "wotPending": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "PendingVouch"
+      }
+    },
     "wotVouch": {
       "request": [
         {

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -8,16 +8,10 @@
   ],
   "types": [
     {
-      "type": "enum",
+      "type": "record",
       "name": "UsernameVerificationType",
-      "symbols": [
-        "NONE_0",
-        "AUDIO_1",
-        "VIDEO_2",
-        "EMAIL_3",
-        "OTHER_CHAT_4",
-        "IN_PERSON_5"
-      ]
+      "fields": [],
+      "typedef": "string"
     },
     {
       "type": "record",
@@ -26,7 +20,7 @@
         {
           "type": {
             "type": "array",
-            "items": "string"
+            "items": "UID"
           },
           "name": "vouchedBy",
           "jsonkey": "vouched_by,omitempty"
@@ -74,7 +68,10 @@
           "name": "vouchTexts"
         },
         {
-          "type": "Confidence",
+          "type": [
+            null,
+            "Confidence"
+          ],
           "name": "confidence"
         }
       ]

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2628,15 +2628,6 @@ export enum UserOrTeamResult {
   user = 1,
   team = 2,
 }
-
-export enum UsernameVerificationType {
-  none = 0,
-  audio = 1,
-  video = 2,
-  email = 3,
-  otherChat = 4,
-  inPerson = 5,
-}
 export type APIRes = {readonly status: String; readonly body: String; readonly httpStatus: Int; readonly appStatus: String}
 export type APIUserKeybaseResult = {readonly username: String; readonly uid: UID; readonly pictureUrl?: String | null; readonly fullName?: String | null; readonly rawScore: Double; readonly stellar?: String | null; readonly isFollowee: Boolean}
 export type APIUserSearchResult = {readonly score: Double; readonly keybase?: APIUserKeybaseResult | null; readonly service?: APIUserServiceResult | null; readonly contact?: ProcessedContact | null; readonly imptofu?: ImpTofuSearchResult | null; readonly servicesSummary: {[key: string]: APIUserServiceSummary}; readonly rawScore: Double}
@@ -2686,7 +2677,7 @@ export type ClientDetails = {readonly pid: Int; readonly clientType: ClientType;
 export type ClientStatus = {readonly details: ClientDetails; readonly connectionID: Int; readonly notificationChannels: NotificationChannels}
 export type CompatibilityTeamID = {typ: TeamType.legacy; legacy: TLFID} | {typ: TeamType.modern; modern: TeamID} | {typ: TeamType.none}
 export type ComponentResult = {readonly name: String; readonly status: Status; readonly exitCode: Int}
-export type Confidence = {readonly vouchedBy?: Array<String> | null; readonly proofs?: Array<SigID> | null; readonly usernameVerifiedVia: UsernameVerificationType; readonly other: String; readonly knownOnKeybaseDays: Int}
+export type Confidence = {readonly vouchedBy?: Array<UID> | null; readonly proofs?: Array<SigID> | null; readonly usernameVerifiedVia: UsernameVerificationType; readonly other: String; readonly knownOnKeybaseDays: Int}
 export type Config = {readonly serverURI: String; readonly socketFile: String; readonly label: String; readonly runMode: String; readonly gpgExists: Boolean; readonly gpgPath: String; readonly version: String; readonly path: String; readonly binaryRealpath: String; readonly configPath: String; readonly versionShort: String; readonly versionFull: String; readonly isAutoForked: Boolean; readonly forkType: ForkType}
 export type ConfigValue = {readonly isNull: Boolean; readonly b?: Boolean | null; readonly i?: Int | null; readonly f?: Double | null; readonly s?: String | null; readonly o?: String | null}
 export type ConfiguredAccount = {readonly username: String; readonly fullname: FullName; readonly hasStoredSecret: Boolean; readonly isCurrent: Boolean}
@@ -2929,7 +2920,7 @@ export type ParamProofServiceConfig = {readonly version: Int; readonly domain: S
 export type ParamProofUsernameConfig = {readonly re: String; readonly min: Int; readonly max: Int}
 export type PassphraseStream = {readonly passphraseStream: Bytes; readonly generation: Int}
 export type Path = {PathType: PathType.local; local: String} | {PathType: PathType.kbfs; kbfs: KBFSPath} | {PathType: PathType.kbfsArchived; kbfsArchived: KBFSArchivedPath}
-export type PendingVouch = {readonly voucher: UserVersion; readonly proof: SigID; readonly vouchTexts?: Array<String> | null; readonly confidence: Confidence}
+export type PendingVouch = {readonly voucher: UserVersion; readonly proof: SigID; readonly vouchTexts?: Array<String> | null; readonly confidence?: Confidence | null}
 export type PerTeamKey = {readonly gen: PerTeamKeyGeneration; readonly seqno: Seqno; readonly sigKID: KID; readonly encKID: KID}
 export type PerTeamKeyAndCheck = {readonly ptk: PerTeamKey; readonly check: PerTeamSeedCheckPostImage}
 export type PerTeamKeyGeneration = Int
@@ -3204,6 +3195,7 @@ export type UserTeamVersionUpdate = {readonly version: UserTeamVersion}
 export type UserVersion = {readonly uid: UID; readonly eldestSeqno: Seqno}
 export type UserVersionPercentForm = String
 export type UserVersionVector = {readonly id: Long; readonly sigHints: Int; readonly sigChain: Long; readonly cachedAt: Time}
+export type UsernameVerificationType = String
 export type VID = String
 export type VerifyAllEmailTodoExt = {readonly lastVerifyEmailDate: UnixTime}
 export type VerifySessionRes = {readonly uid: UID; readonly sid: String; readonly generated: Int; readonly lifetime: Int}

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2929,6 +2929,7 @@ export type ParamProofServiceConfig = {readonly version: Int; readonly domain: S
 export type ParamProofUsernameConfig = {readonly re: String; readonly min: Int; readonly max: Int}
 export type PassphraseStream = {readonly passphraseStream: Bytes; readonly generation: Int}
 export type Path = {PathType: PathType.local; local: String} | {PathType: PathType.kbfs; kbfs: KBFSPath} | {PathType: PathType.kbfsArchived; kbfsArchived: KBFSArchivedPath}
+export type PendingVouch = {readonly voucher: UserVersion; readonly proof: SigID; readonly vouchTexts?: Array<String> | null; readonly confidence: Confidence}
 export type PerTeamKey = {readonly gen: PerTeamKeyGeneration; readonly seqno: Seqno; readonly sigKID: KID; readonly encKID: KID}
 export type PerTeamKeyAndCheck = {readonly ptk: PerTeamKey; readonly check: PerTeamSeedCheckPostImage}
 export type PerTeamKeyGeneration = Int
@@ -4128,5 +4129,6 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.user.findNextMerkleRootAfterRevoke'
 // 'keybase.1.user.findNextMerkleRootAfterReset'
 // 'keybase.1.user.getTeamBlocks'
+// 'keybase.1.wot.wotPending'
 // 'keybase.1.wot.wotVouch'
 // 'keybase.1.wot.wotVouchCLI'


### PR DESCRIPTION
* add a new WotVouchChainLink and some logic for validating sig expansions
* made a handful of updates to the web-of-trust types:
    * make confidence nillable for when the server is storing it as empty
    * uids instead of usernames
    * username verified via as strings instead of ints/strings
* consume the pending vouches from the server. i didn't make a cli command, but i guess we can without too much difficulty. especially once we have logic for accepting / rejecting.
* the other wot stuff is in engine, but fetching something from the api isn't really an engine task. i had general dependency issues, so i put this in libkb so engine and it's tests can get it. but i could easily be convinced to move it. 