### PR TITLE
Revert "Don't try to follow a deeplink when logged out (#22683)"

### DIFF
--- a/shared/actions/deeplinks.tsx
+++ b/shared/actions/deeplinks.tsx
@@ -114,13 +114,6 @@ const handleKeybaseLink = (action: DeeplinksGen.HandleKeybaseLinkPayload) => {
 }
 
 const handleAppLink = (state: Container.TypedState, action: DeeplinksGen.LinkPayload) => {
-  // If we're not logged in, trying to nav around the app as if we were will
-  // put people on broken screens -- instead just let people log in and retry.
-  if (!state.config.loggedIn) {
-    console.warn('Refusing to follow a deeplink when not logged in yet.')
-    return false
-  }
-
   if (action.payload.link.startsWith('web+stellar:')) {
     return WalletsGen.createValidateSEP7Link({link: action.payload.link})
   } else if (action.payload.link.startsWith('keybase://')) {


### PR DESCRIPTION
@keybase/react-hackers CC @songgao 

This reverts commit 050b3a022f3, which was supposed to fix following deeplinks when you're not logged in, but has the side-effect of breaking deeplinks on cold start, since at the time you're doing this test you haven't finished logging in yet, as a race.

I'll try something different using `routeToInitialView`.  For now, for the release, just revert.