### PR TITLE
use ModalTabBarShim only on people tab

### DIFF
--- a/shared/common-adapters/popup-dialog.desktop.tsx
+++ b/shared/common-adapters/popup-dialog.desktop.tsx
@@ -22,7 +22,7 @@ export function PopupDialog({
   styleContainer,
   styleClose,
   styleClipContainer,
-  tabBarShim,
+  tabBarShim, // Move out of the way the nav column.
   allowClipBubbling,
 }: Props) {
   const [mouseDownOnCover, setMouseDownOnCover] = React.useState(false)

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -639,7 +639,7 @@ const mergeProps = (
               }
             : null,
         onClosePopup: dispatchProps._onCancelTeamBuilding,
-        tabBarShim: true,
+        tabBarShim: ownProps.namespace === 'people',
       }
 
   return {


### PR DESCRIPTION
Fix wallet send form's team-building alignment. But without messing up the people tab. A side effect is that all non-people-tab team-building modals are now centered in the window where before they were scooted right.
