### PR TITLE
protocol: GetBlockSizes method for bserver

### DIFF
--- a/go/kbfs/kbfsblock/protocol_utils.go
+++ b/go/kbfs/kbfsblock/protocol_utils.go
@@ -7,6 +7,7 @@ package kbfsblock
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/keybase/backoff"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
@@ -47,6 +48,26 @@ func MakeGetBlockArg(tlfID tlf.ID, id ID, context Context) keybase1.GetBlockArg 
 		Bid:    makeIDCombo(id, context),
 		Folder: tlfID.String(),
 	}
+}
+
+// MakeGetBlockSizesArg builds a keybase1.GetBlockSizesArg from the
+// given params.
+func MakeGetBlockSizesArg(
+	tlfID tlf.ID, ids []ID, contexts []Context) (
+	keybase1.GetBlockSizesArg, error) {
+	if len(ids) != len(contexts) {
+		return keybase1.GetBlockSizesArg{}, fmt.Errorf(
+			"MakeGetBlockSizesArg: %d IDs but %d contexts",
+			len(ids), len(contexts))
+	}
+	arg := keybase1.GetBlockSizesArg{
+		Bids:   make([]keybase1.BlockIdCombo, len(ids)),
+		Folder: tlfID.String(),
+	}
+	for i, id := range ids {
+		arg.Bids[i] = makeIDCombo(id, contexts[i])
+	}
+	return arg, nil
 }
 
 // ParseGetBlockRes parses the given keybase1.GetBlockRes into its

--- a/protocol/avdl/keybase1/block.avdl
+++ b/protocol/avdl/keybase1/block.avdl
@@ -16,6 +16,11 @@ protocol block {
     BlockStatus status;
   }
 
+  record GetBlockSizesRes {
+    array<int> sizes;
+    array<BlockStatus> statuses;
+  }
+
   // Fixed-size nonce to identify a reference to a block
   fixed BlockRefNonce(8);
 
@@ -58,6 +63,7 @@ protocol block {
   void putBlock(BlockIdCombo bid, string folder, string blockKey, bytes buf);
   void putBlockAgain(string folder, BlockReference ref, string blockKey, bytes buf);
   GetBlockRes getBlock(BlockIdCombo bid, string folder, boolean sizeOnly);
+  GetBlockSizesRes getBlockSizes(array<BlockIdCombo> bids, string folder);
 
   void addReference(string folder, BlockReference ref);
   void delReference(string folder, BlockReference ref);

--- a/protocol/json/keybase1/block.json
+++ b/protocol/json/keybase1/block.json
@@ -39,6 +39,26 @@
       ]
     },
     {
+      "type": "record",
+      "name": "GetBlockSizesRes",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "int"
+          },
+          "name": "sizes"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "BlockStatus"
+          },
+          "name": "statuses"
+        }
+      ]
+    },
+    {
       "type": "fixed",
       "name": "BlockRefNonce",
       "size": "8"
@@ -198,6 +218,22 @@
         }
       ],
       "response": "GetBlockRes"
+    },
+    "getBlockSizes": {
+      "request": [
+        {
+          "name": "bids",
+          "type": {
+            "type": "array",
+            "items": "BlockIdCombo"
+          }
+        },
+        {
+          "name": "folder",
+          "type": "string"
+        }
+      ],
+      "response": "GetBlockSizesRes"
     },
     "addReference": {
       "request": [

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2805,6 +2805,7 @@ export type GUIFileContext = {readonly viewType: GUIViewType; readonly contentTy
 export type GcOptions = {readonly maxLooseRefs: Int; readonly pruneMinLooseObjects: Int; readonly pruneExpireTime: Time; readonly maxObjectPacks: Int}
 export type Generic = {readonly m: {[key: string]: Generic}; readonly a?: Array<Generic> | null; readonly s?: String | null; readonly i?: Int | null}
 export type GetBlockRes = {readonly blockKey: String; readonly buf: Bytes; readonly size: Int; readonly status: BlockStatus}
+export type GetBlockSizesRes = {readonly sizes?: Array<Int> | null; readonly statuses?: Array<BlockStatus> | null}
 export type GetLockdownResponse = {readonly history?: Array<LockdownHistory> | null; readonly status: Boolean}
 export type GetPassphraseRes = {readonly passphrase: String; readonly storeSecret: Boolean}
 export type GetRevisionsArgs = {readonly opID: OpID; readonly path: Path; readonly spanType: RevisionSpanType}
@@ -3764,6 +3765,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.block.putBlock'
 // 'keybase.1.block.putBlockAgain'
 // 'keybase.1.block.getBlock'
+// 'keybase.1.block.getBlockSizes'
 // 'keybase.1.block.addReference'
 // 'keybase.1.block.delReference'
 // 'keybase.1.block.archiveReference'


### PR DESCRIPTION
Including a utility method for making `GetBlockSizes` arg.

(A future PR will make use of this to fetch the sizes for multiple blocks at the same time, to improve efficiency.)