### PR TITLE
Show cannot write or edit hint text on exploding messages

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -171,14 +171,14 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
 
   render() {
     let hintText = 'Write a message'
-    if (this.props.isExploding) {
-      hintText = 'Write an exploding message'
-    } else if (this.props.isEditing) {
-      hintText = 'Edit your message'
-    } else if (this.props.cannotWrite) {
+    if (this.props.cannotWrite) {
       hintText = `You must be at least ${indefiniteArticle(this.props.minWriterRole)} ${
         this.props.minWriterRole
       } to post.`
+    } else if (this.props.isEditing) {
+      hintText = 'Edit your message'
+    } else if (this.props.isExploding) {
+      hintText = 'Write an exploding message'
     }
 
     return (


### PR DESCRIPTION
The hint text logic caused the "write an exploding message" hint text to show when the editing message or cannot write hints should have been shown. This PR fixes that issue by rearranging the if/else statements.