### PR TITLE
add accept/reject to web-of-trust vouches

### DIFF
--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -34,6 +34,7 @@ const (
 	SigchainV2TypePerUserKey                  SigchainV2Type = 14
 	SigchainV2TypeWalletStellar               SigchainV2Type = 15
 	SigchainV2TypeWotVouch                    SigchainV2Type = 16
+	SigchainV2TypeWotReact                    SigchainV2Type = 18
 
 	// Team link types
 	// If you add a new one be sure to get all of these too:
@@ -445,6 +446,8 @@ func SigchainV2TypeFromV1TypeAndRevocations(s string, hasRevocations SigHasRevok
 		ret = SigchainV2TypeWalletStellar
 	case string(LinkTypeWotVouch):
 		ret = SigchainV2TypeWotVouch
+	case string(LinkTypeWotReact):
+		ret = SigchainV2TypeWotReact
 	default:
 		teamRes, teamErr := SigchainV2TypeFromV1TypeTeams(s)
 		if teamErr == nil {

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -408,6 +408,7 @@ const (
 	LinkTypePerUserKey        LinkType = "per_user_key"
 	LinkTypeWalletStellar     LinkType = "wallet.stellar"
 	LinkTypeWotVouch          LinkType = "wot.vouch"
+	LinkTypeWotReact          LinkType = "wot.react"
 
 	// team links
 	LinkTypeTeamRoot         LinkType = "team.root"

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -719,6 +719,27 @@ func (u *User) WotVouchProof(m MetaContext, signingKey GenericKey, sigVersion Si
 	return ret, nil
 }
 
+func (u *User) WotReactProof(m MetaContext, signingKey GenericKey, sigVersion SigVersion, mac []byte) (*ProofMetadataRes, error) {
+	md := ProofMetadata{
+		Me:                  u,
+		LinkType:            LinkTypeWotReact,
+		SigningKey:          signingKey,
+		SigVersion:          sigVersion,
+		IgnoreIfUnsupported: true,
+	}
+	ret, err := md.ToJSON2(m)
+	if err != nil {
+		return nil, err
+	}
+
+	body := ret.J.AtKey("body")
+	if err := body.SetKey("wot_react", jsonw.NewString(hex.EncodeToString(mac))); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
 // SimpleSignJson marshals the given Json structure and then signs it.
 func SignJSON(jw *jsonw.Wrapper, key GenericKey) (out string, id keybase1.SigID, lid LinkID, err error) {
 	var tmp []byte

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -4,6 +4,7 @@
 package keybase1
 
 import (
+	"fmt"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 	"time"
@@ -85,8 +86,30 @@ func (o PendingVouch) DeepCopy() PendingVouch {
 	}
 }
 
-type WotPendingArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+type WotReactionType int
+
+const (
+	WotReactionType_ACCEPT WotReactionType = 0
+	WotReactionType_REJECT WotReactionType = 1
+)
+
+func (o WotReactionType) DeepCopy() WotReactionType { return o }
+
+var WotReactionTypeMap = map[string]WotReactionType{
+	"ACCEPT": 0,
+	"REJECT": 1,
+}
+
+var WotReactionTypeRevMap = map[WotReactionType]string{
+	0: "ACCEPT",
+	1: "REJECT",
+}
+
+func (e WotReactionType) String() string {
+	if v, ok := WotReactionTypeRevMap[e]; ok {
+		return v
+	}
+	return fmt.Sprintf("%v", int(e))
 }
 
 type WotVouchArg struct {
@@ -103,31 +126,28 @@ type WotVouchCLIArg struct {
 	Confidence Confidence `codec:"confidence" json:"confidence"`
 }
 
+type WotPendingArg struct {
+	SessionID int `codec:"sessionID" json:"sessionID"`
+}
+
+type WotReactArg struct {
+	SessionID int             `codec:"sessionID" json:"sessionID"`
+	Uv        UserVersion     `codec:"uv" json:"uv"`
+	Proof     SigID           `codec:"proof" json:"proof"`
+	Reaction  WotReactionType `codec:"reaction" json:"reaction"`
+}
+
 type WotInterface interface {
-	WotPending(context.Context, int) ([]PendingVouch, error)
 	WotVouch(context.Context, WotVouchArg) error
 	WotVouchCLI(context.Context, WotVouchCLIArg) error
+	WotPending(context.Context, int) ([]PendingVouch, error)
+	WotReact(context.Context, WotReactArg) error
 }
 
 func WotProtocol(i WotInterface) rpc.Protocol {
 	return rpc.Protocol{
 		Name: "keybase.1.wot",
 		Methods: map[string]rpc.ServeHandlerDescription{
-			"wotPending": {
-				MakeArg: func() interface{} {
-					var ret [1]WotPendingArg
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[1]WotPendingArg)
-					if !ok {
-						err = rpc.NewTypeError((*[1]WotPendingArg)(nil), args)
-						return
-					}
-					ret, err = i.WotPending(ctx, typedArgs[0].SessionID)
-					return
-				},
-			},
 			"wotVouch": {
 				MakeArg: func() interface{} {
 					var ret [1]WotVouchArg
@@ -158,18 +178,42 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 					return
 				},
 			},
+			"wotPending": {
+				MakeArg: func() interface{} {
+					var ret [1]WotPendingArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]WotPendingArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]WotPendingArg)(nil), args)
+						return
+					}
+					ret, err = i.WotPending(ctx, typedArgs[0].SessionID)
+					return
+				},
+			},
+			"wotReact": {
+				MakeArg: func() interface{} {
+					var ret [1]WotReactArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]WotReactArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]WotReactArg)(nil), args)
+						return
+					}
+					err = i.WotReact(ctx, typedArgs[0])
+					return
+				},
+			},
 		},
 	}
 }
 
 type WotClient struct {
 	Cli rpc.GenericClient
-}
-
-func (c WotClient) WotPending(ctx context.Context, sessionID int) (res []PendingVouch, err error) {
-	__arg := WotPendingArg{SessionID: sessionID}
-	err = c.Cli.Call(ctx, "keybase.1.wot.wotPending", []interface{}{__arg}, &res, 0*time.Millisecond)
-	return
 }
 
 func (c WotClient) WotVouch(ctx context.Context, __arg WotVouchArg) (err error) {
@@ -179,5 +223,16 @@ func (c WotClient) WotVouch(ctx context.Context, __arg WotVouchArg) (err error) 
 
 func (c WotClient) WotVouchCLI(ctx context.Context, __arg WotVouchCLIArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouchCLI", []interface{}{__arg}, nil, 0*time.Millisecond)
+	return
+}
+
+func (c WotClient) WotPending(ctx context.Context, sessionID int) (res []PendingVouch, err error) {
+	__arg := WotPendingArg{SessionID: sessionID}
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotPending", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c WotClient) WotReact(ctx context.Context, __arg WotReactArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotReact", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -58,3 +58,16 @@ func (h *WebOfTrustHandler) WotPending(ctx context.Context, sessionID int) (res 
 	mctx := libkb.NewMetaContext(ctx, h.G())
 	return libkb.FetchPendingWotVouches(mctx)
 }
+
+func (h *WebOfTrustHandler) WotReact(ctx context.Context, arg keybase1.WotReactArg) error {
+	ctx = libkb.WithLogTag(ctx, "WOT")
+	mctx := libkb.NewMetaContext(ctx, h.G())
+
+	earg := &engine.WotReactArg{
+		Voucher:  arg.Uv,
+		Proof:    arg.Proof,
+		Reaction: arg.Reaction,
+	}
+	eng := engine.NewWotReact(h.G(), earg)
+	return engine.RunEngine2(mctx, eng)
+}

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -18,6 +18,9 @@ protocol wot {
     int knownOnKeybaseDays;
   }
 
+  void wotVouch(int sessionID, UserVersion uv /* vouchee */, array<string> vouchTexts, Confidence confidence);
+  void wotVouchCLI(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);
+
   record PendingVouch {
     UserVersion voucher;
     SigID proof;
@@ -27,7 +30,9 @@ protocol wot {
 
   array<PendingVouch> wotPending(int sessionID);
 
-  void wotVouch(int sessionID, UserVersion uv, array<string> vouchTexts, Confidence confidence);
-
-  void wotVouchCLI(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);
+  enum WotReactionType {
+    ACCEPT_0,
+    REJECT_1
+  }
+  void wotReact(int sessionID, UserVersion uv /* voucher */, SigID proof, WotReactionType reaction);
 }

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -75,21 +75,17 @@
           "name": "confidence"
         }
       ]
+    },
+    {
+      "type": "enum",
+      "name": "WotReactionType",
+      "symbols": [
+        "ACCEPT_0",
+        "REJECT_1"
+      ]
     }
   ],
   "messages": {
-    "wotPending": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        }
-      ],
-      "response": {
-        "type": "array",
-        "items": "PendingVouch"
-      }
-    },
     "wotVouch": {
       "request": [
         {
@@ -134,6 +130,39 @@
         {
           "name": "confidence",
           "type": "Confidence"
+        }
+      ],
+      "response": null
+    },
+    "wotPending": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "PendingVouch"
+      }
+    },
+    "wotReact": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "uv",
+          "type": "UserVersion"
+        },
+        {
+          "name": "proof",
+          "type": "SigID"
+        },
+        {
+          "name": "reaction",
+          "type": "WotReactionType"
         }
       ],
       "response": null

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2629,6 +2629,11 @@ export enum UserOrTeamResult {
   user = 1,
   team = 2,
 }
+
+export enum WotReactionType {
+  accept = 0,
+  reject = 1,
+}
 export type APIRes = {readonly status: String; readonly body: String; readonly httpStatus: Int; readonly appStatus: String}
 export type APIUserKeybaseResult = {readonly username: String; readonly uid: UID; readonly pictureUrl?: String | null; readonly fullName?: String | null; readonly rawScore: Double; readonly stellar?: String | null; readonly isFollowee: Boolean}
 export type APIUserSearchResult = {readonly score: Double; readonly keybase?: APIUserKeybaseResult | null; readonly service?: APIUserServiceResult | null; readonly contact?: ProcessedContact | null; readonly imptofu?: ImpTofuSearchResult | null; readonly servicesSummary: {[key: string]: APIUserServiceSummary}; readonly rawScore: Double}
@@ -4127,6 +4132,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.user.findNextMerkleRootAfterRevoke'
 // 'keybase.1.user.findNextMerkleRootAfterReset'
 // 'keybase.1.user.getTeamBlocks'
-// 'keybase.1.wot.wotPending'
 // 'keybase.1.wot.wotVouch'
 // 'keybase.1.wot.wotVouchCLI'
+// 'keybase.1.wot.wotPending'
+// 'keybase.1.wot.wotReact'


### PR DESCRIPTION
* add the new sigchain link type for wot_react
* parse them
* dedupe and reorg a little bit of the common code across vouching and reacting

one caveat: i don't think this can be tested in an integration-y way yet