### PR TITLE
kbfsgit: don't include symbolic refs in for-push list

### DIFF
--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -672,8 +672,10 @@ func (r *runner) waitForJournal(ctx context.Context) error {
 // unrecognized attributes are ignored. The list ends with a blank
 // line.
 func (r *runner) handleList(ctx context.Context, args []string) (err error) {
+	forPush := false
 	if len(args) == 1 && args[0] == "for-push" {
-		r.log.CDebugf(ctx, "Treating for-push the same as a regular list")
+		r.log.CDebugf(ctx, "Excluding symbolic refs during a for-push list")
+		forPush = true
 	} else if len(args) > 0 {
 		return errors.Errorf("Bad list request: %v", args)
 	}
@@ -726,7 +728,7 @@ func (r *runner) handleList(ctx context.Context, args []string) (err error) {
 		}
 	}
 
-	if hashesSeen {
+	if hashesSeen && !forPush {
 		for _, refStr := range symRefs {
 			r.log.CDebugf(ctx, "Listing symbolic ref %s", refStr)
 			_, err = r.output.Write([]byte(refStr))


### PR DESCRIPTION
When a mirror push (`git push --mirror`) asks a remote helper for its list of references, it apparently doesn't expect to get back symbolic references.  If it _does_ get back a symbolic reference, it will check the local clone where the push is being done, and if there isn't a symbolic ref, it will delete the one in the remote repo (the one in KBFS, in this case).  This seems to be because symbolic references are not transfered between remotes; it's not part of the network protocol.

For an example of an "official" remote helper demonstrating this, see the "remote-curl" helper in the official git repo: https://github.com/git/git/blob/51ebf55b9309824346a6589c9f3b130c6f371b8f/remote-curl.c#L232

Issue: HOTPOT-1970
Issue: #22520