### PR TITLE
Crypto tab: Don't collapse blank lines to zero height

### DIFF
--- a/shared/crypto/crypto-sub-nav.desktop.tsx
+++ b/shared/crypto/crypto-sub-nav.desktop.tsx
@@ -33,11 +33,13 @@ class CryptoSubNav extends React.PureComponent<NavigationViewProps<any>> {
     return (
       <Kb.Box2 direction="horizontal" fullHeight={true} fullWidth={false}>
         <ListAndActiveOperation routeSelected={descriptor.state.routeName}>
-          <SceneView
-            navigation={childNav}
-            component={descriptor.getComponent()}
-            screenProps={this.props.screenProps || noScreenProps}
-          />
+          <Kb.BoxGrow>
+            <SceneView
+              navigation={childNav}
+              component={descriptor.getComponent()}
+              screenProps={this.props.screenProps || noScreenProps}
+            />
+          </Kb.BoxGrow>
         </ListAndActiveOperation>
       </Kb.Box2>
     )

--- a/shared/crypto/output/index.tsx
+++ b/shared/crypto/output/index.tsx
@@ -259,7 +259,7 @@ const Output = (props: OutputProps) => {
   const {fontSize, lineHeight} = getStyle('HeaderBig')
   const outputLargeStyle = outputTextIsLarge &&
     output &&
-    output.length <= largeOutputLimit && {fontSize, lineHeight}
+    output.length <= largeOutputLimit && {fontSize, lineHeight, minHeight: lineHeight}
 
   const fileOutputTextColor =
     textType === 'cipher' ? Styles.globalColors.greenDark : Styles.globalColors.black

--- a/shared/crypto/output/index.tsx
+++ b/shared/crypto/output/index.tsx
@@ -259,7 +259,7 @@ const Output = (props: OutputProps) => {
   const {fontSize, lineHeight} = getStyle('HeaderBig')
   const outputLargeStyle = outputTextIsLarge &&
     output &&
-    output.length <= largeOutputLimit && {fontSize, lineHeight, minHeight: lineHeight}
+    output.length <= largeOutputLimit && {fontSize, lineHeight}
 
   const fileOutputTextColor =
     textType === 'cipher' ? Styles.globalColors.greenDark : Styles.globalColors.black
@@ -287,17 +287,13 @@ const Output = (props: OutputProps) => {
       </Kb.Box2>
     ) : (
       <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
-        {output &&
-          output.split('\n').map((line, index) => (
-            <Kb.Text
-              key={index}
-              type={textType === 'cipher' ? 'Terminal' : 'Body'}
-              selectable={!actionsDisabled}
-              style={Styles.collapseStyles([styles.output, outputLargeStyle])}
-            >
-              {line}
-            </Kb.Text>
-          ))}
+        <Kb.Text
+          type={textType === 'cipher' ? 'Terminal' : 'Body'}
+          selectable={!actionsDisabled}
+          style={Styles.collapseStyles([styles.output, outputLargeStyle])}
+        >
+          {output}
+        </Kb.Text>
       </Kb.Box2>
     )
   ) : (
@@ -333,7 +329,7 @@ const styles = Styles.styleSheetCreate(
       fileOutputText: {...Styles.globalStyles.fontSemibold},
       output: Styles.platformStyles({
         common: {color: Styles.globalColors.black},
-        isElectron: {wordBreak: 'break-word'},
+        isElectron: {whiteSpace: 'pre-wrap', wordBreak: 'break-word'},
       }),
       outputBarContainer: {...Styles.padding(Styles.globalMargins.tiny)},
       outputPlaceholder: {backgroundColor: Styles.globalColors.blueGreyLight},


### PR DESCRIPTION
@keybase/react-hackers CC @thebearjew 

A message in the output component that was signed with text like
```
a

b

c
```
would instead display as:
```
a
b
c
```
because the `<Kb.Text></Kb.Text>` for those blank lines was collapsed down to zero height, because there are no glyphs inside it.

Since we already calculate `lineHeight`, I thought setting `minHeight` to `lineHeight` might be a good fix.