### PR TITLE
info-panel tablet and keys

### DIFF
--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -406,7 +406,8 @@ export default (p: Props) => {
   const commonSections = [
     ...p.commonSections,
     {
-      data: ['avselector'],
+      key: 'avselector',
+      data: [{key: 'avselector'}],
       renderItem: () => (
         <AttachmentTypeSelector selectedView={selectedAttachmentView} onSelectView={onAttachmentViewChange} />
       ),
@@ -415,7 +416,8 @@ export default (p: Props) => {
   ]
 
   const loadMoreSection = {
-    data: ['load more'],
+    key: 'load-more',
+    data: [{key: 'load more'}],
     renderItem: () => {
       const status = attachmentInfo.status
       if (onLoadMore && status !== 'loading') {
@@ -449,10 +451,11 @@ export default (p: Props) => {
   if (attachmentInfo.messages.length === 0 && attachmentInfo.status !== 'loading') {
     sections = [
       {
-        data: ['No attachments'],
-        renderItem: ({item}: {item: string}) => (
+        key: 'no-attachments',
+        data: [{key: 'no-attachments'}],
+        renderItem: () => (
           <Kb.Box2 centerChildren={true} direction="horizontal" fullWidth={true}>
-            <Kb.Text type="BodySmall">{item}</Kb.Text>
+            <Kb.Text type="BodySmall">No attachments</Kb.Text>
           </Kb.Box2>
         ),
       },
@@ -484,7 +487,9 @@ export default (p: Props) => {
               })),
               rowSize
             ),
-            renderItem: ({item, index}: {item: Array<MediaThumbProps>; index: number}) => (
+            renderItem: (
+              {item, index}: {item: Array<MediaThumbProps>; index: number} // xxx
+            ) => (
               <Kb.Box2 key={index} direction="horizontal" fullWidth={true}>
                 {item.map((cell, i) => {
                   return <MediaThumb key={i} sizing={cell.sizing} thumb={cell.thumb} />

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -288,7 +288,10 @@ const styles = Styles.styleSheetCreate(
         top: '50%',
         width: 24,
       },
-      selectorContainer: {padding: Styles.globalMargins.small},
+      selectorContainer: Styles.platformStyles({
+        common: {padding: Styles.globalMargins.small},
+        isTablet: {maxWidth: 600, alignSelf: 'center'},
+      }),
       selectorDocContainer: {
         borderColor: Styles.globalColors.blue,
         borderLeftWidth: 1,

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -488,24 +488,27 @@ export default (p: Props) => {
                   width: m.previewWidth,
                 } as Thumb)
             )
-          ).map(month => ({
-            key: month.key,
-            data: chunk(
+          ).map(month => {
+            const data = chunk(
               month.data.map(thumb => ({
                 sizing: Constants.zoomImage(thumb.width, thumb.height, maxMediaThumbSize),
                 thumb,
               })),
               rowSize
-            ),
-            renderItem: ({item, index}: {item: Array<MediaThumbProps>; index: number}) => (
-              <Kb.Box2 key={index} direction="horizontal" fullWidth={true}>
-                {item.map((cell, i) => {
-                  return <MediaThumb key={i} sizing={cell.sizing} thumb={cell.thumb} />
-                })}
-              </Kb.Box2>
-            ),
-            renderSectionHeader: () => <Kb.SectionDivider label={`${month.month} ${month.year}`} />,
-          }))
+            ).map((images, i) => ({images, key: i}))
+            return {
+              key: month.key,
+              data,
+              renderItem: ({item}: {item: Unpacked<typeof data>; index: number}) => (
+                <Kb.Box2 direction="horizontal" fullWidth={true}>
+                  {item.images.map(cell => {
+                    return <MediaThumb key={cell.thumb.key} sizing={cell.sizing} thumb={cell.thumb} />
+                  })}
+                </Kb.Box2>
+              ),
+              renderSectionHeader: () => <Kb.SectionDivider label={`${month.month} ${month.year}`} />,
+            }
+          })
           sections = [...commonSections, ...s, loadMoreSection]
         }
         break

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -576,8 +576,8 @@ export default (p: Props) => {
           }, [])
 
           const s = formMonths(links).map(month => ({
-            key: month.key,
             data: month.data,
+            key: month.key,
             renderItem: ({item}: {item: Link}) => {
               return (
                 <Kb.Box2 direction="vertical" fullWidth={true} style={styles.linkContainer} gap="tiny">

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -80,8 +80,8 @@ function formMonths<I extends {ctime: number; key: React.Key}>(
   const dateInfo = getDateInfo(items[0])
   let curMonth = {
     ...dateInfo,
-    key: `month-${dateInfo.year}-${dateInfo.month}`,
     data: [] as Array<I>,
+    key: `month-${dateInfo.year}-${dateInfo.month}`,
   }
   const months = items.reduce<Array<typeof curMonth>>((l, item, index) => {
     const dateInfo = getDateInfo(item)
@@ -91,8 +91,8 @@ function formMonths<I extends {ctime: number; key: React.Key}>(
       }
       curMonth = {
         ...dateInfo,
-        key: `month-${dateInfo.year}-${dateInfo.month}`,
         data: [item],
+        key: `month-${dateInfo.year}-${dateInfo.month}`,
       }
     } else {
       curMonth.data.push(item)
@@ -298,7 +298,7 @@ const styles = Styles.styleSheetCreate(
       },
       selectorContainer: Styles.platformStyles({
         common: {padding: Styles.globalMargins.small},
-        isTablet: {maxWidth: 600, alignSelf: 'center'},
+        isTablet: {alignSelf: 'center', maxWidth: 600},
       }),
       selectorDocContainer: {
         borderColor: Styles.globalColors.blue,
@@ -414,8 +414,8 @@ export default (p: Props) => {
   const commonSections = [
     ...p.commonSections,
     {
-      key: 'avselector',
       data: [{key: 'avselector'}],
+      key: 'avselector',
       renderItem: () => (
         <AttachmentTypeSelector selectedView={selectedAttachmentView} onSelectView={onAttachmentViewChange} />
       ),
@@ -424,8 +424,8 @@ export default (p: Props) => {
   ]
 
   const loadMoreSection = {
-    key: 'load-more',
     data: [{key: 'load more'}],
+    key: 'load-more',
     renderItem: () => {
       const status = attachmentInfo.status
       if (onLoadMore && status !== 'loading') {
@@ -459,8 +459,8 @@ export default (p: Props) => {
   if (attachmentInfo.messages.length === 0 && attachmentInfo.status !== 'loading') {
     sections = [
       {
-        key: 'no-attachments',
         data: [{key: 'no-attachments'}],
+        key: 'no-attachments',
         renderItem: () => (
           <Kb.Box2 centerChildren={true} direction="horizontal" fullWidth={true}>
             <Kb.Text type="BodySmall">No attachments</Kb.Text>
@@ -479,10 +479,10 @@ export default (p: Props) => {
             (attachmentInfo.messages as Array<Types.MessageAttachment>).map(
               m =>
                 ({
-                  key: `media-${m.ordinal}-${m.timestamp}-${m.previewURL}`,
                   ctime: m.timestamp,
                   height: m.previewHeight,
                   isVideo: !!m.videoDuration,
+                  key: `media-${m.ordinal}-${m.timestamp}-${m.previewURL}`,
                   onClick: () => onMediaClick(m),
                   previewURL: m.previewURL,
                   width: m.previewWidth,
@@ -497,8 +497,8 @@ export default (p: Props) => {
               rowSize
             ).map((images, i) => ({images, key: i}))
             return {
-              key: month.key,
               data,
+              key: month.key,
               renderItem: ({item}: {item: Unpacked<typeof data>; index: number}) => (
                 <Kb.Box2 direction="horizontal" fullWidth={true}>
                   {item.images.map(cell => {
@@ -515,11 +515,11 @@ export default (p: Props) => {
       case RPCChatTypes.GalleryItemTyp.doc:
         {
           const docs = (attachmentInfo.messages as Array<Types.MessageAttachment>).map(m => ({
-            key: `doc-${m.ordinal}-${m.author}-${m.timestamp}-${m.fileName}`,
             author: m.author,
             ctime: m.timestamp,
             downloading: m.transferState === 'downloading',
             fileName: m.fileName,
+            key: `doc-${m.ordinal}-${m.author}-${m.timestamp}-${m.fileName}`,
             message: m,
             name: m.title || m.fileName,
             onDownload: () => onDocDownload(m),
@@ -528,8 +528,8 @@ export default (p: Props) => {
           }))
 
           const s = formMonths(docs).map(month => ({
-            key: month.key,
             data: month.data,
+            key: month.key,
             renderItem: ({item}: {item: Doc}) => <DocViewRow item={item} />,
             renderSectionHeader: () => <Kb.SectionDivider label={`${month.month} ${month.year}`} />,
           }))
@@ -540,9 +540,9 @@ export default (p: Props) => {
         {
           const links = attachmentInfo.messages.reduce<
             Array<{
-              key: React.Key
               author: string
               ctime: number
+              key: React.Key
               snippet: string
               title?: string
               url?: string
@@ -553,18 +553,18 @@ export default (p: Props) => {
             }
             if (!m.unfurls.size) {
               l.push({
-                key: `unfurl-empty-${m.ordinal}-${m.author}-${m.timestamp}`,
                 author: m.author,
                 ctime: m.timestamp,
+                key: `unfurl-empty-${m.ordinal}-${m.author}-${m.timestamp}`,
                 snippet: (m.decoratedText && m.decoratedText.stringValue()) ?? '',
               })
             } else {
               ;[...m.unfurls.values()].forEach((u, i) => {
                 if (u.unfurl.unfurlType === RPCChatTypes.UnfurlType.generic && u.unfurl.generic) {
                   l.push({
-                    key: `unfurl-${m.ordinal}-${i}-${m.author}-${m.timestamp}-${u.unfurl.generic.url}`,
                     author: m.author,
                     ctime: m.timestamp,
+                    key: `unfurl-${m.ordinal}-${i}-${m.author}-${m.timestamp}-${u.unfurl.generic.url}`,
                     snippet: (m.decoratedText && m.decoratedText.stringValue()) ?? '',
                     title: u.unfurl.generic.title,
                     url: u.unfurl.generic.url,

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -311,8 +311,8 @@ export default (props: Props) => {
 
   const sections = [
     {
-      key: 'bots',
       data: items,
+      key: 'bots',
       keyExtractor: (item: Unpacked<typeof items>, index: number) => {
         if (typeof item === 'string' || item instanceof String) {
           return item

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -179,6 +179,9 @@ const styles = Styles.styleSheetCreate(
           ...Styles.desktopStyles.clickable,
         },
       }),
+      sectionList: Styles.platformStyles({
+        isTablet: {alignSelf: 'center', minWidth: 400, maxWidth: 800},
+      }),
     } as const)
 )
 
@@ -373,6 +376,7 @@ export default (props: Props) => {
     <Kb.SectionList
       stickySectionHeadersEnabled={true}
       keyboardShouldPersistTaps="handled"
+      style={styles.sectionList}
       renderSectionHeader={({section}: any) => section?.renderSectionHeader?.({section}) ?? null}
       sections={[...props.commonSections, ...sections]}
     />

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -180,7 +180,11 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       sectionList: Styles.platformStyles({
-        isTablet: {alignSelf: 'center', minWidth: 400, maxWidth: 800},
+        isTablet: {
+          alignSelf: 'center',
+          maxWidth: 800,
+          minWidth: 400,
+        },
       }),
     } as const)
 )

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -293,19 +293,28 @@ export default (props: Props) => {
     }
   }, [featuredBotsLength, dispatch, conversationIDKey, loadedAllBots])
 
+  const items = [
+    ...(canManageBots ? [addBotButton] : []),
+    ...(botsInConv.length > 0 ? [inThisChannelHeader] : []),
+    ...usernamesToFeaturedBots(botsInConv),
+    ...(botsInTeam.length > 0 ? [inThisTeamHeader] : []),
+    ...usernamesToFeaturedBots(botsInTeam),
+    featuredBotsHeader,
+    ...(featuredBots.length > 0 ? featuredBots : []),
+    ...(!loadedAllBots && featuredBots.length > 0 ? [loadMoreBotsButton] : []),
+    ...(loadingBots ? [featuredBotSpinner] : []),
+  ]
+
   const sections = [
     {
-      data: [
-        ...(canManageBots ? [addBotButton] : []),
-        ...(botsInConv.length > 0 ? [inThisChannelHeader] : []),
-        ...usernamesToFeaturedBots(botsInConv),
-        ...(botsInTeam.length > 0 ? [inThisTeamHeader] : []),
-        ...usernamesToFeaturedBots(botsInTeam),
-        featuredBotsHeader,
-        ...(featuredBots.length > 0 ? featuredBots : []),
-        ...(!loadedAllBots && featuredBots.length > 0 ? [loadMoreBotsButton] : []),
-        ...(loadingBots ? [featuredBotSpinner] : []),
-      ],
+      key: 'bots',
+      data: items,
+      keyExtractor: (item: Unpacked<typeof items>, index: number) => {
+        if (typeof item === 'string' || item instanceof String) {
+          return item
+        }
+        return item.botUsername ? 'abot-' + item.botUsername : index
+      },
       renderItem: ({item}: {item: any}) => {
         if (item === addBotButton) {
           return (

--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -105,7 +105,8 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
 
   private commonSections = [
     {
-      data: ['header'],
+      key: 'header-section',
+      data: [{key: 'header-item'}], // 'header' cannot be used as a key, RN uses that key.
       renderItem: () => (
         <Kb.Box2 direction="vertical" gap="tiny" gapStart={true} fullWidth={true} style={styles.header}>
           {this.props.teamname && this.props.channelname ? (

--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -105,8 +105,8 @@ class _InfoPanel extends React.PureComponent<InfoPanelProps> {
 
   private commonSections = [
     {
-      key: 'header-section',
       data: [{key: 'header-item'}], // 'header' cannot be used as a key, RN uses that key.
+      key: 'header-section',
       renderItem: () => (
         <Kb.Box2 direction="vertical" gap="tiny" gapStart={true} fullWidth={true} style={styles.header}>
           {this.props.teamname && this.props.channelname ? (

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -61,10 +61,10 @@ export default (props: Props) => {
 
   const participantsItems = participants
     .map(p => ({
-      key: `user-${p}`,
       fullname: (infoMap.get(p) || {fullname: ''}).fullname || participantInfo.contactName.get(p) || '',
       isAdmin: teamname ? TeamConstants.userIsRoleInTeamWithInfo(teamMembers, p, 'admin') : false,
       isOwner: teamname ? TeamConstants.userIsRoleInTeamWithInfo(teamMembers, p, 'owner') : false,
+      key: `user-${p}`,
       username: p,
     }))
     .sort((l, r) => {
@@ -125,7 +125,11 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       sectionList: Styles.platformStyles({
-        isTablet: {alignSelf: 'center', minWidth: 400, maxWidth: 800},
+        isTablet: {
+          alignSelf: 'center',
+          maxWidth: 800,
+          minWidth: 400,
+        },
       }),
     } as const)
 )

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import * as Kb from '../../../common-adapters'
 import * as Types from '../../../constants/types/chat2'
 import * as ProfileGen from '../../../actions/profile-gen'
+import * as Styles from '../../../styles'
 import flags from '../../../util/feature-flags'
 import Participant from './participant'
 
@@ -83,6 +84,7 @@ export default (props: Props) => {
       stickySectionHeadersEnabled={true}
       keyboardShouldPersistTaps="handled"
       renderSectionHeader={({section}: any) => section?.renderSectionHeader?.({section}) ?? null}
+      style={styles.sectionList}
       sections={[
         ...props.commonSections,
         {
@@ -115,3 +117,12 @@ export default (props: Props) => {
     />
   )
 }
+
+const styles = Styles.styleSheetCreate(
+  () =>
+    ({
+      sectionList: Styles.platformStyles({
+        isTablet: {alignSelf: 'center', minWidth: 400, maxWidth: 800},
+      }),
+    } as const)
+)

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -61,6 +61,7 @@ export default (props: Props) => {
 
   const participantsItems = participants
     .map(p => ({
+      key: `user-${p}`,
       fullname: (infoMap.get(p) || {fullname: ''}).fullname || participantInfo.contactName.get(p) || '',
       isAdmin: teamname ? TeamConstants.userIsRoleInTeamWithInfo(teamMembers, p, 'admin') : false,
       isOwner: teamname ? TeamConstants.userIsRoleInTeamWithInfo(teamMembers, p, 'owner') : false,
@@ -79,6 +80,8 @@ export default (props: Props) => {
 
   const onShowProfile = (username: string) => dispatch(ProfileGen.createShowUserProfile({username}))
 
+  const data = [...(showAuditingBanner ? [{key: auditingBannerItem}] : []), ...participantsItems]
+
   return (
     <Kb.SectionList
       stickySectionHeadersEnabled={true}
@@ -88,16 +91,16 @@ export default (props: Props) => {
       sections={[
         ...props.commonSections,
         {
-          data: [...(showAuditingBanner ? [auditingBannerItem] : []), ...participantsItems],
-          renderItem: ({index, item}: {index: number; item: any}) => {
-            if (item === auditingBannerItem) {
+          data,
+          renderItem: ({index, item}: {index: number; item: Unpacked<typeof data>}) => {
+            if (item.key === auditingBannerItem) {
               return (
                 <Kb.Banner color="grey" small={true}>
                   Auditing team members...
                 </Kb.Banner>
               )
             }
-            if (!item.username) {
+            if (!('username' in item) || !item.username) {
               return null
             }
             return (

--- a/shared/chat/conversation/info-panel/settings/index.tsx
+++ b/shared/chat/conversation/info-panel/settings/index.tsx
@@ -309,8 +309,8 @@ export default (p: Props) => {
       sections={[
         ...p.commonSections,
         {
-          key: 'settings-panel',
           data: [{key: 'tab'}],
+          key: 'settings-panel',
           renderItem: () => (
             <SettingsPanel conversationIDKey={p.conversationIDKey} isPreview={p.isPreview} key="settings" />
           ),

--- a/shared/chat/conversation/info-panel/settings/index.tsx
+++ b/shared/chat/conversation/info-panel/settings/index.tsx
@@ -309,7 +309,8 @@ export default (p: Props) => {
       sections={[
         ...p.commonSections,
         {
-          data: ['tab'],
+          key: 'settings-panel',
+          data: [{key: 'tab'}],
           renderItem: () => (
             <SettingsPanel conversationIDKey={p.conversationIDKey} isPreview={p.isPreview} key="settings" />
           ),

--- a/shared/chat/inbox-and-conversation-2.tsx
+++ b/shared/chat/inbox-and-conversation-2.tsx
@@ -17,13 +17,23 @@ const InboxAndConversation = (props: Props) => {
   const infoPanelShowing = Container.useSelector(state => state.chat2.infoPanelShowing)
   const navKey = props.navigation.state.key
 
-  return (
-    <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
-      {!Container.isTablet && inboxSearch ? <InboxSearch /> : <Inbox navKey={navKey} />}
-      <Conversation navigation={props.navigation} />
-      {infoPanelShowing && <InfoPanel />}
-    </Kb.Box2>
-  )
+  if (Container.isMobile) {
+    return (
+      <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
+        {!infoPanelShowing && <Inbox navKey={navKey} />}
+        {!infoPanelShowing && <Conversation navigation={props.navigation} />}
+        {infoPanelShowing && <InfoPanel />}
+      </Kb.Box2>
+    )
+  } else {
+    return (
+      <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true}>
+        {inboxSearch ? <InboxSearch /> : <Inbox navKey={navKey} />}
+        <Conversation navigation={props.navigation} />
+        {infoPanelShowing && <InfoPanel />}
+      </Kb.Box2>
+    )
+  }
 }
 
 InboxAndConversation.navigationOptions = {

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -24,6 +24,7 @@ import ChatInstallBotPick from './conversation/bot/team-picker'
 import ChatSearchBot from './conversation/bot/search'
 import ChatConfirmRemoveBot from './conversation/bot/confirm'
 import ChatPDF from './pdf'
+import * as ChatConstants from '../constants/chat2'
 import flags from '../util/feature-flags'
 
 export const newRoutes = {
@@ -33,7 +34,9 @@ export const newRoutes = {
   },
   chatRoot: {
     getScreen: (): typeof ChatRoot =>
-      isPhone ? require('./inbox/defer-loading').default : require('./inbox-and-conversation-2').default,
+      ChatConstants.isSplit
+        ? require('./inbox-and-conversation-2').default
+        : require('./inbox/defer-loading').default,
   },
 }
 

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -1,4 +1,3 @@
-import {isPhone} from '../constants/platform'
 import ChatConversation from './conversation/container'
 import ChatEnterPaperkey from './conversation/rekey/enter-paper-key'
 import ChatRoot from './inbox/container'


### PR DESCRIPTION
Info panel changes for tablet. And add missing react `key`s to SectionLists in info-panel.

This is still fullscreen info-panel, split info-panel coming in a future PR.