### PR TITLE
Don't show Leave Team button if we are not a team member

### DIFF
--- a/shared/teams/team/menu-container.tsx
+++ b/shared/teams/team/menu-container.tsx
@@ -27,7 +27,7 @@ const mapStateToProps = (state: Container.TypedState, {teamID}: OwnProps) => {
     canCreateSubteam: yourOperations.manageSubteams,
     canDeleteTeam: yourOperations.deleteTeam && teamDetails.subteams?.size === 0,
     canInvite: yourOperations.manageMembers,
-    canLeaveTeam: !Constants.isLastOwner(state, teamID),
+    canLeaveTeam: !Constants.isLastOwner(state, teamID) && role !== 'none',
     canManageChat: yourOperations.renameChannel,
     canViewFolder: !yourOperations.joinTeam,
     isBigTeam,


### PR DESCRIPTION
Currently "Leave Team" button is shown for subteam implicit admins who are not team members.

This patch removes "Leave Team" in this case. Not that this is (like other things related to team leave button) feature gated with `flags.teamsRedesign`.