### PR TITLE
Check role in showTeamByName

### DIFF
--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -19,10 +19,7 @@ import logger from '../logger'
 const handleTeamPageLink = (teamname: string, action: 'add_or_invite' | 'manage_settings' | undefined) => {
   const initialTab = action === 'manage_settings' ? 'settings' : undefined
   const addMembers = action === 'add_or_invite' ? true : undefined
-  return [
-    RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}),
-    TeamsGen.createShowTeamByName({addMembers, initialTab, teamname}),
-  ]
+  return [TeamsGen.createShowTeamByName({addMembers, initialTab, teamname})]
 }
 
 const handleKeybaseLink = (action: DeeplinksGen.HandleKeybaseLinkPayload) => {

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -11,6 +11,7 @@ import * as ChatTypes from '../constants/types/chat2'
 import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Saga from '../util/saga'
+import * as Tabs from '../constants/tabs'
 import * as RouteTreeGen from './route-tree-gen'
 import * as NotificationsGen from './notifications-gen'
 import * as ConfigGen from './config-gen'
@@ -1320,11 +1321,31 @@ async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload, logger: Sa
   let teamID: string
   try {
     teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName: teamname})
-  } catch (e) {
-    logger.info(`showTeamByName: team "${teamname}" cannot be loaded: ${e.toString()}`)
+  } catch (err) {
+    logger.info(`team="${teamname}" cannot be loaded:`, err)
     return null
   }
+
+  if (addMembers) {
+    // Check if we have the right role to be adding members, otherwise don't
+    // show the team builder.
+    try {
+      // Get (hopefully fresh) role map. The app might have just started so it's
+      // not enough to just look in the react store.
+      const map = await RPCTypes.teamsGetTeamRoleMapRpcPromise()
+      const role = map.teams[teamID]?.role ?? map.teams[teamID]?.implicitRole
+      if (role !== RPCTypes.TeamRole.admin && role !== RPCTypes.TeamRole.owner) {
+        logger.info(`ignoring team="${teamname}" with addMember, user is not an admin but role=${role}`)
+        return null
+      }
+    } catch (err) {
+      logger.info(`team="${teamname}" failed to check if user is an admin:`, err)
+      return null
+    }
+  }
+
   return [
+    RouteTreeGen.createSwitchTab({tab: Tabs.teamsTab}),
     RouteTreeGen.createNavigateAppend({
       path: [{props: {initialTab, teamID}, selected: 'team'}],
     }),

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1333,7 +1333,7 @@ async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload, logger: Sa
       // Get (hopefully fresh) role map. The app might have just started so it's
       // not enough to just look in the react store.
       const map = await RPCTypes.teamsGetTeamRoleMapRpcPromise()
-      const role = map.teams[teamID]?.role ?? map.teams[teamID]?.implicitRole
+      const role = map.teams[teamID]?.role || map.teams[teamID]?.implicitRole
       if (role !== RPCTypes.TeamRole.admin && role !== RPCTypes.TeamRole.owner) {
         logger.info(`ignoring team="${teamname}" with addMember, user is not an admin but role=${role}`)
         return null


### PR DESCRIPTION
Check team role in `showTeamByName` when coming from deeplink with addMember=true, like this one: `keybase://team-page/t_658aec3e/add_or_invite`

If we are not an admin or owner of this team, ignore the link altogether.

cc @keybase/y2ksquad @keybase/react-hackers 