### PR TITLE
libfs: support `.kbfs_dirblock_` virtual directories

### DIFF
--- a/go/kbfs/data/data_types.go
+++ b/go/kbfs/data/data_types.go
@@ -335,6 +335,9 @@ const (
 	// Sym is a symbolic link.
 	Sym
 
+	// RealDir can be used to indicate a real directory entry should
+	// be used, usually with a provided BlockPointer.
+	RealDir EntryType = 0xfffd
 	// FakeFile can be used to indicate a faked-out entry for a file,
 	// that will be specially processed by folderBranchOps.
 	FakeFile EntryType = 0xfffe

--- a/go/kbfs/data/data_types.go
+++ b/go/kbfs/data/data_types.go
@@ -143,6 +143,18 @@ func (bdt BlockDirectType) String() string {
 	return fmt.Sprintf("<unknown blockDirectType %d>", bdt)
 }
 
+// BlockDirectTypeFromString returns a direct block type, given the string.
+func BlockDirectTypeFromString(s string) BlockDirectType {
+	switch s {
+	case "direct":
+		return DirectBlock
+	case "indirect":
+		return IndirectBlock
+	default:
+		return UnknownDirectType
+	}
+}
+
 // BlockRef is a block ID/ref nonce pair, which defines a unique
 // reference to a block.
 type BlockRef struct {

--- a/go/kbfs/libfs/constants.go
+++ b/go/kbfs/libfs/constants.go
@@ -122,3 +122,9 @@ const ArchivedRelTimeFilePrefix = ".kbfs_archived_reltime="
 // number of KBFS files and directories currently being held open by
 // the operating system.
 const OpenFileCountFileName = ".kbfs_open_file_count"
+
+// DirBlockPrefix is the prefix to a directory within a TLF, that will
+// direct KBFS to open that specific block as that directory.
+// Useful for recovering data of a subdirectory when the all the root
+// blocks are missing or corrupt for some reason.
+const DirBlockPrefix = ".kbfs_dirblock_"

--- a/go/kbfs/libfs/constants.go
+++ b/go/kbfs/libfs/constants.go
@@ -124,7 +124,11 @@ const ArchivedRelTimeFilePrefix = ".kbfs_archived_reltime="
 const OpenFileCountFileName = ".kbfs_open_file_count"
 
 // DirBlockPrefix is the prefix to a directory within a TLF, that will
-// direct KBFS to open that specific block as that directory.
-// Useful for recovering data of a subdirectory when the all the root
-// blocks are missing or corrupt for some reason.
+// direct KBFS to open that specific block as that directory.  Useful
+// for recovering data of a subdirectory when the all the root blocks
+// are missing or corrupt for some reason.  The format for what comes
+// after the prefix is: id.keyGen.dataVer.creatorUID.directType
+//
+// Note that if this is used for a directory that is already live in
+// the current TLF, it will make that existing directory read-only.
 const DirBlockPrefix = ".kbfs_dirblock_"

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -137,7 +137,8 @@ var _ libkbfs.Node = (*repoDirNode)(nil)
 // repoDirNode.
 func (rdn *repoDirNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString,
+	data.BlockPointer) {
 	namePlain := name.Plaintext()
 	switch {
 	case strings.HasPrefix(namePlain, AutogitBranchPrefix):
@@ -148,7 +149,7 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 		// It's difficult to tell if a given name is a legitimate
 		// prefix for a branch name or not, so just accept everything.
 		// If it's not legit, trying to read the data will error out.
-		return true, ctx, data.FakeDir, nil, data.PathPartString{}
+		return true, ctx, data.FakeDir, nil, data.PathPartString{}, data.ZeroPtr
 	case strings.HasPrefix(namePlain, AutogitCommitPrefix):
 		commit := strings.TrimPrefix(namePlain, AutogitCommitPrefix)
 		if len(commit) == 0 {
@@ -168,7 +169,7 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 			return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 		}
 		return true, ctx, data.FakeFile, f.(*diffFile).GetInfo(),
-			data.PathPartString{}
+			data.PathPartString{}, data.ZeroPtr
 	default:
 		return rdn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -316,7 +317,8 @@ var _ libkbfs.Node = (*rootNode)(nil)
 // rootNode.
 func (rn *rootNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString,
+	data.BlockPointer) {
 	if name.Plaintext() != AutogitRoot {
 		return rn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
@@ -345,7 +347,7 @@ func (rn *rootNode) ShouldCreateMissedLookup(
 		}
 		rn.fs = fs
 	}
-	return true, ctx, data.FakeDir, nil, data.PathPartString{}
+	return true, ctx, data.FakeDir, nil, data.PathPartString{}, data.ZeroPtr
 }
 
 // WrapChild implements the Node interface for rootNode.

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3378,7 +3378,8 @@ func (fbo *folderBranchOps) processMissedLookup(
 	name data.PathPartString, missErr error) (
 	node Node, ei data.EntryInfo, err error) {
 	// Check if the directory node wants to autocreate this.
-	autocreate, ctx, et, fi, sympath := dir.ShouldCreateMissedLookup(ctx, name)
+	autocreate, ctx, et, fi, sympath, _ := dir.ShouldCreateMissedLookup(
+		ctx, name)
 	if !autocreate {
 		return nil, data.EntryInfo{}, missErr
 	}
@@ -3437,7 +3438,8 @@ func (fbo *folderBranchOps) statUsingFS(
 	}
 
 	// First check if this is needs to be a faked-out node.
-	autocreate, _, et, fi, sympath := node.ShouldCreateMissedLookup(ctx, name)
+	autocreate, _, et, fi, sympath, _ := node.ShouldCreateMissedLookup(
+		ctx, name)
 	if autocreate {
 		if et == data.FakeDir {
 			de, err := fbo.makeFakeDirEntry(ctx, node, name)

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3378,13 +3378,14 @@ func (fbo *folderBranchOps) processMissedLookup(
 	name data.PathPartString, missErr error) (
 	node Node, ei data.EntryInfo, err error) {
 	// Check if the directory node wants to autocreate this.
-	autocreate, ctx, et, fi, sympath, _ := dir.ShouldCreateMissedLookup(
+	autocreate, ctx, et, fi, sympath, ptr := dir.ShouldCreateMissedLookup(
 		ctx, name)
 	if !autocreate {
 		return nil, data.EntryInfo{}, missErr
 	}
 
-	if et == data.FakeDir {
+	switch et {
+	case data.FakeDir:
 		de, err := fbo.makeFakeDirEntry(ctx, dir, name)
 		if err != nil {
 			return nil, data.EntryInfo{}, missErr
@@ -3394,10 +3395,27 @@ func (fbo *folderBranchOps) processMissedLookup(
 			return nil, data.EntryInfo{}, err
 		}
 		return node, de.EntryInfo, nil
-	} else if et == data.FakeFile {
+	case data.FakeFile:
 		de, err := fbo.makeFakeFileEntry(ctx, dir, name, fi, sympath)
 		if err != nil {
 			return nil, data.EntryInfo{}, missErr
+		}
+		node, err := fbo.blocks.GetChildNode(lState, dir, name, de)
+		if err != nil {
+			return nil, data.EntryInfo{}, err
+		}
+		return node, de.EntryInfo, nil
+	case data.RealDir:
+		de := data.DirEntry{
+			BlockInfo: data.BlockInfo{
+				BlockPointer: ptr,
+			},
+			EntryInfo: data.EntryInfo{
+				Type:  data.Dir,
+				Size:  uint64(fi.Size()),
+				Mtime: fi.ModTime().Unix(),
+				Ctime: fi.ModTime().Unix(),
+			},
 		}
 		node, err := fbo.blocks.GetChildNode(lState, dir, name, de)
 		if err != nil {
@@ -3438,19 +3456,33 @@ func (fbo *folderBranchOps) statUsingFS(
 	}
 
 	// First check if this is needs to be a faked-out node.
-	autocreate, _, et, fi, sympath, _ := node.ShouldCreateMissedLookup(
+	autocreate, _, et, fi, sympath, ptr := node.ShouldCreateMissedLookup(
 		ctx, name)
 	if autocreate {
-		if et == data.FakeDir {
+		switch et {
+		case data.FakeDir:
 			de, err := fbo.makeFakeDirEntry(ctx, node, name)
 			if err != nil {
 				return data.DirEntry{}, false, err
 			}
 			return de, true, nil
-		} else if et == data.FakeFile {
+		case data.FakeFile:
 			de, err = fbo.makeFakeFileEntry(ctx, node, name, fi, sympath)
 			if err != nil {
 				return data.DirEntry{}, false, err
+			}
+			return de, true, nil
+		case data.RealDir:
+			de := data.DirEntry{
+				BlockInfo: data.BlockInfo{
+					BlockPointer: ptr,
+				},
+				EntryInfo: data.EntryInfo{
+					Type:  data.Dir,
+					Size:  uint64(fi.Size()),
+					Mtime: fi.ModTime().Unix(),
+					Ctime: fi.ModTime().Unix(),
+				},
 			}
 			return de, true, nil
 		}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -192,13 +192,15 @@ type Node interface {
 	// to indicate that the caller should pretend the entry exists,
 	// even if it really does not.  In the case of fake files, a
 	// non-nil `fi` can be returned and used by the caller to
-	// construct the dir entry for the file.  An implementation that
-	// wraps another `Node` (`inner`) must return
+	// construct the dir entry for the file.  It can also return the
+	// type `RealDir`, along with a non-zero `ptr`, to indicate a real
+	// directory corresponding to that pointer should be used.  An
+	// implementation that wraps another `Node` (`inner`) must return
 	// `inner.ShouldCreateMissedLookup()` if it decides not to return
 	// `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name data.PathPartString) (
 		shouldCreate bool, newCtx context.Context, et data.EntryType,
-		fi os.FileInfo, sympath data.PathPartString)
+		fi os.FileInfo, sympath data.PathPartString, ptr data.BlockPointer)
 	// ShouldRetryOnDirRead is called for Nodes representing
 	// directories, whenever a `Lookup` or `GetDirChildren` is done on
 	// them.  It should return true to instruct the caller that it

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -3879,8 +3879,9 @@ type wrappedAutocreateNode struct {
 
 func (wan wrappedAutocreateNode) ShouldCreateMissedLookup(
 	ctx context.Context, _ data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
-	return true, ctx, wan.et, &fakeFileInfo{wan.et}, wan.sympath
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString,
+	data.BlockPointer) {
+	return true, ctx, wan.et, &fakeFileInfo{wan.et}, wan.sympath, data.ZeroPtr
 }
 
 func testKBFSOpsAutocreateNodes(
@@ -4126,9 +4127,10 @@ type testKBFSOpsRootNode struct {
 
 func (n testKBFSOpsRootNode) ShouldCreateMissedLookup(
 	ctx context.Context, name data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString,
+	data.BlockPointer) {
 	if name.Plaintext() == "memfs" {
-		return true, ctx, data.FakeDir, nil, testPPS("")
+		return true, ctx, data.FakeDir, nil, testPPS(""), data.ZeroPtr
 	}
 	return n.Node.ShouldCreateMissedLookup(ctx, name)
 }

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -3714,7 +3714,7 @@ func (mr *MockNodeMockRecorder) RemoveDir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
+func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.PathPartString) (bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString, data.BlockPointer) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -3722,7 +3722,8 @@ func (m *MockNode) ShouldCreateMissedLookup(arg0 context.Context, arg1 data.Path
 	ret2, _ := ret[2].(data.EntryType)
 	ret3, _ := ret[3].(os.FileInfo)
 	ret4, _ := ret[4].(data.PathPartString)
-	return ret0, ret1, ret2, ret3, ret4
+	ret5, _ := ret[5].(data.BlockPointer)
+	return ret0, ret1, ret2, ret3, ret4, ret5
 }
 
 // ShouldCreateMissedLookup indicates an expected call of ShouldCreateMissedLookup

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -114,8 +114,9 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 
 func (n *nodeStandard) ShouldCreateMissedLookup(
 	ctx context.Context, _ data.PathPartString) (
-	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString) {
-	return false, ctx, data.File, nil, data.PathPartString{}
+	bool, context.Context, data.EntryType, os.FileInfo, data.PathPartString,
+	data.BlockPointer) {
+	return false, ctx, data.File, nil, data.PathPartString{}, data.ZeroPtr
 }
 
 func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {


### PR DESCRIPTION
This lets a user directly access a directory given its block pointer. This is useful in bug scenarios where the parent or root directory of a desired directory is corrupt or unavailable, but we still want to read a subdirectory.  We can get the block pointer from the `.kbfs_update_history` file or from the logs.  For example:

```
ls .kbfs_dirblock_02002e7771ea717335454c43dd1a8999d1d6dab20c73fb4372b7df748800195dfe.20.1.ef2e49961eddaa77094b45ed635cfc00.direct
```

This presents a read-only version of the directory block.

If you happen, for some reason, to use this for a directory that's already accessible, it will turn that directory read-only because they will share block pointers in the node cache.

Issue: HOTPOT-1986