### PR TITLE
protocol: add second, compressible methods for getting block quota 

### DIFF
--- a/go/protocol/keybase1/block.go
+++ b/go/protocol/keybase1/block.go
@@ -187,6 +187,78 @@ func (o BlockPingResponse) DeepCopy() BlockPingResponse {
 	return BlockPingResponse{}
 }
 
+type UsageStatRecord struct {
+	Write      int64 `codec:"write" json:"write"`
+	Archive    int64 `codec:"archive" json:"archive"`
+	Read       int64 `codec:"read" json:"read"`
+	MdWrite    int64 `codec:"mdWrite" json:"mdWrite"`
+	GitWrite   int64 `codec:"gitWrite" json:"gitWrite"`
+	GitArchive int64 `codec:"gitArchive" json:"gitArchive"`
+}
+
+func (o UsageStatRecord) DeepCopy() UsageStatRecord {
+	return UsageStatRecord{
+		Write:      o.Write,
+		Archive:    o.Archive,
+		Read:       o.Read,
+		MdWrite:    o.MdWrite,
+		GitWrite:   o.GitWrite,
+		GitArchive: o.GitArchive,
+	}
+}
+
+type UsageStat struct {
+	Bytes  UsageStatRecord `codec:"bytes" json:"bytes"`
+	Blocks UsageStatRecord `codec:"blocks" json:"blocks"`
+	Mtime  Time            `codec:"mtime" json:"mtime"`
+}
+
+func (o UsageStat) DeepCopy() UsageStat {
+	return UsageStat{
+		Bytes:  o.Bytes.DeepCopy(),
+		Blocks: o.Blocks.DeepCopy(),
+		Mtime:  o.Mtime.DeepCopy(),
+	}
+}
+
+type FolderUsageStat struct {
+	FolderID string    `codec:"folderID" json:"folderID"`
+	Stats    UsageStat `codec:"stats" json:"stats"`
+}
+
+func (o FolderUsageStat) DeepCopy() FolderUsageStat {
+	return FolderUsageStat{
+		FolderID: o.FolderID,
+		Stats:    o.Stats.DeepCopy(),
+	}
+}
+
+type BlockQuotaInfo struct {
+	Folders  []FolderUsageStat `codec:"folders" json:"folders"`
+	Total    UsageStat         `codec:"total" json:"total"`
+	Limit    int64             `codec:"limit" json:"limit"`
+	GitLimit int64             `codec:"gitLimit" json:"gitLimit"`
+}
+
+func (o BlockQuotaInfo) DeepCopy() BlockQuotaInfo {
+	return BlockQuotaInfo{
+		Folders: (func(x []FolderUsageStat) []FolderUsageStat {
+			if x == nil {
+				return nil
+			}
+			ret := make([]FolderUsageStat, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Folders),
+		Total:    o.Total.DeepCopy(),
+		Limit:    o.Limit,
+		GitLimit: o.GitLimit,
+	}
+}
+
 type GetSessionChallengeArg struct {
 }
 
@@ -257,6 +329,13 @@ type GetTeamQuotaInfoArg struct {
 	Tid TeamID `codec:"tid" json:"tid"`
 }
 
+type GetUserQuotaInfo2Arg struct {
+}
+
+type GetTeamQuotaInfo2Arg struct {
+	Tid TeamID `codec:"tid" json:"tid"`
+}
+
 type BlockPingArg struct {
 }
 
@@ -275,6 +354,8 @@ type BlockInterface interface {
 	GetReferenceCount(context.Context, GetReferenceCountArg) (ReferenceCountRes, error)
 	GetUserQuotaInfo(context.Context) ([]byte, error)
 	GetTeamQuotaInfo(context.Context, TeamID) ([]byte, error)
+	GetUserQuotaInfo2(context.Context) (BlockQuotaInfo, error)
+	GetTeamQuotaInfo2(context.Context, TeamID) (BlockQuotaInfo, error)
 	BlockPing(context.Context) (BlockPingResponse, error)
 }
 
@@ -482,6 +563,31 @@ func BlockProtocol(i BlockInterface) rpc.Protocol {
 					return
 				},
 			},
+			"getUserQuotaInfo2": {
+				MakeArg: func() interface{} {
+					var ret [1]GetUserQuotaInfo2Arg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.GetUserQuotaInfo2(ctx)
+					return
+				},
+			},
+			"getTeamQuotaInfo2": {
+				MakeArg: func() interface{} {
+					var ret [1]GetTeamQuotaInfo2Arg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]GetTeamQuotaInfo2Arg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]GetTeamQuotaInfo2Arg)(nil), args)
+						return
+					}
+					ret, err = i.GetTeamQuotaInfo2(ctx, typedArgs[0].Tid)
+					return
+				},
+			},
 			"blockPing": {
 				MakeArg: func() interface{} {
 					var ret [1]BlockPingArg
@@ -569,6 +675,17 @@ func (c BlockClient) GetUserQuotaInfo(ctx context.Context) (res []byte, err erro
 func (c BlockClient) GetTeamQuotaInfo(ctx context.Context, tid TeamID) (res []byte, err error) {
 	__arg := GetTeamQuotaInfoArg{Tid: tid}
 	err = c.Cli.Call(ctx, "keybase.1.block.getTeamQuotaInfo", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c BlockClient) GetUserQuotaInfo2(ctx context.Context) (res BlockQuotaInfo, err error) {
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getUserQuotaInfo2", []interface{}{GetUserQuotaInfo2Arg{}}, &res, rpc.CompressionGzip, 0*time.Millisecond)
+	return
+}
+
+func (c BlockClient) GetTeamQuotaInfo2(ctx context.Context, tid TeamID) (res BlockQuotaInfo, err error) {
+	__arg := GetTeamQuotaInfo2Arg{Tid: tid}
+	err = c.Cli.CallCompressed(ctx, "keybase.1.block.getTeamQuotaInfo2", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }
 

--- a/protocol/avdl/keybase1/block.avdl
+++ b/protocol/avdl/keybase1/block.avdl
@@ -76,5 +76,38 @@ protocol block {
   bytes getUserQuotaInfo();
   bytes getTeamQuotaInfo(TeamID tid);
 
+  record UsageStatRecord {
+    int64 write;
+    int64 archive;
+    int64 read;
+    int64 mdWrite;
+    int64 gitWrite;
+    int64 gitArchive;
+  }
+
+  record UsageStat {
+    UsageStatRecord bytes;
+    UsageStatRecord blocks;
+    Time mtime;
+  }
+
+  record FolderUsageStat{
+    string folderID;
+    UsageStat stats;
+  }
+
+  record BlockQuotaInfo{
+    array<FolderUsageStat> folders;
+    UsageStat total;
+    int64 limit;
+    int64 gitLimit;
+  }
+
+  @compression_type("gzip")
+  BlockQuotaInfo getUserQuotaInfo2();
+
+  @compression_type("gzip")
+  BlockQuotaInfo getTeamQuotaInfo2(TeamID tid);
+
   BlockPingResponse blockPing();
 }

--- a/protocol/json/keybase1/block.json
+++ b/protocol/json/keybase1/block.json
@@ -144,6 +144,93 @@
       "type": "record",
       "name": "BlockPingResponse",
       "fields": []
+    },
+    {
+      "type": "record",
+      "name": "UsageStatRecord",
+      "fields": [
+        {
+          "type": "int64",
+          "name": "write"
+        },
+        {
+          "type": "int64",
+          "name": "archive"
+        },
+        {
+          "type": "int64",
+          "name": "read"
+        },
+        {
+          "type": "int64",
+          "name": "mdWrite"
+        },
+        {
+          "type": "int64",
+          "name": "gitWrite"
+        },
+        {
+          "type": "int64",
+          "name": "gitArchive"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "UsageStat",
+      "fields": [
+        {
+          "type": "UsageStatRecord",
+          "name": "bytes"
+        },
+        {
+          "type": "UsageStatRecord",
+          "name": "blocks"
+        },
+        {
+          "type": "Time",
+          "name": "mtime"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "FolderUsageStat",
+      "fields": [
+        {
+          "type": "string",
+          "name": "folderID"
+        },
+        {
+          "type": "UsageStat",
+          "name": "stats"
+        }
+      ]
+    },
+    {
+      "type": "record",
+      "name": "BlockQuotaInfo",
+      "fields": [
+        {
+          "type": {
+            "type": "array",
+            "items": "FolderUsageStat"
+          },
+          "name": "folders"
+        },
+        {
+          "type": "UsageStat",
+          "name": "total"
+        },
+        {
+          "type": "int64",
+          "name": "limit"
+        },
+        {
+          "type": "int64",
+          "name": "gitLimit"
+        }
+      ]
     }
   ],
   "messages": {
@@ -344,6 +431,21 @@
         }
       ],
       "response": "bytes"
+    },
+    "getUserQuotaInfo2": {
+      "request": [],
+      "response": "BlockQuotaInfo",
+      "compression_type": "gzip"
+    },
+    "getTeamQuotaInfo2": {
+      "request": [
+        {
+          "name": "tid",
+          "type": "TeamID"
+        }
+      ],
+      "response": "BlockQuotaInfo",
+      "compression_type": "gzip"
     },
     "blockPing": {
       "request": [],

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2695,6 +2695,7 @@ export type BinaryLinkID = Bytes
 export type BlockIdCombo = {readonly blockHash: String; readonly chargedTo: UserOrTeamID; readonly blockType: BlockType}
 export type BlockIdCount = {readonly id: BlockIdCombo; readonly liveCount: Int}
 export type BlockPingResponse = {}
+export type BlockQuotaInfo = {readonly folders?: Array<FolderUsageStat> | null; readonly total: UsageStat; readonly limit: Int64; readonly gitLimit: Int64}
 export type BlockRefNonce = string | null
 export type BlockReference = {readonly bid: BlockIdCombo; readonly nonce: BlockRefNonce; readonly chargedTo: UserOrTeamID}
 export type BlockReferenceCount = {readonly ref: BlockReference; readonly liveCount: Int}
@@ -2803,6 +2804,7 @@ export type FolderSyncConfig = {readonly mode: FolderSyncMode; readonly paths?: 
 export type FolderSyncConfigAndStatus = {readonly config: FolderSyncConfig; readonly status: FolderSyncStatus}
 export type FolderSyncConfigAndStatusWithFolder = {readonly folder: Folder; readonly config: FolderSyncConfig; readonly status: FolderSyncStatus}
 export type FolderSyncStatus = {readonly localDiskBytesAvailable: Int64; readonly localDiskBytesTotal: Int64; readonly prefetchStatus: PrefetchStatus; readonly prefetchProgress: PrefetchProgress; readonly storedBytesTotal: Int64; readonly outOfSyncSpace: Boolean}
+export type FolderUsageStat = {readonly folderID: String; readonly stats: UsageStat}
 export type FolderWithFavFlags = {readonly folder: Folder; readonly isFavorite: Boolean; readonly isIgnored: Boolean; readonly isNew: Boolean}
 export type FullName = String
 export type FullNamePackage = {readonly version: FullNamePackageVersion; readonly fullName: FullName; readonly eldestSeqno: Seqno; readonly status: StatusCode; readonly cachedAt: Time}
@@ -3211,6 +3213,8 @@ export type UpdateDetails = {readonly message: String}
 export type UpdateInfo = {readonly status: UpdateInfoStatus; readonly message: String}
 export type UpdateInfo2 = {status: UpdateInfoStatus2.ok} | {status: UpdateInfoStatus2.suggested; suggested: UpdateDetails} | {status: UpdateInfoStatus2.critical; critical: UpdateDetails}
 export type UpdaterStatus = {readonly log: String}
+export type UsageStat = {readonly bytes: UsageStatRecord; readonly blocks: UsageStatRecord; readonly mtime: Time}
+export type UsageStatRecord = {readonly write: Int64; readonly archive: Int64; readonly read: Int64; readonly mdWrite: Int64; readonly gitWrite: Int64; readonly gitArchive: Int64}
 export type User = {readonly uid: UID; readonly username: String}
 export type UserBlock = {readonly username: String; readonly chatBlocked: Boolean; readonly followBlocked: Boolean; readonly createTime?: Time | null; readonly modifyTime?: Time | null}
 export type UserBlockArg = {readonly username: String; readonly setChatBlock?: Boolean | null; readonly setFollowBlock?: Boolean | null}
@@ -3788,6 +3792,8 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.block.getReferenceCount'
 // 'keybase.1.block.getUserQuotaInfo'
 // 'keybase.1.block.getTeamQuotaInfo'
+// 'keybase.1.block.getUserQuotaInfo2'
+// 'keybase.1.block.getTeamQuotaInfo2'
 // 'keybase.1.block.blockPing'
 // 'keybase.1.bot.botTokenList'
 // 'keybase.1.bot.botTokenCreate'


### PR DESCRIPTION
The old RPCs for getting quota were so old that they manually encoded/decoded msgpack struct, rather than letting the RPC framework do it.  So the bytes they sent over the wire didn't end up being compressible.

This adds second RPC methods for both user and quota infos, along with new avdl structs, that should be more compressible.

(It doesn't use the new methods yet -- that must wait on a server change.)

Issue: HOTPOT-2091