### PR TITLE
libkbfs: add mode that enables single-op QR, and use in indexing 

### DIFF
--- a/go/kbfs/libfs/file.go
+++ b/go/kbfs/libfs/file.go
@@ -225,7 +225,7 @@ func (f *File) Unlock() (err error) {
 		jManager = nil
 	}
 
-	if f.fs.config.Mode().Type() == libkbfs.InitSingleOp {
+	if f.fs.config.Mode().IsSingleOp() {
 		if jManager != nil {
 			err = jManager.FinishSingleOp(f.fs.ctx,
 				f.fs.root.GetFolderBranch().Tlf, &keybase1.LockContext{

--- a/go/kbfs/libkbfs/data_types.go
+++ b/go/kbfs/libkbfs/data_types.go
@@ -269,6 +269,11 @@ const (
 	// InitTestSearch is the same as the default mode, but with search
 	// enabled for synced TLFs.
 	InitTestSearch
+	// InitSingleOpWithQR is the same as InitSingleOp, except quota
+	// reclamation is enabled.  That way if the user of the mode
+	// writes data to a TLF that exclusive to the mode, it will still
+	// be QR'd.  (Example: the indexer.)
+	InitSingleOpWithQR
 )
 
 func (im InitModeType) String() string {
@@ -285,6 +290,8 @@ func (im InitModeType) String() string {
 		return InitMemoryLimitedString
 	case InitTestSearch:
 		return InitTestSearchString
+	case InitSingleOpWithQR:
+		return InitSingleOpWithQRString
 	default:
 		return "unknown"
 	}

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -876,7 +876,7 @@ func doInit(
 	// (e.g., during a git pull), because KBFS might be running in
 	// constrained mode and the cache remote proxy wouldn't be
 	// available (which is fine).
-	doSendWarnings := config.Mode().Type() != InitSingleOp
+	doSendWarnings := !config.Mode().IsSingleOp()
 	err = config.MakeDiskBlockCacheIfNotExists()
 	if err != nil {
 		log.CWarningf(ctx, "Could not initialize disk cache: %+v", err)

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -46,6 +46,10 @@ const (
 	InitMemoryLimitedString = "memoryLimited"
 	// InitTestSearchString is for when KBFS will index synced TLFs.
 	InitTestSearchString = "testSearch"
+	// InitSingleOpWithQRString is for when KBFS will only be used for
+	// a single logical operation (e.g., as a git remote helper), with
+	// QR enabled.
+	InitSingleOpWithQRString = "singleOpQR"
 )
 
 // CtxInitTagKey is the type used for unique context tags for KBFS init.
@@ -658,6 +662,9 @@ func getInitMode(
 	case InitTestSearchString:
 		log.CDebugf(ctx, "Initializing in testSearch mode")
 		mode = InitTestSearch
+	case InitSingleOpWithQRString:
+		log.CDebugf(ctx, "Initializing in singleOpWithQR mode")
+		mode = InitSingleOpWithQR
 	default:
 		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1924,6 +1924,9 @@ type InitMode interface {
 	Type() InitModeType
 	// IsTestMode returns whether we are running a test.
 	IsTestMode() bool
+	// IsSingleOp returns whether this is a single-op mode (only one
+	// write is expected at a time).
+	IsSingleOp() bool
 	// BlockWorkers returns the number of block workers to run.
 	BlockWorkers() int
 	// PrefetchWorkers returns the number of prefetch workers to run.

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -78,6 +78,10 @@ func (md modeDefault) IsTestMode() bool {
 	return false
 }
 
+func (md modeDefault) IsSingleOp() bool {
+	return false
+}
+
 func (md modeDefault) DirtyBlockCacheEnabled() bool {
 	return true
 }
@@ -233,6 +237,10 @@ func (mm modeMinimal) RekeyQueueSize() int {
 }
 
 func (mm modeMinimal) IsTestMode() bool {
+	return false
+}
+
+func (mm modeMinimal) IsSingleOp() bool {
 	return false
 }
 
@@ -455,6 +463,10 @@ func (mso modeSingleOp) InitialDelayForBackgroundWork() time.Duration {
 func (mso modeSingleOp) BackgroundWorkPeriod() time.Duration {
 	// No background work
 	return math.MaxInt64
+}
+
+func (mso modeSingleOp) IsSingleOp() bool {
+	return true
 }
 
 // Constrained mode:

--- a/go/kbfs/search/init.go
+++ b/go/kbfs/search/init.go
@@ -47,7 +47,7 @@ func Params(kbCtx libkbfs.Context, storageRoot string, uid keybase1.UID) (
 		params.StorageRoot, bserverStorageDir)
 	params.MDServerAddr = "dir:" + filepath.Join(
 		params.StorageRoot, mdserverStorageDir)
-	params.Mode = libkbfs.InitSingleOpString
+	params.Mode = libkbfs.InitSingleOpWithQRString
 
 	return params, nil
 }


### PR DESCRIPTION
This will clean up all the old revisions of the local TLF that the indexer writes to, to save on local disk space usage.

Issue: HOTPOT-1500