### PR TITLE
double selected convo issues

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -614,6 +614,7 @@ type _SelectConversationPayload = {
     | 'teamChat'
     | 'addedToChannel'
     | 'teamMention'
+  readonly skipNav?: boolean
   readonly navKey?: string
 }
 type _SendAudioRecordingPayload = {

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2556,7 +2556,13 @@ const mobileNavigateOnSelect = (
   action: Chat2Gen.SelectConversationPayload,
   logger: Saga.SagaLogger
 ) => {
-  const {conversationIDKey, navKey, reason} = action.payload
+  const {conversationIDKey, navKey, reason, skipNav} = action.payload
+  if (skipNav) {
+    logger.info(
+      `mobileNavigateOnSelect: skipNav passed selected: ${state.chat2.selectedConversation} param: ${conversationIDKey}`
+    )
+    return
+  }
   if (Constants.isValidConversationIDKey(conversationIDKey)) {
     if (reason === 'focused') {
       logger.info(

--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -412,6 +412,10 @@ const routeToInitialScreen2 = (state: Container.TypedState) => {
   if (!state.config.startupDetailsLoaded) {
     return
   }
+  // bail if not bootstrapped
+  if (state.config.daemonHandshakeState !== 'done') {
+    return
+  }
 
   return routeToInitialScreen(state)
 }
@@ -467,6 +471,7 @@ const routeToInitialScreen = (state: Container.TypedState) => {
         ChatGen.createSelectConversation({
           conversationIDKey: state.config.startupConversation,
           reason: state.config.startupWasFromPush ? 'push' : 'savedLastState',
+          skipNav: true,
         }),
       ]
     }

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -43,6 +43,7 @@
         "'addedToChannel'", // just added people to this channel
         "'teamMention'" // from team mention
       ],
+      "skipNav?": "boolean",
       "navKey?": "string"
     },
     "channelSuggestionsTriggered": {


### PR DESCRIPTION
coupe of problems with the current implementation

1. when a new nav came in or bootstrapping was done we'd establish the initial route, but it would let you continue even if bootstrapping wasn't done. This meant it could think you're logged out while establishing the initial screen which means your convo could be lost
1. when disallowing dupes on pushes it internally uses the navigation state which can be racy (its checking before making the action, not disallowing it while the state is reducing) so it'd reset the stack with the inbox+convo, then it'd attempt to see if another convo could be pushed, the nav was 'loading' so it would allow it. To minimize changes i'm making the action to select convo just skipNav (new flag) for now. TODO a better fix soon