### PR TITLE
search: add method for resetting the index

### DIFF
--- a/go/client/cmd_simplefs_reset_index.go
+++ b/go/client/cmd_simplefs_reset_index.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+)
+
+// CmdSimpleFSResetIndex is the 'fs reset-index' command.
+type CmdSimpleFSResetIndex struct {
+	libkb.Contextified
+}
+
+// NewCmdSimpleFSResetIndex creates a new cli.Command.
+func NewCmdSimpleFSResetIndex(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "reset-index",
+		Usage: "delete all local index storage, and resets the indexer",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSResetIndex{
+				Contextified: libkb.NewContextified(g)}, "reset-index", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSResetIndex) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	return cli.SimpleFSResetIndex(context.TODO())
+}
+
+// ParseArgv gets the optional flags and the query.
+func (c *CmdSimpleFSResetIndex) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 0 {
+		return fmt.Errorf("wrong number of arguments")
+	}
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSResetIndex) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -74,6 +74,7 @@ func getBuildSpecificFSCommands(cl *libcmdline.CommandLine, g *libkb.GlobalConte
 		NewCmdSimpleFSUpgrade(cl, g),
 		NewCmdSimpleFSForceConflict(cl, g),
 		NewCmdSimpleFSSearch(cl, g),
+		NewCmdSimpleFSResetIndex(cl, g),
 	}
 }
 

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -386,6 +386,10 @@ func (s SimpleFSMock) SimpleFSSearch(
 	return keybase1.SimpleFSSearchResults{}, nil
 }
 
+func (s SimpleFSMock) SimpleFSResetIndex(ctx context.Context) error {
+	return nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -3291,6 +3291,15 @@ func (k *SimpleFS) SimpleFSSearch(
 	return res, nil
 }
 
+// SimpleFSResetIndex implements the SimpleFSInterface.
+func (k *SimpleFS) SimpleFSResetIndex(ctx context.Context) error {
+	if k.indexer == nil {
+		return errors.New("Indexing not enabled")
+	}
+
+	return k.indexer.ResetIndex(ctx)
+}
+
 // Shutdown shuts down SimpleFS.
 func (k *SimpleFS) Shutdown(ctx context.Context) error {
 	if k.indexer == nil {

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1875,6 +1875,9 @@ type SimpleFSSearchArg struct {
 	StartingFrom int    `codec:"startingFrom" json:"startingFrom"`
 }
 
+type SimpleFSResetIndexArg struct {
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path.
 	// Retrieve results with readList().
@@ -1999,6 +2002,7 @@ type SimpleFSInterface interface {
 	SimpleFSUserIn(context.Context, string) error
 	SimpleFSUserOut(context.Context, string) error
 	SimpleFSSearch(context.Context, SimpleFSSearchArg) (SimpleFSSearchResults, error)
+	SimpleFSResetIndex(context.Context) error
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -2860,6 +2864,16 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSResetIndex": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSResetIndexArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.SimpleFSResetIndex(ctx)
+					return
+				},
+			},
 		},
 	}
 }
@@ -3258,5 +3272,10 @@ func (c SimpleFSClient) SimpleFSUserOut(ctx context.Context, clientID string) (e
 
 func (c SimpleFSClient) SimpleFSSearch(ctx context.Context, __arg SimpleFSSearchArg) (res SimpleFSSearchResults, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSearch", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSResetIndex(ctx context.Context) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSResetIndex", []interface{}{SimpleFSResetIndexArg{}}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -799,3 +799,14 @@ func (s *SimpleFSHandler) SimpleFSSearch(
 	defer cancel()
 	return cli.SimpleFSSearch(ctx, arg)
 }
+
+// SimpleFSResetIndex implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSResetIndex(ctx context.Context) error {
+	cli, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	// Don't use a timeout for resetting the index; let it completely
+	// clean up the storage as needed.
+	return cli.SimpleFSResetIndex(ctx)
+}

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -665,4 +665,6 @@ protocol SimpleFS {
   }
 
   SimpleFSSearchResults simpleFSSearch(string query, int numResults, int startingFrom);
+
+  void simpleFSResetIndex();
 }

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1687,6 +1687,10 @@
         }
       ],
       "response": "SimpleFSSearchResults"
+    },
+    "simpleFSResetIndex": {
+      "request": [],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -4116,6 +4116,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.SimpleFS.simpleFSDeobfuscatePath'
 // 'keybase.1.SimpleFS.simpleFSGetStats'
 // 'keybase.1.SimpleFS.simpleFSSearch'
+// 'keybase.1.SimpleFS.simpleFSResetIndex'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
Also, check contexts and shutdown channel often, to make resetting more responsive.

On the CLI side, the command will exist only for devel builds (for now).

Issue: HOTPOT-1501