### PR TITLE
config_local: don't clean unsynced TLFs when sync DB wasn't loaded

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -67,6 +67,12 @@ const (
 
 	// By default, use v2 block encryption.
 	defaultBlockCryptVersion = kbfscrypto.EncryptionSecretboxWithKeyNonce
+
+	// How many times to retry loading the sync DB in the background
+	// if there's an error.
+	maxSyncDBLoadAttempts = 10
+	// How long to wait between load attempts.
+	syncDBLoadWaitPeriod = 10 * time.Second
 )
 
 // ConfigLocal implements the Config interface using purely local
@@ -107,7 +113,7 @@ type ConfigLocal struct {
 	noBGFlush          bool // logic opposite so the default value is the common setting
 	rwpWaitTime        time.Duration
 	diskLimiter        DiskLimiter
-	syncedTlfs         map[tlf.ID]FolderSyncConfig
+	syncedTlfs         map[tlf.ID]FolderSyncConfig // if nil, couldn't load DB
 	syncedTlfPaths     map[string]bool
 	defaultBlockType   keybase1.BlockType
 	kbfsService        *KBFSService
@@ -1350,6 +1356,29 @@ func (c *ConfigLocal) cleanSyncBlockCache() {
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
+	for i := 0; c.syncedTlfs == nil && i < maxSyncDBLoadAttempts; i++ {
+		// Sometimes transient iOS storage permission errors prevent
+		// us from reading the sync config DB on startup.  In that
+		// case, the `syncedTlfs` map will be nil, but we don't want
+		// to delete all the synced blocks.
+		c.MakeLogger("").CDebugf(
+			ctx, "Re-loading synced TLF list for cleaning")
+
+		err := c.loadSyncedTlfsLocked()
+		if err == nil {
+			break
+		}
+		c.lock.Unlock()
+		time.Sleep(syncDBLoadWaitPeriod)
+		c.lock.Lock()
+	}
+	if c.syncedTlfs == nil {
+		c.MakeLogger("").CDebugf(
+			ctx, "Couldn't load synced TLF list for cleaning; giving up")
+		return
+	}
+
 	cacheTlfIDs, err := c.diskBlockCache.GetTlfIDs(ctx, DiskBlockSyncCache)
 	if err != nil {
 		c.MakeLogger("").CDebugf(
@@ -1483,6 +1512,12 @@ func (c *ConfigLocal) openConfigLevelDB(configName string) (
 func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {
 	defer func() {
 		c.MakeLogger("").CDebugf(context.TODO(), "Loaded synced TLFs: %+v", err)
+		if err != nil {
+			// Should already be nil, but make it explicit just in
+			// case, since the cleaning behavior depends on it being
+			// nil if there has been an error.
+			c.syncedTlfs = nil
+		}
 	}()
 	syncedTlfs := make(map[tlf.ID]FolderSyncConfig)
 	syncedTlfPaths := make(map[string]bool)


### PR DESCRIPTION
Sometimes a temporary storage error prevents us from reading the synced TLF DB on startup (especially on iOS).  Make sure we don't try cleaning the unsynced TLFs in that case, because we might start throwing desired blocks away.

Instead, try reloading it for a while in this background goroutine. If it really can't be loaded, give up.

Issue: HOTPOT-2092