### PR TITLE
Truncate bot aliases

### DIFF
--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -175,11 +175,25 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               onClick={this.onAuthorClick}
               style={styles.avatar}
             />
-            <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
+            <Kb.Box2
+              direction="horizontal"
+              gap="xtiny"
+              fullWidth={true}
+              style={Styles.collapseStyles([styles.usernameCrown])}
+            >
               {this.props.botAlias ? (
                 <Kb.Box2 direction="horizontal">
+                  <Kb.Text
+                    type="BodySmallBold"
+                    style={Styles.collapseStyles([
+                      {color: Styles.globalColors.black, wordBreak: 'break-all', maxWidth: 300},
+                    ])}
+                    lineClamp={1}
+                  >
+                    {this.props.botAlias}
+                  </Kb.Text>
                   <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
-                    {this.props.botAlias} [
+                    &nbsp;[
                   </Kb.Text>
                   {username}
                   <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
@@ -831,7 +845,10 @@ const styles = Styles.styleSheetCreate(
           top: -8,
         },
       }),
-      timestamp: Styles.platformStyles({isElectron: {lineHeight: 19}}),
+      timestamp: Styles.platformStyles({
+        common: {flexShrink: 0},
+        isElectron: {lineHeight: 19},
+      }),
       timestampHighlighted: {color: Styles.globalColors.black_50OrBlack_40},
       usernameCrown: Styles.platformStyles({
         isElectron: {

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -723,12 +723,12 @@ const styles = Styles.styleSheetCreate(
         common: {
           color: Styles.globalColors.black,
         },
-        isMobile: {
-          maxWidth: 120,
-        },
         isElectron: {
           maxWidth: 240,
           wordBreak: 'break-all',
+        },
+        isMobile: {
+          maxWidth: 120,
         },
       }),
       centeredOrdinal: {backgroundColor: Styles.globalColors.yellowOrYellowAlt},
@@ -852,15 +852,18 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       timestamp: Styles.platformStyles({
-        isElectron: {lineHeight: 19, flexShrink: 0},
+        isElectron: {
+          flexShrink: 0,
+          lineHeight: 19,
+        },
       }),
       timestampHighlighted: {color: Styles.globalColors.black_50OrBlack_40},
       usernameCrown: Styles.platformStyles({
         isElectron: {
           alignItems: 'baseline',
           position: 'relative',
-          top: -2,
           marginRight: 48,
+          top: -2,
         },
         isMobile: {
           alignItems: 'center',

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -183,13 +183,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
             >
               {this.props.botAlias ? (
                 <Kb.Box2 direction="horizontal">
-                  <Kb.Text
-                    type="BodySmallBold"
-                    style={Styles.collapseStyles([
-                      {color: Styles.globalColors.black, wordBreak: 'break-all', maxWidth: 300},
-                    ])}
-                    lineClamp={1}
-                  >
+                  <Kb.Text type="BodySmallBold" style={styles.botAlias} lineClamp={1}>
                     {this.props.botAlias}
                   </Kb.Text>
                   <Kb.Text type="BodySmallBold" style={{color: Styles.globalColors.black}}>
@@ -725,6 +719,18 @@ const styles = Styles.styleSheetCreate(
         isElectron: {marginLeft: Styles.globalMargins.small},
         isMobile: {marginLeft: Styles.globalMargins.tiny},
       }),
+      botAlias: Styles.platformStyles({
+        common: {
+          color: Styles.globalColors.black,
+        },
+        isMobile: {
+          maxWidth: 120,
+        },
+        isElectron: {
+          maxWidth: 240,
+          wordBreak: 'break-all',
+        },
+      }),
       centeredOrdinal: {backgroundColor: Styles.globalColors.yellowOrYellowAlt},
       container: Styles.platformStyles({isMobile: {overflow: 'hidden'}}),
       containerNoUsername: Styles.platformStyles({
@@ -846,8 +852,7 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       timestamp: Styles.platformStyles({
-        common: {flexShrink: 0},
-        isElectron: {lineHeight: 19},
+        isElectron: {lineHeight: 19, flexShrink: 0},
       }),
       timestampHighlighted: {color: Styles.globalColors.black_50OrBlack_40},
       usernameCrown: Styles.platformStyles({
@@ -855,8 +860,11 @@ const styles = Styles.styleSheetCreate(
           alignItems: 'baseline',
           position: 'relative',
           top: -2,
+          marginRight: 48,
         },
-        isMobile: {alignItems: 'center'},
+        isMobile: {
+          alignItems: 'center',
+        },
       }),
       usernameHighlighted: {color: Styles.globalColors.blackOrBlack},
     } as const)

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -861,8 +861,8 @@ const styles = Styles.styleSheetCreate(
       usernameCrown: Styles.platformStyles({
         isElectron: {
           alignItems: 'baseline',
-          position: 'relative',
           marginRight: 48,
+          position: 'relative',
           top: -2,
         },
         isMobile: {

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -175,12 +175,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
               onClick={this.onAuthorClick}
               style={styles.avatar}
             />
-            <Kb.Box2
-              direction="horizontal"
-              gap="xtiny"
-              fullWidth={true}
-              style={Styles.collapseStyles([styles.usernameCrown])}
-            >
+            <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
               {this.props.botAlias ? (
                 <Kb.Box2 direction="horizontal">
                   <Kb.Text type="BodySmallBold" style={styles.botAlias} lineClamp={1}>


### PR DESCRIPTION
Restricts display of bot aliases to a reasonable length to prevent display issues + possible username spoofing