### PR TITLE
Taller tablet header height

### DIFF
--- a/shared/common-adapters/header-hoc/index.native.tsx
+++ b/shared/common-adapters/header-hoc/index.native.tsx
@@ -8,6 +8,7 @@ import SafeAreaView, {SafeAreaViewTop} from '../safe-area-view'
 import * as Styles from '../../styles'
 import {Action, Props, LeftActionProps} from '.'
 import {hoistNonReactStatic} from '../../util/container'
+import {tabletHeaderExtraHeight} from '../../constants/router2'
 
 const MAX_RIGHT_ACTIONS = 3
 
@@ -283,6 +284,9 @@ const styles = Styles.styleSheetCreate(() => ({
     },
     isIOS: {
       height: 44,
+    },
+    isTablet: {
+      height: 40 + tabletHeaderExtraHeight,
     },
   }),
   innerWrapper: {

--- a/shared/common-adapters/header-hoc/index.native.tsx
+++ b/shared/common-adapters/header-hoc/index.native.tsx
@@ -8,7 +8,6 @@ import SafeAreaView, {SafeAreaViewTop} from '../safe-area-view'
 import * as Styles from '../../styles'
 import {Action, Props, LeftActionProps} from '.'
 import {hoistNonReactStatic} from '../../util/container'
-import {tabletHeaderExtraHeight} from '../../constants/router2'
 
 const MAX_RIGHT_ACTIONS = 3
 
@@ -286,7 +285,7 @@ const styles = Styles.styleSheetCreate(() => ({
       height: 44,
     },
     isTablet: {
-      height: 40 + tabletHeaderExtraHeight,
+      height: 40 + Styles.headerExtraHeight,
     },
   }),
   innerWrapper: {

--- a/shared/constants/router2.tsx
+++ b/shared/constants/router2.tsx
@@ -110,5 +110,3 @@ export const getActiveKey = (): string => {
   if (!_navigator) return ''
   return _getActiveKey(_navigator.getNavState())
 }
-
-export const tabletHeaderExtraHeight = 16

--- a/shared/constants/router2.tsx
+++ b/shared/constants/router2.tsx
@@ -110,3 +110,5 @@ export const getActiveKey = (): string => {
   if (!_navigator) return ''
   return _getActiveKey(_navigator.getNavState())
 }
+
+export const tabletHeaderExtraHeight = 16

--- a/shared/fs/nav-header/mobile-header.tsx
+++ b/shared/fs/nav-header/mobile-header.tsx
@@ -8,7 +8,6 @@ import * as FsGen from '../../actions/fs-gen'
 import * as Container from '../../util/container'
 import Actions from './actions'
 import MainBanner from './main-banner/container'
-import {tabletHeaderExtraHeight} from '../../constants/router2'
 
 /*
  *
@@ -90,9 +89,7 @@ const getBaseHeight = (path: Types.Path) => {
     Styles.statusBarHeight +
     44 +
     (path === Constants.defaultPath
-      ? Styles.isTablet
-        ? tabletHeaderExtraHeight
-        : 0
+      ? Styles.headerExtraHeight
       : (Styles.isAndroid ? 56 : 44) + (Constants.hasPublicTag(path) ? 7 : 0))
   )
 }

--- a/shared/fs/nav-header/mobile-header.tsx
+++ b/shared/fs/nav-header/mobile-header.tsx
@@ -8,6 +8,7 @@ import * as FsGen from '../../actions/fs-gen'
 import * as Container from '../../util/container'
 import Actions from './actions'
 import MainBanner from './main-banner/container'
+import {tabletHeaderExtraHeight} from '../../constants/router2'
 
 /*
  *
@@ -89,7 +90,9 @@ const getBaseHeight = (path: Types.Path) => {
     Styles.statusBarHeight +
     44 +
     (path === Constants.defaultPath
-      ? 0
+      ? Styles.isTablet
+        ? tabletHeaderExtraHeight
+        : 0
       : (Styles.isAndroid ? 56 : 44) + (Constants.hasPublicTag(path) ? 7 : 0))
   )
 }

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -23,7 +23,6 @@ import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
 import {useScreens} from 'react-native-screens'
 import {getPersistenceFunctions} from './persist.native'
 import Loading from '../login/loading'
-import {tabletHeaderExtraHeight} from '../constants/router2'
 
 const {createStackNavigator} = Stack
 
@@ -55,7 +54,8 @@ const defaultNavigationOptions: any = {
     borderBottomWidth: 1,
     borderStyle: 'solid',
     elevation: undefined, // since we use screen on android turn off drop shadow
-    ...(Styles.isTablet ? {height: 44 + tabletHeaderExtraHeight} : {}),
+    // headerExtraHeight is only hooked up for tablet. On other platforms, react-navigation calculates header height.
+    ...(Styles.isTablet ? {height: 44 + Styles.headerExtraHeight} : {}),
   },
   headerTitle: hp => (
     <Kb.Text type="BodyBig" style={styles.headerTitle} lineClamp={1}>

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -23,6 +23,7 @@ import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
 import {useScreens} from 'react-native-screens'
 import {getPersistenceFunctions} from './persist.native'
 import Loading from '../login/loading'
+import {tabletHeaderExtraHeight} from '../constants/router2'
 
 const {createStackNavigator} = Stack
 
@@ -54,6 +55,7 @@ const defaultNavigationOptions: any = {
     borderBottomWidth: 1,
     borderStyle: 'solid',
     elevation: undefined, // since we use screen on android turn off drop shadow
+    height: Styles.isTablet ? 44 + tabletHeaderExtraHeight : undefined,
   },
   headerTitle: hp => (
     <Kb.Text type="BodyBig" style={styles.headerTitle} lineClamp={1}>

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -55,7 +55,6 @@ const defaultNavigationOptions: any = {
     borderBottomWidth: 1,
     borderStyle: 'solid',
     elevation: undefined, // since we use screen on android turn off drop shadow
-    height: Styles.isTablet ? 44 + tabletHeaderExtraHeight : undefined,
   },
   headerTitle: hp => (
     <Kb.Text type="BodyBig" style={styles.headerTitle} lineClamp={1}>
@@ -63,6 +62,12 @@ const defaultNavigationOptions: any = {
     </Kb.Text>
   ),
 }
+
+if (Styles.isTablet) {
+  // Set height after the fact since literal `height: undefined` would wreck phones.
+  defaultNavigationOptions.headerStyle.height = 44 + tabletHeaderExtraHeight
+}
+
 // workaround for https://github.com/react-navigation/react-navigation/issues/4872 else android will eat clicks
 const headerMode = Styles.isAndroid ? 'screen' : 'float'
 

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -55,17 +55,13 @@ const defaultNavigationOptions: any = {
     borderBottomWidth: 1,
     borderStyle: 'solid',
     elevation: undefined, // since we use screen on android turn off drop shadow
+    ...(Styles.isTablet ? {height: 44 + tabletHeaderExtraHeight} : {}),
   },
   headerTitle: hp => (
     <Kb.Text type="BodyBig" style={styles.headerTitle} lineClamp={1}>
       {hp.children}
     </Kb.Text>
   ),
-}
-
-if (Styles.isTablet) {
-  // Set height after the fact since literal `height: undefined` would wreck phones.
-  defaultNavigationOptions.headerStyle.height = 44 + tabletHeaderExtraHeight
 }
 
 // workaround for https://github.com/react-navigation/react-navigation/issues/4872 else android will eat clicks

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import * as Styles from '../styles'
 import * as Shared from './shim.shared'
 import * as Container from '../util/container'
-import {tabletHeaderExtraHeight} from '../constants/router2'
 
 export const shim = (routes: any) => Shared.shim(routes, shimNewRoute)
 

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as Styles from '../styles'
 import * as Shared from './shim.shared'
 import * as Container from '../util/container'
+import {tabletHeaderExtraHeight} from '../constants/router2'
 
 export const shim = (routes: any) => Shared.shim(routes, shimNewRoute)
 
@@ -40,7 +41,7 @@ const shimNewRoute = (Original: any) => {
         if (Styles.isIPhoneX) {
           headerHeight = 88
         } else {
-          headerHeight = 64
+          headerHeight = 64 + (Styles.isTablet ? tabletHeaderExtraHeight : 0)
         }
       }
     }

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -39,9 +39,9 @@ const shimNewRoute = (Original: any) => {
       } else {
         usesNav2Header = true
         if (Styles.isIPhoneX) {
-          headerHeight = 88
+          headerHeight = 88 + Styles.headerExtraHeight
         } else {
-          headerHeight = 64 + (Styles.isTablet ? tabletHeaderExtraHeight : 0)
+          headerHeight = 64 + Styles.headerExtraHeight
         }
       }
     }

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -129,6 +129,7 @@ export declare const isDarkMode: () => boolean
 export declare const isIPhoneX: boolean
 export declare const dimensionWidth: number
 export declare const dimensionHeight: number
+export declare const headerExtraHeight: number
 
 export {platformStyles, globalMargins, backgroundModeToColor, backgroundModeToTextColor} from './shared'
 export {

--- a/shared/styles/index.desktop.tsx
+++ b/shared/styles/index.desktop.tsx
@@ -223,3 +223,4 @@ export type StylesCrossPlatform = CSS.StylesCrossPlatform
 export const dimensionWidth = 0
 export const dimensionHeight = 0
 export {isDarkMode} from './dark-mode'
+export const headerExtraHeight = 0

--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -85,3 +85,4 @@ export {default as classNames} from 'classnames'
 export const borderRadius = 6
 export const dimensionWidth = Dimensions.get('window').width
 export const dimensionHeight = Dimensions.get('window').height
+export const headerExtraHeight = isTablet ? 16 : 0

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -87,6 +87,7 @@ const Reloadable = (props: ReloadableProps) => {
     </Kb.Reloadable>
   )
 }
+
 Reloadable.navigationOptions = {
   header: undefined,
   headerRightActions: () => <ConnectedHeaderRightActions />,


### PR DESCRIPTION
Boost tablet header height to 80px. Should only affect ipad. Gets both react-navigation and HeaderHoc. KeyboardAvoidingView still seems to work. Also the two kinds of headers were slightly misaligned and now they're aligned.

👋 @chrisnojima 