### PR TITLE
ForceCreateGen for teambot ek

### DIFF
--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -508,7 +508,7 @@ func (e *EKLib) GetOrCreateLatestTeamEK(mctx libkb.MetaContext, teamID keybase1.
 	err = teamEKRetryWrapper(mctx, func() error {
 		e.Lock()
 		defer e.Unlock()
-		ek, created, err = e.getOrCreateLatestTeamEKLocked(mctx, teamID)
+		ek, created, err = e.getOrCreateLatestTeamEKLocked(mctx, teamID, nil)
 		if err != nil {
 			return err
 		}
@@ -521,14 +521,13 @@ func (e *EKLib) GetOrCreateLatestTeamEK(mctx libkb.MetaContext, teamID keybase1.
 	typ, err := ek.KeyType()
 	if err != nil {
 		return ek, false, err
-	}
-	if !typ.IsTeam() {
+	} else if !typ.IsTeam() {
 		return ek, false, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAM)
 	}
 	return ek, created, err
 }
 
-func (e *EKLib) getOrCreateLatestTeamEKLocked(mctx libkb.MetaContext, teamID keybase1.TeamID) (
+func (e *EKLib) getOrCreateLatestTeamEKLocked(mctx libkb.MetaContext, teamID keybase1.TeamID, forceCreateGen *keybase1.EkGeneration) (
 	ek keybase1.TeamEphemeralKey, created bool, err error) {
 	defer mctx.TraceTimed("getOrCreateLatestTeamEKLocked", func() error { return err })()
 
@@ -588,7 +587,7 @@ func (e *EKLib) getOrCreateLatestTeamEKLocked(mctx libkb.MetaContext, teamID key
 				<-e.backgroundCreationTestCh
 			}
 
-			publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
+			publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot, nil)
 			// Grab the lock once we finish publishing so we do don't block
 			e.Lock()
 			defer e.Unlock()
@@ -608,7 +607,16 @@ func (e *EKLib) getOrCreateLatestTeamEKLocked(mctx libkb.MetaContext, teamID key
 			}
 		}()
 	case teamEKNeeded:
-		publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
+		publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot, nil)
+		if err != nil {
+			return ek, false, err
+		}
+		latestGeneration = publishedMetadata.Generation
+	case forceCreateGen != nil && latestGeneration == *forceCreateGen:
+		// Teambot creation can request a new teamEK be force published. We
+		// only want to do this once so we make sure no on else has published
+		// before us and incremented the generation.
+		publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot, forceCreateGen)
 		if err != nil {
 			return ek, false, err
 		}
@@ -662,8 +670,7 @@ func (e *EKLib) GetTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, genera
 	typ, err := ek.KeyType()
 	if err != nil {
 		return ek, err
-	}
-	if !typ.IsTeam() {
+	} else if !typ.IsTeam() {
 		return ek, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAM)
 	}
 	return ek, err
@@ -707,7 +714,7 @@ func (e *EKLib) GetOrCreateLatestTeambotEK(mctx libkb.MetaContext, teamID keybas
 		err = teamEKRetryWrapper(mctx, func() error {
 			e.Lock()
 			defer e.Unlock()
-			ek, created, err = e.getOrCreateLatestTeambotEKLocked(mctx, teamID, botUID)
+			ek, created, err = e.getOrCreateLatestTeambotEKLocked(mctx, teamID, botUID, nil)
 			return err
 		})
 		if err != nil {
@@ -719,15 +726,46 @@ func (e *EKLib) GetOrCreateLatestTeambotEK(mctx libkb.MetaContext, teamID keybas
 	typ, err := ek.KeyType()
 	if err != nil {
 		return ek, false, err
+	} else if !typ.IsTeambot() {
+		return ek, false, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAMBOT)
 	}
-	if !typ.IsTeambot() {
+	return ek, created, err
+}
+
+func (e *EKLib) ForceCreateTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, gBotUID gregor1.UID,
+	forceCreateGen keybase1.EkGeneration) (ek keybase1.TeamEphemeralKey, created bool, err error) {
+	mctx = mctx.WithLogTag("FCTEK")
+	botUID, err := keybase1.UIDFromSlice(gBotUID.Bytes())
+	if err != nil {
+		return ek, false, err
+	}
+
+	// We are the bot, try to access our latest key
+	if teambot.CurrentUserIsBot(mctx, &gBotUID) {
+		return ek, false, fmt.Errorf("Cannot force create as a bot member")
+	}
+	err = teamEKRetryWrapper(mctx, func() error {
+		e.Lock()
+		defer e.Unlock()
+		ek, created, err = e.getOrCreateLatestTeambotEKLocked(mctx, teamID, botUID, &forceCreateGen)
+		return err
+	})
+	if err != nil {
+		return ek, false, err
+	}
+
+	// sanity check key type
+	typ, err := ek.KeyType()
+	if err != nil {
+		return ek, false, err
+	} else if !typ.IsTeambot() {
 		return ek, false, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAMBOT)
 	}
 	return ek, created, err
 }
 
 func (e *EKLib) getOrCreateLatestTeambotEKLocked(mctx libkb.MetaContext, teamID keybase1.TeamID,
-	botUID keybase1.UID) (ek keybase1.TeamEphemeralKey, created bool, err error) {
+	botUID keybase1.UID, forceCreateGen *keybase1.EkGeneration) (ek keybase1.TeamEphemeralKey, created bool, err error) {
 	defer mctx.TraceTimed("getOrCreateLatestTeambotEKLocked", func() error { return err })()
 
 	// first check if we have the teamEK cached, in which case we can just
@@ -747,7 +785,7 @@ func (e *EKLib) getOrCreateLatestTeambotEKLocked(mctx libkb.MetaContext, teamID 
 	}
 
 	// get the latest teamEK to derive the latest teambotEK
-	teamEK, _, err := e.getOrCreateLatestTeamEKLocked(mctx, teamID)
+	teamEK, _, err := e.getOrCreateLatestTeamEKLocked(mctx, teamID, forceCreateGen)
 	if err != nil {
 		return ek, false, err
 	}
@@ -761,8 +799,7 @@ func (e *EKLib) deriveAndMaybePublishTeambotEK(mctx libkb.MetaContext, teamID ke
 	typ, err := teamEK.KeyType()
 	if err != nil {
 		return ek, false, err
-	}
-	if !typ.IsTeam() {
+	} else if !typ.IsTeam() {
 		return ek, false, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAM)
 	}
 
@@ -960,8 +997,7 @@ func (e *EKLib) GetTeambotEK(mctx libkb.MetaContext, teamID keybase1.TeamID, gBo
 	typ, err := ek.KeyType()
 	if err != nil {
 		return ek, err
-	}
-	if !typ.IsTeambot() {
+	} else if !typ.IsTeambot() {
 		return ek, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAMBOT)
 	}
 	return ek, err
@@ -1068,8 +1104,7 @@ func (e *EKLib) BoxLatestTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID, 
 	typ, err := ek.KeyType()
 	if err != nil {
 		return nil, err
-	}
-	if !typ.IsTeam() {
+	} else if !typ.IsTeam() {
 		return nil, NewIncorrectTeamEphemeralKeyTypeError(typ, keybase1.TeamEphemeralKeyType_TEAM)
 	}
 	teamEK := ek.Team()

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -130,7 +130,7 @@ func prepareNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 }
 
 func publishNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
-	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
+	merkleRoot libkb.MerkleRoot, forceCreateGeneration *keybase1.EkGeneration) (metadata keybase1.TeamEkMetadata, err error) {
 	defer mctx.TraceTimed("publishNewTeamEK", func() error { return err })()
 
 	team, err := teams.Load(mctx.Ctx(), mctx.G(), keybase1.LoadTeamArg{
@@ -156,6 +156,14 @@ func publishNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	sig, boxes, teamEKMetadata, myBox, err := prepareNewTeamEK(mctx, teamID, signingKey, membersMetadata, merkleRoot)
 	if err != nil {
 		return metadata, err
+	}
+
+	if forceCreateGeneration != nil {
+		if *forceCreateGeneration+1 != teamEKMetadata.Generation {
+			return metadata, fmt.Errorf("Not posting new teamEK, expected %d, found %d", *forceCreateGeneration+1, teamEKMetadata.Generation)
+		} else {
+			mctx.Debug("forceCreateGeneration set to: %d", *forceCreateGeneration)
+		}
 	}
 
 	if err = postNewTeamEK(mctx, teamID, sig, boxes); err != nil {
@@ -309,7 +317,7 @@ func ForcePublishNewTeamEKForTesting(mctx libkb.MetaContext, teamID keybase1.Tea
 	merkleRoot libkb.MerkleRoot) (metadata keybase1.TeamEkMetadata, err error) {
 	defer mctx.TraceTimed("ForcePublishNewTeamEKForTesting", func() error { return err })()
 	err = teamEKRetryWrapper(mctx, func() error {
-		metadata, err = publishNewTeamEK(mctx, teamID, merkleRoot)
+		metadata, err = publishNewTeamEK(mctx, teamID, merkleRoot, nil)
 		return err
 	})
 	return metadata, err

--- a/go/ephemeral/team_ek.go
+++ b/go/ephemeral/team_ek.go
@@ -161,9 +161,8 @@ func publishNewTeamEK(mctx libkb.MetaContext, teamID keybase1.TeamID,
 	if forceCreateGeneration != nil {
 		if *forceCreateGeneration+1 != teamEKMetadata.Generation {
 			return metadata, fmt.Errorf("Not posting new teamEK, expected %d, found %d", *forceCreateGeneration+1, teamEKMetadata.Generation)
-		} else {
-			mctx.Debug("forceCreateGeneration set to: %d", *forceCreateGeneration)
 		}
+		mctx.Debug("forceCreateGeneration set to: %d", *forceCreateGeneration)
 	}
 
 	if err = postNewTeamEK(mctx, teamID, sig, boxes); err != nil {

--- a/go/ephemeral/team_ek_box_storage_test.go
+++ b/go/ephemeral/team_ek_box_storage_test.go
@@ -32,7 +32,7 @@ func TestTeamEKBoxStorage(t *testing.T) {
 	teamID := createTeam(tc)
 	invalidID := teamID + keybase1.TeamID("foo")
 
-	teamEKMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
+	teamEKMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot, nil)
 	require.NoError(t, err)
 
 	s := tc.G.GetTeamEKBoxStorage()

--- a/go/ephemeral/team_ek_test.go
+++ b/go/ephemeral/team_ek_test.go
@@ -40,7 +40,7 @@ func TestNewTeamEK(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, nilStatement)
 
-	publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot)
+	publishedMetadata, err := publishNewTeamEK(mctx, teamID, merkleRoot, nil)
 	require.NoError(t, err)
 
 	statementPtr, _, _, err := fetchTeamEKStatement(mctx, teamID)
@@ -71,7 +71,7 @@ func TestNewTeamEK(t *testing.T) {
 
 	// If we publish in a bad local state, we can successfully get the
 	// maxGeneration from the server and continue
-	publishedMetadata2, err := publishNewTeamEK(mctx, teamID, merkleRoot)
+	publishedMetadata2, err := publishNewTeamEK(mctx, teamID, merkleRoot, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, publishedMetadata2.Generation)
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -873,7 +873,10 @@ type EKLib interface {
 
 	// Teambot ephemeral keys
 	GetOrCreateLatestTeambotEK(mctx MetaContext, teamID keybase1.TeamID, botUID gregor1.UID) (keybase1.TeamEphemeralKey, bool, error)
-	GetTeambotEK(mctx MetaContext, teamID keybase1.TeamID, botUID gregor1.UID, generation keybase1.EkGeneration, contentCtime *gregor1.Time) (keybase1.TeamEphemeralKey, error)
+	GetTeambotEK(mctx MetaContext, teamID keybase1.TeamID, botUID gregor1.UID, generation keybase1.EkGeneration,
+		contentCtime *gregor1.Time) (keybase1.TeamEphemeralKey, error)
+	ForceCreateTeambotEK(mctx MetaContext, teamID keybase1.TeamID, botUID gregor1.UID,
+		generation keybase1.EkGeneration) (keybase1.TeamEphemeralKey, bool, error)
 	PurgeTeambotEKCachesForTeamIDAndGeneration(mctx MetaContext, teamID keybase1.TeamID, generation keybase1.EkGeneration)
 	PurgeTeambotEKCachesForTeamID(mctx MetaContext, teamID keybase1.TeamID)
 	PurgeAllTeambotMetadataCaches(mctx MetaContext)

--- a/go/protocol/keybase1/notify_ephemeral.go
+++ b/go/protocol/keybase1/notify_ephemeral.go
@@ -20,9 +20,10 @@ type NewTeambotEkArg struct {
 }
 
 type TeambotEkNeededArg struct {
-	Id         TeamID       `codec:"id" json:"id"`
-	Uid        UID          `codec:"uid" json:"uid"`
-	Generation EkGeneration `codec:"generation" json:"generation"`
+	Id                    TeamID        `codec:"id" json:"id"`
+	Uid                   UID           `codec:"uid" json:"uid"`
+	Generation            EkGeneration  `codec:"generation" json:"generation"`
+	ForceCreateGeneration *EkGeneration `codec:"forceCreateGeneration,omitempty" json:"forceCreateGeneration,omitempty"`
 }
 
 type NotifyEphemeralInterface interface {

--- a/go/service/ephemeral_handler.go
+++ b/go/service/ephemeral_handler.go
@@ -101,7 +101,7 @@ func (r *ekHandler) teambotEKNeeded(ctx context.Context, cli gregor1.IncomingInt
 	}
 	r.G().Log.CDebugf(ctx, "ephemeral.teambot_key_needed unmarshaled: %+v", msg)
 
-	if err := ephemeral.HandleTeambotEKNeeded(r.MetaContext(ctx), msg.Id, msg.Uid, msg.Generation); err != nil {
+	if err := ephemeral.HandleTeambotEKNeeded(r.MetaContext(ctx), msg.Id, msg.Uid, msg.Generation, msg.ForceCreateGeneration); err != nil {
 		return err
 	}
 

--- a/protocol/avdl/keybase1/notify_ephemeral.avdl
+++ b/protocol/avdl/keybase1/notify_ephemeral.avdl
@@ -5,5 +5,5 @@ protocol NotifyEphemeral {
   @notify("")
   void newTeamEk(TeamID id, EkGeneration generation);
   void newTeambotEk(TeamID id, EkGeneration generation);
-  void teambotEkNeeded(TeamID id, UID uid, EkGeneration generation);
+  void teambotEkNeeded(TeamID id, UID uid, EkGeneration generation, union { null, EkGeneration } forceCreateGeneration);
 }

--- a/protocol/json/keybase1/notify_ephemeral.json
+++ b/protocol/json/keybase1/notify_ephemeral.json
@@ -48,6 +48,13 @@
         {
           "name": "generation",
           "type": "EkGeneration"
+        },
+        {
+          "name": "forceCreateGeneration",
+          "type": [
+            null,
+            "EkGeneration"
+          ]
         }
       ],
       "response": null

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -72,7 +72,7 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.NotifyEphemeral.teambotEkNeeded': {
-    inParam: {readonly id: TeamID; readonly uid: UID; readonly generation: EkGeneration}
+    inParam: {readonly id: TeamID; readonly uid: UID; readonly generation: EkGeneration; readonly forceCreateGeneration?: EkGeneration | null}
     outParam: void
   }
   'keybase.1.NotifyFS.FSActivity': {


### PR DESCRIPTION
depends on https://github.com/keybase/keybase/pull/5189

Adds support for a new server-set `ForceCreateGeneration` parameter when a bot is requesting the generation of a new teambot EK. The server sets this when the bot does not have access to the teamEK allowing a new generation to be forcefully created for the bot.