### PR TITLE
Y2K-1353 Fix 'Start' to 'Add' for team building

### DIFF
--- a/shared/actions/typed-routes.tsx
+++ b/shared/actions/typed-routes.tsx
@@ -48,6 +48,7 @@ export const appendNewTeamBuilder = (teamID: TeamTypes.TeamID) =>
           filterServices: flags.teamsRedesign
             ? ['keybase', 'twitter', 'facebook', 'github', 'reddit', 'hackernews']
             : undefined,
+          goButtonLabel: 'Add',
           namespace: 'teams',
           teamID,
           title: '',


### PR DESCRIPTION
The "Start" button now correctly says "Add" when trying to add members