### PR TITLE
Reworked blocking modal sizing function

### DIFF
--- a/shared/chat/blocking/block-modal/index.tsx
+++ b/shared/chat/blocking/block-modal/index.tsx
@@ -378,7 +378,12 @@ class BlockModal extends React.PureComponent<Props, State> {
           }
           indexAsKey={true}
           style={
-            Styles.isMobile ? styles.grow : getListHeightStyle((this.props.otherUsernames?.length ?? 0) + 1)
+            Styles.isMobile
+              ? styles.grow
+              : getListHeightStyle(
+                  this.props.otherUsernames?.length ?? 0,
+                  !!this.props.adderUsername && this.getShouldReport(this.props.adderUsername)
+                )
           }
         />
       </Kb.Modal>
@@ -388,7 +393,19 @@ class BlockModal extends React.PureComponent<Props, State> {
 
 export default BlockModal
 
-const getListHeightStyle = (numOthers: number) => ({height: numOthers >= 4 ? 380 : numOthers * 120})
+const getListHeightStyle = (numOthers: number, expanded: boolean) => ({
+  height:
+    120 +
+    (numOthers >= 1
+      ? // "Also block others" is 41px, every row is 2 * 40px rows + a 1px divider.
+        // We cap the count at 4 but even that is greater than the max modal height in Keybase.
+        41 + (numOthers >= 4 ? 4 : numOthers) * 81
+      : 0) +
+    (expanded
+      ? // When you expand the report menu, every option gets an 18px row + 54px for the extra notes + 40px transcript
+        reasons.length * 18 + 54 + 40
+      : 0),
+})
 
 const styles = Styles.styleSheetCreate(() => ({
   checkBoxRow: Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),


### PR DESCRIPTION
multi user impteam:
![image](https://user-images.githubusercontent.com/917230/75995404-a9b1e900-5efc-11ea-95f8-5b7d579faa51.png)

expanding the report button makes the modal larger (pixels shift!)
![image](https://user-images.githubusercontent.com/917230/75995438-b6364180-5efc-11ea-805f-a73b55f0efe4.png)

the expansion isnt as useful in large teams, but it makes it usable when you're just blocking a single person

![image](https://user-images.githubusercontent.com/917230/75995500-cbab6b80-5efc-11ea-91b2-bde0bfe9d2b0.png)

120px grows to much more and your mouse ends up in an useful place (in the middle of the reason selector)

![image](https://user-images.githubusercontent.com/917230/75995532-de25a500-5efc-11ea-95e4-5b7c2231c658.png)

Without reporting it still gets capped by the max modal height at 3 users

![image](https://user-images.githubusercontent.com/917230/75995658-09a88f80-5efd-11ea-9bd1-359f364e6993.png)

No side effects!

tts1 is looking at an tts1/tts2/tts3 impteam in the report mode - all good!
![image](https://user-images.githubusercontent.com/917230/75995766-2e046c00-5efd-11ea-8520-174a1af57774.png)

not in "added by x" mode you just see this
![image](https://user-images.githubusercontent.com/917230/75995892-5ee4a100-5efd-11ea-8132-2bf230eaf611.png)
and height does not change if you open it
![image](https://user-images.githubusercontent.com/917230/75995930-6f951700-5efd-11ea-916f-6f9e8dc32d41.png)
so really the only optimization could be maxing it out in such a scenario but I think it's OK for now