### PR TITLE
Format emails and phone numbers in team invites correctly

### DIFF
--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -714,12 +714,11 @@ export const annotatedInvitesToInviteInfo = (
       const sbs: RPCTypes.TeamInviteSocialNetwork = t.sbs
       username = `${invite.name}@${sbs}`
     }
-    const {e164ToDisplay} = require('../util/phone-numbers')
     arr.push({
       email: invite.type.c === RPCTypes.TeamInviteCategory.email ? invite.name : '',
       id: invite.id,
       name: invite.type.c === RPCTypes.TeamInviteCategory.seitan ? invite.name : '',
-      phone: invite.type.c === RPCTypes.TeamInviteCategory.phone ? e164ToDisplay('+' + invite.name) : '',
+      phone: invite.type.c === RPCTypes.TeamInviteCategory.phone ? invite.name : '',
       role,
       username,
     })

--- a/shared/teams/team/rows/invite-row/invite/container.tsx
+++ b/shared/teams/team/rows/invite-row/invite/container.tsx
@@ -54,7 +54,11 @@ export default Container.connect(
     // TODO: can we just do this by invite ID always?
 
     return {
-      label: user.email || user.username || user.name || user.phone,
+      label:
+        (user.email && `[${user.email}]@email`) ||
+        user.username ||
+        user.name ||
+        (user.phone && `${user.phone}@phone`),
       onCancelInvite,
       role: user.role,
     }


### PR DESCRIPTION
Fixes an issue where team invites to phone numbers or emails would link to a bad profile page that had an infinite spinner. Just needed to use the `[user@domain]@email` and `0000000000@phone` formats for the props to the Usernames component.