### PR TITLE
libkbfs: consolidate quota usage objects

### DIFF
--- a/go/kbfs/libfuse/mount_test.go
+++ b/go/kbfs/libfuse/mount_test.go
@@ -47,7 +47,6 @@ func makeFS(ctx context.Context, t testing.TB, config *libkbfs.ConfigLocal) (
 	fuse.Debug = MakeFuseDebugFn(debugLog, false /* superVerbose */)
 
 	// TODO duplicates main() in kbfsfuse/main.go too much
-	quLog := config.MakeLogger(libkbfs.QuotaUsageLogModule("FSTest"))
 	filesys := &FS{
 		config:        config,
 		log:           log,
@@ -56,8 +55,6 @@ func makeFS(ctx context.Context, t testing.TB, config *libkbfs.ConfigLocal) (
 		errVlog:       config.MakeVLogger(log),
 		notifications: libfs.NewFSNotifications(log),
 		root:          NewRoot(),
-		quotaUsage: libkbfs.NewEventuallyConsistentQuotaUsage(
-			config, quLog, config.MakeVLogger(quLog)),
 	}
 	filesys.root.private = &FolderList{
 		fs:      filesys,

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1206,7 +1206,8 @@ func (c *ConfigLocal) journalizeBcaches(jManager *JournalManager) error {
 	return nil
 }
 
-func (c *ConfigLocal) getQuotaUsage(
+// GetQuotaUsage implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) GetQuotaUsage(
 	chargedTo keybase1.UserOrTeamID) *EventuallyConsistentQuotaUsage {
 	c.lock.RLock()
 	quota, ok := c.quotaUsage[chargedTo]
@@ -1242,7 +1243,7 @@ func (c *ConfigLocal) EnableDiskLimiter(configRoot string) error {
 	}
 
 	params := makeDefaultBackpressureDiskLimiterParams(
-		configRoot, c.getQuotaUsage, c.diskBlockCacheFraction, c.syncBlockCacheFraction)
+		configRoot, c.GetQuotaUsage, c.diskBlockCacheFraction, c.syncBlockCacheFraction)
 	log := c.MakeLogger("")
 	log.Debug("Setting disk storage byte limit to %d and file limit to %d",
 		params.byteLimit, params.fileLimit)

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -74,6 +74,8 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 			loggerFn: func(m string) logger.Logger {
 				return logger.NewTestLogger(ctr.t)
 			},
+			quotaUsage: make(
+				map[keybase1.UserOrTeamID]*EventuallyConsistentQuotaUsage),
 		},
 	}
 	config.mockKbfs = NewMockKBFSOps(c)

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -37,7 +37,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	id := tlf.FakeID(1, tlf.Private)
 	fbo := newFolderBranchOps(ctx, env.EmptyAppStateUpdater{}, config,
 		data.FolderBranch{Tlf: id, Branch: data.MasterBranch}, standard,
-		nil, nil, nil, nil)
+		nil, nil, nil)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(
 		gomock.Any(), gomock.Any(), gomock.Any()).

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -407,7 +407,6 @@ func newFolderBranchOps(
 	ctx context.Context, appStateUpdater env.AppStateUpdater,
 	config Config, fb data.FolderBranch,
 	bType branchType,
-	quotaUsage *EventuallyConsistentQuotaUsage,
 	serviceStatus *kbfsCurrentStatus, favs *Favorites,
 	syncedTlfObservers *syncedTlfObserverList) *folderBranchOps {
 	var nodeCache NodeCache
@@ -466,7 +465,7 @@ func newFolderBranchOps(
 		serviceStatus:      serviceStatus,
 		favs:               favs,
 		status: newFolderBranchStatusKeeper(
-			config, nodeCache, quotaUsage, fb.Tlf.Bytes()),
+			config, nodeCache, fb.Tlf.Bytes()),
 		mdWriterLock: mdWriterLock,
 		headLock:     headLock,
 		syncLock:     syncLock,

--- a/go/kbfs/libkbfs/folder_branch_status_test.go
+++ b/go/kbfs/libkbfs/folder_branch_status_test.go
@@ -33,7 +33,7 @@ func fbStatusTestInit(t *testing.T) (*gomock.Controller, *ConfigMock,
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().Return(idutil.ImplicitTeamInfo{}, errors.New("No such team"))
 	nodeCache := NewMockNodeCache(mockCtrl)
-	fbsk := newFolderBranchStatusKeeper(config, nodeCache, nil, nil)
+	fbsk := newFolderBranchStatusKeeper(config, nodeCache, nil)
 	interposeDaemonKBPKI(config, "alice", "bob")
 	return mockCtrl, config, fbsk, nodeCache
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2216,6 +2216,7 @@ type Config interface {
 	SetRekeyWithPromptWaitTime(time.Duration)
 	// PrefetchStatus returns the prefetch status of a block.
 	PrefetchStatus(context.Context, tlf.ID, data.BlockPointer) PrefetchStatus
+	GetQuotaUsage(keybase1.UserOrTeamID) *EventuallyConsistentQuotaUsage
 
 	// GracePeriod specifies a grace period for which a delayed cancellation
 	// waits before actual cancels the context. This is useful for giving

--- a/go/kbfs/libkbfs/journal_manager_test.go
+++ b/go/kbfs/libkbfs/journal_manager_test.go
@@ -72,7 +72,7 @@ func setupJournalManagerTest(t *testing.T) (
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
-	quotaUsage = config.getQuotaUsage(session.UID.AsUserOrTeam())
+	quotaUsage = config.GetQuotaUsage(session.UID.AsUserOrTeam())
 
 	setupSucceeded = true
 	return tempdir, ctx, cancel, config, quotaUsage, jManager
@@ -157,7 +157,7 @@ func TestJournalManagerOverQuotaError(t *testing.T) {
 	require.NoError(t, err)
 	AddTeamWriterForTestOrBust(t, config, teamID, session.UID)
 	AddTeamWriterForTestOrBust(t, config, subteamID, session.UID)
-	teamQuotaUsage := config.getQuotaUsage(teamID.AsUserOrTeam())
+	teamQuotaUsage := config.GetQuotaUsage(teamID.AsUserOrTeam())
 
 	qbs := &quotaBlockServer{BlockServer: config.BlockServer()}
 	config.SetBlockServer(qbs)

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -59,7 +59,6 @@ type KBFSOpsStandard struct {
 	editShutdown bool
 
 	currentStatus            *kbfsCurrentStatus
-	quotaUsage               *EventuallyConsistentQuotaUsage
 	longOperationDebugDumper *ImpatientDebugDumper
 
 	initLock       sync.Mutex
@@ -86,7 +85,6 @@ func NewKBFSOpsStandard(
 	appStateUpdater env.AppStateUpdater, config Config,
 	initDoneCh <-chan struct{}) *KBFSOpsStandard {
 	log := config.MakeLogger("")
-	quLog := config.MakeLogger(QuotaUsageLogModule("KBFSOps"))
 	kops := &KBFSOpsStandard{
 		appStateUpdater:       appStateUpdater,
 		config:                config,
@@ -98,8 +96,6 @@ func NewKBFSOpsStandard(
 		initDoneCh:            initDoneCh,
 		favs:                  NewFavorites(config),
 		syncedTlfObservers:    newSyncedTlfObserverList(),
-		quotaUsage: NewEventuallyConsistentQuotaUsage(
-			config, quLog, config.MakeVLogger(quLog)),
 		longOperationDebugDumper: NewImpatientDebugDumper(
 			config, longOperationDebugDumpDuration),
 		currentStatus: &kbfsCurrentStatus{},
@@ -745,17 +741,8 @@ func (fs *KBFSOpsStandard) getOpsNoAdd(
 		} else if fb.Branch.IsLocalConflict() {
 			bType = conflict
 		}
-		var quotaUsage *EventuallyConsistentQuotaUsage
-		if fb.Tlf.Type() != tlf.SingleTeam {
-			// If this is a non-team TLF, pass in a shared quota usage
-			// object, since the status of each non-team TLF will show
-			// the same quota usage. TODO: for team TLFs, we should
-			// also pass in a shared instance (see
-			// `ConfigLocal.quotaUsage`).
-			quotaUsage = fs.quotaUsage
-		}
 		ops = newFolderBranchOps(
-			ctx, fs.appStateUpdater, fs.config, fb, bType, quotaUsage,
+			ctx, fs.appStateUpdater, fs.config, fb, bType,
 			fs.currentStatus, fs.favs, fs.syncedTlfObservers)
 		fs.ops[fb] = ops
 	}
@@ -1438,9 +1425,10 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	case nil:
 		if mdserver != nil && mdserver.IsConnected() {
 			var quErr error
+			uid := session.UID.AsUserOrTeam()
 			_, usageBytes, archiveBytes, limitBytes,
 				gitUsageBytes, gitArchiveBytes, gitLimitBytes, quErr =
-				fs.quotaUsage.GetAllTypes(
+				fs.config.GetQuotaUsage(uid).GetAllTypes(
 					ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
 			if quErr != nil {
 				// The error is ignored here so that other fields can still be populated

--- a/go/kbfs/libkbfs/quota_usage.go
+++ b/go/kbfs/libkbfs/quota_usage.go
@@ -254,6 +254,7 @@ func (q *EventuallyConsistentQuotaUsage) Get(
 	ctx context.Context, bgTolerance, blockTolerance time.Duration) (
 	timestamp time.Time, usageBytes, archiveBytes, limitBytes int64,
 	err error) {
+	q.log.CDebugf(ctx, "%+v", errors.New("HERE"))
 	c := q.getCached()
 	err = q.fetcher.Do(ctx, bgTolerance, blockTolerance, c.timestamp)
 	if err != nil {


### PR DESCRIPTION
Use an already-existing map in the `ConfigLocal` instance to deal out quota usage instances everywhere that needs it.  This avoids multiple objects wastefully making the same RPCs many times.

Issue: HOTPOT-2091