### PR TITLE
make file tab header alignment consistent

### DIFF
--- a/shared/fs/nav-header/title.tsx
+++ b/shared/fs/nav-header/title.tsx
@@ -147,6 +147,7 @@ const styles = Styles.styleSheetCreate(
       },
       mainTitleText: Styles.platformStyles({isElectron: Styles.desktopStyles.windowDraggingClickable}),
       rootTitle: {
+        alignSelf: 'center',
         marginLeft: Styles.globalMargins.xsmall,
       },
       slash: {


### PR DESCRIPTION
Center aligns the "Files" title to make the alignment consistent with the Teams and Settings tabs