### PR TITLE
Don't try to follow a deeplink when logged out

### DIFF
--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -101,6 +101,13 @@ const handleKeybaseLink = (action: DeeplinksGen.HandleKeybaseLinkPayload) => {
 }
 
 const handleAppLink = (state: Container.TypedState, action: DeeplinksGen.LinkPayload) => {
+  // If we're not logged in, trying to nav around the app as if we were will
+  // put people on broken screens -- instead just let people log in and retry.
+  if (!state.config.loggedIn) {
+    console.warn('Refusing to follow a deeplink when not logged in yet.')
+    return false
+  }
+
   if (action.payload.link.startsWith('web+stellar:')) {
     return WalletsGen.createValidateSEP7Link({link: action.payload.link})
   } else if (action.payload.link.startsWith('keybase://')) {


### PR DESCRIPTION
@keybase/react-hackers 

Previously it was possible to get into the main nav by following a deeplink when logged out, but of course no tab would actually work without a login.