### PR TITLE
cr_chains: avoid `revertRenames` panic

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -3905,7 +3905,10 @@ func (fbo *folderBranchOps) makeEditNotifications(
 
 		// The crChains creation process splits up a rename op into
 		// a delete and a create.  Turn them back into a rename.
-		chains.revertRenames(ops)
+		err = chains.revertRenames(ops)
+		if err != nil {
+			return nil, err
+		}
 
 		ops = pathSortedOps(make([]op, 0, len(ops)))
 		for _, chain := range chains.byMostRecent {

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -859,7 +859,10 @@ func GetChangesBetweenRevisions(
 		}
 		soFar += len(rmd.data.Changes.Ops)
 	}
-	chains.revertRenames(ops)
+	err = chains.revertRenames(ops)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create the change items for each chain.  Use the following
 	// simplifications:


### PR DESCRIPTION
A user hit a panic here, where `newChain` was `nil`.  Their system seemed to be in a generally bad state -- some of the Nodes seemed to be behaving inconsistently.  But the log wasn't big enough to fully debug why; it could be related to other issues we've already fixed.

Just in case this happens again, avoid the panic here by returning an error with more info.

I'm not 100% sure this is a good idea.  It might be better to have the panic to surface the problem sooner rather than paper over it.  For now I'm leaning towards getting rid of it though, to keep the client more stable, since it probably only affects the edit notification history.

Issue: HOTPOT-2029