### PR TITLE
use a http roundtripper that force tcp conns closed after success

### DIFF
--- a/go/avatars/srv.go
+++ b/go/avatars/srv.go
@@ -83,8 +83,8 @@ func (s *Srv) loadFromURL(raw string) (io.ReadCloser, error) {
 	switch parsed.Scheme {
 	case "http", "https":
 		avatarTransport.Proxy = libkb.MakeProxy(s.G().GetEnv())
-		xprt := libkb.NewInstrumentedTransport(s.G(), func(*http.Request) string { return "AvatarSrv" },
-			avatarTransport)
+		xprt := libkb.NewInstrumentedRoundTripper(s.G(), func(*http.Request) string { return "AvatarSrv" },
+			libkb.NewClosingRoundTripper(avatarTransport))
 		cli := &http.Client{
 			Transport: xprt,
 		}

--- a/go/chat/giphy/search.go
+++ b/go/chat/giphy/search.go
@@ -114,8 +114,9 @@ func httpClient(mctx libkb.MetaContext, host string) *http.Client {
 	xprt.Proxy = libkb.MakeProxy(env)
 
 	return &http.Client{
-		Transport: libkb.NewInstrumentedTransport(mctx.G(), func(*http.Request) string { return host + " Giphy" }, &xprt),
-		Timeout:   10 * time.Second,
+		Transport: libkb.NewInstrumentedRoundTripper(mctx.G(),
+			func(*http.Request) string { return host + " Giphy" }, &xprt),
+		Timeout: 10 * time.Second,
 	}
 }
 

--- a/go/chat/giphy/search.go
+++ b/go/chat/giphy/search.go
@@ -115,7 +115,7 @@ func httpClient(mctx libkb.MetaContext, host string) *http.Client {
 
 	return &http.Client{
 		Transport: libkb.NewInstrumentedRoundTripper(mctx.G(),
-			func(*http.Request) string { return host + " Giphy" }, &xprt),
+			func(*http.Request) string { return host + " Giphy" }, libkb.NewClosingRoundTripper(&xprt)),
 		Timeout: 10 * time.Second,
 	}
 }

--- a/go/chat/maps/maps.go
+++ b/go/chat/maps/maps.go
@@ -89,8 +89,9 @@ func httpClient(g *libkb.GlobalContext, host string) *http.Client {
 	}
 	xprt.TLSClientConfig = tlsConfig
 	return &http.Client{
-		Transport: libkb.NewInstrumentedTransport(g, func(*http.Request) string { return "LocationShare" }, &xprt),
-		Timeout:   10 * time.Second,
+		Transport: libkb.NewInstrumentedRoundTripper(g,
+			func(*http.Request) string { return "LocationShare" }, &xprt),
+		Timeout: 10 * time.Second,
 	}
 }
 

--- a/go/chat/maps/maps.go
+++ b/go/chat/maps/maps.go
@@ -90,7 +90,7 @@ func httpClient(g *libkb.GlobalContext, host string) *http.Client {
 	xprt.TLSClientConfig = tlsConfig
 	return &http.Client{
 		Transport: libkb.NewInstrumentedRoundTripper(g,
-			func(*http.Request) string { return "LocationShare" }, &xprt),
+			func(*http.Request) string { return "LocationShare" }, libkb.NewClosingRoundTripper(&xprt)),
 		Timeout: 10 * time.Second,
 	}
 }

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -238,7 +238,7 @@ func NewClient(g *GlobalContext, config *ClientConfig, needCookie bool) (*Client
 	if jar != nil {
 		ret.cli.Jar = jar
 	}
-	ret.cli.Transport = NewInstrumentedTransport(g, InstrumentationTagFromRequest, &xprt)
+	ret.cli.Transport = NewInstrumentedRoundTripper(g, InstrumentationTagFromRequest, &xprt)
 	return ret, nil
 }
 
@@ -328,17 +328,17 @@ func (b *InstrumentedBody) Close() (err error) {
 	return b.body.Close()
 }
 
-type InstrumentedTransport struct {
+type InstrumentedRoundTripper struct {
 	Contextified
 	RoundTripper http.RoundTripper
 	tagger       func(*http.Request) string
 	gzipPool     sync.Pool
 }
 
-var _ http.RoundTripper = (*InstrumentedTransport)(nil)
+var _ http.RoundTripper = (*InstrumentedRoundTripper)(nil)
 
-func NewInstrumentedTransport(g *GlobalContext, tagger func(*http.Request) string, xprt http.RoundTripper) *InstrumentedTransport {
-	return &InstrumentedTransport{
+func NewInstrumentedRoundTripper(g *GlobalContext, tagger func(*http.Request) string, xprt http.RoundTripper) *InstrumentedRoundTripper {
+	return &InstrumentedRoundTripper{
 		Contextified: NewContextified(g),
 		RoundTripper: xprt,
 		tagger:       tagger,
@@ -350,7 +350,7 @@ func NewInstrumentedTransport(g *GlobalContext, tagger func(*http.Request) strin
 	}
 }
 
-func (i *InstrumentedTransport) getGzipWriter(writer io.Writer) (*gzip.Writer, func()) {
+func (i *InstrumentedRoundTripper) getGzipWriter(writer io.Writer) (*gzip.Writer, func()) {
 	gzipWriter := i.gzipPool.Get().(*gzip.Writer)
 	gzipWriter.Reset(writer)
 	return gzipWriter, func() {
@@ -358,9 +358,9 @@ func (i *InstrumentedTransport) getGzipWriter(writer io.Writer) (*gzip.Writer, f
 	}
 }
 
-func (i *InstrumentedTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	req.Close = true
+func (i *InstrumentedRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	record := rpc.NewNetworkInstrumenter(i.G().RemoteNetworkInstrumenterStorage, i.tagger(req))
+	req.Close = true
 	resp, err = i.RoundTripper.RoundTrip(req)
 	record.EndCall()
 	if err != nil {

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -360,7 +360,6 @@ func (i *InstrumentedRoundTripper) getGzipWriter(writer io.Writer) (*gzip.Writer
 
 func (i *InstrumentedRoundTripper) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	record := rpc.NewNetworkInstrumenter(i.G().RemoteNetworkInstrumenterStorage, i.tagger(req))
-	req.Close = true
 	resp, err = i.RoundTripper.RoundTrip(req)
 	record.EndCall()
 	if err != nil {

--- a/go/libkb/http.go
+++ b/go/libkb/http.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 
@@ -87,4 +88,19 @@ func HTTPArgsFromKeyValuePair(key string, val HTTPValue) HTTPArgs {
 	ret := HTTPArgs{}
 	ret[key] = val
 	return ret
+}
+
+type ClosingRoundTripper struct {
+	transport *http.Transport
+}
+
+func NewClosingRoundTripper(transport *http.Transport) *ClosingRoundTripper {
+	return &ClosingRoundTripper{
+		transport: transport,
+	}
+}
+
+func (t ClosingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Close = true
+	return t.transport.RoundTrip(req)
 }

--- a/go/libkb/http.go
+++ b/go/libkb/http.go
@@ -91,16 +91,16 @@ func HTTPArgsFromKeyValuePair(key string, val HTTPValue) HTTPArgs {
 }
 
 type ClosingRoundTripper struct {
-	transport *http.Transport
+	rt http.RoundTripper
 }
 
-func NewClosingRoundTripper(transport *http.Transport) *ClosingRoundTripper {
+func NewClosingRoundTripper(rt http.RoundTripper) *ClosingRoundTripper {
 	return &ClosingRoundTripper{
-		transport: transport,
+		rt: rt,
 	}
 }
 
 func (t ClosingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Close = true
-	return t.transport.RoundTrip(req)
+	return t.rt.RoundTrip(req)
 }

--- a/go/libkb/proxy.go
+++ b/go/libkb/proxy.go
@@ -300,13 +300,13 @@ func ProxyDialWithOpts(ctx context.Context, env *Env, network string, address st
 // type of request we are proxying so we don't leak URL information to the
 // instrumenter.
 func ProxyHTTPGet(g *GlobalContext, env *Env, u, instrumentationTag string) (*http.Response, error) {
-	xprt := NewInstrumentedTransport(g, func(*http.Request) string { return instrumentationTag }, &http.Transport{
-		Proxy: MakeProxy(env),
-	})
+	xprt := NewInstrumentedRoundTripper(g, func(*http.Request) string { return instrumentationTag },
+		&http.Transport{
+			Proxy: MakeProxy(env),
+		})
 	client := &http.Client{
 		Transport: xprt,
 	}
-
 	return client.Get(u)
 }
 

--- a/go/libkb/proxy.go
+++ b/go/libkb/proxy.go
@@ -310,17 +310,6 @@ func ProxyHTTPGet(g *GlobalContext, env *Env, u, instrumentationTag string) (*ht
 	return client.Get(u)
 }
 
-func ProxyHTTPDo(g *GlobalContext, env *Env, req *http.Request, instrumentationTag string) (*http.Response, error) {
-	xprt := NewInstrumentedTransport(g, func(*http.Request) string { return instrumentationTag }, &http.Transport{
-		Proxy: MakeProxy(env),
-	})
-	client := &http.Client{
-		Transport: xprt,
-	}
-
-	return client.Do(req)
-}
-
 // A struct that implements rpc.Dialable from go-framed-msgpack-rpc
 type ProxyDialable struct {
 	env       *Env

--- a/go/libkb/proxy.go
+++ b/go/libkb/proxy.go
@@ -310,6 +310,17 @@ func ProxyHTTPGet(g *GlobalContext, env *Env, u, instrumentationTag string) (*ht
 	return client.Get(u)
 }
 
+func ProxyHTTPDo(g *GlobalContext, env *Env, req *http.Request, instrumentationTag string) (*http.Response, error) {
+	xprt := NewInstrumentedTransport(g, func(*http.Request) string { return instrumentationTag }, &http.Transport{
+		Proxy: MakeProxy(env),
+	})
+	client := &http.Client{
+		Transport: xprt,
+	}
+
+	return client.Do(req)
+}
+
 // A struct that implements rpc.Dialable from go-framed-msgpack-rpc
 type ProxyDialable struct {
 	env       *Env

--- a/go/stellar/stellarsvc/anchor.go
+++ b/go/stellar/stellarsvc/anchor.go
@@ -281,7 +281,8 @@ func (a *anchorInteractor) get(mctx libkb.MetaContext, u *url.URL, okResponse fm
 func httpGet(mctx libkb.MetaContext, url, authToken string) (int, []byte, error) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
-		Transport: libkb.NewInstrumentedTransport(mctx.G(), func(*http.Request) string { return "GET StellarAnchor" },
+		Transport: libkb.NewInstrumentedRoundTripper(mctx.G(),
+			func(*http.Request) string { return "GET StellarAnchor" },
 			http.DefaultTransport.(*http.Transport)),
 	}
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -312,7 +313,8 @@ func httpGet(mctx libkb.MetaContext, url, authToken string) (int, []byte, error)
 func httpPost(mctx libkb.MetaContext, url string, data url.Values) (int, []byte, error) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
-		Transport: libkb.NewInstrumentedTransport(mctx.G(), func(*http.Request) string { return "POST StellarAnchor" },
+		Transport: libkb.NewInstrumentedRoundTripper(mctx.G(),
+			func(*http.Request) string { return "POST StellarAnchor" },
 			http.DefaultTransport.(*http.Transport)),
 	}
 	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(data.Encode()))

--- a/go/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/go/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,127 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -1884,6 +1884,12 @@
 			"revisionTime": "2016-07-15T18:54:39Z"
 		},
 		{
+			"checksumSHA1": "MTRW5w1fGNY0KEKHo98/I9D8LsA=",
+			"path": "golang.org/x/sync/semaphore",
+			"revision": "cd5d95a43a6e21273425c7ae415d3df9ea832eeb",
+			"revisionTime": "2019-08-30T23:09:31Z"
+		},
+		{
 			"checksumSHA1": "CQfE0XDYpqkQ/o+Hr3yEEIGRwTo=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "f460065e899abee61eb86816fd1fd684ea5a0f26",


### PR DESCRIPTION
I found that short of setting `req.Close` in the actual `RoundTripper`, I could not get Go to clean up TCP conns fast enough if there is a flurry of outgoing HTTP requests. Even with these drastic measures, I still see somewhere around 10 simultaneous connections open to S3 at a time, but not enough to "out of file descriptor" the process on macOS (with the 256 process limit). 

The reason you need to set this in the `RoundTripper` is that `http.Client` changes the `http.Request` you pass in, and drops the `Close` field. You can set it back again in `RoundTrip`, which is the purpose of `ClosingRoundTripper`. Note: I know about `DisableKeepAlive`, it didn't seem to act quick enough though.