### PR TITLE
Windows: fix app-already-started deeplinks, both URL and file

### DIFF
--- a/shared/desktop/app/node.desktop.tsx
+++ b/shared/desktop/app/node.desktop.tsx
@@ -82,7 +82,10 @@ const focusSelfOnAnotherInstanceLaunching = (commandLine: Array<string>) => {
   if (commandLine.length > 1 && commandLine[1]) {
     // Allow both argv1 and argv2 to be the link to support "/usr/lib/electron/electron path-to-app"-style
     // invocations (used in the Arch community packages).
-    for (let link of commandLine.slice(1, 3)) {
+    //
+    // Windows looks like:
+    // ["Keybase.exe", "--somearg", "--someotherarg", "actuallink"]
+    for (let link of commandLine.slice(1, 9)) {
       if (isRelevantDeepLink(link)) {
         mainWindowDispatch(DeeplinksGen.createLink({link}))
         return

--- a/shared/desktop/app/node.desktop.tsx
+++ b/shared/desktop/app/node.desktop.tsx
@@ -85,7 +85,7 @@ const focusSelfOnAnotherInstanceLaunching = (commandLine: Array<string>) => {
     //
     // Windows looks like:
     // ["Keybase.exe", "--somearg", "--someotherarg", "actuallink"]
-    for (let link of commandLine.slice(1, 9)) {
+    for (let link of commandLine.slice(1)) {
       if (isRelevantDeepLink(link)) {
         mainWindowDispatch(DeeplinksGen.createLink({link}))
         return


### PR DESCRIPTION
@keybase/react-hackers 

Windows gets extra Chromium arguments in argv, so extend the search area for paths.  Fixes SEP7 and Saltpack file links on Windows, was likely broken in last public release too.