### PR TITLE
remove unused method: teamChangeMembership

### DIFF
--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -3721,12 +3721,6 @@ type TeamListSubteamsRecursiveArg struct {
 	ForceRepoll    bool   `codec:"forceRepoll" json:"forceRepoll"`
 }
 
-type TeamChangeMembershipArg struct {
-	SessionID int           `codec:"sessionID" json:"sessionID"`
-	Name      string        `codec:"name" json:"name"`
-	Req       TeamChangeReq `codec:"req" json:"req"`
-}
-
 type TeamAddMemberArg struct {
 	SessionID            int              `codec:"sessionID" json:"sessionID"`
 	TeamID               TeamID           `codec:"teamID" json:"teamID"`
@@ -4032,7 +4026,6 @@ type TeamsInterface interface {
 	TeamListTeammates(context.Context, TeamListTeammatesArg) (AnnotatedTeamList, error)
 	TeamListVerified(context.Context, TeamListVerifiedArg) (AnnotatedTeamList, error)
 	TeamListSubteamsRecursive(context.Context, TeamListSubteamsRecursiveArg) ([]TeamIDAndName, error)
-	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
 	TeamAddMember(context.Context, TeamAddMemberArg) (TeamAddMemberResult, error)
 	TeamAddMembers(context.Context, TeamAddMembersArg) (TeamAddMembersResult, error)
 	TeamAddMembersMultiRole(context.Context, TeamAddMembersMultiRoleArg) (TeamAddMembersResult, error)
@@ -4284,21 +4277,6 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamListSubteamsRecursive(ctx, typedArgs[0])
-					return
-				},
-			},
-			"teamChangeMembership": {
-				MakeArg: func() interface{} {
-					var ret [1]TeamChangeMembershipArg
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[1]TeamChangeMembershipArg)
-					if !ok {
-						err = rpc.NewTypeError((*[1]TeamChangeMembershipArg)(nil), args)
-						return
-					}
-					err = i.TeamChangeMembership(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -5113,11 +5091,6 @@ func (c TeamsClient) TeamListVerified(ctx context.Context, __arg TeamListVerifie
 
 func (c TeamsClient) TeamListSubteamsRecursive(ctx context.Context, __arg TeamListSubteamsRecursiveArg) (res []TeamIDAndName, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamListSubteamsRecursive", []interface{}{__arg}, &res, 0*time.Millisecond)
-	return
-}
-
-func (c TeamsClient) TeamChangeMembership(ctx context.Context, __arg TeamChangeMembershipArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamChangeMembership", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -241,14 +241,6 @@ func (h *TeamsHandler) TeamListSubteamsRecursive(ctx context.Context, arg keybas
 	return teams.ListSubteamsRecursive(ctx, h.G().ExternalG(), arg.ParentTeamName, arg.ForceRepoll)
 }
 
-func (h *TeamsHandler) TeamChangeMembership(ctx context.Context, arg keybase1.TeamChangeMembershipArg) error {
-	ctx = libkb.WithLogTag(ctx, "TM")
-	if err := assertLoggedIn(ctx, h.G().ExternalG()); err != nil {
-		return err
-	}
-	return teams.ChangeRoles(ctx, h.G().ExternalG(), arg.Name, arg.Req)
-}
-
 func (h *TeamsHandler) TeamAddMember(ctx context.Context, arg keybase1.TeamAddMemberArg) (res keybase1.TeamAddMemberResult, err error) {
 	ctx = libkb.WithLogTag(ctx, "TM")
 	defer h.G().CTraceTimed(ctx, fmt.Sprintf("TeamAddMember(%s,username=%q,email=%q,phone=%q)", arg.TeamID, arg.Username, arg.Email, arg.Phone),

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1236,8 +1236,6 @@ protocol teams {
   // admin only
   array<TeamIDAndName> teamListSubteamsRecursive(int sessionID, string parentTeamName, boolean forceRepoll);
 
-  void teamChangeMembership(int sessionID, string name, TeamChangeReq req);
-
   TeamAddMemberResult teamAddMember(int sessionID, TeamID teamID, string email, string phone, string username,
     TeamRole role, union { null, TeamBotSettings } botSettings, boolean sendChatNotification, union { null, string } emailInviteMessage);
 

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -3449,23 +3449,6 @@
         "items": "TeamIDAndName"
       }
     },
-    "teamChangeMembership": {
-      "request": [
-        {
-          "name": "sessionID",
-          "type": "int"
-        },
-        {
-          "name": "name",
-          "type": "string"
-        },
-        {
-          "name": "req",
-          "type": "TeamChangeReq"
-        }
-      ],
-      "response": null
-    },
     "teamAddMember": {
       "request": [
         {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -4106,7 +4106,6 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.teams.teamListTeammates'
 // 'keybase.1.teams.teamListVerified'
 // 'keybase.1.teams.teamListSubteamsRecursive'
-// 'keybase.1.teams.teamChangeMembership'
 // 'keybase.1.teams.teamAddMembers'
 // 'keybase.1.teams.teamRemoveMembers'
 // 'keybase.1.teams.teamEditMembers'


### PR DESCRIPTION
@zapu I noticed from your PR that `teamChangeMembership` is dead code. So `record TeamChangeReq` is only used internally to the service.