### PR TITLE
add listing for web of trust

### DIFF
--- a/go/client/cmd_wot.go
+++ b/go/client/cmd_wot.go
@@ -9,6 +9,7 @@ import (
 func newCmdWebOfTrust(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	// please keep sorted
 	subcommands := []cli.Command{
+		newCmdWotList(cl, g),
 		newCmdWotVouch(cl, g),
 	}
 	return cli.Command{

--- a/go/client/cmd_wot_list.go
+++ b/go/client/cmd_wot_list.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+)
+
+type cmdWotList struct {
+	libkb.Contextified
+	username *string
+}
+
+func newCmdWotList(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	cmd := &cmdWotList{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:        "list",
+		Usage:       "List a user's web-of-trust attestations",
+		Description: "List a user's web-of-trust attestations",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "list", c)
+		},
+		Flags: []cli.Flag{},
+	}
+}
+
+func (c *cmdWotList) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) > 1 {
+		return errors.New("too many arguments")
+	}
+	if len(ctx.Args()) == 1 {
+		username := ctx.Args()[0]
+		c.username = &username
+	}
+	return nil
+}
+
+func (c *cmdWotList) Run() error {
+	ctx := context.Background()
+	arg := keybase1.WotListCLIArg{
+		Username: c.username,
+	}
+	cli, err := GetWebOfTrustClient(c.G())
+	if err != nil {
+		return err
+	}
+	res, err := cli.WotListCLI(ctx, arg)
+	if err != nil {
+		return err
+	}
+	dui := c.G().UI.GetDumbOutputUI()
+	line := func(format string, args ...interface{}) {
+		dui.Printf(format+"\n", args...)
+	}
+	line("Web-Of-Trust")
+	if len(res) == 0 {
+		line("no attestations to show")
+		return nil
+	}
+	line("  STATUS   | VOUCHER : ATTESTATION")
+	for _, vouch := range res {
+		vouchTexts := strings.Join(vouch.VouchTexts, ", ")
+		voucher, err := c.G().GetUPAKLoader().LookupUsername(ctx, vouch.Voucher.Uid)
+		if err != nil {
+			return fmt.Errorf("error looking up username for vouch: %s", err.Error())
+		}
+		line("%10s | %s: \"%s\"", vouch.Status, voucher, vouchTexts)
+	}
+	return nil
+}
+
+func (c *cmdWotList) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -224,17 +224,18 @@ func TestWebOfTrustAccept(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("bob vouches for alice with confidence")
 
-	pending, err := libkb.FetchPendingWotVouches(mctxA)
+	vouches, err := libkb.FetchMyWot(mctxA)
 	require.NoError(t, err)
-	require.Len(t, pending, 1)
-	bobVouch := pending[0]
+	require.Len(t, vouches, 1)
+	bobVouch := vouches[0]
+	require.Equal(t, keybase1.WotStatusType_PROPOSED, bobVouch.Status)
 	require.Equal(t, bob.User.GetUID(), bobVouch.Voucher.Uid)
 	require.Equal(t, vouchTexts, bobVouch.VouchTexts)
 	t.Log("alice fetches one pending vouch")
 
 	argR := &WotReactArg{
 		Voucher:  bob.User.ToUserVersion(),
-		Proof:    pending[0].Proof,
+		Proof:    bobVouch.VouchProof,
 		Reaction: keybase1.WotReactionType_ACCEPT,
 	}
 	engR := NewWotReact(tcAlice.G, argR)
@@ -242,7 +243,7 @@ func TestWebOfTrustAccept(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("alice accepts")
 
-	vouches, err := libkb.FetchMyWot(mctxA)
+	vouches, err = libkb.FetchMyWot(mctxA)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(vouches))
 	vouch := vouches[0]
@@ -292,17 +293,18 @@ func TestWebOfTrustReject(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("bob vouches for alice without confidence")
 
-	pending, err := libkb.FetchPendingWotVouches(mctxA)
+	vouches, err := libkb.FetchMyWot(mctxA)
 	require.NoError(t, err)
-	require.Len(t, pending, 1)
-	bobVouch := pending[0]
+	require.Len(t, vouches, 1)
+	bobVouch := vouches[0]
+	require.Equal(t, keybase1.WotStatusType_PROPOSED, bobVouch.Status)
 	require.Equal(t, bob.User.GetUID(), bobVouch.Voucher.Uid)
 	require.Equal(t, vouchTexts, bobVouch.VouchTexts)
 	t.Log("alice fetches one pending vouch")
 
 	argR := &WotReactArg{
 		Voucher:  bob.User.ToUserVersion(),
-		Proof:    pending[0].Proof,
+		Proof:    bobVouch.VouchProof,
 		Reaction: keybase1.WotReactionType_REJECT,
 	}
 	engR := NewWotReact(tcAlice.G, argR)
@@ -310,7 +312,7 @@ func TestWebOfTrustReject(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("alice rejects it")
 
-	vouches, err := libkb.FetchMyWot(mctxA)
+	vouches, err = libkb.FetchMyWot(mctxA)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(vouches))
 	vouch := vouches[0]

--- a/go/libkb/wot.go
+++ b/go/libkb/wot.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -17,15 +18,10 @@ func getWotVouchChainLink(mctx MetaContext, uid keybase1.UID, sigID keybase1.Sig
 	if link == nil {
 		return nil, nil, fmt.Errorf("Could not find link from sigID")
 	}
-	if link.revoked {
-		return nil, nil, fmt.Errorf("Link is revoked")
-	}
-
 	tlink, w := NewTypedChainLink(link)
 	if w != nil {
 		return nil, nil, fmt.Errorf("Could not get typed chain link: %v", w.Warning())
 	}
-
 	vlink, ok := tlink.(*WotVouchChainLink)
 	if !ok {
 		return nil, nil, fmt.Errorf("Link is not a WotVouchChainLink: %v", tlink)
@@ -33,19 +29,31 @@ func getWotVouchChainLink(mctx MetaContext, uid keybase1.UID, sigID keybase1.Sig
 	return vlink, user, nil
 }
 
-func assertVouchIsForMe(mctx MetaContext, vouchedUser wotExpansionUser) (err error) {
-	me, err := LoadMe(NewLoadUserArgWithMetaContext(mctx))
-	if err != nil {
-		return fmt.Errorf("error loading myself: %s", err.Error())
+func getWotReactChainLink(mctx MetaContext, user *User, sigID keybase1.SigID) (cl *WotReactChainLink, err error) {
+	link := user.LinkFromSigID(sigID)
+	if link == nil {
+		return nil, fmt.Errorf("Could not find link from sigID")
 	}
-	if me.GetName() != vouchedUser.Username {
-		return fmt.Errorf("wot username isn't me %s != %s", me.GetName(), vouchedUser.Username)
+	tlink, w := NewTypedChainLink(link)
+	if w != nil {
+		return nil, fmt.Errorf("Could not get typed chain link: %v", w.Warning())
 	}
-	if me.GetUID() != vouchedUser.UID {
-		return fmt.Errorf("wot uid isn't me %s != %s", me.GetUID(), vouchedUser.UID)
+	rlink, ok := tlink.(*WotReactChainLink)
+	if !ok {
+		return nil, fmt.Errorf("Link is not a WotReactChainLink: %v", tlink)
 	}
-	if me.GetEldestKID() != vouchedUser.Eldest.KID {
-		return fmt.Errorf("wot eldest kid isn't me %s != %s", me.GetEldestKID(), vouchedUser.Eldest.KID)
+	return rlink, nil
+}
+
+func assertVouchIsForUser(mctx MetaContext, vouchedUser wotExpansionUser, user *User) (err error) {
+	if user.GetName() != vouchedUser.Username {
+		return fmt.Errorf("wot username isn't expected %s != %s", user.GetName(), vouchedUser.Username)
+	}
+	if user.GetUID() != vouchedUser.UID {
+		return fmt.Errorf("wot uid isn't me %s != %s", user.GetUID(), vouchedUser.UID)
+	}
+	if user.GetEldestKID() != vouchedUser.Eldest.KID {
+		return fmt.Errorf("wot eldest kid isn't me %s != %s", user.GetEldestKID(), vouchedUser.Eldest.KID)
 	}
 	return nil
 }
@@ -64,10 +72,15 @@ type wotExpansionUser struct {
 	Username string
 }
 
-type wotExpansionDetails struct {
+type vouchExpansion struct {
 	User       wotExpansionUser     `json:"user"`
 	Confidence *keybase1.Confidence `json:"confidence,omitempty"`
 	VouchTexts []string             `json:"vouch_text"`
+}
+
+type reactionExpansion struct {
+	SigID    keybase1.SigID `json:"sig_id"`
+	Reaction string         `json:"reaction"`
 }
 
 func transformPending(mctx MetaContext, serverVouch serverWotVouch) (res *keybase1.PendingVouch, err error) {
@@ -79,13 +92,16 @@ func transformPending(mctx MetaContext, serverVouch serverWotVouch) (res *keybas
 	if err != nil {
 		return res, fmt.Errorf("error finding the pending vouch in the voucher's sigchain: %s", err.Error())
 	}
+	if wotVouchLink.revoked {
+		return res, fmt.Errorf("%s is revoked", serverVouch.VouchSigID)
+	}
 	// extract the sig expansion
 	expansionObject, err := ExtractExpansionObj(wotVouchLink.ExpansionID, serverVouch.VouchExpansionJSON)
 	if err != nil {
 		return res, fmt.Errorf("error extracting and validating the expansion: %s", err.Error())
 	}
 	// load it into the right type for web-of-trust vouching
-	var wotObj wotExpansionDetails
+	var wotObj vouchExpansion
 	err = json.Unmarshal(expansionObject, &wotObj)
 	if err != nil {
 		return res, fmt.Errorf("error casting expansion object to expected web-of-trust schema: %s", err.Error())
@@ -94,7 +110,11 @@ func transformPending(mctx MetaContext, serverVouch serverWotVouch) (res *keybas
 		// nil out an empty confidence
 		wotObj.Confidence = nil
 	}
-	err = assertVouchIsForMe(mctx, wotObj.User)
+	me, err := LoadMe(NewLoadUserArgWithMetaContext(mctx))
+	if err != nil {
+		return res, fmt.Errorf("error loading myself: %s", err.Error())
+	}
+	err = assertVouchIsForUser(mctx, wotObj.User, me)
 	if err != nil {
 		mctx.Debug("web-of-trust pending vouch user-section doesn't look right: %+v", wotObj.User)
 		return res, fmt.Errorf("error verifying user section of web-of-trust expansion: %s", err.Error())
@@ -119,12 +139,93 @@ type serverWotVouch struct {
 	Status                keybase1.WotStatusType `json:"status"`
 }
 
+func transformUserVouch(mctx MetaContext, serverVouch serverWotVouch, vouchee *User) (res keybase1.WotVouch, err error) {
+	// load the voucher and fetch the relevant chain link
+	wotVouchLink, voucher, err := getWotVouchChainLink(mctx, serverVouch.Voucher, serverVouch.VouchSigID)
+	if err != nil {
+		return res, fmt.Errorf("error finding the vouch in the voucher's sigchain: %s", err.Error())
+	}
+	// extract the sig expansion
+	expansionObject, err := ExtractExpansionObj(wotVouchLink.ExpansionID, serverVouch.VouchExpansionJSON)
+	if err != nil {
+		return res, fmt.Errorf("error extracting and validating the vouch expansion: %s", err.Error())
+	}
+	// load it into the right type for web-of-trust vouching
+	var wotObj vouchExpansion
+	err = json.Unmarshal(expansionObject, &wotObj)
+	if err != nil {
+		return res, fmt.Errorf("error casting vouch expansion object to expected web-of-trust schema: %s", err.Error())
+	}
+	if wotObj.Confidence != nil && reflect.DeepEqual(*wotObj.Confidence, keybase1.Confidence{}) {
+		// nil out an empty confidence
+		wotObj.Confidence = nil
+	}
+
+	err = assertVouchIsForUser(mctx, wotObj.User, vouchee)
+	if err != nil {
+		mctx.Debug("web-of-trust vouch user-section doesn't look right: %+v", wotObj.User)
+		return res, fmt.Errorf("error verifying user section of web-of-trust expansion: %s", err.Error())
+	}
+
+	hasReaction := serverVouch.ReactionSigID != nil
+	var reactionObj reactionExpansion
+	var reactionStatus keybase1.WotReactionType
+	var wotReactLink *WotReactChainLink
+	if hasReaction {
+		wotReactLink, err = getWotReactChainLink(mctx, vouchee, *serverVouch.ReactionSigID)
+		if err != nil {
+			return res, fmt.Errorf("error finding the vouch in the vouchee's sigchain: %s", err.Error())
+		}
+		// extract the sig expansion
+		expansionObject, err = ExtractExpansionObj(wotReactLink.ExpansionID, *serverVouch.ReactionExpansionJSON)
+		if err != nil {
+			return res, fmt.Errorf("error extracting and validating the vouch expansion: %s", err.Error())
+		}
+		// load it into the right type for web-of-trust vouching
+		err = json.Unmarshal(expansionObject, &reactionObj)
+		if err != nil {
+			return res, fmt.Errorf("error casting vouch expansion object to expected web-of-trust schema: %s", err.Error())
+		}
+		if reactionObj.SigID.String()[:30] != wotVouchLink.GetSigID().String()[:30] {
+			return res, fmt.Errorf("reaction sigID doesn't match the original attestation: %s != %s", reactionObj.SigID, wotVouchLink.GetSigID())
+		}
+		reactionStatus = keybase1.WotReactionTypeMap[strings.ToUpper(reactionObj.Reaction)]
+	}
+
+	var status keybase1.WotStatusType
+	switch {
+	case wotVouchLink.revoked:
+		status = keybase1.WotStatusType_REVOKED
+	case wotReactLink != nil && wotReactLink.revoked:
+		status = keybase1.WotStatusType_REVOKED
+	case !hasReaction:
+		status = keybase1.WotStatusType_PROPOSED
+	case reactionStatus == keybase1.WotReactionType_ACCEPT:
+		status = keybase1.WotStatusType_ACCEPTED
+	case reactionStatus == keybase1.WotReactionType_REJECT:
+		status = keybase1.WotStatusType_REJECTED
+	default:
+		return res, fmt.Errorf("could not determine the status of web-of-trust from %s", voucher.GetName())
+	}
+
+	// build a WotVouch
+	return keybase1.WotVouch{
+		Status:     status,
+		Voucher:    voucher.ToUserVersion(),
+		VouchTexts: wotObj.VouchTexts,
+		VouchProof: serverVouch.VouchSigID,
+		VouchedAt:  keybase1.ToTime(wotVouchLink.GetCTime()),
+		Confidence: wotObj.Confidence,
+	}, nil
+}
+
 type apiWot struct {
 	AppStatusEmbed
 	Vouches []serverWotVouch `json:"webOfTrust"`
 }
 
 func fetchWot(mctx MetaContext, username *string) (res []serverWotVouch, err error) {
+	defer mctx.Trace("fetchWot", func() error { return err })()
 	apiArg := APIArg{
 		Endpoint:    "wot/get",
 		SessionType: APISessionTypeREQUIRED,
@@ -138,6 +239,7 @@ func fetchWot(mctx MetaContext, username *string) (res []serverWotVouch, err err
 		mctx.Debug("error fetching web-of-trust vouches: %s", err.Error())
 		return nil, err
 	}
+	mctx.Debug("server returned %d web-of-trust vouches", len(response.Vouches))
 	return response.Vouches, nil
 }
 
@@ -159,5 +261,51 @@ func FetchPendingWotVouches(mctx MetaContext) (res []keybase1.PendingVouch, err 
 		}
 	}
 	mctx.Debug("found %d pending web-of-trust vouches", len(res))
+	return res, nil
+}
+
+func FetchMyWot(mctx MetaContext) (res []keybase1.WotVouch, err error) {
+	defer mctx.Trace("FetchMyWot", func() error { return err })()
+	serverVouches, err := fetchWot(mctx, nil)
+	if err != nil {
+		mctx.Debug("error fetching pending web-of-trust vouches: %s", err.Error())
+		return nil, err
+	}
+	me, err := LoadMe(NewLoadUserArgWithMetaContext(mctx))
+	if err != nil {
+		return nil, fmt.Errorf("error loading myself: %s", err.Error())
+	}
+	for _, serverVouch := range serverVouches {
+		vouch, err := transformUserVouch(mctx, serverVouch, me)
+		if err != nil {
+			mctx.Debug("error validating server-reported pending web-of-trust vouches: %s", err.Error())
+			return nil, err
+		}
+		res = append(res, vouch)
+	}
+	mctx.Debug("found %d web-of-trust vouches", len(res))
+	return res, nil
+}
+
+func FetchUserWot(mctx MetaContext, username string) (res []keybase1.WotVouch, err error) {
+	defer mctx.Trace("FetchUserWot", func() error { return err })()
+	vouches, err := fetchWot(mctx, &username)
+	if err != nil {
+		mctx.Debug("error fetching web-of-trust vouches for %s: %s", username, err.Error())
+		return nil, err
+	}
+	vouchee, err := LoadUser(NewLoadUserArgWithMetaContext(mctx).WithName(username))
+	if err != nil {
+		return res, fmt.Errorf("error loading vouchee: %s", err.Error())
+	}
+	for _, serverVouch := range vouches {
+		vouch, err := transformUserVouch(mctx, serverVouch, vouchee)
+		if err != nil {
+			mctx.Debug("error validating server-reported web-of-trust vouches for %s: %s", username, err.Error())
+			return nil, err
+		}
+		res = append(res, vouch)
+	}
+	mctx.Debug("found %d web-of-trust vouches for %s", username, len(res))
 	return res, nil
 }

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -10,6 +10,41 @@ import (
 	"time"
 )
 
+type WotStatusType int
+
+const (
+	WotStatusType_NONE     WotStatusType = 0
+	WotStatusType_PROPOSED WotStatusType = 1
+	WotStatusType_ACCEPTED WotStatusType = 2
+	WotStatusType_REJECTED WotStatusType = 3
+	WotStatusType_REVOKED  WotStatusType = 4
+)
+
+func (o WotStatusType) DeepCopy() WotStatusType { return o }
+
+var WotStatusTypeMap = map[string]WotStatusType{
+	"NONE":     0,
+	"PROPOSED": 1,
+	"ACCEPTED": 2,
+	"REJECTED": 3,
+	"REVOKED":  4,
+}
+
+var WotStatusTypeRevMap = map[WotStatusType]string{
+	0: "NONE",
+	1: "PROPOSED",
+	2: "ACCEPTED",
+	3: "REJECTED",
+	4: "REVOKED",
+}
+
+func (e WotStatusType) String() string {
+	if v, ok := WotStatusTypeRevMap[e]; ok {
+		return v
+	}
+	return fmt.Sprintf("%v", int(e))
+}
+
 type UsernameVerificationType string
 
 func (o UsernameVerificationType) DeepCopy() UsernameVerificationType {

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -53,12 +53,6 @@ func (h *WebOfTrustHandler) WotVouchCLI(ctx context.Context, arg keybase1.WotVou
 	return engine.RunEngine2(mctx, eng)
 }
 
-func (h *WebOfTrustHandler) WotPending(ctx context.Context, sessionID int) (res []keybase1.PendingVouch, err error) {
-	ctx = libkb.WithLogTag(ctx, "WOT")
-	mctx := libkb.NewMetaContext(ctx, h.G())
-	return libkb.FetchPendingWotVouches(mctx)
-}
-
 func (h *WebOfTrustHandler) WotListCLI(ctx context.Context, arg keybase1.WotListCLIArg) (res []keybase1.WotVouch, err error) {
 	ctx = libkb.WithLogTag(ctx, "WOT")
 	mctx := libkb.NewMetaContext(ctx, h.G())

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -59,6 +59,15 @@ func (h *WebOfTrustHandler) WotPending(ctx context.Context, sessionID int) (res 
 	return libkb.FetchPendingWotVouches(mctx)
 }
 
+func (h *WebOfTrustHandler) WotListCLI(ctx context.Context, arg keybase1.WotListCLIArg) (res []keybase1.WotVouch, err error) {
+	ctx = libkb.WithLogTag(ctx, "WOT")
+	mctx := libkb.NewMetaContext(ctx, h.G())
+	if arg.Username == nil {
+		return libkb.FetchMyWot(mctx)
+	}
+	return libkb.FetchUserWot(mctx, *arg.Username)
+}
+
 func (h *WebOfTrustHandler) WotReact(ctx context.Context, arg keybase1.WotReactArg) error {
 	ctx = libkb.WithLogTag(ctx, "WOT")
 	mctx := libkb.NewMetaContext(ctx, h.G())

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -119,7 +119,7 @@ func (u *UIDMap) findFullNameLocally(ctx context.Context, g libkb.UIDMapperConte
 	key := fullNameDBKey(uid)
 	found, err := g.GetKVStore().GetInto(&tmp, key)
 	if err != nil {
-		g.GetLog().CInfof(ctx, "failed to get dbkey %v: %s", key, err)
+		g.GetLog().CDebugf(ctx, "findFullNameLocally: failed to get dbkey %v: %s", key, err)
 		return doNotFoundReturn()
 	}
 	if !found {
@@ -156,7 +156,7 @@ func (u *UIDMap) findUsernameLocally(ctx context.Context, g libkb.UIDMapperConte
 	key := usernameDBKey(uid)
 	found, err := g.GetKVStore().GetInto(&s, key)
 	if err != nil {
-		g.GetLog().CInfof(ctx, "failed to get dbkey %v: %s", key, err)
+		g.GetLog().CDebugf(ctx, "findUsernameLocally: failed to get dbkey %v: %s", key, err)
 		return libkb.NormalizedUsername(""), notFound
 	}
 	if !found {
@@ -426,7 +426,7 @@ func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMappe
 					key := usernameDBKey(uid)
 					err := g.GetKVStore().PutObj(key, nil, nun.String())
 					if err != nil {
-						g.GetLog().CInfof(ctx, "failed to put %v -> %s: %s", key, nun, err)
+						g.GetLog().CDebugf(ctx, "failed to put %v -> %s: %s", key, nun, err)
 					}
 				}
 
@@ -436,7 +436,7 @@ func (u *UIDMap) MapUIDsToUsernamePackages(ctx context.Context, g libkb.UIDMappe
 					key := fullNameDBKey(uid)
 					err := g.GetKVStore().PutObj(key, nil, *fn)
 					if err != nil {
-						g.GetLog().CInfof(ctx, "failed to put %v -> %v: %s", key, *fn, err)
+						g.GetLog().CDebugf(ctx, "failed to put %v -> %v: %s", key, *fn, err)
 					}
 					// If we had previously busted this lookup, then clear the refresher
 					// on the server, so we don't have to do it next time through.

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -43,4 +43,16 @@ protocol wot {
     REJECT_1
   }
   void wotReact(int sessionID, UserVersion uv /* voucher */, SigID proof, WotReactionType reaction);
+
+  record WotVouch {
+    WotStatusType status;
+    SigID vouchProof;
+    UserVersion voucher;
+    array<string> vouchTexts;
+    Time vouchedAt;
+    union { null, Confidence } confidence;
+  }
+
+  array<WotVouch> wotListCLI(int sessionID, union {null, string} username);
+
 }

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -29,15 +29,6 @@ protocol wot {
   void wotVouch(int sessionID, UserVersion uv /* vouchee */, array<string> vouchTexts, Confidence confidence);
   void wotVouchCLI(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);
 
-  record PendingVouch {
-    UserVersion voucher;
-    SigID proof;
-    array<string> vouchTexts;
-    union { null, Confidence } confidence;
-  }
-
-  array<PendingVouch> wotPending(int sessionID);
-
   enum WotReactionType {
     ACCEPT_0,
     REJECT_1

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -3,6 +3,14 @@
 protocol wot {
   import idl "common.avdl";
 
+  enum WotStatusType {
+    NONE_0,
+    PROPOSED_1,
+    ACCEPTED_2,
+    REJECTED_3,
+    REVOKED_4
+  }
+
   // none (""), audio, video, email, other_chat, in_person
   @typedef("string")
   record UsernameVerificationType {}

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -60,34 +60,6 @@
       ]
     },
     {
-      "type": "record",
-      "name": "PendingVouch",
-      "fields": [
-        {
-          "type": "UserVersion",
-          "name": "voucher"
-        },
-        {
-          "type": "SigID",
-          "name": "proof"
-        },
-        {
-          "type": {
-            "type": "array",
-            "items": "string"
-          },
-          "name": "vouchTexts"
-        },
-        {
-          "type": [
-            null,
-            "Confidence"
-          ],
-          "name": "confidence"
-        }
-      ]
-    },
-    {
       "type": "enum",
       "name": "WotReactionType",
       "symbols": [
@@ -180,18 +152,6 @@
         }
       ],
       "response": null
-    },
-    "wotPending": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        }
-      ],
-      "response": {
-        "type": "array",
-        "items": "PendingVouch"
-      }
     },
     "wotReact": {
       "request": [

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -8,6 +8,17 @@
   ],
   "types": [
     {
+      "type": "enum",
+      "name": "WotStatusType",
+      "symbols": [
+        "NONE_0",
+        "PROPOSED_1",
+        "ACCEPTED_2",
+        "REJECTED_3",
+        "REVOKED_4"
+      ]
+    },
+    {
       "type": "record",
       "name": "UsernameVerificationType",
       "fields": [],

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -94,6 +94,42 @@
         "ACCEPT_0",
         "REJECT_1"
       ]
+    },
+    {
+      "type": "record",
+      "name": "WotVouch",
+      "fields": [
+        {
+          "type": "WotStatusType",
+          "name": "status"
+        },
+        {
+          "type": "SigID",
+          "name": "vouchProof"
+        },
+        {
+          "type": "UserVersion",
+          "name": "voucher"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "string"
+          },
+          "name": "vouchTexts"
+        },
+        {
+          "type": "Time",
+          "name": "vouchedAt"
+        },
+        {
+          "type": [
+            null,
+            "Confidence"
+          ],
+          "name": "confidence"
+        }
+      ]
     }
   ],
   "messages": {
@@ -177,6 +213,25 @@
         }
       ],
       "response": null
+    },
+    "wotListCLI": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "username",
+          "type": [
+            null,
+            "string"
+          ]
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "WotVouch"
+      }
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2952,7 +2952,6 @@ export type ParamProofServiceConfig = {readonly version: Int; readonly domain: S
 export type ParamProofUsernameConfig = {readonly re: String; readonly min: Int; readonly max: Int}
 export type PassphraseStream = {readonly passphraseStream: Bytes; readonly generation: Int}
 export type Path = {PathType: PathType.local; local: String} | {PathType: PathType.kbfs; kbfs: KBFSPath} | {PathType: PathType.kbfsArchived; kbfsArchived: KBFSArchivedPath}
-export type PendingVouch = {readonly voucher: UserVersion; readonly proof: SigID; readonly vouchTexts?: Array<String> | null; readonly confidence?: Confidence | null}
 export type PerTeamKey = {readonly gen: PerTeamKeyGeneration; readonly seqno: Seqno; readonly sigKID: KID; readonly encKID: KID}
 export type PerTeamKeyAndCheck = {readonly ptk: PerTeamKey; readonly check: PerTeamSeedCheckPostImage}
 export type PerTeamKeyGeneration = Int
@@ -4163,6 +4162,5 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.user.getTeamBlocks'
 // 'keybase.1.wot.wotVouch'
 // 'keybase.1.wot.wotVouchCLI'
-// 'keybase.1.wot.wotPending'
 // 'keybase.1.wot.wotReact'
 // 'keybase.1.wot.wotListCLI'

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2650,6 +2650,14 @@ export enum WotReactionType {
   accept = 0,
   reject = 1,
 }
+
+export enum WotStatusType {
+  none = 0,
+  proposed = 1,
+  accepted = 2,
+  rejected = 3,
+  revoked = 4,
+}
 export type APIRes = {readonly status: String; readonly body: String; readonly httpStatus: Int; readonly appStatus: String}
 export type APIUserKeybaseResult = {readonly username: String; readonly uid: UID; readonly pictureUrl?: String | null; readonly fullName?: String | null; readonly rawScore: Double; readonly stellar?: String | null; readonly isFollowee: Boolean}
 export type APIUserSearchResult = {readonly score: Double; readonly keybase?: APIUserKeybaseResult | null; readonly service?: APIUserServiceResult | null; readonly contact?: ProcessedContact | null; readonly imptofu?: ImpTofuSearchResult | null; readonly servicesSummary: {[key: string]: APIUserServiceSummary}; readonly rawScore: Double}

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -3236,6 +3236,7 @@ export type VerifyAllEmailTodoExt = {readonly lastVerifyEmailDate: UnixTime}
 export type VerifySessionRes = {readonly uid: UID; readonly sid: String; readonly generated: Int; readonly lifetime: Int}
 export type WalletAccountInfo = {readonly accountID: String; readonly numUnread: Int}
 export type WebProof = {readonly hostname: String; readonly protocols?: Array<String> | null}
+export type WotVouch = {readonly status: WotStatusType; readonly vouchProof: SigID; readonly voucher: UserVersion; readonly vouchTexts?: Array<String> | null; readonly vouchedAt: Time; readonly confidence?: Confidence | null}
 export type WriteArgs = {readonly opID: OpID; readonly path: Path; readonly offset: Long}
 
 export type IncomingCallMapType = {
@@ -4164,3 +4165,4 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.wot.wotVouchCLI'
 // 'keybase.1.wot.wotPending'
 // 'keybase.1.wot.wotReact'
+// 'keybase.1.wot.wotListCLI'


### PR DESCRIPTION
I realized building this that fetch-pending is just a special case of the normal listing. 
* pull down user vouches from the server, either for yourself or for another user
* for each of them, (1) load the voucher, (2) verify and unpack the vouch expansion, (3) if there's a reaction, do the same stuff (4) calculate the correct status, (5) package it all up
* remove fetch pending since you have all of that data anyway now in `list`
* i tried to take inspiration on the schema from https://github.com/keybase/client/pull/22373
```
keybase wot list <username>
```
if listing for yourself (i.e. not passing in a username), you'll get back all of the attestations for which you are the vouchee. if you specify someone else, you'll only see `ACCEPTED` ones.

this branch will fail on CI until merging https://github.com/keybase/keybase/pull/5198 which is the server side. it has the same cannibalization of FetchPending. and actually, once this goes in, i'll push up another PR to completely remove the now unused endpoint. 