### PR TITLE
Hide join/leave snippets

### DIFF
--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -787,8 +787,7 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 		// Fetch max messages unboxed, using either a custom function or through
 		// the conversation source configured in the global context
 		var summaries []chat1.MessageSummary
-		snippetSummary, err := utils.PickLatestMessageSummary(conversationRemote,
-			append(append([]chat1.MessageType{}, chat1.VisibleChatMessageTypes()...), chat1.MessageType_DELETEHISTORY))
+		snippetSummary, err := utils.PickLatestMessageSummary(conversationRemote, chat1.SnippetChatMessageTypes())
 		if err == nil {
 			summaries = append(summaries, snippetSummary)
 		}
@@ -851,12 +850,12 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 	var maxValidID chat1.MessageID
 	s.Debug(ctx, "localizing %d max msgs", len(maxMsgs))
 	for _, mm := range maxMsgs {
-		if mm.IsValid() && (mm.IsVisible() || mm.GetMessageType() == chat1.MessageType_DELETEHISTORY) {
-			if conversationLocal.Info.SnippetMsg == nil ||
-				conversationLocal.Info.SnippetMsg.GetMessageID() < mm.GetMessageID() {
-				conversationLocal.Info.SnippetMsg = new(chat1.MessageUnboxed)
-				*conversationLocal.Info.SnippetMsg = mm
-			}
+		if mm.IsValid() &&
+			utils.IsSnippetChatMessageType(mm.GetMessageType()) &&
+			(conversationLocal.Info.SnippetMsg == nil ||
+				conversationLocal.Info.SnippetMsg.GetMessageID() < mm.GetMessageID()) {
+			conversationLocal.Info.SnippetMsg = new(chat1.MessageUnboxed)
+			*conversationLocal.Info.SnippetMsg = mm
 		}
 		if mm.IsValid() {
 			body := mm.Valid().MessageBody

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -948,10 +948,6 @@ func GetConvMtime(rc types.RemoteConversation) (res gregor1.Time) {
 	conv := rc.Conv
 	var summaries []chat1.MessageSummary
 	for _, typ := range chat1.VisibleChatMessageTypes() {
-		switch typ {
-		case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
-			continue
-		}
 		summary, err := conv.GetMaxMessage(typ)
 		if err == nil {
 			summaries = append(summaries, summary)

--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -440,6 +440,10 @@ func IsVisibleChatMessageType(messageType chat1.MessageType) bool {
 	return checkMessageTypeQual(messageType, chat1.VisibleChatMessageTypes())
 }
 
+func IsSnippetChatMessageType(messageType chat1.MessageType) bool {
+	return checkMessageTypeQual(messageType, chat1.SnippetChatMessageTypes())
+}
+
 func IsBadgeableMessageType(messageType chat1.MessageType) bool {
 	return checkMessageTypeQual(messageType, chat1.BadgeableMessageTypes())
 }
@@ -944,6 +948,10 @@ func GetConvMtime(rc types.RemoteConversation) (res gregor1.Time) {
 	conv := rc.Conv
 	var summaries []chat1.MessageSummary
 	for _, typ := range chat1.VisibleChatMessageTypes() {
+		switch typ {
+		case chat1.MessageType_JOIN, chat1.MessageType_LEAVE:
+			continue
+		}
 		summary, err := conv.GetMaxMessage(typ)
 		if err == nil {
 			summaries = append(summaries, summary)

--- a/go/protocol/chat1/extras.go
+++ b/go/protocol/chat1/extras.go
@@ -272,6 +272,23 @@ func NonEmptyConvMessageTypes() []MessageType {
 	return badgeableMessageTypes
 }
 
+var snippetMessageTypes = []MessageType{
+	MessageType_TEXT,
+	MessageType_ATTACHMENT,
+	MessageType_SYSTEM,
+	MessageType_DELETEHISTORY,
+	MessageType_SENDPAYMENT,
+	MessageType_REQUESTPAYMENT,
+	MessageType_FLIP,
+	MessageType_HEADLINE,
+	MessageType_PIN,
+}
+
+// Snippet chat messages can be the snippet of a conversation.
+func SnippetChatMessageTypes() []MessageType {
+	return snippetMessageTypes
+}
+
 var editableMessageTypesByEdit = []MessageType{
 	MessageType_TEXT,
 }


### PR DESCRIPTION
Snippets for convs where the latest visible message no longer show "whoeverjoined: ", and instead show the previous message. Join and leaves still bump the mtime. Mtime seemed like it would be sketchier to change since it falls back to some other mtime.