### PR TITLE
iPad: file upload bar should go fully across the screen

### DIFF
--- a/shared/fs/footer/upload.native.tsx
+++ b/shared/fs/footer/upload.native.tsx
@@ -158,13 +158,8 @@ const styles = Styles.styleSheetCreate(
       backgroundBox: Styles.platformStyles({
         common: {
           height: 48,
-          width: '100%',
-        },
-        isAndroid: {
-          zIndex: -100, // Android doesn't support `overflow: 'hidden'`.
-        },
-        isIOS: {
           overflow: 'hidden',
+          width: '100%',
         },
       }),
       backgroundImage: {

--- a/shared/fs/footer/upload.native.tsx
+++ b/shared/fs/footer/upload.native.tsx
@@ -169,7 +169,7 @@ const styles = Styles.styleSheetCreate(
       }),
       backgroundImage: {
         height: 160,
-        width: 600, // Android doesn't support resizeMode="repeat", so use a super wide image here. TODO it does now!
+        width: '100%',
       },
       box: {
         ...Styles.globalStyles.flexBoxColumn,


### PR DESCRIPTION
@keybase/react-hackers 

Before:

<img width="1339" alt="Screen Shot 2020-02-20 at 11 39 38 PM" src="https://user-images.githubusercontent.com/21217/75014072-5ccd0d80-543a-11ea-85c0-11e532628766.png">

After:

<img width="1339" alt="Screen Shot 2020-02-20 at 11 40 02 PM" src="https://user-images.githubusercontent.com/21217/75014089-648cb200-543a-11ea-9078-a1f89bc334f0.png">

The non-max width was a workaround put in place for Android, which doesn't need it anymore.  After:

![Screenshot_20200220-233800](https://user-images.githubusercontent.com/21217/75014188-9736aa80-543a-11ea-895a-981cd6a290cc.png)
