### PR TITLE
libkb: codify previous bugs in sigID generation

### DIFF
--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -389,7 +389,7 @@ func (e *Kex2Provisionee) decodeSig(sig []byte) (*decodedSig, error) {
 		return nil, err
 	}
 	res := decodedSig{
-		sigID:  kbcrypto.ComputeSigIDFromSigBody(body),
+		sigID:  kbcrypto.ComputeSigIDFromSigBody(body).ToSigIDLegacy(),
 		linkID: libkb.ComputeLinkID(naclSig.Payload),
 	}
 	res.seqno, err = jw.AtKey("seqno").GetInt()
@@ -565,7 +565,7 @@ func (e *Kex2Provisionee) dhKeyProof(m libkb.MetaContext, dh libkb.GenericKey, e
 		return "", "", err
 	}
 
-	return dhSig, dhSigID, nil
+	return dhSig, dhSigID.ToSigIDLegacy(), nil
 
 }
 

--- a/go/engine/kex2_provisionee.go
+++ b/go/engine/kex2_provisionee.go
@@ -527,7 +527,7 @@ func makeKeyArgs(sigID keybase1.SigID, sig []byte, delType libkb.DelegationType,
 		return nil, err
 	}
 	args := libkb.HTTPArgs{
-		"sig_id_base":     libkb.S{Val: sigID.ToString(false)},
+		"sig_id_base":     libkb.S{Val: sigID.StripSuffix().String()},
 		"sig_id_short":    libkb.S{Val: sigID.ToShortID()},
 		"sig":             libkb.S{Val: string(sig)},
 		"type":            libkb.S{Val: string(delType)},

--- a/go/engine/revoke_sigs_test.go
+++ b/go/engine/revoke_sigs_test.go
@@ -61,7 +61,7 @@ func TestRevokeSig(t *testing.T) {
 		t.Fatal(err)
 	}
 	sigID := realUser.GetSigIDFromSeqno(FirstPGPSigSeqno)
-	revokeEngine = NewRevokeSigsEngine(tc.G, []string{sigID.ToString(true)})
+	revokeEngine = NewRevokeSigsEngine(tc.G, []string{sigID.String()})
 	err = RunEngine2(m, revokeEngine)
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func TestRevokeSig(t *testing.T) {
 	assertNumDevicesAndKeys(tc, u, 2, 5) // The first PGP key is gone.
 
 	// Revoking the same key again should fail.
-	revokeEngine = NewRevokeSigsEngine(tc.G, []string{sigID.ToString(true)})
+	revokeEngine = NewRevokeSigsEngine(tc.G, []string{sigID.String()})
 	err = RunEngine2(m, revokeEngine)
 	if err == nil {
 		t.Fatal("RevokeSigs should have failed, but it didn't")
@@ -77,7 +77,7 @@ func TestRevokeSig(t *testing.T) {
 	assertNumDevicesAndKeys(tc, u, 2, 5) // no change
 
 	// Revoke the second pgp key by prefix:
-	nextID := realUser.GetSigIDFromSeqno(SecondPGPSigSeqno).ToString(true)
+	nextID := realUser.GetSigIDFromSeqno(SecondPGPSigSeqno).String()
 
 	// Short prefix should fail:
 	revokeEngine = NewRevokeSigsEngine(tc.G, []string{nextID[0:4]})

--- a/go/engine/track_proof_test.go
+++ b/go/engine/track_proof_test.go
@@ -534,7 +534,7 @@ func _testTrackProofRooterRevoke(t *testing.T, sigVersion libkb.SigVersion) {
 	// revoke the rooter proof
 	Logout(tc)
 	proofUser.LoginOrBust(tc)
-	revEng := NewRevokeSigsEngine(tc.G, []string{sigID.ToString(true)})
+	revEng := NewRevokeSigsEngine(tc.G, []string{sigID.String()})
 	uis := libkb.UIs{
 		LogUI:    tc.G.UI.GetLogUI(),
 		SecretUI: proofUser.NewSecretUI(),

--- a/go/engine/track_token.go
+++ b/go/engine/track_token.go
@@ -258,7 +258,7 @@ func (e *TrackToken) storeRemoteTrack(m libkb.MetaContext, pubKID keybase1.KID) 
 	}
 
 	httpsArgs := libkb.HTTPArgs{
-		"sig_id_base":  libkb.S{Val: sigID.ToString(false)},
+		"sig_id_base":  libkb.S{Val: sigID.StripSuffix().String()},
 		"sig_id_short": libkb.S{Val: sigID.ToShortID()},
 		"sig":          libkb.S{Val: sig},
 		"uid":          libkb.UIDArg(e.them.GetUID()),

--- a/go/engine/untrack.go
+++ b/go/engine/untrack.go
@@ -218,7 +218,7 @@ func (e *UntrackEngine) storeRemoteUntrack(m libkb.MetaContext, them *libkb.User
 	}
 
 	httpsArgs := libkb.HTTPArgs{
-		"sig_id_base":  libkb.S{Val: sigID.ToString(false)},
+		"sig_id_base":  libkb.S{Val: sigID.StripSuffix().String()},
 		"sig_id_short": libkb.S{Val: sigID.ToShortID()},
 		"sig":          libkb.S{Val: sig},
 		"uid":          libkb.UIDArg(them.GetUID()),

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -170,11 +170,12 @@ func (rc *GenericSocialProofChecker) CheckStatus(mctx libkb.MetaContext, _ libkb
 	mctx = mctx.WithLogTag("PCS")
 	defer mctx.TraceTimed("GenericSocialProofChecker.CheckStatus", func() error { return retErr })()
 
-	_, sigID, err := libkb.OpenSig(rc.proof.GetArmoredSig())
+	_, sigIDBase, err := libkb.OpenSig(rc.proof.GetArmoredSig())
 	if err != nil {
 		return nil, libkb.NewProofError(keybase1.ProofStatus_BAD_SIGNATURE,
 			"Bad signature: %v", err)
 	}
+	sigID := sigIDBase.ToSigIDLegacy()
 
 	remoteUsername := rc.proof.GetRemoteUsername()
 	if err := rc.config.validateRemoteUsername(remoteUsername); err != nil {

--- a/go/kbcrypto/nacl_sig_info.go
+++ b/go/kbcrypto/nacl_sig_info.go
@@ -194,7 +194,7 @@ func NaclVerifyWithPayload(sig string, payloadIn []byte) (nk *NaclSigningKeyPubl
 	return nk, fullBody, nil
 }
 
-func (s NaclSigInfo) SigID() (ret keybase1.SigID, err error) {
+func (s NaclSigInfo) SigID() (ret keybase1.SigIDBase, err error) {
 	var body []byte
 	body, err = EncodePacketToBytes(&s)
 	if err != nil {

--- a/go/kbcrypto/nacl_signing_key.go
+++ b/go/kbcrypto/nacl_signing_key.go
@@ -75,7 +75,7 @@ func (k NaclSigningKeyPrivate) SignInfoV0(msg []byte, public NaclSigningKeyPubli
 	}
 }
 
-func (k NaclSigningKeyPrivate) SignToStringV0(msg []byte, public NaclSigningKeyPublic) (string, keybase1.SigID, error) {
+func (k NaclSigningKeyPrivate) SignToStringV0(msg []byte, public NaclSigningKeyPublic) (string, keybase1.SigIDBase, error) {
 	naclSig := k.SignInfoV0(msg, public)
 
 	body, err := EncodePacketToBytes(&naclSig)

--- a/go/kbcrypto/sig.go
+++ b/go/kbcrypto/sig.go
@@ -9,6 +9,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-func ComputeSigIDFromSigBody(body []byte) keybase1.SigID {
-	return keybase1.SigIDFromBytes(sha256.Sum256(body))
+func ComputeSigIDFromSigBody(body []byte) keybase1.SigIDBase {
+	return keybase1.SigIDBaseFromBytes(sha256.Sum256(body))
 }

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -1244,7 +1244,8 @@ func (c *ChainLink) verifyPayloadV1() error {
 	if err != nil {
 		return err
 	}
-	c.markPayloadVerified(sigid)
+	params := keybase1.SigIDSuffixParametersFromTypeAndVersion(c.unpacked.typ, keybase1.SigVersion(1))
+	c.markPayloadVerified(sigid.ToSigID(params))
 	return nil
 }
 
@@ -1283,10 +1284,10 @@ func (c *ChainLink) PutSigCheckCache(cki *ComputedKeyInfos) {
 }
 
 func (c *ChainLink) VerifySigWithKeyFamily(ckf ComputedKeyFamily) (err error) {
-
 	var key GenericKey
 	var verifyKID keybase1.KID
-	var sigID keybase1.SigID
+	var sigIDBase keybase1.SigIDBase
+	var params keybase1.SigIDSuffixParameters
 
 	if c.IsStubbed() {
 		return ChainLinkError{"cannot verify signature -- none available; is this a stubbed out link?"}
@@ -1315,10 +1316,11 @@ func (c *ChainLink) VerifySigWithKeyFamily(ckf ComputedKeyFamily) (err error) {
 		return err
 	}
 
-	if sigID, err = key.VerifyString(c.G().Log, c.unpacked.sig, sigPayload); err != nil {
+	if sigIDBase, err = key.VerifyString(c.G().Log, c.unpacked.sig, sigPayload); err != nil {
 		return BadSigError{err.Error()}
 	}
-	c.unpacked.sigID = sigID
+	params = keybase1.SigIDSuffixParametersFromTypeAndVersion(c.unpacked.typ, keybase1.SigVersion(c.unpacked.sigVersion))
+	c.unpacked.sigID = sigIDBase.ToSigID(params)
 
 	return nil
 }

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -515,13 +515,13 @@ func (c *ChainLink) GetRevocations() []keybase1.SigID {
 		return nil
 	}
 	if s, err := jsonparserw.GetString(payload, "body", "revoke", "sig_id"); err == nil {
-		if sigID, err := keybase1.SigIDFromString(s, true); err == nil {
+		if sigID, err := keybase1.SigIDFromString(s); err == nil {
 			ret = append(ret, sigID)
 		}
 	}
 
 	_, _ = jsonparserw.ArrayEach(payload, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
-		if s, err := keybase1.SigIDFromString(string(value), true); err == nil {
+		if s, err := keybase1.SigIDFromString(string(value)); err == nil {
 			ret = append(ret, s)
 		}
 	}, "body", "revoke", "sig_ids")
@@ -954,7 +954,7 @@ func (c *ChainLink) unpackFromLocalStorage(m MetaContext, selfUID keybase1.UID, 
 	if err != nil {
 		return err
 	}
-	c.unpacked.sigID, err = keybase1.SigIDFromString(s, true)
+	c.unpacked.sigID, err = keybase1.SigIDFromString(s)
 	if err != nil {
 		return err
 	}
@@ -1543,7 +1543,7 @@ func (c ChainLink) ToMerkleTriple() *MerkleTriple {
 	return &MerkleTriple{
 		Seqno:  c.GetSeqno(),
 		LinkID: c.id,
-		SigID:  c.GetSigID(),
+		SigID:  c.GetSigID().StripSuffix(),
 	}
 }
 

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -202,10 +202,12 @@ func (d *Delegator) Run(m MetaContext) (err error) {
 
 func (d *Delegator) SignAndPost(m MetaContext, proof *ProofMetadataRes) (err error) {
 	d.proof = proof
-	if d.sig, d.sigID, d.linkID, err = SignJSON(proof.J, d.GetSigningKey()); err != nil {
+	var sigIDBase keybase1.SigIDBase
+	if d.sig, sigIDBase, d.linkID, err = SignJSON(proof.J, d.GetSigningKey()); err != nil {
 		m.Debug("| Failure in SignJson()")
 		return err
 	}
+	d.sigID = sigIDBase.ToSigIDLegacy()
 	if err = d.post(m); err != nil {
 		m.Debug("| Failure in post()")
 		return err

--- a/go/libkb/delegatekey.go
+++ b/go/libkb/delegatekey.go
@@ -226,7 +226,7 @@ func (d *Delegator) isHighDelegator() bool {
 
 func (d *Delegator) updateLocalState(linkID LinkID) (err error) {
 	d.Me.SigChainBump(linkID, d.sigID, d.isHighDelegator())
-	d.merkleTriple = MerkleTriple{LinkID: linkID, SigID: d.sigID}
+	d.merkleTriple = MerkleTriple{LinkID: linkID, SigID: d.sigID.StripSuffix()}
 	return d.Me.localDelegateKey(d.NewKey, d.sigID, d.getExistingKID(), d.IsSibkeyOrEldest(), d.IsEldest(), d.getMerkleHashMeta(), keybase1.Seqno(0))
 }
 
@@ -237,7 +237,7 @@ func (d *Delegator) post(m MetaContext) (err error) {
 	}
 
 	hargs := HTTPArgs{
-		"sig_id_base":     S{Val: d.sigID.ToString(false)},
+		"sig_id_base":     S{Val: d.sigID.StripSuffix().String()},
 		"sig_id_short":    S{Val: d.sigID.ToShortID()},
 		"sig":             S{Val: d.sig},
 		"type":            S{Val: string(d.DelegationType)},

--- a/go/libkb/generickey.go
+++ b/go/libkb/generickey.go
@@ -24,16 +24,16 @@ type GenericKey interface {
 
 	// Sign to an ASCII signature (which includes the message
 	// itself) and return it, along with a derived ID.
-	SignToString(msg []byte) (sig string, id keybase1.SigID, err error)
+	SignToString(msg []byte) (sig string, id keybase1.SigIDBase, err error)
 
 	// Verify that the given signature is valid and extracts the
 	// embedded message from it. Also returns the signature ID.
-	VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigID, err error)
+	VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigIDBase, err error)
 
 	// Verify that the given signature is valid and that its
 	// embedded message matches the given one. Also returns the
 	// signature ID.
-	VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error)
+	VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigIDBase, err error)
 
 	// Encrypt to an ASCII armored encryption; optionally include a sender's
 	// (private) key so that we can provably see who sent the message.

--- a/go/libkb/gpg_fallback_test.go
+++ b/go/libkb/gpg_fallback_test.go
@@ -10,7 +10,7 @@ type TestGenericKey struct {
 	GenericKey
 }
 
-func (k *TestGenericKey) SignToString(msg []byte) (sig string, id keybase1.SigID, err error) {
+func (k *TestGenericKey) SignToString(msg []byte) (sig string, id keybase1.SigIDBase, err error) {
 	sig = "TestSignature"
 	return
 }

--- a/go/libkb/gpg_key.go
+++ b/go/libkb/gpg_key.go
@@ -45,11 +45,11 @@ func (g *GPGKey) GetAlgoType() kbcrypto.AlgoType {
 	return kbcrypto.KIDPGPBase
 }
 
-func (g *GPGKey) SignToString(msg []byte) (sig string, id keybase1.SigID, err error) {
+func (g *GPGKey) SignToString(msg []byte) (sig string, id keybase1.SigIDBase, err error) {
 	return g.SignToStringMctx(NewMetaContext(context.TODO(), g.G()), msg)
 }
 
-func (g *GPGKey) SignToStringMctx(mctx MetaContext, msg []byte) (sig string, id keybase1.SigID, err error) {
+func (g *GPGKey) SignToStringMctx(mctx MetaContext, msg []byte) (sig string, id keybase1.SigIDBase, err error) {
 	mctx.Debug("+ GPGKey Signing %s", string(msg))
 	defer func() {
 		mctx.Debug("- GPGKey Signing -> %s", err)
@@ -73,19 +73,18 @@ func (g *GPGKey) SignToStringMctx(mctx MetaContext, msg []byte) (sig string, id 
 	if err != nil {
 		return sig, id, err
 	}
-	id, err = keybase1.SigIDFromSlice(h.Sum(nil))
-	if err != nil {
-		return sig, id, err
-	}
-
+	var hsh [32]byte
+	var tmp = h.Sum(nil)
+	copy(hsh[:], tmp)
+	id = keybase1.SigIDBaseFromBytes(hsh)
 	return sig, id, nil
 }
 
-func (g *GPGKey) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigID, err error) {
+func (g *GPGKey) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigIDBase, err error) {
 	return msg, id, errors.New("VerifyStringAndExtract not implemented")
 }
 
-func (g *GPGKey) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error) {
+func (g *GPGKey) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigIDBase, err error) {
 	return id, errors.New("VerifyString not implemented")
 }
 

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1270,7 +1270,7 @@ func (r *RevokeChainLink) ToDisplayString() string {
 	v := r.GetRevocations()
 	list := make([]string, len(v))
 	for i, s := range v {
-		list[i] = s.ToString(true)
+		list[i] = s.String()
 	}
 	return strings.Join(list, ",")
 }

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -181,7 +181,7 @@ func (u *User) ToTrackingStatementSeqTail() *jsonw.Wrapper {
 		return jsonw.NewNil()
 	}
 	ret := jsonw.NewDictionary()
-	_ = ret.SetKey("sig_id", jsonw.NewString(mul.SigID.ToString(true)))
+	_ = ret.SetKey("sig_id", jsonw.NewString(mul.SigID.ToSigIDLegacy().String()))
 	_ = ret.SetKey("seqno", jsonw.NewInt(int(mul.Seqno)))
 	_ = ret.SetKey("payload_hash", jsonw.NewString(mul.LinkID.String()))
 	return ret
@@ -276,7 +276,7 @@ func (u *User) ToUntrackingStatement(w *jsonw.Wrapper) (err error) {
 func (g *GenericChainLink) BaseToTrackingStatement(state keybase1.ProofState) *jsonw.Wrapper {
 	ret := jsonw.NewDictionary()
 	_ = ret.SetKey("curr", jsonw.NewString(g.id.String()))
-	_ = ret.SetKey("sig_id", jsonw.NewString(g.GetSigID().ToString(true)))
+	_ = ret.SetKey("sig_id", jsonw.NewString(g.GetSigID().String()))
 
 	rkp := jsonw.NewDictionary()
 	_ = ret.SetKey("remote_key_proof", rkp)
@@ -859,7 +859,7 @@ func (u *User) RevokeSigsProof(m MetaContext, key GenericKey, sigIDsToRevoke []k
 	revokeSection := jsonw.NewDictionary()
 	idsArray := jsonw.NewArray(len(sigIDsToRevoke))
 	for i, id := range sigIDsToRevoke {
-		err := idsArray.SetIndex(i, jsonw.NewString(id.ToString(true)))
+		err := idsArray.SetIndex(i, jsonw.NewString(id.String()))
 		if err != nil {
 			return nil, err
 		}
@@ -910,7 +910,7 @@ func (u *User) CryptocurrencySig(m MetaContext, key GenericKey, address string, 
 	}
 	if len(sigToRevoke) > 0 {
 		revokeSection := jsonw.NewDictionary()
-		err := revokeSection.SetKey("sig_id", jsonw.NewString(sigToRevoke.ToString(true /* suffix */)))
+		err := revokeSection.SetKey("sig_id", jsonw.NewString(sigToRevoke.String()))
 		if err != nil {
 			return nil, err
 		}

--- a/go/libkb/merkle_client.go
+++ b/go/libkb/merkle_client.go
@@ -276,9 +276,9 @@ func (mr MerkleRoot) IsNil() bool {
 type SkipSequence []MerkleRootPayload
 
 type MerkleTriple struct {
-	Seqno  keybase1.Seqno `json:"seqno"`
-	LinkID LinkID         `json:"id"`
-	SigID  keybase1.SigID `json:"sigid,omitempty"`
+	Seqno  keybase1.Seqno     `json:"seqno"`
+	LinkID LinkID             `json:"id"`
+	SigID  keybase1.SigIDBase `json:"sigid,omitempty"`
 }
 
 type MerkleUserLeaf struct {
@@ -1457,9 +1457,9 @@ func parseTriple(jw *jsonw.Wrapper) (*MerkleTriple, error) {
 		return nil, err
 	}
 
-	var si keybase1.SigID
+	var si keybase1.SigIDBase
 	if l == 3 {
-		si, err = GetSigID(jw.AtIndex(2), false)
+		si, err = GetSigIDBase(jw.AtIndex(2))
 		if err != nil {
 			return nil, err
 		}

--- a/go/libkb/merkle_tools.go
+++ b/go/libkb/merkle_tools.go
@@ -165,8 +165,8 @@ func FindNextMerkleRootAfterRevoke(m MetaContext, arg keybase1.FindNextMerkleRoo
 	if sigID.IsNil() {
 		return res, MerkleClientError{fmt.Sprintf("unknown seqno in sigchain: %d", arg.Loc.Seqno), merkleErrorBadSeqno}
 	}
-	if !sigID.Eq(leaf.Public.SigID) {
-		return res, MerkleClientError{fmt.Sprintf("sigID sent down by server didn't match: %s != %s", sigID.String(), leaf.Public.SigID.String()), merkleErrorBadSigID}
+	if !sigID.StripSuffix().Eq(leaf.Public.SigID) {
+		return res, MerkleClientError{fmt.Sprintf("sigID sent down by server didn't match: %s != %s", sigID.String(), string(leaf.Public.SigID)), merkleErrorBadSigID}
 	}
 	res.Res = &keybase1.MerkleRootV2{
 		HashMeta: root.HashMeta(),

--- a/go/libkb/naclwrap.go
+++ b/go/libkb/naclwrap.go
@@ -315,11 +315,11 @@ func (k NaclSigningKeyPair) SignV2(msg []byte, prefix kbcrypto.SignaturePrefix) 
 	return k.Private.SignInfoV2(msg, k.Public, prefix)
 }
 
-func (k NaclSigningKeyPair) SignToString(msg []byte) (string, keybase1.SigID, error) {
+func (k NaclSigningKeyPair) SignToString(msg []byte) (string, keybase1.SigIDBase, error) {
 	return k.Private.SignToStringV0(msg, k.Public)
 }
 
-func (k NaclSigningKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigID, err error) {
+func (k NaclSigningKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigIDBase, err error) {
 	var keyInSignature *kbcrypto.NaclSigningKeyPublic
 	var fullSigBody []byte
 	keyInSignature, msg, fullSigBody, err = kbcrypto.NaclVerifyAndExtract(sig)
@@ -338,7 +338,7 @@ func (k NaclSigningKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string
 	return msg, id, nil
 }
 
-func (k NaclSigningKeyPair) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error) {
+func (k NaclSigningKeyPair) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigIDBase, err error) {
 	var keyInSignature *kbcrypto.NaclSigningKeyPublic
 	var fullSigBody []byte
 	keyInSignature, fullSigBody, err = kbcrypto.NaclVerifyWithPayload(sig, msg)
@@ -356,17 +356,17 @@ func (k NaclSigningKeyPair) VerifyString(ctx VerifyContext, sig string, msg []by
 	return id, nil
 }
 
-func (k NaclDHKeyPair) SignToString(msg []byte) (sig string, id keybase1.SigID, err error) {
+func (k NaclDHKeyPair) SignToString(msg []byte) (sig string, id keybase1.SigIDBase, err error) {
 	err = KeyCannotSignError{}
 	return
 }
 
-func (k NaclDHKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigID, err error) {
+func (k NaclDHKeyPair) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigIDBase, err error) {
 	err = KeyCannotVerifyError{}
 	return
 }
 
-func (k NaclDHKeyPair) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error) {
+func (k NaclDHKeyPair) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigIDBase, err error) {
 	err = KeyCannotVerifyError{}
 	return
 }
@@ -488,7 +488,7 @@ func KbOpenSig(armored string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(armored)
 }
 
-func SigExtractKbPayloadAndKID(armored string) (payload []byte, kid keybase1.KID, sigID keybase1.SigID, err error) {
+func SigExtractKbPayloadAndKID(armored string) (payload []byte, kid keybase1.KID, sigID keybase1.SigIDBase, err error) {
 	var byt []byte
 	var sig kbcrypto.NaclSigInfo
 
@@ -505,9 +505,9 @@ func SigExtractKbPayloadAndKID(armored string) (payload []byte, kid keybase1.KID
 	return payload, kid, sigID, nil
 }
 
-func SigAssertKbPayload(armored string, expected []byte) (sigID keybase1.SigID, err error) {
+func SigAssertKbPayload(armored string, expected []byte) (sigID keybase1.SigIDBase, err error) {
 	var payload []byte
-	nilSigID := keybase1.SigID("")
+	nilSigID := keybase1.SigIDBase("")
 	payload, _, sigID, err = SigExtractKbPayloadAndKID(armored)
 	if err != nil {
 		return nilSigID, err

--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -766,14 +766,14 @@ func (k *PGPKeyBundle) CheckFingerprint(fp *PGPFingerprint) error {
 	return nil
 }
 
-func (k *PGPKeyBundle) SignToString(msg []byte) (sig string, id keybase1.SigID, err error) {
+func (k *PGPKeyBundle) SignToString(msg []byte) (sig string, id keybase1.SigIDBase, err error) {
 	if sig, id, err = SimpleSign(msg, *k); err != nil && k.GPGFallbackKey != nil {
 		return k.GPGFallbackKey.SignToString(msg)
 	}
 	return
 }
 
-func (k PGPKeyBundle) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigID, err error) {
+func (k PGPKeyBundle) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg []byte, id keybase1.SigIDBase, err error) {
 	var ps *ParsedSig
 	if ps, err = PGPOpenSig(sig); err != nil {
 		return
@@ -787,7 +787,7 @@ func (k PGPKeyBundle) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg
 	return
 }
 
-func (k PGPKeyBundle) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigID, err error) {
+func (k PGPKeyBundle) VerifyString(ctx VerifyContext, sig string, msg []byte) (id keybase1.SigIDBase, err error) {
 	extractedMsg, resID, err := k.VerifyStringAndExtract(ctx, sig)
 	if err != nil {
 		return

--- a/go/libkb/post.go
+++ b/go/libkb/post.go
@@ -34,7 +34,7 @@ type PostProofArg struct {
 
 func PostProof(m MetaContext, arg PostProofArg) (*PostProofRes, error) {
 	hargs := HTTPArgs{
-		"sig_id_base":     S{arg.SigID.ToString(false)},
+		"sig_id_base":     S{arg.SigID.StripSuffix().String()},
 		"sig_id_short":    S{arg.SigID.ToShortID()},
 		"sig":             S{arg.Sig},
 		"is_remote_proof": B{true},
@@ -165,7 +165,7 @@ func checkPostedAPICall(mctx MetaContext, sigID keybase1.SigID) (found bool, sta
 		Endpoint:    "sig/posted",
 		SessionType: APISessionTypeREQUIRED,
 		Args: HTTPArgs{
-			"sig_id": S{sigID.ToString(true)},
+			"sig_id": S{sigID.String()},
 		},
 	})
 	if e2 != nil {

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -217,7 +217,7 @@ func (pc *ProofCache) Get(sid keybase1.SigID, pvlHash keybase1.MerkleStoreKitHas
 }
 
 func (pc *ProofCache) dbKey(sid keybase1.SigID) (DbKey, string) {
-	sidstr := sid.ToString(true)
+	sidstr := sid.String()
 	key := DbKey{Typ: DBProofCheck, Key: sidstr}
 	return key, sidstr
 }

--- a/go/libkb/sig.go
+++ b/go/libkb/sig.go
@@ -49,7 +49,7 @@ func PGPOpenSig(armored string) (ps *ParsedSig, err error) {
 // OpenSig takes an armored PGP or Keybase signature and opens
 // the armor.  It will return the body of the signature, the
 // sigID of the body, or an error if it didn't work out.
-func OpenSig(armored string) (ret []byte, id keybase1.SigID, err error) {
+func OpenSig(armored string) (ret []byte, id keybase1.SigIDBase, err error) {
 	if isPGPBundle(armored) {
 		var ps *ParsedSig
 		if ps, err = PGPOpenSig(armored); err == nil {
@@ -67,7 +67,7 @@ func OpenSig(armored string) (ret []byte, id keybase1.SigID, err error) {
 // SigExtractPayloadAndKID extracts the payload and KID of the key that
 // was supposedly used to sign this message. A KID will only be returned
 // for KB messages, and not for PGP messages
-func SigExtractPayloadAndKID(armored string) (payload []byte, kid keybase1.KID, sigID keybase1.SigID, err error) {
+func SigExtractPayloadAndKID(armored string) (payload []byte, kid keybase1.KID, sigID keybase1.SigIDBase, err error) {
 	if isPGPBundle(armored) {
 		payload, sigID, err = SigExtractPGPPayload(armored)
 	} else {
@@ -76,14 +76,14 @@ func SigExtractPayloadAndKID(armored string) (payload []byte, kid keybase1.KID, 
 	return payload, kid, sigID, err
 }
 
-func SigAssertPayload(armored string, expected []byte) (sigID keybase1.SigID, err error) {
+func SigAssertPayload(armored string, expected []byte) (sigID keybase1.SigIDBase, err error) {
 	if isPGPBundle(armored) {
 		return SigAssertPGPPayload(armored, expected)
 	}
 	return SigAssertKbPayload(armored, expected)
 }
 
-func SigAssertPGPPayload(armored string, expected []byte) (sigID keybase1.SigID, err error) {
+func SigAssertPGPPayload(armored string, expected []byte) (sigID keybase1.SigIDBase, err error) {
 	var ps *ParsedSig
 	ps, err = PGPOpenSig(armored)
 	if err != nil {
@@ -97,7 +97,7 @@ func SigAssertPGPPayload(armored string, expected []byte) (sigID keybase1.SigID,
 	return
 }
 
-func SigExtractPGPPayload(armored string) (payload []byte, sigID keybase1.SigID, err error) {
+func SigExtractPGPPayload(armored string) (payload []byte, sigID keybase1.SigIDBase, err error) {
 	var ps *ParsedSig
 	ps, err = PGPOpenSig(armored)
 	if err != nil {
@@ -177,7 +177,7 @@ func (ps *ParsedSig) Verify(k PGPKeyBundle) (err error) {
 	return nil
 }
 
-func (ps *ParsedSig) ID() keybase1.SigID {
+func (ps *ParsedSig) ID() keybase1.SigIDBase {
 	return kbcrypto.ComputeSigIDFromSigBody(ps.SigBody)
 }
 

--- a/go/libkb/sig.go
+++ b/go/libkb/sig.go
@@ -17,12 +17,20 @@ import (
 	jsonw "github.com/keybase/go-jsonw"
 )
 
-func GetSigID(w *jsonw.Wrapper, suffix bool) (keybase1.SigID, error) {
+func GetSigID(w *jsonw.Wrapper) (keybase1.SigID, error) {
 	s, err := w.GetString()
 	if err != nil {
 		return "", err
 	}
-	return keybase1.SigIDFromString(s, suffix)
+	return keybase1.SigIDFromString(s)
+}
+
+func GetSigIDBase(w *jsonw.Wrapper) (keybase1.SigIDBase, error) {
+	s, err := w.GetString()
+	if err != nil {
+		return "", err
+	}
+	return keybase1.SigIDBaseFromString(s)
 }
 
 type ParsedSig struct {

--- a/go/libkb/sig_hints.go
+++ b/go/libkb/sig_hints.go
@@ -30,7 +30,7 @@ func NewSigHint(jw *jsonw.Wrapper) (sh *SigHint, err error) {
 		return nil, nil
 	}
 	sh = &SigHint{}
-	sh.sigID, err = GetSigID(jw.AtKey("sig_id"), true)
+	sh.sigID, err = GetSigID(jw.AtKey("sig_id"))
 	sh.remoteID, _ = jw.AtKey("remote_id").GetString()
 	sh.apiURL, _ = jw.AtKey("api_url").GetString()
 	sh.humanURL, _ = jw.AtKey("human_url").GetString()
@@ -52,7 +52,7 @@ func NewVerifiedSigHint(sigID keybase1.SigID, remoteID, apiURL, humanURL, checkT
 
 func (sh SigHint) MarshalToJSON() *jsonw.Wrapper {
 	ret := jsonw.NewDictionary()
-	_ = ret.SetKey("sig_id", jsonw.NewString(sh.sigID.ToString(true)))
+	_ = ret.SetKey("sig_id", jsonw.NewString(sh.sigID.String()))
 	_ = ret.SetKey("remote_id", jsonw.NewString(sh.remoteID))
 	_ = ret.SetKey("api_url", jsonw.NewString(sh.apiURL))
 	_ = ret.SetKey("human_url", jsonw.NewString(sh.humanURL))

--- a/go/libkb/sign.go
+++ b/go/libkb/sign.go
@@ -17,7 +17,7 @@ import (
 
 // SimpleSign signs the given data stream, outputs an armored string which is
 // the attached signature of the input data
-func SimpleSign(payload []byte, key PGPKeyBundle) (out string, id keybase1.SigID, err error) {
+func SimpleSign(payload []byte, key PGPKeyBundle) (out string, id keybase1.SigIDBase, err error) {
 	var outb bytes.Buffer
 	var in io.WriteCloser
 	var h HashSummer
@@ -35,7 +35,7 @@ func SimpleSign(payload []byte, key PGPKeyBundle) (out string, id keybase1.SigID
 		return
 	}
 	out = outb.String()
-	if id, err = keybase1.SigIDFromSlice(h()); err != nil {
+	if id, err = keybase1.SigIDBaseFromSlice(h()); err != nil {
 		return
 	}
 	return

--- a/go/libkb/user.go
+++ b/go/libkb/user.go
@@ -728,7 +728,7 @@ func (u *User) localDelegatePerUserKey(perUserKey keybase1.PerUserKey) error {
 // in order to set the new high skip pointer to the delegator's link, so subsequent
 // keys in the multikey will supply the correct high skip.
 func (u *User) SigChainBump(linkID LinkID, sigID keybase1.SigID, isHighDelegator bool) {
-	u.SigChainBumpMT(MerkleTriple{LinkID: linkID, SigID: sigID}, isHighDelegator)
+	u.SigChainBumpMT(MerkleTriple{LinkID: linkID, SigID: sigID.StripSuffix()}, isHighDelegator)
 }
 
 func (u *User) SigChainBumpMT(mt MerkleTriple, isHighDelegator bool) {

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -137,6 +137,10 @@ func HashMetaFromString(s string) (ret HashMeta, err error) {
 	return HashMeta(b), nil
 }
 
+func cieq(s string, t string) bool {
+	return strings.ToLower(s) == strings.ToLower(t)
+}
+
 func KBFSRootHashFromString(s string) (ret KBFSRootHash, err error) {
 	if s == "null" {
 		return nil, nil
@@ -281,7 +285,7 @@ func (k KID) Match(q string, exact bool) bool {
 	}
 
 	if exact {
-		return strings.ToLower(k.String()) == strings.ToLower(q)
+		return cieq(k.String(), q)
 	}
 
 	if strings.HasPrefix(k.String(), strings.ToLower(q)) {
@@ -650,58 +654,35 @@ func (s SigID) ToDisplayString(verbose bool) string {
 	return fmt.Sprintf("%s...", s[0:SigIDQueryMin])
 }
 
-func (s SigID) ToString(suffix bool) string {
-	if len(s) == 0 {
-		return ""
-	}
-	if suffix {
-		return string(s)
-	}
-	return string(s[0 : len(s)-2])
-}
-
 func (s SigID) PrefixMatch(q string, exact bool) bool {
 	if s.IsNil() {
 		return false
 	}
 
 	if exact {
-		return strings.ToLower(s.ToString(true)) == strings.ToLower(q)
+		return cieq(string(s), q)
 	}
 
-	if strings.HasPrefix(s.ToString(true), strings.ToLower(q)) {
+	if strings.HasPrefix(strings.ToLower(string(s)), strings.ToLower(q)) {
 		return true
 	}
 
 	return false
 }
 
-func SigIDFromString(s string, suffix bool) (SigID, error) {
-	blen := SIG_ID_LEN
-	if suffix {
-		blen++
-	}
+func SigIDFromString(s string) (SigID, error) {
+	// Add 1 extra byte for the suffix
+	blen := SIG_ID_LEN + 1
 	if len(s) != hex.EncodedLen(blen) {
-		return "", fmt.Errorf("Invalid SigID string length: %d, expected %d (suffix = %v)", len(s), hex.EncodedLen(blen), suffix)
+		return "", fmt.Errorf("Invalid SigID string length: %d, expected %d", len(s), hex.EncodedLen(blen))
 	}
-	if suffix {
-		return SigID(s), nil
+	s = strings.ToLower(s)
+	// Throw the outcome away, but we're checking that we can decode the value as hex
+	_, err := hex.DecodeString(s)
+	if err != nil {
+		return "", err
 	}
-	return SigID(fmt.Sprintf("%s%02x", s, SIG_ID_SUFFIX)), nil
-}
-
-func SigIDFromBytes(b [SIG_ID_LEN]byte) SigID {
-	s := hex.EncodeToString(b[:])
-	return SigID(fmt.Sprintf("%s%02x", s, SIG_ID_SUFFIX))
-}
-
-func SigIDFromSlice(b []byte) (SigID, error) {
-	if len(b) != SIG_ID_LEN {
-		return "", fmt.Errorf("invalid byte slice for SigID: len == %d, expected %d", len(b), SIG_ID_LEN)
-	}
-	var x [SIG_ID_LEN]byte
-	copy(x[:], b)
-	return SigIDFromBytes(x), nil
+	return SigID(s), nil
 }
 
 func (s SigID) ToBytes() []byte {
@@ -710,6 +691,14 @@ func (s SigID) ToBytes() []byte {
 		return nil
 	}
 	return b[0:SIG_ID_LEN]
+}
+
+func (s SigID) StripSuffix() SigIDBase {
+	l := hex.EncodedLen(SIG_ID_LEN)
+	if len(s) == l {
+		return SigIDBase(string(s))
+	}
+	return SigIDBase(string(s[0:l]))
 }
 
 func (s SigID) Eq(t SigID) bool {
@@ -744,6 +733,10 @@ func (s SigID) ToShortID() string {
 
 type SigIDBase string
 
+func (s SigIDBase) String() string {
+	return string(s)
+}
+
 func SigIDBaseFromBytes(b [SIG_ID_LEN]byte) SigIDBase {
 	s := hex.EncodeToString(b[:])
 	return SigIDBase(s)
@@ -767,7 +760,7 @@ func SigIDBaseFromString(s string) (SigIDBase, error) {
 }
 
 func (s SigIDBase) EqSigID(t SigID) bool {
-	return string(s) == string(t[0:64])
+	return cieq(string(s), string(t[0:64]))
 }
 
 type SigIDSuffixParameters struct {
@@ -810,7 +803,7 @@ func (s SigIDBase) ToSigIDLegacy() SigID {
 }
 
 func (s SigIDBase) Eq(t SigIDBase) bool {
-	return string(s) == string(t)
+	return cieq(string(s), string(t))
 }
 
 func (s SigIDBase) ToBytes() []byte {
@@ -1020,7 +1013,7 @@ func (k *KID) Size() int {
 }
 
 func (s *SigID) UnmarshalJSON(b []byte) error {
-	sigID, err := SigIDFromString(Unquote(b), true)
+	sigID, err := SigIDFromString(Unquote(b))
 	if err != nil {
 		return err
 	}
@@ -1029,7 +1022,7 @@ func (s *SigID) UnmarshalJSON(b []byte) error {
 }
 
 func (s *SigID) MarshalJSON() ([]byte, error) {
-	return Quote(s.ToString(true)), nil
+	return Quote(s.String()), nil
 }
 
 func (f Folder) ToString() string {

--- a/go/pvl/interp.go
+++ b/go/pvl/interp.go
@@ -132,7 +132,7 @@ func checkProofInner(m metaContext, pvlS string, service keybase1.ProofType, inf
 		return perr
 	}
 
-	sigBody, sigID, err := libkb.OpenSig(info.ArmoredSig)
+	sigBody, sigIDBase, err := libkb.OpenSig(info.ArmoredSig)
 	if err != nil {
 		return libkb.NewProofError(keybase1.ProofStatus_BAD_SIGNATURE,
 			"Bad signature: %v", err)
@@ -160,6 +160,8 @@ func checkProofInner(m metaContext, pvlS string, service keybase1.ProofType, inf
 				"Bad protocol in sig: %s", info.Protocol)
 		}
 	}
+
+	sigID := sigIDBase.ToSigIDLegacy()
 
 	mknewstate := func(i int) (scriptState, libkb.ProofError) {
 		state := scriptState{

--- a/go/sigid/sigid.go
+++ b/go/sigid/sigid.go
@@ -65,7 +65,7 @@ func isModernSigIDMaker(clientName string, clientVersionString string) YNM {
 //
 // So code on opposite sides of this bug will generate SigIDs in two
 // different ways.
-func isMaybeModernSigIDMakerModern(sigID keybase1.SigID) bool {
+func isMaybeModernSigIDMakerModern(sigID keybase1.SigIDBase) bool {
 	buf := sigID.ToBytes()
 	if buf == nil {
 		return true
@@ -102,7 +102,7 @@ func isMaybeModernSigIDMakerModern(sigID keybase1.SigID) bool {
 	return true
 }
 
-func ComputeSigBodyAndID(sigInfo *kbcrypto.NaclSigInfo, clientName string, clientVersion string) (body []byte, sigID keybase1.SigID, err error) {
+func ComputeSigBodyAndID(sigInfo *kbcrypto.NaclSigInfo, clientName string, clientVersion string) (body []byte, sigID keybase1.SigIDBase, err error) {
 	isModern := isModernSigIDMaker(clientName, clientVersion)
 	body, err = kbcrypto.EncodePacketToBytes(sigInfo)
 	sigID = kbcrypto.ComputeSigIDFromSigBody(body)

--- a/go/sigid/sigid_test.go
+++ b/go/sigid/sigid_test.go
@@ -21,7 +21,7 @@ func testOne(t *testing.T, sig string, sigID string) {
 	require.NoError(t, err)
 	_, computedSigID, err := ComputeSigBodyAndID(&si, name, version)
 	require.NoError(t, err)
-	require.True(t, expectedSigID.Eq(computedSigID))
+	require.True(t, expectedSigID.Eq(computedSigID.ToSigIDLegacy()))
 }
 
 func TestSignatures(t *testing.T) {
@@ -92,7 +92,7 @@ func TestSignatures(t *testing.T) {
 
 func TestPrefixTable(t *testing.T) {
 	for _, tv := range testVectors {
-		res := isMaybeModernSigIDMakerModern(keybase1.SigID(tv.sigID))
+		res := isMaybeModernSigIDMakerModern(keybase1.SigIDBase(tv.sigID[0:64]))
 		require.Equal(t, res, tv.isModern)
 	}
 }

--- a/go/sigid/sigid_test.go
+++ b/go/sigid/sigid_test.go
@@ -17,7 +17,7 @@ func testOne(t *testing.T, sig string, sigID string) {
 	require.NoError(t, err)
 	version, err := jsonparserw.GetString(payload, "client", "version")
 	require.NoError(t, err)
-	expectedSigID, err := keybase1.SigIDFromString(sigID, true)
+	expectedSigID, err := keybase1.SigIDFromString(sigID)
 	require.NoError(t, err)
 	_, computedSigID, err := ComputeSigBodyAndID(&si, name, version)
 	require.NoError(t, err)


### PR DESCRIPTION
- this is a PR that does largely nothing aside for introduce the possibility of future bugs
- however, it makes our code more correct; the current interaction between client and server
  is that all user sigs (except wallet.stellar) get sigID suffix 0x0f, all team sigs
  get 0x22, and wallet.stellar get 0x22.
- this is enforced in keybase's database via server code
- but the client currently is deriving these sig ID suffixes differently
- it doesn't quite matter since it ignores the suffix for doing comparisons
- but it would be nice if the two agreed internally