### PR TITLE
Crypto Frontend Fixes for 5.3.0

### DIFF
--- a/shared/app/preload.native.tsx
+++ b/shared/app/preload.native.tsx
@@ -33,6 +33,7 @@ global.KB = {
   },
   path: {
     basename: invalidPreload,
+    dirname: invalidPreload,
     extname: invalidPreload,
     join: invalidPreload,
     resolve: invalidPreload,

--- a/shared/crypto/output/index.stories.tsx
+++ b/shared/crypto/output/index.stories.tsx
@@ -90,12 +90,24 @@ const load = () => {
       Sb.updateStoreDecorator(store, draftState => {
         const {encrypt} = draftState.crypto
         encrypt.outputStatus = undefined
+        encrypt.inProgress = false
+        encrypt.bytesComplete = 0
+        encrypt.bytesTotal = 1073741824
+      })
+    )
+    .add('Progress - Hidden', () => <Output operation={Constants.Operations.Encrypt} />)
+
+  Sb.storiesOf('Crypto/Output Progress', module)
+    .addDecorator(
+      Sb.updateStoreDecorator(store, draftState => {
+        const {encrypt} = draftState.crypto
+        encrypt.outputStatus = undefined
         encrypt.inProgress = true
         encrypt.bytesComplete = 0
         encrypt.bytesTotal = 1073741824
       })
     )
-    .add('Progress - None', () => <Output operation={Constants.Operations.Encrypt} />)
+    .add('Progress - Zero', () => <Output operation={Constants.Operations.Encrypt} />)
 
   Sb.storiesOf('Crypto/Output Progress', module)
     .addDecorator(

--- a/shared/crypto/output/index.tsx
+++ b/shared/crypto/output/index.tsx
@@ -14,8 +14,9 @@ import {humanizeBytes} from '../../constants/fs'
 import capitalize from 'lodash/capitalize'
 import {getStyle} from '../../common-adapters/text'
 
-const {electron} = KB
+const {electron, path: nodePath} = KB
 const {showOpenDialog} = electron.dialog
+const {dirname} = nodePath
 
 type OutputProps = {
   operation: Types.Operations
@@ -265,11 +266,12 @@ const OutputFileDestination = (props: {operation: Types.Operations}) => {
   const input = Container.useSelector(state => state.crypto[operation].input.stringValue())
 
   const onOpenFile = async () => {
+    const defaultPath = dirname(input)
     const options = {
       allowDirectories: true,
       allowFiles: false,
       buttonLabel: 'Select',
-      ...(Platforms.isDarwin ? {defaultPath: input} : {}),
+      ...(Platforms.isDarwin ? {defaultPath} : {}),
     }
     const filePaths = await showOpenDialog(options)
     if (!filePaths) return

--- a/shared/crypto/output/index.tsx
+++ b/shared/crypto/output/index.tsx
@@ -121,12 +121,13 @@ export const OutputProgress = (props: OutputProgressProps) => {
 
   const bytesTotal = Container.useSelector(state => state.crypto[operation].bytesTotal)
   const bytesComplete = Container.useSelector(state => state.crypto[operation].bytesComplete)
+  const inProgress = Container.useSelector(state => state.crypto[operation].inProgress)
 
-  const progress = bytesComplete === 0 ? 0 : bytesComplete / bytesTotal
+  const ratio = bytesComplete === 0 ? 0 : bytesComplete / bytesTotal
 
-  return progress ? (
+  return inProgress ? (
     <Kb.Box2 direction="vertical" fullWidth={true} alignItems="center">
-      <Kb.ProgressBar ratio={progress} style={styles.progressBar} />
+      <Kb.ProgressBar ratio={ratio} style={styles.progressBar} />
       <Kb.Text type="Body">{`${humanizeBytes(bytesComplete, 1)} / ${humanizeBytes(bytesTotal, 1)}`}</Kb.Text>
     </Kb.Box2>
   ) : null

--- a/shared/desktop/renderer/preload-main.shared.desktop.tsx
+++ b/shared/desktop/renderer/preload-main.shared.desktop.tsx
@@ -152,6 +152,7 @@ target.KB = {
   },
   path: {
     basename: path.basename,
+    dirname: path.dirname,
     extname: path.extname,
     join: path.join,
     resolve: path.resolve,

--- a/shared/globals.d.ts
+++ b/shared/globals.d.ts
@@ -86,6 +86,7 @@ declare var KB: {
   }
   path: {
     basename: (p: string, ext?: string) => string
+    dirname: (p: string) => string
     extname: (p: string) => string
     join: (...paths: Array<string>) => string
     resolve: (...pathSegments: Array<string>) => string

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -148,6 +148,8 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     op.inputType = inputType
     op.input = value
     op.outputValid = outputValid
+    op.errorMessage = new HiddenString('')
+    op.warningMessage = new HiddenString('')
 
     // Reset output when file input changes
     // Prompt for destination dir
@@ -161,6 +163,8 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
 
     const op = draftState[operation]
     op.outputValid = false
+    op.errorMessage = new HiddenString('')
+    op.warningMessage = new HiddenString('')
   },
   [CryptoGen.saltpackDone]: (draftState, action) => {
     const {operation} = action.payload

--- a/shared/reducers/crypto.tsx
+++ b/shared/reducers/crypto.tsx
@@ -267,6 +267,14 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     op.outputStatus = 'error'
     op.errorMessage = errorMessage
   },
+  [CryptoGen.saltpackStart]: (draftState, action) => {
+    const {operation} = action.payload
+    if (operationGuard(operation, action)) return
+
+    // Gets the progress bar on screen sooner. This matters most when encrypting/signing a directory (since progress is slow)
+    const op = draftState[operation]
+    op.inProgress = true
+  },
   [CryptoGen.saltpackProgress]: (draftState, action) => {
     const {bytesComplete, bytesTotal, operation} = action.payload
     if (operationGuard(operation, action)) return


### PR DESCRIPTION
1. Shows output progress bar for file operations earlier (on `saltpackStart`). When encrypting/signing a directory there might e be large delay between `saltpackStart` and the first `saltpackProgress` notification.

2. Clears errors and warnings when changing/resetting `destinationDir`

* Note: Adds `dirname` from `path` to preload cc @chrisnojima 