### PR TITLE
indexer: share a batch across multiple index operations

### DIFF
--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -96,6 +96,8 @@ func writeFile(
 
 	t.Log("Index the file")
 	namePPS := data.NewPathPartString(name, nil)
+	err = i.refreshBatch(ctx)
+	require.NoError(t, err)
 	if newFile {
 		ids, err := i.blocksDb.GetNextDocIDs(1)
 		require.NoError(t, err)
@@ -108,6 +110,8 @@ func writeFile(
 		require.NoError(t, err)
 		require.NotNil(t, dirDoneFn)
 	}
+	err = i.flushBatch(ctx)
+	require.NoError(t, err)
 
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -213,7 +217,11 @@ func TestIndexFile(t *testing.T) {
 		ctx, rootNode, data.NewPathPartString(dName, nil), rootNode,
 		newDNamePPS)
 	require.NoError(t, err)
+	err = i.refreshBatch(ctx)
+	require.NoError(t, err)
 	err = i.renameChild(ctx, rootNode, "", newDNamePPS, 1)
+	require.NoError(t, err)
+	err = i.flushBatch(ctx)
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
@@ -227,9 +235,13 @@ func TestIndexFile(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps.RemoveEntry(ctx, rootNode, aNamePPS)
 	require.NoError(t, err)
+	err = i.refreshBatch(ctx)
+	require.NoError(t, err)
 	err = i.deleteFromUnrefs(
 		ctx, rootNode.GetFolderBranch().Tlf,
 		[]data.BlockPointer{md.BlockInfo.BlockPointer})
+	require.NoError(t, err)
+	err = i.flushBatch(ctx)
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)


### PR DESCRIPTION
This lets batches of ~100 MB build up before flushing them to the index. It also buffers up other DB operations, so that they don't hit the disk until after their corresponding index operations have been flushed.

This reduced the time to index a large directory from 3m52s to 1m48s. It also reduced the total size of the `kbfs_index` directory from 5.5 GB to 1.7 GB, I think mostly due to many fewer revisions and blocks being stored to disk.  (Future work will clean up old GC'd blocks, but that's not yet in place.)

Because the indexing process uses the `IndexedBlocksDb`, that db also needs to have an in-memory DB that only gets flushed to disk after the corresponding index batch is flushed to disk, so that adds some complexity.

Issue: HOTPOT-1984