### PR TITLE
fix: change padding, positioning on file download icon

### DIFF
--- a/shared/chat/conversation/messages/attachment/file/index.tsx
+++ b/shared/chat/conversation/messages/attachment/file/index.tsx
@@ -95,12 +95,12 @@ const styles = Styles.styleSheetCreate(
       },
       downloadedIconWrapperStyle: {
         ...Styles.globalStyles.flexBoxCenter,
+        ...Styles.padding(3, 0, 3, 3),
         backgroundColor: Styles.globalColors.white,
         borderRadius: 20,
         bottom: 0,
-        padding: 3,
         position: 'absolute',
-        right: 0,
+        right: Styles.globalMargins.small,
       },
       error: {color: Styles.globalColors.redDark},
       iconStyle: {


### PR DESCRIPTION
The download icon for files was pushed to the edge of the screen. This PR fixes that by adjusting the absolute positioning of the icon and its padding.