### PR TITLE
search: add a preliminary way to track indexer progress

### DIFF
--- a/go/client/cmd_simplefs_index_progress.go
+++ b/go/client/cmd_simplefs_index_progress.go
@@ -1,0 +1,99 @@
+// Copyright 2020 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// CmdSimpleFSIndexProgress is the 'fs index-progress' command.
+type CmdSimpleFSIndexProgress struct {
+	libkb.Contextified
+}
+
+// NewCmdSimpleFSIndexProgress creates a new cli.Command.
+func NewCmdSimpleFSIndexProgress(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:  "index-progress",
+		Usage: "print the current progress of the indexer",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSIndexProgress{
+				Contextified: libkb.NewContextified(g)}, "index-progress", c)
+			cl.SetNoStandalone()
+		},
+	}
+}
+
+func printIndexProgress(
+	ui libkb.TerminalUI, p keybase1.IndexProgressRecord) {
+	ui.Printf("\t%s/%s (%.2f%%)\n",
+		humanizeBytes(p.BytesSoFar, false),
+		humanizeBytes(p.BytesTotal, false),
+		100*float64(p.BytesSoFar)/float64(p.BytesTotal))
+
+	if p.EndEstimate > 0 {
+		timeRemaining := time.Until(keybase1.FromTime(p.EndEstimate))
+		ui.Printf("\tEstimated time remaining: %s\n",
+			timeRemaining.Round(1*time.Second))
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSIndexProgress) Run() error {
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+
+	p, err := cli.SimpleFSGetIndexProgress(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	ui := c.G().UI.GetTerminalUI()
+	if p.OverallProgress.BytesTotal == 0 {
+		ui.Printf("No indexing in progress\n")
+		return nil
+	}
+
+	ui.Printf("Overall index progress:\n")
+	printIndexProgress(ui, p.OverallProgress)
+	if p.CurrFolder.Name != "" {
+		ui.Printf("\nCurrent index progress (%s):\n", p.CurrFolder)
+		printIndexProgress(ui, p.CurrProgress)
+	}
+
+	if len(p.FoldersLeft) > 0 {
+		ui.Printf("\nFolders waiting to be indexed:\n")
+		for _, f := range p.FoldersLeft {
+			ui.Printf("\t%s\n", f)
+		}
+	}
+	return nil
+}
+
+// ParseArgv gets the optional flags and the query.
+func (c *CmdSimpleFSIndexProgress) ParseArgv(ctx *cli.Context) error {
+	if len(ctx.Args()) != 0 {
+		return fmt.Errorf("wrong number of arguments")
+	}
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSIndexProgress) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -75,6 +75,7 @@ func getBuildSpecificFSCommands(cl *libcmdline.CommandLine, g *libkb.GlobalConte
 		NewCmdSimpleFSForceConflict(cl, g),
 		NewCmdSimpleFSSearch(cl, g),
 		NewCmdSimpleFSResetIndex(cl, g),
+		NewCmdSimpleFSIndexProgress(cl, g),
 	}
 }
 

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -390,6 +390,11 @@ func (s SimpleFSMock) SimpleFSResetIndex(ctx context.Context) error {
 	return nil
 }
 
+func (s SimpleFSMock) SimpleFSGetIndexProgress(
+	ctx context.Context) (res keybase1.SimpleFSIndexProgress, err error) {
+	return keybase1.SimpleFSIndexProgress{}, nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3645,7 +3645,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 			mostRecentMergedMD = mergedMDs[len(mergedMDs)-1]
 		} else {
 			branchPoint := unmergedMDs[0].Revision() - 1
-			mostRecentMergedMD, err = getSingleMD(ctx, cr.config, cr.fbo.id(),
+			mostRecentMergedMD, err = GetSingleMD(ctx, cr.config, cr.fbo.id(),
 				kbfsmd.NullBranchID, branchPoint, kbfsmd.Merged, nil)
 			if err != nil {
 				return

--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1470,7 +1470,7 @@ func (fbm *folderBlockManager) doCleanDiskCache(cacheType DiskBlockCacheType) (
 		fbm.log.CDebugf(ctx, "Done cleaning %s: %+v", cacheType, err)
 	}()
 	for nextRev := lastRev + 1; nextRev <= recentRev; nextRev++ {
-		rmd, err := getSingleMD(
+		rmd, err := GetSingleMD(
 			ctx, fbm.config, fbm.id, kbfsmd.NullBranchID, nextRev,
 			kbfsmd.Merged, nil)
 		if err != nil {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -2484,7 +2484,7 @@ func (fbo *folderBranchOps) getMostRecentFullyMergedMD(ctx context.Context) (
 	}
 
 	// Otherwise, use the specified revision.
-	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
+	rmd, err := GetSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
 		mergedRev, kbfsmd.Merged, nil)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
@@ -7032,7 +7032,7 @@ func (fbo *folderBranchOps) getLatestMergedMD(
 	if rev == kbfsmd.RevisionUninitialized {
 		return ImmutableRootMetadata{}, nil
 	}
-	return getSingleMD(
+	return GetSingleMD(
 		ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID, rev, kbfsmd.Merged, nil)
 }
 
@@ -7174,7 +7174,7 @@ func (fbo *folderBranchOps) undoUnmergedMDUpdatesLocked(
 	// the updates.
 	fbo.setBranchIDLocked(lState, kbfsmd.NullBranchID)
 
-	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
+	rmd, err := GetSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
 		currHead, kbfsmd.Merged, nil)
 	if err != nil {
 		return nil, err
@@ -8474,7 +8474,7 @@ func (fbo *folderBranchOps) handleMDFlush(
 	}()
 
 	// Get that revision.
-	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
+	rmd, err := GetSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
 		rev, kbfsmd.Merged, nil)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't get revision %d for archiving: %v",
@@ -9766,7 +9766,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 		// `defer` above kick one off.
 		latestMergedRev := fbo.getLatestMergedRevision(lState)
 		if maxRev == latestMergedRev {
-			rmd, err = getSingleMD(
+			rmd, err = GetSingleMD(
 				ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID, maxRev,
 				kbfsmd.Merged, nil)
 			if err != nil {

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -940,7 +940,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 			}
 		}
 
-		md, err = getSingleMD(
+		md, err = GetSingleMD(
 			ctx, fs.config, h.TlfID(), kbfsmd.NullBranchID, rev,
 			kbfsmd.Merged, nil)
 		// This will error if there's no corresponding MD, which is

--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -717,7 +717,7 @@ func (md *MDOpsStandard) verifyWriterKey(ctx context.Context,
 		// extra work by downloading the same MDs twice (for those
 		// that aren't yet in the cache).  That should be so rare that
 		// it's not worth optimizing.
-		rmd, err := getSingleMD(ctx, md.config, rmds.MD.TlfID(),
+		rmd, err := GetSingleMD(ctx, md.config, rmds.MD.TlfID(),
 			rmds.MD.BID(), prevRev, rmds.MD.MergedStatus(), nil)
 		if err != nil {
 			return err

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -813,13 +813,15 @@ func (ci ChangeItem) String() string {
 
 // GetChangesBetweenRevisions returns a list of all the changes
 // between the two given revisions (after `oldRev`, up to and
-// including `newRev`).
+// including `newRev`). Also returns the sum of all the newly ref'd
+// block sizes (in bytes), as a crude estimate of how big this change
+// set is.
 func GetChangesBetweenRevisions(
 	ctx context.Context, config Config, id tlf.ID,
 	oldRev, newRev kbfsmd.Revision) (
-	changes []*ChangeItem, err error) {
+	changes []*ChangeItem, refSize uint64, err error) {
 	if newRev <= oldRev {
-		return nil, errors.Errorf(
+		return nil, 0, errors.Errorf(
 			"Can't get changes between %d and %d", oldRev, newRev)
 	}
 
@@ -827,23 +829,23 @@ func GetChangesBetweenRevisions(
 		ctx, config, id, kbfsmd.NullBranchID, oldRev+1, newRev,
 		kbfsmd.Merged, nil)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	fbo, err := getOpsSafe(config, id)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	chains, err := newCRChainsForIRMDs(
 		ctx, config.Codec(), config, rmds, &fbo.blocks, true)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	err = fbo.blocks.populateChainPaths(
 		ctx, config.MakeLogger(""), chains, true)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// The crChains creation process splits up a rename op into
@@ -859,10 +861,11 @@ func GetChangesBetweenRevisions(
 			ops[soFar+i] = op.deepCopy()
 		}
 		soFar += len(rmd.data.Changes.Ops)
+		refSize += rmd.RefBytes()
 	}
 	err = chains.revertRenames(ops)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	// Create the change items for each chain.  Use the following
@@ -917,7 +920,7 @@ func GetChangesBetweenRevisions(
 				item.Type = ChangeTypeRename
 				err := item.addUnrefs(chains, op)
 				if err != nil {
-					return nil, err
+					return nil, 0, err
 				}
 				// Don't force there to be a pointer for the node,
 				// since it could be a symlink.
@@ -928,14 +931,14 @@ func GetChangesBetweenRevisions(
 				// Find the original block pointers for each unref.
 				err := item.addUnrefs(chains, op)
 				if err != nil {
-					return nil, err
+					return nil, 0, err
 				}
 				unrefs := op.Unrefs()
 				if len(unrefs) > 0 {
 					unref := unrefs[0]
 					ptr, err := chains.originalFromMostRecentOrSame(unref)
 					if err != nil {
-						return nil, err
+						return nil, 0, err
 					}
 					item.CurrPath = item.CurrPath.ChildPath(
 						realOp.obfuscatedOldName(), ptr, fbo.makeObfuscator())
@@ -969,7 +972,7 @@ func GetChangesBetweenRevisions(
 					oldPtr, err := chains.originalFromMostRecentOrSame(
 						currPath.TailPointer())
 					if err != nil {
-						return nil, err
+						return nil, 0, err
 					}
 					item := &ChangeItem{
 						Type:     ChangeTypeWrite,
@@ -986,5 +989,6 @@ func GetChangesBetweenRevisions(
 	for _, itemSlice := range items {
 		changes = append(changes, itemSlice...)
 	}
-	return changes, nil
+
+	return changes, refSize, nil
 }

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -173,10 +173,11 @@ func getMDRange(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.Branch
 	return rmds, nil
 }
 
-// getSingleMD returns an MD that is required to exist.
-func getSingleMD(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.BranchID,
-	rev kbfsmd.Revision, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
-	ImmutableRootMetadata, error) {
+// GetSingleMD returns an MD that is required to exist.
+func GetSingleMD(
+	ctx context.Context, config Config, id tlf.ID, bid kbfsmd.BranchID,
+	rev kbfsmd.Revision, mStatus kbfsmd.MergeStatus,
+	lockBeforeGet *keybase1.LockID) (ImmutableRootMetadata, error) {
 	rmds, err := getMDRange(
 		ctx, config, id, bid, rev, rev, mStatus, lockBeforeGet)
 	if err != nil {

--- a/go/kbfs/libkbfs/md_util_test.go
+++ b/go/kbfs/libkbfs/md_util_test.go
@@ -236,7 +236,7 @@ func TestGetChangesBetweenRevisions(t *testing.T) {
 
 	t.Log("Check single revision")
 	tlfID := rootNode.GetFolderBranch().Tlf
-	changes, err := GetChangesBetweenRevisions(
+	changes, _, err := GetChangesBetweenRevisions(
 		ctx, config, tlfID, kbfsmd.Revision(1), kbfsmd.Revision(2))
 	require.NoError(t, err)
 	checkChanges(
@@ -246,7 +246,7 @@ func TestGetChangesBetweenRevisions(t *testing.T) {
 		})
 
 	t.Log("Check multiple revisions")
-	changes, err = GetChangesBetweenRevisions(
+	changes, _, err = GetChangesBetweenRevisions(
 		ctx, config, tlfID, kbfsmd.Revision(1), kbfsmd.Revision(5))
 	require.NoError(t, err)
 	checkChanges(
@@ -258,7 +258,7 @@ func TestGetChangesBetweenRevisions(t *testing.T) {
 		})
 
 	t.Log("Check rename")
-	changes, err = GetChangesBetweenRevisions(
+	changes, _, err = GetChangesBetweenRevisions(
 		ctx, config, tlfID, kbfsmd.Revision(5), kbfsmd.Revision(6))
 	require.NoError(t, err)
 	checkChanges(
@@ -269,7 +269,7 @@ func TestGetChangesBetweenRevisions(t *testing.T) {
 		})
 
 	t.Log("Check internal rename")
-	changes, err = GetChangesBetweenRevisions(
+	changes, _, err = GetChangesBetweenRevisions(
 		ctx, config, tlfID, kbfsmd.Revision(1), kbfsmd.Revision(6))
 	require.NoError(t, err)
 	checkChanges(
@@ -281,7 +281,7 @@ func TestGetChangesBetweenRevisions(t *testing.T) {
 		})
 
 	t.Log("Check delete")
-	changes, err = GetChangesBetweenRevisions(
+	changes, _, err = GetChangesBetweenRevisions(
 		ctx, config, tlfID, kbfsmd.Revision(6), kbfsmd.Revision(7))
 	require.NoError(t, err)
 	checkChanges(
@@ -291,7 +291,7 @@ func TestGetChangesBetweenRevisions(t *testing.T) {
 		})
 
 	t.Log("Check full sequence")
-	changes, err = GetChangesBetweenRevisions(
+	changes, _, err = GetChangesBetweenRevisions(
 		ctx, config, tlfID, kbfsmd.Revision(1), kbfsmd.Revision(7))
 	require.NoError(t, err)
 	checkChanges(

--- a/go/kbfs/search/indexer.go
+++ b/go/kbfs/search/indexer.go
@@ -997,7 +997,10 @@ func (i *Indexer) doFullIndex(
 	if err != nil {
 		return err
 	}
-	i.progress.startIndex(m.tlfID, md.DiskUsage(), indexFull)
+	err = i.progress.startIndex(m.tlfID, md.DiskUsage(), indexFull)
+	if err != nil {
+		return err
+	}
 	defer func() {
 		progErr := i.progress.finishIndex(m.tlfID)
 		if progErr != nil {
@@ -1062,7 +1065,10 @@ func (i *Indexer) doIncrementalIndex(
 		return err
 	}
 
-	i.progress.startIndex(m.tlfID, refSize, indexIncremental)
+	err = i.progress.startIndex(m.tlfID, refSize, indexIncremental)
+	if err != nil {
+		return err
+	}
 	defer func() {
 		progErr := i.progress.finishIndex(m.tlfID)
 		if progErr != nil {

--- a/go/kbfs/search/progress.go
+++ b/go/kbfs/search/progress.go
@@ -60,9 +60,15 @@ func (p *Progress) tlfUnqueue(id tlf.ID) {
 	delete(p.tlfSizesToIndex, id)
 }
 
-func (p *Progress) startIndex(id tlf.ID, sizeEstimate uint64, t indexType) {
+func (p *Progress) startIndex(
+	id tlf.ID, sizeEstimate uint64, t indexType) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	if p.currTlf != tlf.NullID {
+		return errors.Errorf("Cannot index %s before finishing index of %s",
+			id, p.currTlf)
+	}
 
 	p.currTlf = id
 	delete(p.tlfSizesToIndex, id)
@@ -70,6 +76,7 @@ func (p *Progress) startIndex(id tlf.ID, sizeEstimate uint64, t indexType) {
 	p.currHasIndexed = 0
 	p.currIndexType = t
 	p.currStartTime = p.clock.Now()
+	return nil
 }
 
 func (p *Progress) indexedBytes(size uint64) {

--- a/go/kbfs/search/progress.go
+++ b/go/kbfs/search/progress.go
@@ -1,0 +1,164 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/pkg/errors"
+)
+
+type indexType int
+
+const (
+	indexNone indexType = iota
+	indexFull
+	indexIncremental
+)
+
+// Progress represents the current state of the indexer, and how far
+// along the indexing is.
+type Progress struct {
+	clock libkbfs.Clock
+
+	lock             sync.RWMutex
+	tlfSizesToIndex  map[tlf.ID]uint64
+	currTlf          tlf.ID
+	currTotalToIndex uint64
+	currHasIndexed   uint64
+	currIndexType    indexType
+	currStartTime    time.Time
+	lastIndexRate    float64 // (bytes/second)
+}
+
+// NewProgress creates a new Progress instance.
+func NewProgress(clock libkbfs.Clock) *Progress {
+	return &Progress{
+		clock:           clock,
+		tlfSizesToIndex: make(map[tlf.ID]uint64),
+	}
+}
+
+func (p *Progress) tlfQueue(id tlf.ID, sizeEstimate uint64) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// Overwrite whatever was already there.
+	p.tlfSizesToIndex[id] = sizeEstimate
+}
+
+func (p *Progress) tlfUnqueue(id tlf.ID) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	delete(p.tlfSizesToIndex, id)
+}
+
+func (p *Progress) startIndex(id tlf.ID, sizeEstimate uint64, t indexType) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.currTlf = id
+	delete(p.tlfSizesToIndex, id)
+	p.currTotalToIndex = sizeEstimate
+	p.currHasIndexed = 0
+	p.currIndexType = t
+	p.currStartTime = p.clock.Now()
+}
+
+func (p *Progress) indexedBytes(size uint64) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.currHasIndexed += size
+	if p.currHasIndexed > p.currTotalToIndex {
+		// The provided size estimate was wrong.  But we don't know by
+		// how much.  So just add the newly-indexed bytes onto it, ot
+		// make sure we're still under the limit.
+		p.currTotalToIndex += size
+	}
+}
+
+func (p *Progress) finishIndex(id tlf.ID) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if id != p.currTlf {
+		return errors.Errorf(
+			"Cannot finish index for %s, because %s is the current TLF",
+			id, p.currTlf)
+	}
+
+	// Estimate how long these bytes took to index.
+	timeSecs := p.clock.Now().Sub(p.currStartTime).Seconds()
+	if timeSecs > 0 {
+		p.lastIndexRate = float64(p.currHasIndexed) / timeSecs
+	} else {
+		p.lastIndexRate = 0
+	}
+
+	p.currTlf = tlf.NullID
+	p.currTotalToIndex = 0
+	p.currHasIndexed = 0
+	p.currIndexType = indexNone
+	p.currStartTime = time.Time{}
+	return nil
+}
+
+func (p *Progress) fillInProgressRecord(
+	total, soFar uint64, rate float64, rec *keybase1.IndexProgressRecord) {
+	if rate > 0 {
+		bytesLeft := total - soFar
+		timeLeft := time.Duration(
+			(float64(bytesLeft) / rate) * float64(time.Second))
+		rec.EndEstimate = keybase1.ToTime(p.clock.Now().Add(timeLeft))
+	}
+	rec.BytesSoFar = int64(soFar)
+	rec.BytesTotal = int64(total)
+}
+
+// GetStatus returns the current progress status.
+func (p *Progress) GetStatus() (
+	currProgress, overallProgress keybase1.IndexProgressRecord,
+	currTlf tlf.ID, queuedTlfs []tlf.ID) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	// At what rate is the current indexer running?
+	rate := p.lastIndexRate
+	if !p.currStartTime.IsZero() && p.currHasIndexed != 0 {
+		timeSecs := p.clock.Now().Sub(p.currStartTime).Seconds()
+		rate = float64(p.currHasIndexed) / timeSecs
+	}
+
+	if p.currTlf != tlf.NullID {
+		p.fillInProgressRecord(
+			p.currTotalToIndex, p.currHasIndexed, rate, &currProgress)
+	}
+
+	queuedTlfs = make([]tlf.ID, 0, len(p.tlfSizesToIndex))
+	var totalSize, soFar uint64
+	if p.currTlf != tlf.NullID {
+		totalSize += p.currTotalToIndex
+		soFar += p.currHasIndexed
+	}
+	for id, size := range p.tlfSizesToIndex {
+		if id == p.currTlf {
+			continue
+		}
+		totalSize += size
+		queuedTlfs = append(queuedTlfs, id)
+	}
+	if totalSize != 0 {
+		p.fillInProgressRecord(
+			totalSize, soFar, rate, &overallProgress)
+	}
+
+	return currProgress, overallProgress, p.currTlf, queuedTlfs
+}

--- a/go/kbfs/search/progress_test.go
+++ b/go/kbfs/search/progress_test.go
@@ -1,0 +1,119 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/kbfs/test/clocktest"
+	"github.com/keybase/client/go/kbfs/tlf"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProgress(t *testing.T) {
+	clock, start := clocktest.NewTestClockAndTimeNow()
+	p := NewProgress(clock)
+
+	t.Log("Queue one TLF")
+	id1 := tlf.FakeID(1, tlf.Private)
+	size1 := uint64(100)
+	p.tlfQueue(id1, size1)
+
+	type expectedProg struct {
+		currTlf      tlf.ID
+		q            []tlf.ID
+		overallTotal int64
+		overallSoFar int64
+		overallEnd   keybase1.Time
+		currTotal    int64
+		currSoFar    int64
+		currEnd      keybase1.Time
+	}
+	checkStatus := func(e expectedProg) {
+		currProg, overallProg, currTlf, q := p.GetStatus()
+		require.Len(t, q, len(e.q))
+		m := make(map[tlf.ID]bool, len(q))
+		for _, id := range q {
+			m[id] = true
+		}
+		for _, id := range e.q {
+			delete(m, id)
+		}
+		require.Len(t, m, 0)
+		require.Equal(t, e.currTlf, currTlf)
+		require.Equal(t, e.overallTotal, overallProg.BytesTotal)
+		require.Equal(t, e.overallSoFar, overallProg.BytesSoFar)
+		require.Equal(t, e.overallEnd, overallProg.EndEstimate)
+		require.Equal(t, e.currTotal, currProg.BytesTotal)
+		require.Equal(t, e.currSoFar, currProg.BytesSoFar)
+		require.Equal(t, e.currEnd, currProg.EndEstimate)
+	}
+	checkStatus(expectedProg{
+		q:            []tlf.ID{id1},
+		overallTotal: int64(size1),
+	})
+
+	t.Log("Start the index")
+	p.startIndex(id1, size1, indexFull)
+	checkStatus(expectedProg{
+		currTlf:      id1,
+		currTotal:    int64(size1),
+		overallTotal: int64(size1),
+	})
+
+	t.Log("Index 10 bytes in 1 second")
+	clock.Add(1 * time.Second)
+	p.indexedBytes(10)
+	currEndEstimate := keybase1.ToTime(start.Add(10 * time.Second))
+	checkStatus(expectedProg{
+		currTlf:      id1,
+		currTotal:    int64(size1),
+		currSoFar:    10,
+		currEnd:      currEndEstimate,
+		overallTotal: int64(size1),
+		overallSoFar: 10,
+		overallEnd:   currEndEstimate,
+	})
+
+	t.Log("Queue another TLF")
+	id2 := tlf.FakeID(2, tlf.Private)
+	size2 := uint64(900)
+	p.tlfQueue(id2, size2)
+	overallEndEstimate := keybase1.ToTime(start.Add(100 * time.Second))
+	checkStatus(expectedProg{
+		currTlf:      id1,
+		q:            []tlf.ID{id2},
+		currTotal:    int64(size1),
+		currSoFar:    10,
+		currEnd:      currEndEstimate,
+		overallTotal: int64(size1 + size2),
+		overallSoFar: 10,
+		overallEnd:   overallEndEstimate,
+	})
+
+	t.Log("Complete first index")
+	clock.Add(9 * time.Second)
+	p.indexedBytes(90)
+	checkStatus(expectedProg{
+		currTlf:      id1,
+		q:            []tlf.ID{id2},
+		currTotal:    int64(size1),
+		currSoFar:    int64(size1),
+		currEnd:      currEndEstimate,
+		overallTotal: int64(size1 + size2),
+		overallSoFar: int64(size1),
+		overallEnd:   overallEndEstimate,
+	})
+
+	err := p.finishIndex(id1)
+	require.NoError(t, err)
+	checkStatus(expectedProg{
+		q:            []tlf.ID{id2},
+		overallTotal: int64(size2),
+		overallEnd:   overallEndEstimate,
+	})
+}

--- a/go/kbfs/search/progress_test.go
+++ b/go/kbfs/search/progress_test.go
@@ -58,7 +58,8 @@ func TestProgress(t *testing.T) {
 	})
 
 	t.Log("Start the index")
-	p.startIndex(id1, size1, indexFull)
+	err := p.startIndex(id1, size1, indexFull)
+	require.NoError(t, err)
 	checkStatus(expectedProg{
 		currTlf:      id1,
 		currTotal:    int64(size1),
@@ -109,7 +110,7 @@ func TestProgress(t *testing.T) {
 		overallEnd:   overallEndEstimate,
 	})
 
-	err := p.finishIndex(id1)
+	err = p.finishIndex(id1)
 	require.NoError(t, err)
 	checkStatus(expectedProg{
 		q:            []tlf.ID{id2},

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -810,3 +810,15 @@ func (s *SimpleFSHandler) SimpleFSResetIndex(ctx context.Context) error {
 	// clean up the storage as needed.
 	return cli.SimpleFSResetIndex(ctx)
 }
+
+// SimpleFSGetIndexProgress implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSGetIndexProgress(
+	ctx context.Context) (res keybase1.SimpleFSIndexProgress, err error) {
+	cli, err := s.client(ctx)
+	if err != nil {
+		return keybase1.SimpleFSIndexProgress{}, err
+	}
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	return cli.SimpleFSGetIndexProgress(ctx)
+}

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -667,4 +667,21 @@ protocol SimpleFS {
   SimpleFSSearchResults simpleFSSearch(string query, int numResults, int startingFrom);
 
   void simpleFSResetIndex();
+
+  record IndexProgressRecord {
+    Time endEstimate;
+    int64 bytesTotal;
+    int64 bytesSoFar;
+}
+
+  record SimpleFSIndexProgress {
+    IndexProgressRecord overallProgress;
+
+    Folder currFolder;
+    IndexProgressRecord currProgress;
+
+    array<Folder> foldersLeft;
+  }
+
+  SimpleFSIndexProgress simpleFSGetIndexProgress();
 }

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -966,6 +966,49 @@
           "name": "nextResult"
         }
       ]
+    },
+    {
+      "type": "record",
+      "name": "IndexProgressRecord",
+      "fields": [
+        {
+          "type": "Time",
+          "name": "endEstimate"
+        },
+        {
+          "type": "int64",
+          "name": "bytesTotal"
+        },
+        {
+          "type": "int64",
+          "name": "bytesSoFar"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "SimpleFSIndexProgress",
+      "fields": [
+        {
+          "type": "IndexProgressRecord",
+          "name": "overallProgress"
+        },
+        {
+          "type": "Folder",
+          "name": "currFolder"
+        },
+        {
+          "type": "IndexProgressRecord",
+          "name": "currProgress"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "Folder"
+          },
+          "name": "foldersLeft"
+        }
+      ]
     }
   ],
   "messages": {
@@ -1691,6 +1734,10 @@
     "simpleFSResetIndex": {
       "request": [],
       "response": null
+    },
+    "simpleFSGetIndexProgress": {
+      "request": [],
+      "response": "SimpleFSIndexProgress"
     }
   },
   "namespace": "keybase.1"

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2879,6 +2879,7 @@ export type ImplicitTeamConflictInfo = {readonly generation: ConflictGeneration;
 export type ImplicitTeamDisplayName = {readonly isPublic: Boolean; readonly writers: ImplicitTeamUserSet; readonly readers: ImplicitTeamUserSet; readonly conflictInfo?: ImplicitTeamConflictInfo | null}
 export type ImplicitTeamUserSet = {readonly keybaseUsers?: Array<String> | null; readonly unresolvedUsers?: Array<SocialAssertion> | null}
 export type IncomingShareItem = {readonly type: IncomingShareType; readonly originalPath: String; readonly originalSize: Int; readonly scaledPath?: String | null; readonly thumbnailPath?: String | null; readonly content?: String | null}
+export type IndexProgressRecord = {readonly endEstimate: Time; readonly bytesTotal: Int64; readonly bytesSoFar: Int64}
 export type InstallResult = {readonly componentResults?: Array<ComponentResult> | null; readonly status: Status; readonly fatal: Boolean}
 export type InstrumentationStat = {readonly t: /* tag */ String; readonly n: /* numCalls */ Int; readonly c: /* ctime */ Time; readonly m: /* mtime */ Time; readonly ad: /* avgDur */ DurationMsec; readonly xd: /* maxDur */ DurationMsec; readonly nd: /* minDur */ DurationMsec; readonly td: /* totalDur */ DurationMsec; readonly as: /* avgSize */ Int64; readonly xs: /* maxSize */ Int64; readonly ns: /* minSize */ Int64; readonly ts: /* totalSize */ Int64}
 export type InterestingPerson = {readonly uid: UID; readonly username: String; readonly fullname: String; readonly serviceMap: {[key: string]: String}}
@@ -3079,6 +3080,7 @@ export type SigVersion = Int
 export type SignatureMetadata = {readonly signingKID: KID; readonly prevMerkleRootSigned: MerkleRootV2; readonly firstAppearedUnverified: Seqno; readonly time: Time; readonly sigChainLocation: SigChainLocation}
 export type Signer = {readonly e: Seqno; readonly k: KID; readonly u: UID}
 export type SignupRes = {readonly passphraseOk: Boolean; readonly postOk: Boolean; readonly writeOk: Boolean; readonly paperKey: String}
+export type SimpleFSIndexProgress = {readonly overallProgress: IndexProgressRecord; readonly currFolder: Folder; readonly currProgress: IndexProgressRecord; readonly foldersLeft?: Array<Folder> | null}
 export type SimpleFSListResult = {readonly entries?: Array<Dirent> | null; readonly progress: Progress}
 export type SimpleFSQuotaUsage = {readonly usageBytes: Int64; readonly archiveBytes: Int64; readonly limitBytes: Int64; readonly gitUsageBytes: Int64; readonly gitArchiveBytes: Int64; readonly gitLimitBytes: Int64}
 export type SimpleFSSearchHit = {readonly path: String}
@@ -4117,6 +4119,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.SimpleFS.simpleFSGetStats'
 // 'keybase.1.SimpleFS.simpleFSSearch'
 // 'keybase.1.SimpleFS.simpleFSResetIndex'
+// 'keybase.1.SimpleFS.simpleFSGetIndexProgress'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
This adds a new CLI command (devel-only for now) that shows the current progress status of the KBFS indexer.  Here is what it looks like in action:

```
$ keybase fs index-progress
Overall index progress:
	1.33 GB/1.79 GB (74.44%)
	Estimated time remaining: 41s

Current index progress (private/strib,songgao):
	1.33 GB/1.35 GB (98.65%)
	Estimated time remaining: 2s

Folders waiting to be indexed:
	private/strib,chris
	team/coolkids
```

The byte-tracking and time estimates are _very_ crude. I mostly consider this just a starting place, and we can refine it as we see how the progress will be used in practice.  Here's how it works in this PR:

* Whenever a TLF is enqueued to be indexed, we add its entire **encrypted/padded** size to the overall total size estimate, even if it's only going to be an incremental indexing.
* Then when we start indexing it, if we find out its incremental, we replace its size estimate with the total newly-ref'd bytes (again **encrypted/padded**) in the revisions that are going to be indexed.  This is not a great estimate since a small byte change to a huge file will cause the whole huge file to be reindexed.  But I don't have any better ideas right now on how to get that estimate.
* Each time a node is indexed, whether just for its name or for its contents as well, we mark the **plaintext** size of it as having been indexed.  This is obviously different from the encrypted size, but it's the easiest/fastest thing to do, and this is all just an estimate.
* Bytes are only counted while going through the file tree, not actually when the bleve batch is being processed.  This makes the progress seem to go in chunks rather than smoothly. A future iteration here might be to count the bytes once while reading the files, and once while doing the batch, but not sure how best to do that yet, so just did the easy thing for now.
* Time is estimated based on the processing of the current TLF, or if there is no current TLF, it's based on the last TLF to have been completely indexed.  It is pretty much guaranteed to be wildly inaccurate because of the points above.

Open to suggestions for refining this, though if they're too involved I'll probably punt them to a future PR.

Issue: HOTPOT-1503