### PR TITLE
update circle ci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     parallelism: 1
 
     docker:
-    - image: keybaseprivate/circleci-client@sha256:70d727f7de73d35a172d7dbd81628b3db62fbe252e91327f15d9adfabb58b4d5
+    - image: keybaseprivate/circleci-client@sha256:db626a8307a0daa7ab9d7f124bc0e3c2ca29046bd5218974f5f817fb00544149
 
     steps:
     ##


### PR DESCRIPTION
locally ran:
```
make build
make test
docker push keybaseprivate/circleci-client
```

upgrade image to use go 1.13.7