### PR TITLE
folder_block_manager: don't QR if head root block is unreadable

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1079,8 +1079,35 @@ func (fbm *folderBlockManager) isQRNecessary(
 	//   * The head has changed since last time, OR
 	//   * The last QR did not completely clean every available thing, OR
 	//   * The head is now old enough for QR
-	return head.Revision() != fbm.lastQRHeadRev || !fbm.wasLastQRComplete ||
-		fbm.isOldEnough(head)
+	isNecessary := head.Revision() != fbm.lastQRHeadRev ||
+		!fbm.wasLastQRComplete || fbm.isOldEnough(head)
+	if !isNecessary {
+		return false
+	}
+
+	// Make sure the root block of the TLF is readable.  If not, we
+	// don't want to to garbage collect, since we might need to
+	// recover to those older versions of the TLF.
+	headRootPtr := head.data.Dir.BlockPointer
+	ch := fbm.config.BlockOps().BlockRetriever().Request(
+		ctx, defaultOnDemandRequestPriority, head, headRootPtr,
+		data.NewDirBlock(), data.TransientEntry, BlockRequestSolo)
+	select {
+	case err := <-ch:
+		if err != nil {
+			fbm.log.CWarningf(
+				ctx, "Couldn't fetch root block %v for TLF %s: %+v",
+				headRootPtr, head.TlfID(), err)
+			return false
+		}
+	case <-ctx.Done():
+		fbm.log.CDebugf(
+			ctx, "Couldn't fetch root block %v for TLF %s: %+v",
+			headRootPtr, head.TlfID(), ctx.Err())
+		return false
+	}
+
+	return true
 }
 
 func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {


### PR DESCRIPTION
If a TLF is in such a bad state that the root block for its current revision can't be read (i.e., because due to some other bug, an old block pointer was left in the MD data structure, and that block was already deleted for some reason), we shouldn't continue to do quota reclamation on the TLF.  If we do, we might end up deleting old blocks that could otherwise be used to restore the TLF to some old revision.

Issue: HOTPOT-1971