### PR TITLE
Prevent outdated results in bot search modal

### DIFF
--- a/shared/actions/bots-gen.tsx
+++ b/shared/actions/bots-gen.tsx
@@ -17,7 +17,10 @@ type _GetFeaturedBotsPayload = {readonly limit?: number; readonly page?: number}
 type _SearchFeaturedAndUsersPayload = {readonly query: string}
 type _SearchFeaturedBotsPayload = {readonly query: string; readonly limit?: number; readonly offset?: number}
 type _SetLoadedAllBotsPayload = {readonly loaded: boolean}
-type _SetSearchFeaturedAndUsersResultsPayload = {readonly results?: Types.BotSearchResults}
+type _SetSearchFeaturedAndUsersResultsPayload = {
+  readonly query: string
+  readonly results?: Types.BotSearchResults
+}
 type _UpdateFeaturedBotsPayload = {readonly bots: Array<RPCTypes.FeaturedBot>; readonly page?: number}
 
 // Action Creators
@@ -44,7 +47,7 @@ export const createSearchFeaturedAndUsers = (
  * Set results of a search
  */
 export const createSetSearchFeaturedAndUsersResults = (
-  payload: _SetSearchFeaturedAndUsersResultsPayload = Object.freeze({})
+  payload: _SetSearchFeaturedAndUsersResultsPayload
 ): SetSearchFeaturedAndUsersResultsPayload => ({payload, type: setSearchFeaturedAndUsersResults})
 /**
  * Sets a flag if all featured bots have been loaded

--- a/shared/actions/bots.tsx
+++ b/shared/actions/bots.tsx
@@ -99,6 +99,7 @@ const searchFeaturedAndUsers = async (action: BotsGen.SearchFeaturedAndUsersPayl
     return
   }
   return BotsGen.createSetSearchFeaturedAndUsersResults({
+    query,
     results: {
       bots: botRes?.bots ?? [],
       users: (userRes ?? []).reduce<Array<string>>((l, r) => {

--- a/shared/actions/json/bots.json
+++ b/shared/actions/json/bots.json
@@ -27,6 +27,7 @@
     },
     "setSearchFeaturedAndUsersResults": {
       "_description": "Set results of a search",
+      "query": "string",
       "results?": "Types.BotSearchResults"
     }
   }

--- a/shared/chat/conversation/bot/search.tsx
+++ b/shared/chat/conversation/bot/search.tsx
@@ -44,7 +44,7 @@ const SearchBotPopup = (props: Props) => {
     if (query.length > 0) {
       dispatch(BotsGen.createSearchFeaturedAndUsers({query}))
     } else {
-      dispatch(BotsGen.createSetSearchFeaturedAndUsersResults({results: undefined}))
+      dispatch(BotsGen.createSetSearchFeaturedAndUsersResults({query, results: undefined}))
     }
   }, 200)
   const onSelect = (username: string) => {
@@ -66,12 +66,14 @@ const SearchBotPopup = (props: Props) => {
   }
   // lifecycle
   React.useEffect(() => {
-    dispatch(BotsGen.createSetSearchFeaturedAndUsersResults({results: undefined}))
+    dispatch(BotsGen.createSetSearchFeaturedAndUsersResults({query: '', results: undefined}))
     dispatch(BotsGen.createGetFeaturedBots({}))
   }, [dispatch])
 
   const botData: Array<RPCTypes.FeaturedBot | string> =
-    lastQuery.length > 0 ? results?.bots.slice() ?? [] : Constants.getFeaturedSorted(featuredBotsMap)
+    lastQuery.length > 0
+      ? results?.get(lastQuery)?.bots.slice() ?? []
+      : Constants.getFeaturedSorted(featuredBotsMap)
   if (!botData.length && !waiting) {
     botData.push(resultEmptyPlaceholder)
   }
@@ -93,7 +95,10 @@ const SearchBotPopup = (props: Props) => {
   }
   const userData = !lastQuery.length
     ? [userEmptyPlaceholder]
-    : results?.users.filter(u => !featuredBotsMap.get(u)).slice(0, 3) ?? []
+    : results
+        .get(lastQuery)
+        ?.users.filter(u => !featuredBotsMap.get(u))
+        .slice(0, 3) ?? []
   if (!userData.length && !waiting) {
     userData.push(resultEmptyPlaceholder)
   }

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -41,6 +41,7 @@ export const makeState = (): Types.State => ({
   blockButtonsMap: new Map(),
   botCommandsUpdateStatusMap: new Map(),
   botPublicCommands: new Map(),
+  botSearchResults: new Map(),
   botSettings: new Map(),
   botTeamRoleInConvMap: new Map(),
   channelSearchText: '',

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -195,7 +195,7 @@ export type State = {
     RPCChatTypes.UIBotCommandsUpdateStatusTyp
   >
   readonly botPublicCommands: Map<string, BotPublicCommands>
-  readonly botSearchResults: Map<string, BotSearchResults> // Keyed so that we never show results that don't match the user's input (e.g. outdated results)
+  readonly botSearchResults: Map<string, BotSearchResults | undefined> // Keyed so that we never show results that don't match the user's input (e.g. outdated results)
   readonly botSettings: Map<Common.ConversationIDKey, Map<string, RPCTypes.TeamBotSettings>>
   readonly botTeamRoleInConvMap: Map<Common.ConversationIDKey, Map<string, Team.TeamRoleType | null>>
   readonly channelSearchText: string

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -195,7 +195,7 @@ export type State = {
     RPCChatTypes.UIBotCommandsUpdateStatusTyp
   >
   readonly botPublicCommands: Map<string, BotPublicCommands>
-  readonly botSearchResults: Map<string, BotSearchResults>
+  readonly botSearchResults: Map<string, BotSearchResults> // Keyed so that we never show results that don't match the user's input (e.g. outdated results)
   readonly botSettings: Map<Common.ConversationIDKey, Map<string, RPCTypes.TeamBotSettings>>
   readonly botTeamRoleInConvMap: Map<Common.ConversationIDKey, Map<string, Team.TeamRoleType | null>>
   readonly channelSearchText: string

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -195,7 +195,7 @@ export type State = {
     RPCChatTypes.UIBotCommandsUpdateStatusTyp
   >
   readonly botPublicCommands: Map<string, BotPublicCommands>
-  readonly botSearchResults?: BotSearchResults
+  readonly botSearchResults: Map<string, BotSearchResults>
   readonly botSettings: Map<Common.ConversationIDKey, Map<string, RPCTypes.TeamBotSettings>>
   readonly botTeamRoleInConvMap: Map<Common.ConversationIDKey, Map<string, Team.TeamRoleType | null>>
   readonly channelSearchText: string

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -76,9 +76,7 @@ const botActions: Container.ActionHandler<Actions, Types.State> = {
     draftState.featuredBotsLoaded = loaded
   },
   [BotsGen.setSearchFeaturedAndUsersResults]: (draftState, action) => {
-    if (action.payload.results) {
-      draftState.botSearchResults.set(action.payload.query, action.payload.results)
-    }
+    draftState.botSearchResults.set(action.payload.query, action.payload.results)
   },
 }
 

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -76,7 +76,9 @@ const botActions: Container.ActionHandler<Actions, Types.State> = {
     draftState.featuredBotsLoaded = loaded
   },
   [BotsGen.setSearchFeaturedAndUsersResults]: (draftState, action) => {
-    draftState.botSearchResults = action.payload.results
+    if (action.payload.results) {
+      draftState.botSearchResults.set(action.payload.query, action.payload.results)
+    }
   },
 }
 


### PR DESCRIPTION
Makes `botSearchResults` associate results with the query (like the team builder modal does) to prevent showing results that don't match a user's input.