### PR TITLE
disallow pushing / replace dupe nav state on a stack

### DIFF
--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -46,12 +46,20 @@ let Conversation = (p: SwitchProps) => {
 
   const onBack = () => dispatch(RouteTreeGen.createNavigateUp())
 
+  // @ts-ignore
+  const lastIsFocused = React.useRef<boolean>(p.isFocused)
   // temporary until nav 5
   if (Container.isMobile) {
     // @ts-ignore
     const {isFocused} = p
     // eslint-disable-next-line
     React.useEffect(() => {
+      // only do something if the focused changed
+      if (lastIsFocused.current === isFocused) {
+        return
+      }
+
+      lastIsFocused.current = isFocused
       if (isFocused) {
         if (_storeConvoIDKey !== conversationIDKey && Constants.isValidConversationIDKey(conversationIDKey)) {
           dispatch(Chat2Gen.createSelectConversation({conversationIDKey, reason: 'focused'}))

--- a/shared/constants/router2.tsx
+++ b/shared/constants/router2.tsx
@@ -43,7 +43,7 @@ const findModalRoute = (s: NavState) => {
 // this returns the full path as seen from a stack. So if you pop you'll go up
 // this path stack
 // TODO this depends on our specific nav setup, check for it somehow
-const _getStackPathHelper = (arr: Array<NavState>, s: NavState): Array<NavState> => {
+export const _getStackPathHelper = (arr: Array<NavState>, s: NavState): Array<NavState> => {
   if (!s) return arr
   if (!s.routes) return arr
   const route = s.routes[s.index]


### PR DESCRIPTION
This addresses an issue where it's possible to have duplicate nav state on the stack. We have some old logic to do this when creating actions, but its racy as the nav state can be out of sync. Instead this overwrites the stack router's reducer with a custom one which disallows this behavior.

This is the core issue w/ the chat/send useEffect looping. The flow is like this
1. Select a convID 'a1'
1. Send lumens to a person
1. Submit
1. Create a preview conversation with the recipient on send (aka push a convID 'PENDING-WAITING') onto the stack
1. Preview rpc resolves to convID 'a1', do a navigationAppend + replace with convID 'a'

now you have two 'a1' convos on the stack on top of each other

now the loops happens. Basically you have two copies of the convo and the useEffect is firing back and forth as they keep on selecting/deselecting the same convo id.
In order to change this behavior (already fixed by the dupe cleaning above) i only run the effect if the focus changed
