### PR TITLE
remove the startup shortcut from wix

### DIFF
--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -257,7 +257,7 @@ func ToggleAutostart(context Context, on bool, forAutoinstallIgnored bool) error
 
 // This is the old startup info logging. Retain it for now, but it is soon useless.
 // TODO Remove in 2021.
-func deprecatedStartupInfo(logFile *os.File) {
+func cleanupDeprecatedStartupInfo(logFile *os.File) {
 	if appDataDir, err := libkb.AppDataDir(); err != nil {
 		logFile.WriteString("Error getting AppDataDir\n")
 	} else {
@@ -303,7 +303,7 @@ func getVersionAndDrivers(logFile *os.File) {
 	logFile.WriteString("\n")
 
 	// Check whether the service shortcut is still present and not disabled
-	deprecatedStartupInfo(logFile)
+	cleanupDeprecatedStartupInfo(logFile)
 	status, err := autostartStatus()
 	logFile.WriteString(fmt.Sprintf("AutoStart: %v, %v\n", status, err))
 

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -257,7 +257,7 @@ func ToggleAutostart(context Context, on bool, forAutoinstallIgnored bool) error
 
 // This is the old startup info logging. Retain it for now, but it is soon useless.
 // TODO Remove in 2021.
-func cleanupDeprecatedStartupInfo(logFile *os.File) {
+func deprecatedStartupInfo(logFile *os.File) {
 	if appDataDir, err := libkb.AppDataDir(); err != nil {
 		logFile.WriteString("Error getting AppDataDir\n")
 	} else {
@@ -303,7 +303,7 @@ func getVersionAndDrivers(logFile *os.File) {
 	logFile.WriteString("\n")
 
 	// Check whether the service shortcut is still present and not disabled
-	cleanupDeprecatedStartupInfo(logFile)
+	deprecatedStartupInfo(logFile)
 	status, err := autostartStatus()
 	logFile.WriteString(fmt.Sprintf("AutoStart: %v, %v\n", status, err))
 

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -261,8 +261,12 @@ func deprecatedStartupInfo(logFile *os.File) {
 	if appDataDir, err := libkb.AppDataDir(); err != nil {
 		logFile.WriteString("Error getting AppDataDir\n")
 	} else {
-		if exists, err := libkb.FileExists(filepath.Join(appDataDir, "Microsoft\\Windows\\Start Menu\\Programs\\Startup\\KeybaseStartup.lnk")); err == nil && exists == false {
+		autostartLinkPath := filepath.Join(appDataDir, "Microsoft\\Windows\\Start Menu\\Programs\\Startup\\KeybaseStartup.lnk")
+		if exists, err := libkb.FileExists(autostartLinkPath); err == nil && exists == false {
 			logFile.WriteString("  -- Service startup shortcut missing! --\n\n")
+		} else if exists == true {
+			// file exists. remove it because we have a new way of doing this.
+			_ = os.Remove(autostartLinkPath)
 		} else if err != nil {
 			k, err := registry.OpenKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\StartupFolder", registry.QUERY_VALUE|registry.READ)
 			if err != nil {

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -261,12 +261,8 @@ func deprecatedStartupInfo(logFile *os.File) {
 	if appDataDir, err := libkb.AppDataDir(); err != nil {
 		logFile.WriteString("Error getting AppDataDir\n")
 	} else {
-		autostartLinkPath := filepath.Join(appDataDir, "Microsoft\\Windows\\Start Menu\\Programs\\Startup\\KeybaseStartup.lnk")
-		if exists, err := libkb.FileExists(autostartLinkPath); err == nil && exists == false {
+		if exists, err := libkb.FileExists(filepath.Join(appDataDir, "Microsoft\\Windows\\Start Menu\\Programs\\Startup\\KeybaseStartup.lnk")); err == nil && exists == false {
 			logFile.WriteString("  -- Service startup shortcut missing! --\n\n")
-		} else if exists == true {
-			// file exists. remove it because we have a new way of doing this.
-			_ = os.Remove(autostartLinkPath)
 		} else if err != nil {
 			k, err := registry.OpenKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\StartupFolder", registry.QUERY_VALUE|registry.READ)
 			if err != nil {

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -374,7 +374,18 @@ func LsofMount(mountDir string, log Log) ([]CommonLsofResult, error) {
 	return nil, fmt.Errorf("Cannot use lsof on Windows.")
 }
 
+// delete this function and calls to it if present after 2022
+func deleteDeprecatedFileIfPresent() {
+	// this file is no longer how we do things, and if it's present (which it shouldn't be) it could
+	// cause unexpected behavior
+	if appDataDir, err := libkb.AppDataDir(); err != nil {
+		autostartLinkPath := filepath.Join(appDataDir, "Microsoft\\Windows\\Start Menu\\Programs\\Startup\\KeybaseStartup.lnk")
+		_ = os.Remove(autostartLinkPath)
+	}
+}
+
 func GetAutostart(context Context) keybase1.OnLoginStartupStatus {
+	deleteDeprecatedFileIfPresent()
 	status, err := autostartStatus()
 	if err != nil {
 		return keybase1.OnLoginStartupStatus_UNKNOWN

--- a/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
+++ b/packaging/windows/WIXInstallers/KeybaseApps/KeybaseApps.wxs
@@ -21,7 +21,6 @@
       <ComponentGroupRef Id="ProductComponents" />
       <ComponentGroupRef Id="GuiComps" />
       <ComponentRef Id="GUIShortCutComponent" />
-      <ComponentGroupRef Id="StartupShortcuts" />
       <ComponentGroupRef Id="GuiStartMenuTileColors" />
       <ComponentGroupRef Id="BrowserExtensionKbnm" />
       <ComponentGroupRef Id="DokanInstallerComponents" />
@@ -118,20 +117,6 @@
           <RegistryValue Name="prompterexe" Value="1" KeyPath="yes" Type="integer" />
         </RegistryKey>
         <File Id="prompter.exe" Source="$(env.GOPATH)\src\github.com\keybase\go-updater\windows\WpfPrompter\WpfApplication1\bin\Release\prompter.exe" Checksum="yes"/>
-      </Component>
-    </ComponentGroup>
-  </Fragment>
-  <Fragment>
-    <ComponentGroup Id="StartupShortcuts" Directory="StartupFolder">
-      <Component Id="AppShortCutStartUpComponent" Guid="{648c099c-748c-4e54-986a-ebd48e5cc0cb}">
-        <Shortcut Id="AppShortCutStartUp" Name="KeybaseStartup"
-                  Description="Start Keybase at boot"
-                  Target="[INSTALLFOLDER]keybaserq.exe"
-                  Arguments="keybase.exe --log-format=file --log-prefix=&quot;[INSTALLFOLDER]watchdog.&quot; ctl watchdog"
-                  WorkingDirectory="INSTALLFOLDER"/>
-        <RegistryKey Root="HKCU" Key="Software\Keybase\Keybase">
-          <RegistryValue Name="ShortCutStartUp" Type="integer" Value="1" KeyPath="yes"  />
-        </RegistryKey>
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
this was auto-starting all of the non-Gui services. when we changed the way auto-start works (so that it would actually work) this was still hanging around. 