### PR TITLE
Fix TestAccessRequestIgnore test

### DIFF
--- a/go/teams/request_test.go
+++ b/go/teams/request_test.go
@@ -84,8 +84,6 @@ func TestAccessRequestAccept(t *testing.T) {
 }
 
 func TestAccessRequestIgnore(t *testing.T) {
-	t.Skip() // Y2K-1455
-
 	tc, owner, u1, _, teamName := memberSetupMultiple(t)
 	defer tc.Cleanup()
 
@@ -94,53 +92,42 @@ func TestAccessRequestIgnore(t *testing.T) {
 	require.NoError(t, err)
 
 	// u1 requests access to the team
-	if err := u1.Login(tc.G); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := RequestAccess(context.Background(), tc.G, teamName); err != nil {
-		t.Fatal(err)
-	}
+	err = u1.Login(tc.G)
+	require.NoError(t, err)
+
+	_, err = RequestAccess(context.Background(), tc.G, teamName)
+	require.NoError(t, err)
+
+	// Change full name
 	fullName, err := libkb.RandString("test", 5)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := kbtest.EditProfile(u1.User.MetaContext(context.Background()), keybase1.ProfileEditArg{
+	require.NoError(t, err)
+	err = kbtest.EditProfile(tc.MetaContext(), keybase1.ProfileEditArg{
 		FullName: fullName,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
 	// owner lists requests, sees u1 request
 	err = tc.Logout()
 	require.NoError(t, err)
-	if err := owner.Login(tc.G); err != nil {
-		t.Fatal(err)
-	}
-	require.NoError(t, tc.G.UIDMapper.ClearUIDFullName(context.Background(), tc.G, u1.User.GetUID()))
+	err = owner.Login(tc.G)
+	require.NoError(t, err)
+
+	// Clear UIDMapper cache because user1 changes full name.
+	err = tc.G.UIDMapper.ClearUIDFullName(context.Background(), tc.G, u1.User.GetUID())
+	require.NoError(t, err)
+
 	reqs, err := ListRequests(context.Background(), tc.G, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(reqs) != 1 {
-		t.Fatalf("num requests: %d, expected 1", len(reqs))
-	}
-	if reqs[0].Name != teamName {
-		t.Errorf("request team name: %q, expected %q", reqs[0].Name, teamName)
-	}
-	if reqs[0].Username != u1.Username {
-		t.Errorf("request username: %q, expected %q", reqs[0].Username, u1.Username)
-	}
-	if !reqs[0].Ctime.Time().After(time.Now().Add(-1 * time.Minute)) {
-		t.Errorf("request ctime %q, expected during last minute", reqs[0].Ctime)
-	}
-	if reqs[0].FullName.String() != fullName {
-		t.Errorf("request full name %q, expected %q", reqs[0].FullName, fullName)
-	}
+	require.NoError(t, err)
+
+	require.Len(t, reqs, 1)
+	require.Equal(t, teamName, reqs[0].Name)
+	require.Equal(t, u1.Username, reqs[0].Username)
+	require.True(t, reqs[0].Ctime.Time().After(time.Now().Add(-1*time.Minute)), "ctime within last minute")
+	require.Equal(t, fullName, reqs[0].FullName.String())
 
 	// owner ignores u1 request
-	if err := IgnoreRequest(context.Background(), tc.G, reqs[0].Name, reqs[0].Username); err != nil {
-		t.Fatal(err)
-	}
+	err = IgnoreRequest(context.Background(), tc.G, reqs[0].Name, reqs[0].Username)
+	require.NoError(t, err)
 
 	// owner lists requests, sees no requests
 	assertNoRequests(tc)
@@ -148,36 +135,27 @@ func TestAccessRequestIgnore(t *testing.T) {
 	// u1 requests access to the team again
 	err = tc.Logout()
 	require.NoError(t, err)
-	if err := u1.Login(tc.G); err != nil {
-		t.Fatal(err)
-	}
+
+	err = u1.Login(tc.G)
+	require.NoError(t, err)
+
 	_, err = RequestAccess(context.Background(), tc.G, teamName)
-	if err == nil {
-		t.Fatal("second RequestAccess success, expected error")
-	}
+	require.Error(t, err)
 	aerr, ok := err.(libkb.AppStatusError)
-	if !ok {
-		t.Fatalf("error %s (%T), expected libkb.AppStatusError", err, err)
-	}
-	if aerr.Code != libkb.SCTeamTarDuplicate {
-		t.Errorf("status code: %d, expected %d", aerr.Code, libkb.SCTeamTarDuplicate)
-	}
+	require.True(t, ok, "error is libkb.AppStatusError")
+	require.Equal(t, libkb.SCTeamTarDuplicate, aerr.Code, "expected status code")
+
 	err = tc.Logout()
 	require.NoError(t, err)
 
 	// owner lists requests, sees no requests
-	if err := owner.Login(tc.G); err != nil {
-		t.Fatal(err)
-	}
+	err = owner.Login(tc.G)
+	require.NoError(t, err)
 	assertNoRequests(tc)
 }
 
 func assertNoRequests(tc libkb.TestContext) {
-	reqs, err := ListRequests(context.Background(), tc.G, nil)
-	if err != nil {
-		tc.T.Fatal(err)
-	}
-	if len(reqs) != 0 {
-		tc.T.Fatalf("num requests: %d, expected 0", len(reqs))
-	}
+	reqs, err := ListRequests(context.Background(), tc.G, nil /* teamName */)
+	require.NoError(tc.T, err)
+	require.Len(tc.T, reqs, 0)
 }

--- a/go/teams/request_test.go
+++ b/go/teams/request_test.go
@@ -98,6 +98,11 @@ func TestAccessRequestIgnore(t *testing.T) {
 	_, err = RequestAccess(context.Background(), tc.G, teamName)
 	require.NoError(t, err)
 
+	// Set no caching mode. If we change our full name and ask UidMapper about
+	// it quickly, we might still be getting the old version because of pubsub
+	// delay.
+	tc.G.UIDMapper.SetTestingNoCachingMode(true)
+
 	// Change full name
 	fullName, err := libkb.RandString("test", 5)
 	require.NoError(t, err)
@@ -110,10 +115,6 @@ func TestAccessRequestIgnore(t *testing.T) {
 	err = tc.Logout()
 	require.NoError(t, err)
 	err = owner.Login(tc.G)
-	require.NoError(t, err)
-
-	// Clear UIDMapper cache because user1 changes full name.
-	err = tc.G.UIDMapper.ClearUIDFullName(context.Background(), tc.G, u1.User.GetUID())
 	require.NoError(t, err)
 
 	reqs, err := ListRequests(context.Background(), tc.G, nil)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -1582,7 +1582,7 @@ func ListRequests(ctx context.Context, g *libkb.GlobalContext, teamName *string)
 	}
 
 	packages, err := g.UIDMapper.MapUIDsToUsernamePackages(ctx, g, requesterUIDs,
-		defaultFullnameFreshness, 10*time.Second, true)
+		defaultFullnameFreshness, 10*time.Second, true /* forceNetworkForFullNames */)
 	if err != nil {
 		g.Log.Debug("TeamsListRequests: failed to run uid mapper: %s", err)
 	}


### PR DESCRIPTION
Actual fix is in the second commit, first commit refactors the test to use `require`.

The cause for this and related uidmapper bugs / flakes is that API servers have uidmapper caches as well. That cache is cleared with `user.identity_change` pubsub message, so when someone does something on one API server, e.g. calls `profile-edit`, all of the API servers should have their uidmapper cache for that uid cleared afterwards.

The issue is if you do the change and then the subsequent uidmapper `user/names` request API too quickly - before the pubsub message propagates - you can still get the old value from server's cache.

You know what they say - one of the hardest problems in computer science is: "".

The real fix here is to make `profile-edit` and similar not return before the pubsub message is consumed by everyone, but that's not feasible right now and could also be error prone in different ways.

Note that `SetTestingNoCachingMode(true)` only affects server cache by passing `no_cache` argument to API server. Client uidmapper cache, freshness system etc. is still in play.

Also note: I removed `ClearUIDFullName` which was the first attempt to fix this problem. Turns out profile edit engine already does that: https://github.com/keybase/client/blob/master/go/engine/profile_edit.go#L40