### PR TITLE
md_util: copy ops before sending them to revertRenames

### DIFF
--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -854,7 +854,9 @@ func GetChangesBetweenRevisions(
 	ops := make([]op, opsCount)
 	soFar := 0
 	for _, rmd := range rmds {
-		copy(ops[soFar:], rmd.data.Changes.Ops)
+		for i, op := range rmd.data.Changes.Ops {
+			ops[soFar+i] = op.deepCopy()
+		}
 		soFar += len(rmd.data.Changes.Ops)
 	}
 	chains.revertRenames(ops)


### PR DESCRIPTION
Since revertRenames could modify the ops concurrently with something else handling the same rmd object.