### PR TITLE
iPad prettify selected BigTeamChannel row

### DIFF
--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -7,15 +7,15 @@ import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 import {appendNewChatBuilder} from '../../actions/typed-routes'
 import Inbox from '.'
 import {isPhone} from '../../constants/platform'
+import {Props} from '.'
 import {
-  Props,
   RowItemSmall,
   RowItemBig,
   RowItemBigHeader,
   RowItemDivider,
   RowItemTeamBuilder,
   RowItem,
-} from '.'
+} from './row/types.d'
 import * as Kb from '../../common-adapters'
 import {HeaderNewChatButton} from './new-chat-button'
 // @ts-ignore

--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -15,7 +15,7 @@ import {
   RowItemDivider,
   RowItemTeamBuilder,
   RowItem,
-} from './row/types.d'
+} from '../../constants/types/chat2/rowitem'
 import * as Kb from '../../common-adapters'
 import {HeaderNewChatButton} from './new-chat-button'
 // @ts-ignore

--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -8,14 +8,6 @@ import {appendNewChatBuilder} from '../../actions/typed-routes'
 import Inbox from '.'
 import {isPhone} from '../../constants/platform'
 import {Props} from '.'
-import {
-  RowItemSmall,
-  RowItemBig,
-  RowItemBigHeader,
-  RowItemDivider,
-  RowItemTeamBuilder,
-  RowItem,
-} from '../../constants/types/chat2/rowitem'
 import * as Kb from '../../common-adapters'
 import {HeaderNewChatButton} from './new-chat-button'
 // @ts-ignore
@@ -27,7 +19,7 @@ type OwnProps = {
 
 const makeBigRows = (
   bigTeams: Array<RPCChatTypes.UIInboxBigTeamRow>
-): Array<RowItemBig | RowItemBigHeader | RowItemTeamBuilder> => {
+): Array<Types.ChatInboxRowItemBig | Types.ChatInboxRowItemBigHeader | Types.ChatInboxRowItemTeamBuilder> => {
   return bigTeams.map(t => {
     switch (t.state) {
       case RPCChatTypes.UIInboxBigTeamRowTyp.channel:
@@ -54,7 +46,7 @@ const makeBigRows = (
 
 const makeSmallRows = (
   smallTeams: Array<RPCChatTypes.UIInboxSmallTeamRow>
-): Array<RowItemSmall | RowItemTeamBuilder> => {
+): Array<Types.ChatInboxRowItemSmall | Types.ChatInboxRowItemTeamBuilder> => {
   return smallTeams.map(t => {
     return {
       conversationIDKey: Types.stringToConversationIDKey(t.convID),
@@ -167,11 +159,11 @@ const Connected = Container.namedConnect(
     }
     let smallRows = makeSmallRows(smallTeams)
     let bigRows = makeBigRows(bigTeams)
-    const teamBuilder: RowItemTeamBuilder = {type: 'teamBuilder'}
+    const teamBuilder: Types.ChatInboxRowItemTeamBuilder = {type: 'teamBuilder'}
 
     const hasAllSmallTeamConvs =
       (stateProps._inboxLayout?.smallTeams?.length ?? 0) === (stateProps._inboxLayout?.totalSmallTeams ?? 0)
-    const divider: Array<RowItemDivider | RowItemTeamBuilder> =
+    const divider: Array<Types.ChatInboxRowItemDivider | Types.ChatInboxRowItemTeamBuilder> =
       bigRows.length !== 0 || !hasAllSmallTeamConvs
         ? [{showButton: !hasAllSmallTeamConvs || smallTeamsBelowTheFold, type: 'divider'}]
         : []
@@ -186,7 +178,7 @@ const Connected = Container.namedConnect(
         bigRows.push(teamBuilder)
       }
     }
-    const rows: Array<RowItem> = [...smallRows, ...divider, ...bigRows]
+    const rows: Array<Types.ChatInboxRowItem> = [...smallRows, ...divider, ...bigRows]
 
     const unreadIndices: Array<number> = []
     for (let i = rows.length - 1; i >= 0; i--) {

--- a/shared/chat/inbox/index.d.ts
+++ b/shared/chat/inbox/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {ConversationIDKey} from '../../constants/types/chat2'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
-import {RowItem} from '../../constants/types/chat2/rowitem'
+import * as Types from '../../constants/types/chat2'
 
 export type Props = {
   allowShowFloatingButton: boolean
@@ -13,7 +13,7 @@ export type Props = {
   neverLoaded: boolean
   onNewChat: () => void
   onUntrustedInboxVisible: (conversationIDKeys: Array<ConversationIDKey>) => void
-  rows: Array<RowItem>
+  rows: Array<Types.ChatInboxRowItem>
   setInboxNumSmallRows: (rows: number) => void
   smallTeamsExpanded: boolean
   toggleSmallTeamsExpanded: () => void

--- a/shared/chat/inbox/index.d.ts
+++ b/shared/chat/inbox/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {ConversationIDKey} from '../../constants/types/chat2'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
-import {RowItem} from './row/types'
+import {RowItem} from '../../constants/types/chat2/rowitem'
 
 export type Props = {
   allowShowFloatingButton: boolean

--- a/shared/chat/inbox/index.d.ts
+++ b/shared/chat/inbox/index.d.ts
@@ -1,65 +1,7 @@
 import * as React from 'react'
 import {ConversationIDKey} from '../../constants/types/chat2'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
-
-export type RowItemSmall = {
-  type: 'small'
-  teamname: string
-  isTeam: boolean
-  conversationIDKey: ConversationIDKey
-  time: number
-  snippet?: string
-  snippetDecoration: RPCChatTypes.SnippetDecoration
-}
-export type RowItemBigTeamsLabel = {
-  type: 'bigTeamsLabel'
-  isFiltered: boolean
-  isTeam?: boolean
-  teamname?: never
-  conversationIDKey?: never
-  snippet?: string
-  snippetDecoration: RPCChatTypes.SnippetDecoration
-  time?: number
-}
-export type RowItemBigHeader = {
-  type: 'bigHeader'
-  isTeam?: boolean
-  teamname: string
-  teamID: string
-  conversationIDKey?: never
-  snippet?: string
-  snippetDecoration: RPCChatTypes.SnippetDecoration
-  time?: number
-}
-export type RowItemBig = {
-  type: 'big'
-  isTeam?: boolean
-  conversationIDKey: ConversationIDKey
-  teamname: string
-  channelname: string
-  snippet?: string
-  snippetDecoration: RPCChatTypes.SnippetDecoration
-  time?: number
-}
-export type RowItemDivider = {
-  conversationIDKey?: never
-  teamname?: never
-  showButton: boolean
-  type: 'divider'
-}
-export type RowItemTeamBuilder = {
-  conversationIDKey?: never
-  teamname?: never
-  type: 'teamBuilder'
-}
-
-export type RowItem =
-  | RowItemSmall
-  | RowItemBigTeamsLabel
-  | RowItemBigHeader
-  | RowItemBig
-  | RowItemDivider
-  | RowItemTeamBuilder
+import {RowItem} from './row/types'
 
 export type Props = {
   allowShowFloatingButton: boolean

--- a/shared/chat/inbox/index.desktop.tsx
+++ b/shared/chat/inbox/index.desktop.tsx
@@ -2,7 +2,6 @@ import * as Constants from '../../constants/chat2'
 import * as React from 'react'
 import * as Styles from '../../styles'
 import * as T from './index.d'
-import * as T2 from './row/types.d'
 import * as Types from '../../constants/types/chat2'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import BigTeamsDivider from './row/big-teams-divider/container'
@@ -518,7 +517,4 @@ const styles = Styles.styleSheetCreate(
     } as const)
 )
 
-export type RowItem = T2.RowItem
-export type RowItemSmall = T2.RowItemSmall
-export type RowItemBig = T2.RowItemBig
 export default Inbox

--- a/shared/chat/inbox/index.desktop.tsx
+++ b/shared/chat/inbox/index.desktop.tsx
@@ -2,6 +2,7 @@ import * as Constants from '../../constants/chat2'
 import * as React from 'react'
 import * as Styles from '../../styles'
 import * as T from './index.d'
+import * as T2 from './row/types.d'
 import * as Types from '../../constants/types/chat2'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import BigTeamsDivider from './row/big-teams-divider/container'
@@ -517,7 +518,7 @@ const styles = Styles.styleSheetCreate(
     } as const)
 )
 
-export type RowItem = T.RowItem
-export type RowItemSmall = T.RowItemSmall
-export type RowItemBig = T.RowItemBig
+export type RowItem = T2.RowItem
+export type RowItemSmall = T2.RowItemSmall
+export type RowItemBig = T2.RowItemBig
 export default Inbox

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as RowSizes from './row/sizes'
 import * as Styles from '../../styles'
 import * as T from './index.d'
-import * as RowTypes from './row/types.d'
+import {RowItem} from '../../constants/types/chat2/rowitem'
 import * as Types from '../../constants/types/chat2'
 import BigTeamsDivider from './row/big-teams-divider/container'
 import BuildTeam from './row/build-team'
@@ -311,5 +311,3 @@ const styles = Styles.styleSheetCreate(
 )
 
 export default Inbox
-export type RowItem = RowTypes.RowItem
-export type RowItemSmall = RowTypes.RowItemSmall

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import * as RowSizes from './row/sizes'
 import * as Styles from '../../styles'
 import * as T from './index.d'
-import {RowItem} from '../../constants/types/chat2/rowitem'
 import * as Types from '../../constants/types/chat2'
 import BigTeamsDivider from './row/big-teams-divider/container'
 import BuildTeam from './row/build-team'
@@ -15,6 +14,8 @@ import debounce from 'lodash/debounce'
 import {makeRow} from './row'
 import {virtualListMarks} from '../../local-debug'
 import shallowEqual from 'shallowequal'
+
+type RowItem = Types.ChatInboxRowItem
 
 const NoChats = (props: {onNewChat: () => void}) => (
   <Kb.Box2 direction="vertical" gap="small" style={styles.noChatsContainer}>

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as RowSizes from './row/sizes'
 import * as Styles from '../../styles'
 import * as T from './index.d'
+import * as RowTypes from './row/types.d'
 import * as Types from '../../constants/types/chat2'
 import BigTeamsDivider from './row/big-teams-divider/container'
 import BuildTeam from './row/build-team'
@@ -109,7 +110,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
     )
   }
 
-  _askForUnboxing = (rows: Array<T.RowItem>) => {
+  _askForUnboxing = (rows: Array<RowItem>) => {
     const toUnbox = rows.reduce<Array<Types.ConversationIDKey>>((arr, r) => {
       if (r.type === 'small' && r.conversationIDKey) {
         arr.push(r.conversationIDKey)
@@ -176,7 +177,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
     }
   }
 
-  _onScrollUnbox = debounce((data: {viewableItems: Array<{item: T.RowItem}>}) => {
+  _onScrollUnbox = debounce((data: {viewableItems: Array<{item: RowItem}>}) => {
     const {viewableItems} = data
     const item = viewableItems?.[0]
     if (item && Object.prototype.hasOwnProperty.call(item, 'index')) {
@@ -186,11 +187,11 @@ class Inbox extends React.PureComponent<T.Props, State> {
 
   _maxVisible = Math.ceil(Kb.NativeDimensions.get('window').height / 64)
 
-  _setRef = (r: Kb.NativeFlatList<T.RowItem> | null) => {
+  _setRef = (r: Kb.NativeFlatList<RowItem> | null) => {
     this._list = r
   }
 
-  _getItemLayout = (data: null | Array<T.RowItem>, index: number) => {
+  _getItemLayout = (data: null | Array<RowItem>, index: number) => {
     // We cache the divider location so we can divide the list into small and large. We can calculate the small cause they're all
     // the same height. We iterate over the big since that list is small and we don't know the number of channels easily
     const smallHeight = RowSizes.smallRowHeight
@@ -310,5 +311,5 @@ const styles = Styles.styleSheetCreate(
 )
 
 export default Inbox
-export type RowItem = T.RowItem
-export type RowItemSmall = T.RowItemSmall
+export type RowItem = RowTypes.RowItem
+export type RowItemSmall = RowTypes.RowItemSmall

--- a/shared/chat/inbox/index.stories.tsx
+++ b/shared/chat/inbox/index.stories.tsx
@@ -5,19 +5,12 @@ import * as Sb from '../../stories/storybook'
 import {isDarwin} from '../../constants/platform'
 import {isMobile, globalColors, globalMargins} from '../../styles'
 import Inbox from '.'
-import {
-  RowItemSmall,
-  RowItemBigHeader,
-  RowItemBig,
-  RowItemDivider,
-  RowItemTeamBuilder,
-} from '../../constants/types/chat2/rowitem'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 
 /*
  * Rows
  */
-const makeRowItemSmall = (conversationIDKey: string = ''): RowItemSmall => ({
+const makeRowItemSmall = (conversationIDKey: string = ''): Types.ChatInboxRowItemSmall => ({
   type: 'small',
   conversationIDKey: Types.stringToConversationIDKey(conversationIDKey),
   snippetDecoration: RPCChatTypes.SnippetDecoration.none,
@@ -25,7 +18,7 @@ const makeRowItemSmall = (conversationIDKey: string = ''): RowItemSmall => ({
   isTeam: false,
   time: 1569718345,
 })
-const makeRowItemBigHeader = (teamname: string = ''): RowItemBigHeader => ({
+const makeRowItemBigHeader = (teamname: string = ''): Types.ChatInboxRowItemBigHeader => ({
   snippetDecoration: RPCChatTypes.SnippetDecoration.none,
   type: 'bigHeader',
   teamID: '',
@@ -35,15 +28,18 @@ const makeRowItemBigChannel = (
   conversationIDKey: Types.ConversationIDKey,
   teamname: string,
   channelname: string
-): RowItemBig => ({
+): Types.ChatInboxRowItemBig => ({
   type: 'big',
   teamname,
   channelname,
   conversationIDKey: Types.stringToConversationIDKey(conversationIDKey),
   snippetDecoration: RPCChatTypes.SnippetDecoration.none,
 })
-const makeRowItemDivider = (showButton: boolean = false): RowItemDivider => ({type: 'divider', showButton})
-const makeRowItemTeamBuilder = (): RowItemTeamBuilder => ({type: 'teamBuilder'})
+const makeRowItemDivider = (showButton: boolean = false): Types.ChatInboxRowItemDivider => ({
+  type: 'divider',
+  showButton,
+})
+const makeRowItemTeamBuilder = (): Types.ChatInboxRowItemTeamBuilder => ({type: 'teamBuilder'})
 
 /*
  * Component Prop Map

--- a/shared/chat/inbox/index.stories.tsx
+++ b/shared/chat/inbox/index.stories.tsx
@@ -5,7 +5,13 @@ import * as Sb from '../../stories/storybook'
 import {isDarwin} from '../../constants/platform'
 import {isMobile, globalColors, globalMargins} from '../../styles'
 import Inbox from '.'
-import {RowItemSmall, RowItemBigHeader, RowItemBig, RowItemDivider, RowItemTeamBuilder} from './row/types.d'
+import {
+  RowItemSmall,
+  RowItemBigHeader,
+  RowItemBig,
+  RowItemDivider,
+  RowItemTeamBuilder,
+} from '../../constants/types/chat2/rowitem'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 
 /*

--- a/shared/chat/inbox/index.stories.tsx
+++ b/shared/chat/inbox/index.stories.tsx
@@ -5,7 +5,7 @@ import * as Sb from '../../stories/storybook'
 import {isDarwin} from '../../constants/platform'
 import {isMobile, globalColors, globalMargins} from '../../styles'
 import Inbox from '.'
-import {RowItemSmall, RowItemBigHeader, RowItemBig, RowItemDivider, RowItemTeamBuilder} from './index'
+import {RowItemSmall, RowItemBigHeader, RowItemBig, RowItemDivider, RowItemTeamBuilder} from './row/types.d'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 
 /*

--- a/shared/chat/inbox/row/big-team-channel.tsx
+++ b/shared/chat/inbox/row/big-team-channel.tsx
@@ -126,22 +126,22 @@ const styles = Styles.styleSheetCreate(() => ({
       marginLeft: Styles.globalMargins.large,
       paddingRight: Styles.globalMargins.tiny,
     },
-    isPhone: {
-      ...Styles.globalStyles.fillAbsolute,
-      flex: 1,
-      paddingLeft: Styles.globalMargins.small,
-    },
     isElectron: {
       borderBottomLeftRadius: 3,
       borderTopLeftRadius: 3,
       paddingLeft: Styles.globalMargins.tiny,
     },
+    isPhone: {
+      ...Styles.globalStyles.fillAbsolute,
+      flex: 1,
+      paddingLeft: Styles.globalMargins.small,
+    },
     isTablet: {
       borderBottomLeftRadius: 3,
       borderTopLeftRadius: 3,
       height: '80%',
-      paddingLeft: Styles.globalMargins.tiny,
       marginLeft: 48,
+      paddingLeft: Styles.globalMargins.tiny,
     },
   }),
   channelHash: {color: Styles.globalColors.black_20},

--- a/shared/chat/inbox/row/big-team-channel.tsx
+++ b/shared/chat/inbox/row/big-team-channel.tsx
@@ -62,7 +62,7 @@ const BigTeamChannel = (props: Props) => {
         <Kb.Box2
           className="hover_background_color_blueGreyDark"
           direction="horizontal"
-          fullWidth={!Styles.isMobile}
+          fullWidth={!Styles.isPhone}
           style={Styles.collapseStyles([
             styles.channelBackground,
             isSelected && styles.selectedChannelBackground,
@@ -97,7 +97,7 @@ const BigTeamChannel = (props: Props) => {
               color={isSelected ? Styles.globalColors.white : Styles.globalColors.black_20}
               style={styles.muted}
               type={
-                Styles.isMobile ? (isSelected ? 'icon-shh-active-26-21' : 'icon-shh-26-21') : 'iconfont-shh'
+                Styles.isPhone ? (isSelected ? 'icon-shh-active-26-21' : 'icon-shh-26-21') : 'iconfont-shh'
               }
             />
           )}
@@ -126,15 +126,20 @@ const styles = Styles.styleSheetCreate(() => ({
       marginLeft: Styles.globalMargins.large,
       paddingRight: Styles.globalMargins.tiny,
     },
+    isPhone: {
+      ...Styles.globalStyles.fillAbsolute,
+      flex: 1,
+      paddingLeft: Styles.globalMargins.small,
+    },
     isElectron: {
       borderBottomLeftRadius: 3,
       borderTopLeftRadius: 3,
       paddingLeft: Styles.globalMargins.tiny,
     },
-    isMobile: {
-      ...Styles.globalStyles.fillAbsolute,
-      flex: 1,
-      paddingLeft: Styles.globalMargins.small,
+    isTablet: {
+      borderBottomLeftRadius: 3,
+      borderTopLeftRadius: 3,
+      paddingLeft: Styles.globalMargins.tiny,
     },
   }),
   channelHash: {color: Styles.globalColors.black_20},

--- a/shared/chat/inbox/row/big-team-channel.tsx
+++ b/shared/chat/inbox/row/big-team-channel.tsx
@@ -58,7 +58,7 @@ const BigTeamChannel = (props: Props) => {
 
   return (
     <Kb.ClickableBox onClick={onSelectConversation} style={styles.container}>
-      <Kb.Box style={styles.rowContainer}>
+      <Kb.Box2 direction="horizontal" fullHeight={true} style={styles.rowContainer}>
         <Kb.Box2
           className="hover_background_color_blueGreyDark"
           direction="horizontal"
@@ -113,7 +113,7 @@ const BigTeamChannel = (props: Props) => {
             {hasBadge && <Kb.Box style={styles.unread} />}
           </Kb.Box>
         </Kb.Box2>
-      </Kb.Box>
+      </Kb.Box2>
     </Kb.ClickableBox>
   )
 }
@@ -139,7 +139,9 @@ const styles = Styles.styleSheetCreate(() => ({
     isTablet: {
       borderBottomLeftRadius: 3,
       borderTopLeftRadius: 3,
+      height: '80%',
       paddingLeft: Styles.globalMargins.tiny,
+      marginLeft: 48,
     },
   }),
   channelHash: {color: Styles.globalColors.black_20},
@@ -159,13 +161,12 @@ const styles = Styles.styleSheetCreate(() => ({
   muted: {marginLeft: Styles.globalMargins.xtiny},
   rowContainer: Styles.platformStyles({
     common: {
-      ...Styles.globalStyles.flexBoxRow,
       alignItems: 'stretch',
-      height: '100%',
       paddingLeft: Styles.globalMargins.tiny,
       paddingRight: 0,
     },
     isElectron: Styles.desktopStyles.clickable,
+    isTablet: {alignItems: 'center'},
   }),
   selectedChannelBackground: {backgroundColor: Styles.globalColors.blue},
   textError: {color: Styles.globalColors.redDark},

--- a/shared/chat/inbox/row/sizes.tsx
+++ b/shared/chat/inbox/row/sizes.tsx
@@ -1,6 +1,7 @@
 // In order for the inbox rows to be calculated quickly we use fixed sizes for each type so
 // in order for the list and the rows to ensure they're the same size we keep the sizes here
 import {isMobile} from '../../../styles'
+import {RowType} from './types'
 
 export const smallRowHeight = isMobile ? 64 : 56
 export const bigRowHeight = isMobile ? 40 : 24
@@ -16,20 +17,22 @@ export const dividerHeight = (showingButton: boolean) => {
   }
 }
 
-type rowType = 'bigTeamsLabel' | 'bigHeader' | 'big' | 'small' | 'divider'
-
-export const getRowHeight = (type: rowType, showingDividerButton: boolean) => {
-  switch (type) {
-    case 'bigTeamsLabel':
-      return bigHeaderHeight
-    case 'bigHeader':
-      return bigHeaderHeight
-    case 'big':
-      return bigRowHeight
-    case 'small':
-      return smallRowHeight
-    case 'divider':
-      return dividerHeight(showingDividerButton)
+export const getRowHeight = (type: RowType, showingDividerButton: boolean) => {
+  const exhaustive = (type: RowType, showingDividerButton: boolean) => {
+    switch (type) {
+      case 'bigTeamsLabel':
+        return bigHeaderHeight
+      case 'bigHeader':
+        return bigHeaderHeight
+      case 'big':
+        return bigRowHeight
+      case 'small':
+        return smallRowHeight
+      case 'divider':
+        return dividerHeight(showingDividerButton)
+      case 'teamBuilder':
+        return 0
+    }
   }
-  return 0
+  return exhaustive(type, showingDividerButton) ?? 0
 }

--- a/shared/chat/inbox/row/sizes.tsx
+++ b/shared/chat/inbox/row/sizes.tsx
@@ -1,7 +1,7 @@
 // In order for the inbox rows to be calculated quickly we use fixed sizes for each type so
 // in order for the list and the rows to ensure they're the same size we keep the sizes here
 import {isMobile} from '../../../styles'
-import {RowType} from './types'
+import {RowType} from '../../../constants/types/chat2/rowitem'
 
 export const smallRowHeight = isMobile ? 64 : 56
 export const bigRowHeight = isMobile ? 40 : 24

--- a/shared/chat/inbox/row/sizes.tsx
+++ b/shared/chat/inbox/row/sizes.tsx
@@ -16,11 +16,12 @@ export const dividerHeight = (showingButton: boolean) => {
   }
 }
 
-export const getRowHeight = (type: string, showingDividerButton: boolean) => {
-  if (type === 'bigTeamsLabel') {
-    return bigHeaderHeight
-  }
+type rowType = 'bigTeamsLabel' | 'bigHeader' | 'big' | 'small' | 'divider'
+
+export const getRowHeight = (type: rowType, showingDividerButton: boolean) => {
   switch (type) {
+    case 'bigTeamsLabel':
+      return bigHeaderHeight
     case 'bigHeader':
       return bigHeaderHeight
     case 'big':

--- a/shared/chat/inbox/row/sizes.tsx
+++ b/shared/chat/inbox/row/sizes.tsx
@@ -1,7 +1,7 @@
 // In order for the inbox rows to be calculated quickly we use fixed sizes for each type so
 // in order for the list and the rows to ensure they're the same size we keep the sizes here
 import {isMobile} from '../../../styles'
-import {RowType} from '../../../constants/types/chat2/rowitem'
+import * as Types from '../../../constants/types/chat2'
 
 export const smallRowHeight = isMobile ? 64 : 56
 export const bigRowHeight = isMobile ? 40 : 24
@@ -17,8 +17,8 @@ export const dividerHeight = (showingButton: boolean) => {
   }
 }
 
-export const getRowHeight = (type: RowType, showingDividerButton: boolean) => {
-  const exhaustive = (type: RowType, showingDividerButton: boolean) => {
+export const getRowHeight = (type: Types.ChatInboxRowType, showingDividerButton: boolean) => {
+  const exhaustive = (type: Types.ChatInboxRowType, showingDividerButton: boolean) => {
     switch (type) {
       case 'bigTeamsLabel':
         return bigHeaderHeight

--- a/shared/chat/inbox/row/teams-divider/container.tsx
+++ b/shared/chat/inbox/row/teams-divider/container.tsx
@@ -2,7 +2,7 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Container from '../../../../util/container'
 import * as Styles from '../../../../styles'
 import * as Types from '../../../../constants/types/chat2'
-import {RowItem} from '../..'
+import {RowItem} from '../../../../constants/types/chat2/rowitem'
 import {TeamsDivider} from '.'
 import {memoize} from '../../../../util/memoize'
 

--- a/shared/chat/inbox/row/teams-divider/container.tsx
+++ b/shared/chat/inbox/row/teams-divider/container.tsx
@@ -2,20 +2,19 @@ import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Container from '../../../../util/container'
 import * as Styles from '../../../../styles'
 import * as Types from '../../../../constants/types/chat2'
-import {RowItem} from '../../../../constants/types/chat2/rowitem'
 import {TeamsDivider} from '.'
 import {memoize} from '../../../../util/memoize'
 
 type OwnProps = {
   hiddenCountDelta?: number
   smallTeamsExpanded: boolean
-  rows: Array<RowItem>
+  rows: Array<Types.ChatInboxRowItem>
   showButton: boolean
   toggle: () => void
   style?: Styles.StylesCrossPlatform
 }
 
-const getRowCounts = memoize((badges: Types.ConversationCountMap, rows: Array<RowItem>) => {
+const getRowCounts = memoize((badges: Types.ConversationCountMap, rows: Array<Types.ChatInboxRowItem>) => {
   let badgeCount = 0
   let hiddenCount = 0
 

--- a/shared/chat/inbox/row/types.d.ts
+++ b/shared/chat/inbox/row/types.d.ts
@@ -1,0 +1,63 @@
+import {ConversationIDKey} from '../../../constants/types/chat2'
+import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
+
+export type RowItemSmall = {
+  type: 'small'
+  teamname: string
+  isTeam: boolean
+  conversationIDKey: ConversationIDKey
+  time: number
+  snippet?: string
+  snippetDecoration: RPCChatTypes.SnippetDecoration
+}
+export type RowItemBigTeamsLabel = {
+  type: 'bigTeamsLabel'
+  isFiltered: boolean
+  isTeam?: boolean
+  teamname?: never
+  conversationIDKey?: never
+  snippet?: string
+  snippetDecoration: RPCChatTypes.SnippetDecoration
+  time?: number
+}
+export type RowItemBigHeader = {
+  type: 'bigHeader'
+  isTeam?: boolean
+  teamname: string
+  teamID: string
+  conversationIDKey?: never
+  snippet?: string
+  snippetDecoration: RPCChatTypes.SnippetDecoration
+  time?: number
+}
+export type RowItemBig = {
+  type: 'big'
+  isTeam?: boolean
+  conversationIDKey: ConversationIDKey
+  teamname: string
+  channelname: string
+  snippet?: string
+  snippetDecoration: RPCChatTypes.SnippetDecoration
+  time?: number
+}
+export type RowItemDivider = {
+  conversationIDKey?: never
+  teamname?: never
+  showButton: boolean
+  type: 'divider'
+}
+export type RowItemTeamBuilder = {
+  conversationIDKey?: never
+  teamname?: never
+  type: 'teamBuilder'
+}
+
+export type RowItem =
+  | RowItemSmall
+  | RowItemBigTeamsLabel
+  | RowItemBigHeader
+  | RowItemBig
+  | RowItemDivider
+  | RowItemTeamBuilder
+
+export type RowType = RowItem['type']

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -8,6 +8,7 @@ import * as TeamBuildingTypes from '../team-building'
 import * as Team from '../teams'
 import HiddenString from '../../../util/hidden-string'
 import {AmpTracker} from '../../../chat/audio/amptracker'
+import * as ChatInboxRowTypes from './rowitem'
 
 export type QuoteInfo = {
   // Always positive and monotonically increasing.
@@ -330,3 +331,12 @@ export {
   stringToOutboxID,
 } from './message'
 export {stringToConversationIDKey, conversationIDKeyToString} from './common'
+
+export type ChatInboxRowItemSmall = ChatInboxRowTypes.ChatInboxRowItemSmall
+export type ChatInboxRowItemBigTeamsLabel = ChatInboxRowTypes.ChatInboxRowItemBigTeamsLabel
+export type ChatInboxRowItemBigHeader = ChatInboxRowTypes.ChatInboxRowItemBigHeader
+export type ChatInboxRowItemBig = ChatInboxRowTypes.ChatInboxRowItemBig
+export type ChatInboxRowItemDivider = ChatInboxRowTypes.ChatInboxRowItemDivider
+export type ChatInboxRowItemTeamBuilder = ChatInboxRowTypes.ChatInboxRowItemTeamBuilder
+export type ChatInboxRowItem = ChatInboxRowTypes.ChatInboxRowItem
+export type ChatInboxRowType = ChatInboxRowTypes.ChatInboxRowType

--- a/shared/constants/types/chat2/rowitem.tsx
+++ b/shared/constants/types/chat2/rowitem.tsx
@@ -1,9 +1,7 @@
-// Chat inbox row items
-
 import {ConversationIDKey} from '../../../constants/types/chat2'
 import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 
-export type RowItemSmall = {
+export type ChatInboxRowItemSmall = {
   type: 'small'
   teamname: string
   isTeam: boolean
@@ -12,7 +10,7 @@ export type RowItemSmall = {
   snippet?: string
   snippetDecoration: RPCChatTypes.SnippetDecoration
 }
-export type RowItemBigTeamsLabel = {
+export type ChatInboxRowItemBigTeamsLabel = {
   type: 'bigTeamsLabel'
   isFiltered: boolean
   isTeam?: boolean
@@ -22,7 +20,7 @@ export type RowItemBigTeamsLabel = {
   snippetDecoration: RPCChatTypes.SnippetDecoration
   time?: number
 }
-export type RowItemBigHeader = {
+export type ChatInboxRowItemBigHeader = {
   type: 'bigHeader'
   isTeam?: boolean
   teamname: string
@@ -32,7 +30,7 @@ export type RowItemBigHeader = {
   snippetDecoration: RPCChatTypes.SnippetDecoration
   time?: number
 }
-export type RowItemBig = {
+export type ChatInboxRowItemBig = {
   type: 'big'
   isTeam?: boolean
   conversationIDKey: ConversationIDKey
@@ -42,24 +40,24 @@ export type RowItemBig = {
   snippetDecoration: RPCChatTypes.SnippetDecoration
   time?: number
 }
-export type RowItemDivider = {
+export type ChatInboxRowItemDivider = {
   conversationIDKey?: never
   teamname?: never
   showButton: boolean
   type: 'divider'
 }
-export type RowItemTeamBuilder = {
+export type ChatInboxRowItemTeamBuilder = {
   conversationIDKey?: never
   teamname?: never
   type: 'teamBuilder'
 }
 
-export type RowItem =
-  | RowItemSmall
-  | RowItemBigTeamsLabel
-  | RowItemBigHeader
-  | RowItemBig
-  | RowItemDivider
-  | RowItemTeamBuilder
+export type ChatInboxRowItem =
+  | ChatInboxRowItemSmall
+  | ChatInboxRowItemBigTeamsLabel
+  | ChatInboxRowItemBigHeader
+  | ChatInboxRowItemBig
+  | ChatInboxRowItemDivider
+  | ChatInboxRowItemTeamBuilder
 
-export type RowType = RowItem['type']
+export type ChatInboxRowType = ChatInboxRowItem['type']

--- a/shared/constants/types/chat2/rowitem.tsx
+++ b/shared/constants/types/chat2/rowitem.tsx
@@ -1,3 +1,5 @@
+// Chat inbox row items
+
 import {ConversationIDKey} from '../../../constants/types/chat2'
 import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
 


### PR DESCRIPTION
Blue selected BigTeamChannel row is better. Shouldn't visually change non-iPad platforms.

Also move some stuff around to get `getRowHeight` typed.

![image](https://user-images.githubusercontent.com/705646/75588105-f2bdf500-5a45-11ea-86df-219f5893ebad.png)
