### PR TITLE
Fix formatting for Channel page

### DIFF
--- a/shared/chat/conversation/info-panel/settings/index.tsx
+++ b/shared/chat/conversation/info-panel/settings/index.tsx
@@ -281,7 +281,7 @@ const styles = Styles.styleSheetCreate(
         isTablet: {alignSelf: 'center', maxWidth: 600},
       }),
       settingsHeader: {
-        marginBottom: Styles.globalMargins.small,
+        display: 'flex',
         paddingLeft: Styles.globalMargins.small,
         paddingRight: Styles.globalMargins.small,
       },


### PR DESCRIPTION
Broken:
================================================================
<img width="307" alt="Screen Shot 2020-02-26 at 5 16 41 PM" src="https://user-images.githubusercontent.com/2541326/75393310-c8403080-58bb-11ea-96dc-ee72918a09ff.png">

Fixed:
================================================================
<img width="304" alt="Screen Shot 2020-02-26 at 5 16 21 PM" src="https://user-images.githubusercontent.com/2541326/75393308-c7a79a00-58bb-11ea-8713-7c2cdfdf1060.png">
