### PR TITLE
jump to chat when tapping on channel/team mention on mobile

### DIFF
--- a/shared/chat/conversation/maybe-mention/team.tsx
+++ b/shared/chat/conversation/maybe-mention/team.tsx
@@ -34,7 +34,7 @@ class TeamMention extends React.Component<Props, State> {
   }
 
   _onClick = () => {
-    if (!Styles.isMobile && this.props.onChat) {
+    if (this.props.onChat) {
       this.props.onChat()
     } else {
       this.setState({showPopup: true})


### PR DESCRIPTION
This PR changes the team mention component so tapping on a channel/team mention you can chat in sends you to that channel on mobile.