### PR TITLE
Clicking a 'Start chat' button should switch tab to Chat

### DIFF
--- a/shared/chat/chat-button.tsx
+++ b/shared/chat/chat-button.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import * as ChatConstants from '../constants/chat2'
+import * as Tabs from '../constants/tabs'
 import * as Chat2Gen from '../actions/chat2-gen'
+import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as ConfigGen from '../actions/config-gen'
 import * as Container from '../util/container'
 import * as Styles from '../styles'
@@ -16,6 +18,7 @@ const ChatButton = ({small, style, username}: Props) => {
   const dispatch = Container.useDispatch()
   const chat = () => {
     dispatch(ConfigGen.createShowMain())
+    dispatch(RouteTreeGen.createSwitchTab({tab: Tabs.chatTab}))
     dispatch(Chat2Gen.createPreviewConversation({participants: [username], reason: 'tracker'}))
   }
   return (


### PR DESCRIPTION
@keybase/react-hackers 

Was looking at this from the perspective of iPad (where clicking Chat on Profile didn't visibly do anything, but in fact it did create the convo and just didn't switch you to Chat tab) but it was present on all platforms.  Other sites that dispatch these actions do the tab switch themselves, looks like it was missed here.