### PR TITLE
Flex team header to enable better wrapping

### DIFF
--- a/shared/teams/team/nav-header/index.tsx
+++ b/shared/teams/team/nav-header/index.tsx
@@ -140,6 +140,8 @@ const styles = Styles.styleSheetCreate(
           ...Styles.desktopStyles.windowDraggingClickable,
           alignSelf: 'flex-end',
           paddingRight: Styles.globalMargins.tiny,
+          display: 'flex',
+          flexWrap: 'wrap',
         },
       }),
     } as const)


### PR DESCRIPTION
The text in team settings was wrapping, but the problem was in the header.