### PR TITLE
simplefs: don't follow symlinks when listing or removing

### DIFF
--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -942,7 +942,7 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 				// With listing, we don't know the totals ahead of time,
 				// so just start with a 0 total.
 				k.setProgressTotals(arg.OpID, 0, 0)
-				finalElemFI, err := fs.Stat(finalElem)
+				finalElemFI, err := fs.Lstat(finalElem)
 				if err != nil {
 					return err
 				}
@@ -1023,7 +1023,7 @@ func (k *SimpleFS) listRecursiveToDepth(opID keybase1.OpID,
 		// With listing, we don't know the totals ahead of time,
 		// so just start with a 0 total.
 		k.setProgressTotals(opID, 0, 0)
-		fi, err := fs.Stat(finalElem)
+		fi, err := fs.Lstat(finalElem)
 		if err != nil {
 			return err
 		}
@@ -1492,7 +1492,7 @@ func (k *SimpleFS) doRemove(
 		// recursively delete a TLF.
 		return errors.Errorf("Cannot recursively delete %s", fs.Root())
 	}
-	fi, err := fs.Stat(finalElem)
+	fi, err := fs.Lstat(finalElem)
 	if err != nil {
 		return err
 	}
@@ -1730,7 +1730,7 @@ func (k *SimpleFS) SimpleFSSetStat(
 	if err != nil {
 		return err
 	}
-	fi, err := fs.Stat(finalElem)
+	fi, err := fs.Lstat(finalElem)
 	if err != nil {
 		return err
 	}

--- a/go/kbfs/simplefs/simplefs_test.go
+++ b/go/kbfs/simplefs/simplefs_test.go
@@ -251,6 +251,23 @@ func TestSymlink(t *testing.T) {
 		Link:   badLink,
 	})
 	require.Error(t, err)
+
+	// Regression test for HOTPOT-2007.
+	t.Log("Make sure a symlink can be deleted")
+	opid, err = sfs.SimpleFSMakeOpid(ctx)
+	require.NoError(t, err)
+	err = sfs.SimpleFSRemove(ctx, keybase1.SimpleFSRemoveArg{
+		OpID:      opid,
+		Path:      link,
+		Recursive: true,
+	})
+	require.NoError(t, err)
+	checkPendingOp(
+		ctx, t, sfs, opid, keybase1.AsyncOps_REMOVE, link, keybase1.Path{},
+		true)
+	err = sfs.SimpleFSWait(ctx, opid)
+	require.NoError(t, err)
+	testList(ctx, t, sfs, p, "test1.txt")
 }
 
 func TestList(t *testing.T) {


### PR DESCRIPTION
We want to list/remove the actual symlink, not try to follow it (which would cause failures when the target doesn't exist).

Issue: HOTPOT-2007