### PR TITLE
add note about managed bots error

### DIFF
--- a/go/client/chat_svc_handler.go
+++ b/go/client/chat_svc_handler.go
@@ -1404,6 +1404,8 @@ func (c *chatServiceHandler) getExistingConvs(ctx context.Context, convID chat1.
 		}
 		convs := gilres.Conversations
 		if len(convs) == 0 {
+			// NOTE: don't change this error without also changing the managed-bots repo
+			// https://github.com/keybase/managed-bots/blob/4ed0f563e6f3276a953bd33a00f98a75dc32d102/base/output.go#L75
 			return nil, nil, fmt.Errorf("no conversations matched %q", convID)
 		}
 		return convs, gilres.RateLimits, nil


### PR DESCRIPTION
adds a small comment to prevent strings from getting out of sync with managed-bots