### PR TITLE
Narrow chat input suggestions on ipad

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -14,6 +14,7 @@ import CommandMarkdown from '../../command-markdown/container'
 import CommandStatus from '../../command-status/container'
 import Giphy from '../../giphy/container'
 import ReplyPreview from '../../reply-preview/container'
+import {infoPanelWidthTablet} from '../../info-panel/common'
 
 // Standalone throttled function to ensure we never accidentally recreate it and break the throttling
 const throttled = throttle((f, param) => f(param), 2000)
@@ -674,6 +675,7 @@ const styles = Styles.styleSheetCreate(
       }),
       suggestionOverlay: Styles.platformStyles({
         isElectron: {marginLeft: 15, marginRight: 15, marginTop: 'auto'},
+        isTablet: {marginLeft: '30%', marginRight: infoPanelWidthTablet},
       }),
       suggestionSpinnerStyle: Styles.platformStyles({
         common: {

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -336,27 +336,6 @@ const EmojiPicker = ({
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      accessory: {
-        bottom: 1,
-        display: 'flex',
-        left: 0,
-        position: 'absolute',
-        right: 0,
-      },
-      accessoryContainer: {
-        position: 'relative',
-        width: '100%',
-      },
-      boomIcon: Styles.platformStyles({
-        common: {
-          left: 231,
-          marginTop: -30,
-          position: 'absolute',
-        },
-        isElectron: {
-          cursor: 'text',
-        },
-      }),
       cancelEditing: Styles.platformStyles({
         common: {
           ...Styles.globalStyles.flexBoxColumn,
@@ -468,22 +447,6 @@ const styles = Styles.styleSheetCreate(
         marginLeft: Styles.globalMargins.small,
         marginRight: Styles.globalMargins.small,
       },
-      mentionCatcher: {
-        ...Styles.globalStyles.fillAbsolute,
-        backgroundColor: Styles.globalColors.transparent,
-      },
-      mentionHud: Styles.platformStyles({
-        common: {
-          borderRadius: 4,
-          height: 224,
-          marginLeft: Styles.globalMargins.small,
-          marginRight: Styles.globalMargins.small,
-          width: '100%',
-        },
-        isElectron: {
-          ...Styles.desktopStyles.boxShadow,
-        },
-      }),
       walletsIcon: {
         alignSelf: 'flex-end',
         marginBottom: 6,

--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -423,32 +423,11 @@ const PlatformInput = AddSuggestors(_PlatformInput)
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      accessory: {
-        bottom: 1,
-        display: 'flex',
-        left: 0,
-        position: 'absolute',
-        right: 0,
-      },
-      accessoryContainer: {
-        position: 'relative',
-        width: '100%',
-      },
       actionContainer: {
         flexShrink: 0,
         marginLeft: Styles.globalMargins.tiny,
         marginRight: Styles.globalMargins.tiny,
         minHeight: 32,
-      },
-      actionText: {
-        alignSelf: 'flex-end',
-        paddingBottom: Styles.globalMargins.xsmall,
-        paddingRight: Styles.globalMargins.tiny,
-      },
-      animatedContainer: {
-        bottom: 0,
-        position: 'absolute',
-        right: 0,
       },
       container: {
         alignItems: 'center',
@@ -518,20 +497,6 @@ const styles = Styles.styleSheetCreate(
         flexShrink: 1,
         maxHeight: '100%',
         paddingBottom: Styles.globalMargins.tiny,
-      },
-      marginRightSmall: {
-        marginRight: Styles.globalMargins.small,
-      },
-      mentionHud: {
-        borderColor: Styles.globalColors.black_20,
-        borderTopWidth: 1,
-        flex: 1,
-        height: 160,
-        width: '100%',
-      },
-      smallGap: {
-        height: Styles.globalMargins.small,
-        width: Styles.globalMargins.small,
       },
     } as const)
 )


### PR DESCRIPTION
Narrow the suggestions popup to make room for the inbox and info panel.
![image](https://user-images.githubusercontent.com/705646/75898122-a1c44d00-5e07-11ea-857d-069543312d10.png)
![image](https://user-images.githubusercontent.com/705646/75898143-aab51e80-5e07-11ea-8675-cdf0577550f6.png)


It might be better to move the gateway (or not use gateways). This way seems low risk.