### PR TITLE
accepting and rejecting wot from the cli

### DIFF
--- a/go/client/cmd_wot.go
+++ b/go/client/cmd_wot.go
@@ -9,7 +9,9 @@ import (
 func newCmdWebOfTrust(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	// please keep sorted
 	subcommands := []cli.Command{
+		newCmdWotAccept(cl, g),
 		newCmdWotList(cl, g),
+		newCmdWotReject(cl, g),
 		newCmdWotVouch(cl, g),
 	}
 	return cli.Command{

--- a/go/client/cmd_wot_list.go
+++ b/go/client/cmd_wot_list.go
@@ -15,6 +15,7 @@ import (
 type cmdWotList struct {
 	libkb.Contextified
 	username *string
+	ownWot   bool
 }
 
 func newCmdWotList(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
@@ -36,9 +37,11 @@ func (c *cmdWotList) ParseArgv(ctx *cli.Context) error {
 	if len(ctx.Args()) > 1 {
 		return errors.New("too many arguments")
 	}
+	c.ownWot = true
 	if len(ctx.Args()) == 1 {
 		username := ctx.Args()[0]
 		c.username = &username
+		c.ownWot = false
 	}
 	return nil
 }
@@ -60,19 +63,34 @@ func (c *cmdWotList) Run() error {
 	line := func(format string, args ...interface{}) {
 		dui.Printf(format+"\n", args...)
 	}
-	line("Web-Of-Trust")
+	var targetUsername string
+	if c.ownWot {
+		targetUsername = c.G().Env.GetUsername().String()
+	} else {
+		targetUsername = *c.username
+	}
+	line("Web-Of-Trust for %s", targetUsername)
+	line("-------------------------------")
 	if len(res) == 0 {
 		line("no attestations to show")
 		return nil
 	}
-	line("  STATUS   | VOUCHER : ATTESTATION")
 	for _, vouch := range res {
 		vouchTexts := strings.Join(vouch.VouchTexts, ", ")
 		voucher, err := c.G().GetUPAKLoader().LookupUsername(ctx, vouch.Voucher.Uid)
 		if err != nil {
 			return fmt.Errorf("error looking up username for vouch: %s", err.Error())
 		}
-		line("%10s | %s: \"%s\"", vouch.Status, voucher, vouchTexts)
+		line("Voucher: %s", voucher)
+		line("Attestation: \"%s\"", vouchTexts)
+		line("Status: %s", vouch.Status)
+		if c.ownWot && vouch.Status == keybase1.WotStatusType_PROPOSED {
+			line("    `keybase wot accept %s` to accept this into your web-of-trust", voucher)
+		}
+		if vouch.Confidence != nil {
+			line("Additional Details: %+v", *vouch.Confidence)
+		}
+		line("-------------------------------")
 	}
 	return nil
 }

--- a/go/client/cmd_wot_react.go
+++ b/go/client/cmd_wot_react.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"errors"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	context "golang.org/x/net/context"
+)
+
+type cmdWotAccept struct {
+	username string
+	libkb.Contextified
+}
+
+func newCmdWotAccept(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := []cli.Flag{}
+	cmd := &cmdWotAccept{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:        "accept",
+		Usage:       "Accept a claim made by another user",
+		Description: "Accept a claim made by another user",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "accept", c)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *cmdWotAccept) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return errors.New("accept requires a username")
+	}
+	c.username = ctx.Args()[0]
+	return nil
+}
+
+func (c *cmdWotAccept) Run() error {
+	arg := keybase1.WotReactCLIArg{
+		Username: c.username,
+		Reaction: keybase1.WotReactionType_ACCEPT,
+	}
+
+	cli, err := GetWebOfTrustClient(c.G())
+	if err != nil {
+		return err
+	}
+	return cli.WotReactCLI(context.Background(), arg)
+}
+
+func (c *cmdWotAccept) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}
+
+/////////////////////////////////////////
+
+type cmdWotReject struct {
+	username string
+	libkb.Contextified
+}
+
+func newCmdWotReject(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	flags := []cli.Flag{}
+	cmd := &cmdWotReject{
+		Contextified: libkb.NewContextified(g),
+	}
+	return cli.Command{
+		Name:        "reject",
+		Usage:       "Reject a claim made by another user",
+		Description: "Reject a claim made by another user",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(cmd, "reject", c)
+		},
+		Flags: flags,
+	}
+}
+
+func (c *cmdWotReject) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 1 {
+		return errors.New("reject requires a username")
+	}
+	c.username = ctx.Args()[0]
+	return nil
+}
+
+func (c *cmdWotReject) Run() error {
+	arg := keybase1.WotReactCLIArg{
+		Username: c.username,
+		Reaction: keybase1.WotReactionType_REJECT,
+	}
+
+	cli, err := GetWebOfTrustClient(c.G())
+	if err != nil {
+		return err
+	}
+	return cli.WotReactCLI(context.Background(), arg)
+}
+
+func (c *cmdWotReject) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		API:       true,
+		KbKeyring: true,
+	}
+}

--- a/go/client/cmd_wot_vouch.go
+++ b/go/client/cmd_wot_vouch.go
@@ -76,14 +76,20 @@ func (c *cmdWotVouch) ParseArgv(ctx *cli.Context) error {
 		}
 		c.confidence.UsernameVerifiedVia = viaType
 	}
-	vouchingUsernames := strings.Split(ctx.String("vouched-by"), ",")
-	var vouchers []keybase1.UID
-	for _, username := range vouchingUsernames {
-		uid := libkb.UsernameToUID(username)
-		vouchers = append(vouchers, uid)
+	vouchingUsernamesRaw := ctx.String("verified-via")
+	if vouchingUsernamesRaw != "" {
+		vouchingUsernames := strings.Split(vouchingUsernamesRaw, ",")
+		var vouchers []keybase1.UID
+		for _, username := range vouchingUsernames {
+			uid := libkb.UsernameToUID(username)
+			vouchers = append(vouchers, uid)
+		}
+		c.confidence.VouchedBy = vouchers
 	}
-	c.confidence.VouchedBy = vouchers
-	c.confidence.Other = ctx.String("other")
+	other := ctx.String("other")
+	if other != "" {
+		c.confidence.Other = ctx.String("other")
+	}
 	return nil
 }
 

--- a/go/client/cmd_wot_vouch.go
+++ b/go/client/cmd_wot_vouch.go
@@ -61,6 +61,9 @@ func (c *cmdWotVouch) ParseArgv(ctx *cli.Context) error {
 	}
 	c.assertion = ctx.Args()[0]
 	c.message = ctx.String("message")
+	if len(c.message) == 0 {
+		return errors.New("vouch requires an attestation e.g. `-m \"Alice plays the banjo\"`")
+	}
 	kf := ctx.Int("known-for")
 	if kf > 0 {
 		c.confidence.KnownOnKeybaseDays = kf

--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -178,6 +178,13 @@ func TestWebOfTrustPending(t *testing.T) {
 	require.NoError(t, err)
 	t.Log("charlie vouches for alice with confidence")
 
+	// ensure alice does a full load of bob by adding another link
+	// to bob's chain so the wot.vouch isn't the last one (which is always unstubbed)
+	// and nuking alice's local db to wipe any cache
+	trackUser(tcBob, bob, charlie.NormalizedUsername(), sigVersion)
+	_, err = mctxA.G().LocalDb.Nuke()
+	require.NoError(t, err)
+
 	vouches, err = libkb.FetchMyWot(mctxA)
 	require.NoError(t, err)
 	require.Len(t, vouches, 2)

--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -335,6 +335,7 @@ func TestWebOfTrustReject(t *testing.T) {
 	t.Log("bob cannot see it")
 }
 
+// perhaps revisit after Y2K-1494
 func TestWebOfTrustSigBug(t *testing.T) {
 	tcAlice := SetupEngineTest(t, "wot")
 	tcBob := SetupEngineTest(t, "wot")

--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -388,4 +388,10 @@ func TestWebOfTrustSigBug(t *testing.T) {
 	engV2 := NewWotVouch(tcBob.G, argV)
 	err = RunEngine2(mctxB, engV2)
 	require.NoError(t, err)
+
+	// this attestation is correctly recognized as proposed
+	vouches, err = libkb.FetchMyWot(mctxA)
+	require.NoError(t, err)
+	bobVouch = vouches[0]
+	require.Equal(t, bobVouch.Status, keybase1.WotStatusType_PROPOSED)
 }

--- a/go/engine/wot_vouch.go
+++ b/go/engine/wot_vouch.go
@@ -53,7 +53,7 @@ func (e *WotVouch) SubConsumers() []libkb.UIConsumer {
 
 // Run starts the engine.
 func (e *WotVouch) Run(mctx libkb.MetaContext) error {
-	luArg := libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(e.arg.Vouchee.Uid)
+	luArg := libkb.NewLoadUserArgWithMetaContext(mctx).WithUID(e.arg.Vouchee.Uid).WithStubMode(libkb.StubModeUnstubbed)
 	them, err := libkb.LoadUser(luArg)
 	if err != nil {
 		return err

--- a/go/libkb/wot.go
+++ b/go/libkb/wot.go
@@ -10,7 +10,8 @@ import (
 )
 
 func getWotVouchChainLink(mctx MetaContext, uid keybase1.UID, sigID keybase1.SigID) (cl *WotVouchChainLink, voucher *User, err error) {
-	user, err := LoadUser(NewLoadUserArgWithMetaContext(mctx).WithUID(uid))
+	// requires a full chain load
+	user, err := LoadUser(NewLoadUserArgWithMetaContext(mctx).WithUID(uid).WithStubMode(StubModeUnstubbed))
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error loading user: %v", err)
 	}

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -172,6 +172,12 @@ type WotReactArg struct {
 	Reaction  WotReactionType `codec:"reaction" json:"reaction"`
 }
 
+type WotReactCLIArg struct {
+	SessionID int             `codec:"sessionID" json:"sessionID"`
+	Username  string          `codec:"username" json:"username"`
+	Reaction  WotReactionType `codec:"reaction" json:"reaction"`
+}
+
 type WotListCLIArg struct {
 	SessionID int     `codec:"sessionID" json:"sessionID"`
 	Username  *string `codec:"username,omitempty" json:"username,omitempty"`
@@ -181,6 +187,7 @@ type WotInterface interface {
 	WotVouch(context.Context, WotVouchArg) error
 	WotVouchCLI(context.Context, WotVouchCLIArg) error
 	WotReact(context.Context, WotReactArg) error
+	WotReactCLI(context.Context, WotReactCLIArg) error
 	WotListCLI(context.Context, WotListCLIArg) ([]WotVouch, error)
 }
 
@@ -233,6 +240,21 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 					return
 				},
 			},
+			"wotReactCLI": {
+				MakeArg: func() interface{} {
+					var ret [1]WotReactCLIArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]WotReactCLIArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]WotReactCLIArg)(nil), args)
+						return
+					}
+					err = i.WotReactCLI(ctx, typedArgs[0])
+					return
+				},
+			},
 			"wotListCLI": {
 				MakeArg: func() interface{} {
 					var ret [1]WotListCLIArg
@@ -268,6 +290,11 @@ func (c WotClient) WotVouchCLI(ctx context.Context, __arg WotVouchCLIArg) (err e
 
 func (c WotClient) WotReact(ctx context.Context, __arg WotReactArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.wot.wotReact", []interface{}{__arg}, nil, 0*time.Millisecond)
+	return
+}
+
+func (c WotClient) WotReactCLI(ctx context.Context, __arg WotReactCLIArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotReactCLI", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -73,4 +75,55 @@ func (h *WebOfTrustHandler) WotReact(ctx context.Context, arg keybase1.WotReactA
 	}
 	eng := engine.NewWotReact(h.G(), earg)
 	return engine.RunEngine2(mctx, eng)
+}
+
+func (h *WebOfTrustHandler) WotReactCLI(ctx context.Context, arg keybase1.WotReactCLIArg) error {
+	ctx = libkb.WithLogTag(ctx, "WOT")
+	mctx := libkb.NewMetaContext(ctx, h.G())
+
+	upak, _, err := h.G().GetUPAKLoader().Load(libkb.NewLoadUserArg(h.G()).WithName(arg.Username))
+	if err != nil {
+		return err
+	}
+	expectedVoucher := upak.Base.ToUserVersion()
+	myVouches, err := libkb.FetchMyWot(mctx)
+	if err != nil {
+		return err
+	}
+	var reactingVouch *keybase1.WotVouch
+	for _, attestation := range myVouches {
+		if attestation.Voucher.Eq(expectedVoucher) {
+			reactingVouch = &attestation
+			break
+		}
+	}
+	if reactingVouch == nil {
+		return fmt.Errorf("could not find an attestation of you by %s", arg.Username)
+	}
+
+	switch reactingVouch.Status {
+	case keybase1.WotStatusType_NONE:
+		return fmt.Errorf("something is wrong with this attestation; please ask %s to recreate it", arg.Username)
+	case keybase1.WotStatusType_REJECTED:
+		return fmt.Errorf("cannot react to an attestation that was previously rejected")
+	case keybase1.WotStatusType_REVOKED:
+		return fmt.Errorf("cannot react to an attestation that was previously revoked")
+	case keybase1.WotStatusType_ACCEPTED:
+		if arg.Reaction == keybase1.WotReactionType_ACCEPT {
+			return fmt.Errorf("already accepted")
+		}
+		// rejected a previously accepted vouch, which is fine
+	case keybase1.WotStatusType_PROPOSED:
+		// expected happy path
+	default:
+		return fmt.Errorf("unknown status on web-of-trust attestation: %v", reactingVouch.Status)
+	}
+
+	rarg := keybase1.WotReactArg{
+		SessionID: arg.SessionID,
+		Uv:        expectedVoucher,
+		Proof:     reactingVouch.VouchProof,
+		Reaction:  arg.Reaction,
+	}
+	return h.WotReact(ctx, rarg)
 }

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -34,6 +34,7 @@ protocol wot {
     REJECT_1
   }
   void wotReact(int sessionID, UserVersion uv /* voucher */, SigID proof, WotReactionType reaction);
+  void wotReactCLI(int sessionID, string username /* voucher */, WotReactionType reaction);
 
   record WotVouch {
     WotStatusType status;
@@ -45,5 +46,4 @@ protocol wot {
   }
 
   array<WotVouch> wotListCLI(int sessionID, union {null, string} username);
-
 }

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -174,6 +174,23 @@
       ],
       "response": null
     },
+    "wotReactCLI": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "reaction",
+          "type": "WotReactionType"
+        }
+      ],
+      "response": null
+    },
     "wotListCLI": {
       "request": [
         {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -4167,4 +4167,5 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.wot.wotVouch'
 // 'keybase.1.wot.wotVouchCLI'
 // 'keybase.1.wot.wotReact'
+// 'keybase.1.wot.wotReactCLI'
 // 'keybase.1.wot.wotListCLI'


### PR DESCRIPTION
add accept and reject for wot from the cli. works like this:

alice> `keybase wot vouch bob -m "bob is amazeballz"`
bob> `keybase wot list`
```
Web-Of-Trust for bob
-------------------------------
Voucher: alice
Attestation: "bob is amazeballz"
Status: PROPOSED
    `keybase wot accept alice` to accept this into your web-of-trust
-------------------------------
```
bob> `keybase wot accept alice`
bob> `keybase wot list`
```
Web-Of-Trust for bob
-------------------------------
Voucher: alice
Attestation: "bob is amazeballz"
Status: ACCEPTED
-------------------------------
```
alice can now see them because it's been accepted
alice> `keybase wot list bob`
```
Web-Of-Trust for bob
-------------------------------
Voucher: alice
Attestation: "bob is amazeballz"
Status: ACCEPTED
-------------------------------
```

###########################

the listing CLI doesn't really show the confidence node very nicely, but it does spit out the info. happy to give that some love. it currently looks like this:
```
Additional Confidence: &{VouchedBy:[6ed8919ce20490a5e3ad8630a4fab619] Proofs:[] UsernameVerifiedVia:audio Other:some other info KnownOnKeybaseDays:100}
```