### PR TITLE
do not init perflog in postinstall

### DIFF
--- a/go/client/cmd_config.go
+++ b/go/client/cmd_config.go
@@ -396,7 +396,7 @@ func NewCmdConfigInfo(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 
 func (v *CmdConfigGet) GetUsage() libkb.Usage {
 	return libkb.Usage{
-		Config: true,
+		Config: !v.Direct,
 		// The root user may use the "config get -d" command to read
 		// config files.
 		AllowRoot: v.Direct,

--- a/go/client/cmd_config.go
+++ b/go/client/cmd_config.go
@@ -396,7 +396,6 @@ func NewCmdConfigInfo(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 
 func (v *CmdConfigGet) GetUsage() libkb.Usage {
 	return libkb.Usage{
-		Config: !v.Direct,
 		// The root user may use the "config get -d" command to read
 		// config files.
 		AllowRoot: v.Direct,

--- a/go/client/cmd_config.go
+++ b/go/client/cmd_config.go
@@ -396,6 +396,7 @@ func NewCmdConfigInfo(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Co
 
 func (v *CmdConfigGet) GetUsage() libkb.Usage {
 	return libkb.Usage{
+		Config: true,
 		// The root user may use the "config get -d" command to read
 		// config files.
 		AllowRoot: v.Direct,

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -359,7 +359,6 @@ func (g *GlobalContext) simulateServiceRestart() {
 // ConfigureLogging should be given non-nil Usage if called by the main
 // service.
 func (g *GlobalContext) ConfigureLogging(usage *Usage) error {
-	g.initPerfLogFile()
 	style := g.Env.GetLogFormat()
 	debug := g.Env.GetDebug()
 
@@ -377,16 +376,26 @@ func (g *GlobalContext) ConfigureLogging(usage *Usage) error {
 	}
 	g.VDL.Configure(g.Env.GetVDebugSetting())
 
-	shouldConfigureGUILog := true
+	// On Linux, the post-install script calls `keybase --use-root-config-file
+	// config get --direct` to figure out if the redirector should be enabled or not.
+	// That command, like all other commands, goes through all these initial steps
+	// like ConfigureLogging before executing the command. On Ubuntu, '$HOME' is *not*
+	// changed to the root's user's HOME when using sudo, which basically means
+	// that `sudo bash -c 'mkdir $HOME/.cache'`, e.g., creates it within the *user's*
+	// home directory with root permissions (unlike Debian, Fedora, Arch, etc.).
+	// So, in this case, we do not configure the log files so as not to mess up
+	// permissions in the user's home directory.
+	shouldInitLogs := true
 	if usage != nil && usage.AllowRoot {
 		isAdmin, _, err := IsSystemAdminUser()
 		if err == nil && isAdmin {
-			shouldConfigureGUILog = false
+			shouldInitLogs = false
 		}
 	}
 
-	if shouldConfigureGUILog {
+	if shouldInitLogs {
 		g.initGUILogFile()
+		g.initPerfLogFile()
 	}
 
 	return nil


### PR DESCRIPTION
I realize this situation is crazy... I will try to fix this at a higher level after the release.