### PR TITLE
Fix android username cutoff

### DIFF
--- a/shared/common-adapters/usernames/index.tsx
+++ b/shared/common-adapters/usernames/index.tsx
@@ -88,7 +88,11 @@ const UsernameText = (props: Props) => {
         const _onUsernameClicked = props.onUsernameClicked
         const isNegative = backgroundModeIsNegative(props.backgroundMode || null)
         const renderText = (onLongPress?: () => void) => (
-          <Text type={props.type} key={u.username}>
+          // type is set to Body here to prevent unwanted hover behaviors
+          // line height is unset to prevent some text clipping issues
+          // in children with larger text styles on Android (HOTPOT-2112)
+          // see also https://github.com/keybase/client/pull/22331#discussion_r374224355
+          <Text type="Body" style={{lineHeight: undefined}} key={u.username}>
             {i !== 0 && i === props.users.length - 1 && props.showAnd && (
               <Text type={props.type} negative={isNegative} style={derivedJoinerStyle} underlineNever={true}>
                 {'and '}

--- a/shared/common-adapters/usernames/index.tsx
+++ b/shared/common-adapters/usernames/index.tsx
@@ -88,7 +88,7 @@ const UsernameText = (props: Props) => {
         const _onUsernameClicked = props.onUsernameClicked
         const isNegative = backgroundModeIsNegative(props.backgroundMode || null)
         const renderText = (onLongPress?: () => void) => (
-          <Text type="Body" key={u.username}>
+          <Text type={props.type} key={u.username}>
             {i !== 0 && i === props.users.length - 1 && props.showAnd && (
               <Text type={props.type} negative={isNegative} style={derivedJoinerStyle} underlineNever={true}>
                 {'and '}


### PR DESCRIPTION
Fixes an issue where usernames were cut off on profile pages on Android by unsetting the line height of a `Body` text component inside of `Usernames`.