### PR TITLE
folder_block_ops: fetch encoded block sizes in chunks

### DIFF
--- a/go/kbfs/libkbfs/bserver_disk.go
+++ b/go/kbfs/libkbfs/bserver_disk.go
@@ -155,14 +155,14 @@ func (b *BlockServerDisk) Get(
 	return data, keyServerHalf, nil
 }
 
-// GetEncodedSize implements the BlockServer interface for
+// GetEncodedSizes implements the BlockServer interface for
 // BlockServerDisk.
-func (b *BlockServerDisk) GetEncodedSize(
-	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
-	size uint32, status keybase1.BlockStatus, err error) {
+func (b *BlockServerDisk) GetEncodedSizes(
+	ctx context.Context, tlfID tlf.ID, ids []kbfsblock.ID,
+	contexts []kbfsblock.Context) (
+	sizes []uint32, statuses []keybase1.BlockStatus, err error) {
 	if err := checkContext(ctx); err != nil {
-		return 0, 0, err
+		return nil, nil, err
 	}
 
 	defer func() {
@@ -170,31 +170,41 @@ func (b *BlockServerDisk) GetEncodedSize(
 	}()
 	b.log.CDebugf(ctx,
 		"BlockServerDisk.GetEncodedSize id=%s tlfID=%s context=%s",
-		id, tlfID, context)
+		ids, tlfID, contexts)
 	tlfStorage, err := b.getStorage(tlfID)
 	if err != nil {
-		return 0, 0, err
+		return nil, nil, err
 	}
 
 	tlfStorage.lock.RLock()
 	defer tlfStorage.lock.RUnlock()
 	if tlfStorage.store == nil {
-		return 0, 0, errBlockServerDiskShutdown
+		return nil, nil, errBlockServerDiskShutdown
 	}
 
-	hasContext, refStatus, err := tlfStorage.store.hasContext(ctx, id, context)
-	if err != nil {
-		return 0, 0, err
-	}
-	if !hasContext {
-		return 0, 0, blockNonExistentError{id}
-	}
+	sizes = make([]uint32, len(ids))
+	statuses = make([]keybase1.BlockStatus, len(ids))
+	for i, id := range ids {
+		context := contexts[i]
+		hasContext, refStatus, err := tlfStorage.store.hasContext(
+			ctx, id, context)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !hasContext {
+			sizes[i] = 0
+			statuses[i] = keybase1.BlockStatus_UNKNOWN
+			continue
+		}
 
-	size64, err := tlfStorage.store.getDataSize(ctx, id)
-	if err != nil {
-		return 0, 0, err
+		size64, err := tlfStorage.store.getDataSize(ctx, id)
+		if err != nil {
+			return nil, nil, err
+		}
+		sizes[i] = uint32(size64)
+		statuses[i] = refStatus.toBlockStatus()
 	}
-	return uint32(size64), refStatus.toBlockStatus(), nil
+	return sizes, statuses, nil
 }
 
 // Put implements the BlockServer interface for BlockServerDisk.

--- a/go/kbfs/libkbfs/bserver_disk.go
+++ b/go/kbfs/libkbfs/bserver_disk.go
@@ -169,7 +169,7 @@ func (b *BlockServerDisk) GetEncodedSizes(
 		err = translateToBlockServerError(err)
 	}()
 	b.log.CDebugf(ctx,
-		"BlockServerDisk.GetEncodedSize id=%s tlfID=%s context=%s",
+		"BlockServerDisk.GetEncodedSizes id=%s tlfID=%s context=%s",
 		ids, tlfID, contexts)
 	tlfStorage, err := b.getStorage(tlfID)
 	if err != nil {

--- a/go/kbfs/libkbfs/bserver_measured.go
+++ b/go/kbfs/libkbfs/bserver_measured.go
@@ -67,15 +67,16 @@ func (b BlockServerMeasured) Get(
 	return buf, serverHalf, err
 }
 
-// GetEncodedSize implements the BlockServer interface for BlockServerMeasured.
-func (b BlockServerMeasured) GetEncodedSize(
-	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
-	size uint32, status keybase1.BlockStatus, err error) {
+// GetEncodedSizes implements the BlockServer interface for BlockServerMeasured.
+func (b BlockServerMeasured) GetEncodedSizes(
+	ctx context.Context, tlfID tlf.ID, ids []kbfsblock.ID,
+	contexts []kbfsblock.Context) (
+	sizes []uint32, statuses []keybase1.BlockStatus, err error) {
 	b.getEncodedSizeTimer.Time(func() {
-		size, status, err = b.delegate.GetEncodedSize(ctx, tlfID, id, context)
+		sizes, statuses, err = b.delegate.GetEncodedSizes(
+			ctx, tlfID, ids, contexts)
 	})
-	return size, status, err
+	return sizes, statuses, err
 }
 
 // Put implements the BlockServer interface for BlockServerMeasured.

--- a/go/kbfs/libkbfs/bserver_memory.go
+++ b/go/kbfs/libkbfs/bserver_memory.go
@@ -94,49 +94,60 @@ func (b *BlockServerMemory) Get(
 	return entry.blockData, entry.keyServerHalf, nil
 }
 
-// GetEncodedSize implements the BlockServer interface for
-// BlockServerDisk.
-func (b *BlockServerMemory) GetEncodedSize(
-	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
-	size uint32, status keybase1.BlockStatus, err error) {
+// GetEncodedSizes implements the BlockServer interface for
+// BlockServerMemory.
+func (b *BlockServerMemory) GetEncodedSizes(
+	ctx context.Context, tlfID tlf.ID, ids []kbfsblock.ID,
+	contexts []kbfsblock.Context) (
+	sizes []uint32, statuses []keybase1.BlockStatus, err error) {
 	if err := checkContext(ctx); err != nil {
-		return 0, 0, err
+		return nil, nil, err
 	}
 
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
 	b.log.CDebugf(ctx,
-		"BlockServerMemory.GetEncodedSize id=%s tlfID=%s context=%s",
-		id, tlfID, context)
+		"BlockServerMemory.GetEncodedSizes ids=%s tlfID=%s contexts=%s",
+		ids, tlfID, contexts)
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
 	if b.m == nil {
-		return 0, 0, errBlockServerMemoryShutdown
+		return nil, nil, errBlockServerMemoryShutdown
 	}
 
-	entry, ok := b.m[id]
-	if !ok {
-		return 0, 0, kbfsblock.ServerErrorBlockNonExistent{
-			Msg: fmt.Sprintf("Block ID %s does not exist.", id)}
+	sizes = make([]uint32, len(ids))
+	statuses = make([]keybase1.BlockStatus, len(ids))
+	for i, id := range ids {
+		entry, ok := b.m[id]
+		if !ok {
+			sizes[i] = 0
+			statuses[i] = keybase1.BlockStatus_UNKNOWN
+			continue
+		}
+
+		if entry.tlfID != tlfID {
+			return nil, nil, fmt.Errorf("TLF ID mismatch: expected %s, got %s",
+				entry.tlfID, tlfID)
+		}
+
+		context := contexts[i]
+		exists, refStatus, err := entry.refs.checkExists(context)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !exists {
+			sizes[i] = 0
+			statuses[i] = keybase1.BlockStatus_UNKNOWN
+			continue
+		}
+
+		sizes[i] = uint32(len(entry.blockData))
+		statuses[i] = refStatus.toBlockStatus()
 	}
 
-	if entry.tlfID != tlfID {
-		return 0, 0, fmt.Errorf("TLF ID mismatch: expected %s, got %s",
-			entry.tlfID, tlfID)
-	}
-
-	exists, refStatus, err := entry.refs.checkExists(context)
-	if err != nil {
-		return 0, 0, err
-	}
-	if !exists {
-		return 0, 0, blockNonExistentError{id}
-	}
-
-	return uint32(len(entry.blockData)), refStatus.toBlockStatus(), nil
+	return sizes, statuses, nil
 }
 
 func validateBlockPut(checkNonzeroRef bool, id kbfsblock.ID, context kbfsblock.Context,

--- a/go/kbfs/libkbfs/bserver_remote.go
+++ b/go/kbfs/libkbfs/bserver_remote.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -422,34 +423,47 @@ func (b *BlockServerRemote) Get(
 	return kbfsblock.ParseGetBlockRes(res, err)
 }
 
-// GetEncodedSize implements the BlockServer interface for BlockServerRemote.
-func (b *BlockServerRemote) GetEncodedSize(
-	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
-	size uint32, status keybase1.BlockStatus, err error) {
+// GetEncodedSizes implements the BlockServer interface for BlockServerRemote.
+func (b *BlockServerRemote) GetEncodedSizes(
+	ctx context.Context, tlfID tlf.ID, ids []kbfsblock.ID,
+	contexts []kbfsblock.Context) (
+	sizes []uint32, statuses []keybase1.BlockStatus, err error) {
 	ctx = rpc.WithFireNow(ctx)
-	b.log.LazyTrace(ctx, "BServer: GetEncodedSize %s", id)
+	b.log.LazyTrace(ctx, "BServer: GetEncodedSize %s", ids)
 	defer func() {
 		b.log.LazyTrace(
-			ctx, "BServer: GetEncodedSize %s done (err=%v)", id, err)
+			ctx, "BServer: GetEncodedSize %s done (err=%v)", ids, err)
 		if err != nil {
 			b.deferLog.CWarningf(
-				ctx, "GetEncodedSize id=%s tlf=%s context=%s err=%v",
-				id, tlfID, context, err)
+				ctx, "GetEncodedSize ids=%s tlf=%s contexts=%s err=%v",
+				ids, tlfID, contexts, err)
 		} else {
 			b.deferLog.CDebugf(
-				ctx, "GetEncodedSize id=%s tlf=%s context=%s sz=%d status=%s",
-				id, tlfID, context, size, status)
+				ctx, "GetEncodedSize ids=%s tlf=%s contexts=%s "+
+					"szs=%d statuses=%s",
+				ids, tlfID, contexts, sizes, statuses)
 		}
 	}()
 
-	arg := kbfsblock.MakeGetBlockArg(tlfID, id, context)
-	arg.SizeOnly = true
-	res, err := b.getConn.getClient().GetBlock(ctx, arg)
+	arg, err := kbfsblock.MakeGetBlockSizesArg(tlfID, ids, contexts)
 	if err != nil {
-		return 0, 0, nil
+		return nil, nil, err
 	}
-	return uint32(res.Size), res.Status, nil
+	res, err := b.getConn.getClient().GetBlockSizes(ctx, arg)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(res.Sizes) != len(res.Statuses) {
+		return nil, nil, errors.Errorf(
+			"Unexpected return param slice size difference: "+
+				"len(sizes)=%d != len(statuses)=%d",
+			len(res.Sizes), len(res.Statuses))
+	}
+	sizes = make([]uint32, len(res.Sizes))
+	for i, size := range res.Sizes {
+		sizes[i] = uint32(size)
+	}
+	return sizes, res.Statuses, nil
 }
 
 // Put implements the BlockServer interface for BlockServerRemote.

--- a/go/kbfs/libkbfs/bserver_remote.go
+++ b/go/kbfs/libkbfs/bserver_remote.go
@@ -429,17 +429,17 @@ func (b *BlockServerRemote) GetEncodedSizes(
 	contexts []kbfsblock.Context) (
 	sizes []uint32, statuses []keybase1.BlockStatus, err error) {
 	ctx = rpc.WithFireNow(ctx)
-	b.log.LazyTrace(ctx, "BServer: GetEncodedSize %s", ids)
+	b.log.LazyTrace(ctx, "BServer: GetEncodedSizes %s", ids)
 	defer func() {
 		b.log.LazyTrace(
-			ctx, "BServer: GetEncodedSize %s done (err=%v)", ids, err)
+			ctx, "BServer: GetEncodedSizes %s done (err=%v)", ids, err)
 		if err != nil {
 			b.deferLog.CWarningf(
-				ctx, "GetEncodedSize ids=%s tlf=%s contexts=%s err=%v",
+				ctx, "GetEncodedSizes ids=%s tlf=%s contexts=%s err=%v",
 				ids, tlfID, contexts, err)
 		} else {
 			b.deferLog.CDebugf(
-				ctx, "GetEncodedSize ids=%s tlf=%s contexts=%s "+
+				ctx, "GetEncodedSizes ids=%s tlf=%s contexts=%s "+
 					"szs=%d statuses=%s",
 				ids, tlfID, contexts, sizes, statuses)
 		}

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -345,18 +345,21 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	// goroutines may be operating on the data assuming they have the
 	// lock.
 	bops := fbo.config.BlockOps()
+	var sizes []uint32
+	var statuses []keybase1.BlockStatus
+	ptrs := []data.BlockPointer{ptr}
 	if rtype != data.BlockReadParallel && rtype != data.BlockLookup {
 		fbo.blockLock.DoRUnlockedIfPossible(lState, func(*kbfssync.LockState) {
-			size, status, err = bops.GetEncodedSize(ctx, kmd, ptr)
+			sizes, statuses, err = bops.GetEncodedSizes(ctx, kmd, ptrs)
 		})
 	} else {
-		size, status, err = bops.GetEncodedSize(ctx, kmd, ptr)
+		sizes, statuses, err = bops.GetEncodedSizes(ctx, kmd, ptrs)
 	}
 	if err != nil {
 		return 0, 0, err
 	}
 
-	return size, status, nil
+	return sizes[0], statuses[0], nil
 }
 
 // getBlockHelperLocked retrieves the block pointed to by ptr, which

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/idutil"
-	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfssync"
 	"github.com/keybase/client/go/kbfs/libkey"
@@ -267,15 +266,17 @@ func (fbo *folderBlockOps) GetState(
 	return dirtyState
 }
 
-// getCleanEncodedBlockHelperLocked retrieves the encoded size of the
-// clean block pointed to by ptr, which must be valid, either from the
-// cache or from the server.  If `rtype` is `blockReadParallel`, it's
-// assumed that some coordinating goroutine is holding the correct
-// locks, and in that case `lState` must be `nil`.
-func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
-	lState *kbfssync.LockState, kmd libkey.KeyMetadata, ptr data.BlockPointer,
-	branch data.BranchName, rtype data.BlockReqType, assumeCacheIsLive bool) (
-	size uint32, status keybase1.BlockStatus, err error) {
+// getCleanEncodedBlockSizesLocked retrieves the encoded sizes and
+// block statuses of the clean blocks pointed to each of the block
+// pointers in `ptrs`, which must be valid, either from the cache or
+// from the server.  If `rtype` is `blockReadParallel`, it's assumed
+// that some coordinating goroutine is holding the correct locks, and
+// in that case `lState` must be `nil`.
+func (fbo *folderBlockOps) getCleanEncodedBlockSizesLocked(ctx context.Context,
+	lState *kbfssync.LockState, kmd libkey.KeyMetadata,
+	ptrs []data.BlockPointer, branch data.BranchName,
+	rtype data.BlockReqType, assumeCacheIsLive bool) (
+	sizes []uint32, statuses []keybase1.BlockStatus, err error) {
 	if rtype != data.BlockReadParallel {
 		if rtype == data.BlockWrite {
 			panic("Cannot get the size of a block for writing")
@@ -286,50 +287,64 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 			"with blockReadParallel")
 	}
 
-	if !ptr.IsValid() {
-		return 0, 0, InvalidBlockRefError{ptr.Ref()}
-	}
-
-	if assumeCacheIsLive {
-		// If we're assuming all blocks in the cache are live, we just
-		// need to get the block size, which we can do from either one
-		// of the caches.
-		if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
-			return block.GetEncodedSize(), keybase1.BlockStatus_LIVE, nil
+	sizes = make([]uint32, len(ptrs))
+	statuses = make([]keybase1.BlockStatus, len(ptrs))
+	var toFetchIndices []int
+	var ptrsToFetch []data.BlockPointer
+	for i, ptr := range ptrs {
+		if !ptr.IsValid() {
+			return nil, nil, InvalidBlockRefError{ptr.Ref()}
 		}
-		if diskBCache := fbo.config.DiskBlockCache(); diskBCache != nil {
-			cacheType := DiskBlockAnyCache
-			if fbo.config.IsSyncedTlf(fbo.id()) {
-				cacheType = DiskBlockSyncCache
+
+		if assumeCacheIsLive {
+			// If we're assuming all blocks in the cache are live, we just
+			// need to get the block size, which we can do from either one
+			// of the caches.
+			if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
+				sizes[i] = block.GetEncodedSize()
+				statuses[i] = keybase1.BlockStatus_LIVE
+				continue
 			}
-			if buf, _, _, err := diskBCache.Get(
-				ctx, fbo.id(), ptr.ID, cacheType); err == nil {
-				return uint32(len(buf)), keybase1.BlockStatus_LIVE, nil
+			if diskBCache := fbo.config.DiskBlockCache(); diskBCache != nil {
+				cacheType := DiskBlockAnyCache
+				if fbo.config.IsSyncedTlf(fbo.id()) {
+					cacheType = DiskBlockSyncCache
+				}
+				if buf, _, _, err := diskBCache.Get(
+					ctx, fbo.id(), ptr.ID, cacheType); err == nil {
+					sizes[i] = uint32(len(buf))
+					statuses[i] = keybase1.BlockStatus_LIVE
+					continue
+				}
 			}
 		}
-	}
 
-	if err := checkDataVersion(fbo.config, data.Path{}, ptr); err != nil {
-		return 0, 0, err
+		if err := checkDataVersion(fbo.config, data.Path{}, ptr); err != nil {
+			return nil, nil, err
+		}
+
+		// Fetch this block from the server.
+		ptrsToFetch = append(ptrsToFetch, ptr)
+		toFetchIndices = append(toFetchIndices, i)
 	}
 
 	defer func() {
 		fbo.vlog.CLogf(
-			ctx, libkb.VLog1, "GetEncodedSize ptr=%v size=%d status=%s: %+v",
-			ptr, size, status, err)
+			ctx, libkb.VLog1, "GetEncodedSize ptrs=%v sizes=%d statuses=%s: "+
+				"%+v", ptrs, sizes, statuses, err)
 		// In certain testing situations, a block might be represented
 		// with a 0 size in our journal or be missing from our local
 		// data stores, and we need to reconstruct the size using the
 		// cache in order to make the accounting work out for the test.
-		_, isBlockNotFound :=
-			errors.Cause(err).(kbfsblock.ServerErrorBlockNonExistent)
-		if isBlockNotFound || size == 0 {
-			if block, cerr := fbo.config.BlockCache().Get(ptr); cerr == nil {
-				fbo.vlog.CLogf(
-					ctx, libkb.VLog1,
-					"Fixing encoded size of %v with cached copy", ptr)
-				size = block.GetEncodedSize()
-				err = nil
+		for i, ptr := range ptrs {
+			if sizes[i] == 0 {
+				if block, cerr := fbo.config.BlockCache().Get(
+					ptr); cerr == nil {
+					fbo.vlog.CLogf(
+						ctx, libkb.VLog1,
+						"Fixing encoded size of %v with cached copy (%d)", ptr, block.GetEncodedSize())
+					sizes[i] = block.GetEncodedSize()
+				}
 			}
 		}
 	}()
@@ -345,21 +360,27 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	// goroutines may be operating on the data assuming they have the
 	// lock.
 	bops := fbo.config.BlockOps()
-	var sizes []uint32
-	var statuses []keybase1.BlockStatus
-	ptrs := []data.BlockPointer{ptr}
+	var fetchedSizes []uint32
+	var fetchedStatuses []keybase1.BlockStatus
 	if rtype != data.BlockReadParallel && rtype != data.BlockLookup {
 		fbo.blockLock.DoRUnlockedIfPossible(lState, func(*kbfssync.LockState) {
-			sizes, statuses, err = bops.GetEncodedSizes(ctx, kmd, ptrs)
+			fetchedSizes, fetchedStatuses, err = bops.GetEncodedSizes(
+				ctx, kmd, ptrsToFetch)
 		})
 	} else {
-		sizes, statuses, err = bops.GetEncodedSizes(ctx, kmd, ptrs)
+		fetchedSizes, fetchedStatuses, err = bops.GetEncodedSizes(
+			ctx, kmd, ptrsToFetch)
 	}
 	if err != nil {
-		return 0, 0, err
+		return nil, nil, err
 	}
 
-	return sizes[0], statuses[0], nil
+	for i, j := range toFetchIndices {
+		sizes[j] = fetchedSizes[i]
+		statuses[j] = fetchedStatuses[i]
+	}
+
+	return sizes, statuses, nil
 }
 
 // getBlockHelperLocked retrieves the block pointed to by ptr, which
@@ -528,9 +549,9 @@ func (fbo *folderBlockOps) GetCleanEncodedBlocksSizeSum(ctx context.Context,
 	for i := 0; i < numWorkers; i++ {
 		eg.Go(func() error {
 			for ptr := range ptrCh {
-				size, status, err := fbo.getCleanEncodedBlockSizeLocked(
-					groupCtx, nil, kmd, ptr, branch, data.BlockReadParallel,
-					assumeCacheIsLive)
+				sizes, statuses, err := fbo.getCleanEncodedBlockSizesLocked(
+					groupCtx, nil, kmd, []data.BlockPointer{ptr}, branch,
+					data.BlockReadParallel, assumeCacheIsLive)
 				// TODO: we might be able to recover the size of the
 				// top-most block of a removed file using the merged
 				// directory entry, the same way we do in
@@ -541,14 +562,14 @@ func (fbo *folderBlockOps) GetCleanEncodedBlocksSizeSum(ctx context.Context,
 						"error for block %v: %v", ptr, err)
 					continue
 				}
-
 				if err != nil {
 					return err
 				}
-				if onlyCountIfLive && status != keybase1.BlockStatus_LIVE {
+
+				if onlyCountIfLive && statuses[0] != keybase1.BlockStatus_LIVE {
 					sumCh <- 0
 				} else {
-					sumCh <- size
+					sumCh <- sizes[0]
 				}
 			}
 			return nil

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1459,11 +1459,12 @@ type BlockOps interface {
 	Get(ctx context.Context, kmd libkey.KeyMetadata, blockPtr data.BlockPointer,
 		block data.Block, cacheLifetime data.BlockCacheLifetime) error
 
-	// GetEncodedSize gets the encoded size of the block associated
-	// with the given block pointer (which belongs to the TLF with the
-	// given key metadata).
-	GetEncodedSize(ctx context.Context, kmd libkey.KeyMetadata,
-		blockPtr data.BlockPointer) (uint32, keybase1.BlockStatus, error)
+	// GetEncodedSizes gets the encoded sizes and statuses of the
+	// block associated with the given block pointers (which belongs
+	// to the TLF with the given key metadata).  If a block is not
+	// found, it gets a size of 0 and an UNKNOWN status.
+	GetEncodedSizes(ctx context.Context, kmd libkey.KeyMetadata,
+		blockPtrs []data.BlockPointer) ([]uint32, []keybase1.BlockStatus, error)
 
 	// Delete instructs the server to delete the given block references.
 	// It returns the number of not-yet deleted references to
@@ -1712,12 +1713,13 @@ type BlockServer interface {
 		context kbfsblock.Context, cacheType DiskBlockCacheType) (
 		[]byte, kbfscrypto.BlockCryptKeyServerHalf, error)
 
-	// GetEncodedSize gets the encoded size of the block associated
-	// with the given block pointer (which belongs to the TLF with the
-	// given key metadata).
-	GetEncodedSize(
-		ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-		context kbfsblock.Context) (uint32, keybase1.BlockStatus, error)
+	// GetEncodedSizes gets the encoded sizes and statuses of the
+	// blocks associated with the given block IDs (which belong to the
+	// TLF with the given key metadata).  If a block is not found, it
+	// gets a size of 0 and an UNKNOWN status.
+	GetEncodedSizes(
+		ctx context.Context, tlfID tlf.ID, ids []kbfsblock.ID,
+		contexts []kbfsblock.Context) ([]uint32, []keybase1.BlockStatus, error)
 
 	// Put stores the (encrypted) block data under the given ID
 	// and context on the server, along with the server half of

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -105,20 +105,20 @@ func (mr *MockBlockOpsMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockOps)(nil).Get), arg0, arg1, arg2, arg3, arg4)
 }
 
-// GetEncodedSize mocks base method
-func (m *MockBlockOps) GetEncodedSize(arg0 context.Context, arg1 libkey.KeyMetadata, arg2 data.BlockPointer) (uint32, keybase1.BlockStatus, error) {
+// GetEncodedSizes mocks base method
+func (m *MockBlockOps) GetEncodedSizes(arg0 context.Context, arg1 libkey.KeyMetadata, arg2 []data.BlockPointer) ([]uint32, []keybase1.BlockStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEncodedSize", arg0, arg1, arg2)
-	ret0, _ := ret[0].(uint32)
-	ret1, _ := ret[1].(keybase1.BlockStatus)
+	ret := m.ctrl.Call(m, "GetEncodedSizes", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]uint32)
+	ret1, _ := ret[1].([]keybase1.BlockStatus)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetEncodedSize indicates an expected call of GetEncodedSize
-func (mr *MockBlockOpsMockRecorder) GetEncodedSize(arg0, arg1, arg2 interface{}) *gomock.Call {
+// GetEncodedSizes indicates an expected call of GetEncodedSizes
+func (mr *MockBlockOpsMockRecorder) GetEncodedSizes(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSize", reflect.TypeOf((*MockBlockOps)(nil).GetEncodedSize), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSizes", reflect.TypeOf((*MockBlockOps)(nil).GetEncodedSizes), arg0, arg1, arg2)
 }
 
 // GetLiveCount mocks base method
@@ -262,20 +262,20 @@ func (mr *MockBlockServerMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockServer)(nil).Get), arg0, arg1, arg2, arg3, arg4)
 }
 
-// GetEncodedSize mocks base method
-func (m *MockBlockServer) GetEncodedSize(arg0 context.Context, arg1 tlf.ID, arg2 kbfsblock.ID, arg3 kbfsblock.Context) (uint32, keybase1.BlockStatus, error) {
+// GetEncodedSizes mocks base method
+func (m *MockBlockServer) GetEncodedSizes(arg0 context.Context, arg1 tlf.ID, arg2 []kbfsblock.ID, arg3 []kbfsblock.Context) ([]uint32, []keybase1.BlockStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEncodedSize", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(uint32)
-	ret1, _ := ret[1].(keybase1.BlockStatus)
+	ret := m.ctrl.Call(m, "GetEncodedSizes", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]uint32)
+	ret1, _ := ret[1].([]keybase1.BlockStatus)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetEncodedSize indicates an expected call of GetEncodedSize
-func (mr *MockBlockServerMockRecorder) GetEncodedSize(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// GetEncodedSizes indicates an expected call of GetEncodedSizes
+func (mr *MockBlockServerMockRecorder) GetEncodedSizes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSize", reflect.TypeOf((*MockBlockServer)(nil).GetEncodedSize), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSizes", reflect.TypeOf((*MockBlockServer)(nil).GetEncodedSizes), arg0, arg1, arg2, arg3)
 }
 
 // GetLiveBlockReferences mocks base method


### PR DESCRIPTION
This makes it possible to get sizes for a bunch of blocks in one RPC (in this PR, I've set it to 20 per RPC, but happy to change that if anyone has better suggestions).  This helps especially when removing (or renaming over) large files where the blocks aren't in the local cache; without this, `SyncAll` would end up blocking on all the individual RPCs.  They were being sent concurrently (50 at a time) but this multiplies that concurrency by the chunk size.

Issue: HOTPOT-1995