### PR TITLE
files: deal with deleted user errors better

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -603,7 +603,7 @@ const letResetUserBackIn = async (action: FsGen.LetResetUserBackInPayload) => {
       username: action.payload.username,
     })
   } catch (error) {
-    return makeUnretriableErrorHandler(action, Constants.defaultPath)(error)
+    return errorToActionOrThrow(error)
   }
 }
 

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -592,6 +592,19 @@ const loadPathMetadata = async (_: Container.TypedState, action: FsGen.LoadPathM
       pathItem: makeEntry(dirent),
     })
   } catch (err) {
+    if (err.code === RPCTypes.StatusCode.scidentifiesfailed) {
+      // This is specifically to address the situation where when user tries to
+      // remove a shared TLF from their favorites but another user of the TLF has
+      // deleted their account the subscribePath call cauused from the popup will
+      // get SCIdentifiesFailed error. We can't do anything here so just move on.
+      // (Ideally we'd be able to tell it's becaue the user was deleted, but we
+      // don't have that from Go right now.)
+      //
+      // TODO: TRIAGE-2379 this should probably be ignored on Go side. We
+      // already use fsGui identifyBehavior and there's no reason we should get
+      // an identify error here.
+      return null
+    }
     return errorToActionOrThrow(err, path)
   }
 }

--- a/shared/actions/fs/shared.tsx
+++ b/shared/actions/fs/shared.tsx
@@ -8,7 +8,11 @@ const noAccessErrorCodes = [RPCTypes.StatusCode.scsimplefsnoaccess, RPCTypes.Sta
 export const errorToActionOrThrow = (
   error: any,
   path?: Types.Path
-): FsGen.CheckKbfsDaemonRpcStatusPayload | FsGen.SetPathSoftErrorPayload | FsGen.SetTlfSoftErrorPayload => {
+):
+  | FsGen.RedbarPayload
+  | FsGen.CheckKbfsDaemonRpcStatusPayload
+  | FsGen.SetPathSoftErrorPayload
+  | FsGen.SetTlfSoftErrorPayload => {
   if (error?.code === RPCTypes.StatusCode.sckbfsclienttimeout) {
     return FsGen.createCheckKbfsDaemonRpcStatus()
   }
@@ -20,6 +24,10 @@ export const errorToActionOrThrow = (
     if (tlfPath) {
       return FsGen.createSetTlfSoftError({path: tlfPath, softError: Types.SoftError.NoAccess})
     }
+  }
+  if (error?.code === RPCTypes.StatusCode.scdeleted) {
+    // The user is deleted. Let user know and move on.
+    return FsGen.createRedbar({error: 'A user in this shared folder has deleted their account.'})
   }
   throw error
 }

--- a/shared/fs/common/tlf-info-line.tsx
+++ b/shared/fs/common/tlf-info-line.tsx
@@ -15,11 +15,13 @@ export type Props = {
 
 const getOtherResetText = (names: Array<string>): string => {
   if (names.length === 1) {
-    return `${names[0]} has reset their account.`
+    return `${names[0]} has reset or deleted their account.`
   } else if (names.length === 2) {
-    return `${names[0]} and ${names[1]} have reset their accounts.`
+    return `${names[0]} and ${names[1]} have reset or deleted their accounts.`
   }
-  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]} have reset their accounts.`
+  return `${names.slice(0, -1).join(', ')}, and ${
+    names[names.length - 1]
+  } have reset or deleted their accounts.`
 }
 
 const newMetaMaybe = (props: Props) =>


### PR DESCRIPTION
* Show a more meaningful error banner indicating the user has deleted their account if error code says so. This covers the case where user tries let a deleted user "back in".
* change from "blahblah has reset their account" into "blahblah has reset or deleted their account".
* ignore identify fails in subscribePath, which is called when the path action popup shows, which is a necessary step to ignore a TLF from GUI.