### PR TITLE
Prevent saltpack file open from firing on mobile

### DIFF
--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -481,7 +481,7 @@ const routeToInitialScreen = (state: Container.TypedState) => {
     }
 
     // A saltpack file open
-    if (state.config.startupFile) {
+    if (state.config.startupFile.stringValue() && Platform.isElectron) {
       logger.info('Saltpack file open after log in')
       return DeeplinksGen.createSaltpackFileOpen({
         path: state.config.startupFile,


### PR DESCRIPTION
Missed checking `stringValue` since `startupFile` went from a string to a HiddenString

Platform checks for isElectron

cc @chrisnojima @mmaxim @cjb 