### PR TITLE
typo in deselect logic

### DIFF
--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -57,7 +57,7 @@ let Conversation = (p: SwitchProps) => {
           dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'focused'}))
         }
       } else {
-        if (!Constants.isSplit && _storeConvoIDKey !== conversationIDKey) {
+        if (!Constants.isSplit && _storeConvoIDKey === conversationIDKey) {
           dispatch(Chat2Gen.createDeselectConversation({ifConversationIDKey: conversationIDKey}))
         }
       }


### PR DESCRIPTION
this port inverted the logic of this nested ternary: https://github.com/keybase/client/commit/ef9121429ade2783601f039875c75a2f8a6bdfb7#diff-e5cbe0a46f0c650e57efe1d68f85b925L120