### PR TITLE
fix CJK input by avoiding triggering events when composing IME

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -250,8 +250,8 @@ class Input extends React.Component<InputProps, InputState> {
     }
   }
 
-  _onKeyDown = (e: React.KeyboardEvent, isComposingIME: boolean) => {
-    if (e.key === 'Enter' && !(e.altKey || e.shiftKey || e.metaKey) && !isComposingIME) {
+  _onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !(e.altKey || e.shiftKey || e.metaKey)) {
       e.preventDefault()
       if (this._lastText) {
         this._onSubmit(this._lastText)

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -89,9 +89,9 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
     return false
   }
 
-  _onKeyDown = (e: React.KeyboardEvent, isComposingIME: boolean) => {
+  _onKeyDown = (e: React.KeyboardEvent) => {
     this._commonOnKeyDown(e)
-    this.props.onKeyDown && this.props.onKeyDown(e, isComposingIME)
+    this.props.onKeyDown && this.props.onKeyDown(e)
   }
 
   _onChangeText = (text: string) => {

--- a/shared/chat/conversation/input-area/normal/types.tsx
+++ b/shared/chat/conversation/input-area/normal/types.tsx
@@ -73,7 +73,7 @@ export type InputProps = {
 export type PlatformInputProps = {
   inputSetRef: (r: null | PlainInput) => void
   onChangeText: (newText: string) => void
-  onKeyDown: (evt: React.KeyboardEvent, isComposingIME: boolean) => void
+  onKeyDown: (evt: React.KeyboardEvent) => void
   setHeight: (inputHeight: number) => void
   suggestBotCommandsUpdateStatus: RPCChatTypes.UIBotCommandsUpdateStatusTyp
 } & CommonProps

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -78,7 +78,7 @@ type SuggestorHooks = {
   suggestionsVisible: boolean
   inputRef: React.RefObject<Kb.PlainInput> | null
   onChangeText: (arg0: string) => void
-  onKeyDown: (event: React.KeyboardEvent, isComposingIME: boolean) => void
+  onKeyDown: (event: React.KeyboardEvent) => void
   onBlur: () => void
   onFocus: () => void
   onSelectionChange: (arg0: {start: number | null; end: number | null}) => void
@@ -243,14 +243,14 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
       this._checkTrigger()
     }
 
-    _onKeyDown = (evt: React.KeyboardEvent, ici: boolean) => {
+    _onKeyDown = (evt: React.KeyboardEvent) => {
       if (evt.key === 'ArrowLeft' || evt.key === 'ArrowRight') {
         this._checkTrigger()
       }
 
       if (!this.state.active || this._getResults().data.length === 0) {
         // not showing list, bail
-        this.props.onKeyDown && this.props.onKeyDown(evt, ici)
+        this.props.onKeyDown && this.props.onKeyDown(evt)
         return
       }
 
@@ -281,7 +281,7 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
       }
 
       if (shouldCallParentCallback) {
-        this.props.onKeyDown && this.props.onKeyDown(evt, ici)
+        this.props.onKeyDown && this.props.onKeyDown(evt)
       }
     }
 

--- a/shared/chat/inbox/filter-row/index.tsx
+++ b/shared/chat/inbox/filter-row/index.tsx
@@ -23,8 +23,8 @@ export type Props = {
 class ConversationFilterInput extends React.PureComponent<Props> {
   private input = React.createRef<Kb.SearchFilter>()
 
-  private onKeyDown = (e: React.KeyboardEvent, isComposingIME: boolean) => {
-    if (e.key === 'Escape' && !isComposingIME) {
+  private onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
       this.props.onStopSearch()
     } else if (e.key === 'ArrowDown') {
       e.preventDefault()

--- a/shared/common-adapters/input.d.ts
+++ b/shared/common-adapters/input.d.ts
@@ -65,8 +65,8 @@ export type Props = {
   // If true it won't use its internal value to drive its rendering
   uncontrolled?: boolean
   // Desktop only.
-  onKeyDown?: (event: React.KeyboardEvent, isComposingIME: boolean) => void
-  onKeyUp?: (event: React.KeyboardEvent, isComposingIME: boolean) => void
+  onKeyDown?: (event: React.KeyboardEvent) => void
+  onKeyUp?: (event: React.KeyboardEvent) => void
   // Mobile only
   onEndEditing?: () => void
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters'

--- a/shared/common-adapters/input.desktop.tsx
+++ b/shared/common-adapters/input.desktop.tsx
@@ -188,8 +188,11 @@ class Input extends React.PureComponent<Props, State> {
   }
 
   _onKeyDown = (e: React.KeyboardEvent) => {
+    if (this._isComposingIME) {
+      return
+    }
     if (this.props.onKeyDown) {
-      this.props.onKeyDown(e, this._isComposingIME)
+      this.props.onKeyDown(e)
     }
     if (this.props.onEnterKeyDown && e.key === 'Enter' && !e.shiftKey && !this._isComposingIME) {
       if (e.altKey || e.ctrlKey) {
@@ -212,8 +215,11 @@ class Input extends React.PureComponent<Props, State> {
   }
 
   _onKeyUp = (e: React.KeyboardEvent) => {
+    if (this._isComposingIME) {
+      return
+    }
     if (this.props.onKeyUp) {
-      this.props.onKeyUp(e, this._isComposingIME)
+      this.props.onKeyUp(e)
     }
   }
 

--- a/shared/common-adapters/plain-input.d.ts
+++ b/shared/common-adapters/plain-input.d.ts
@@ -93,8 +93,8 @@ export type Props = {
   onEnterKeyDown?: (event?: React.BaseSyntheticEvent) => void
   // Desktop only
   onClick?: (event: Event) => void
-  onKeyDown?: (event: React.KeyboardEvent, isComposingIME: boolean) => void
-  onKeyUp?: (event: React.KeyboardEvent, isComposingIME: boolean) => void
+  onKeyDown?: (event: React.KeyboardEvent) => void
+  onKeyUp?: (event: React.KeyboardEvent) => void
   // Mobile only
   children?: React.ReactNode
   allowFontScaling?: boolean

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -136,8 +136,11 @@ class PlainInput extends React.PureComponent<InternalProps> {
   }
 
   _onKeyDown = (e: React.KeyboardEvent) => {
+    if (this._isComposingIME) {
+      return
+    }
     if (this.props.onKeyDown) {
-      this.props.onKeyDown(e, this._isComposingIME)
+      this.props.onKeyDown(e)
     }
     if (this.props.onEnterKeyDown && e.key === 'Enter' && !(e.shiftKey || e.ctrlKey || e.altKey)) {
       this.props.onEnterKeyDown(e)
@@ -145,8 +148,11 @@ class PlainInput extends React.PureComponent<InternalProps> {
   }
 
   _onKeyUp = (e: React.KeyboardEvent) => {
+    if (this._isComposingIME) {
+      return
+    }
     if (this.props.onKeyUp) {
-      this.props.onKeyUp(e, this._isComposingIME)
+      this.props.onKeyUp(e)
     }
   }
 

--- a/shared/common-adapters/search-filter.tsx
+++ b/shared/common-adapters/search-filter.tsx
@@ -50,8 +50,8 @@ type Props = {
   hotkey?: 'f' | 'k' | null // desktop only,
   // Maps to onSubmitEditing on native
   onEnterKeyDown?: (event?: React.BaseSyntheticEvent) => void
-  onKeyDown?: (event: React.KeyboardEvent, isComposingIME: boolean) => void
-  onKeyUp?: (event: React.KeyboardEvent, isComposingIME: boolean) => void
+  onKeyDown?: (event: React.KeyboardEvent) => void
+  onKeyUp?: (event: React.KeyboardEvent) => void
   onKeyPress?: (event: {
     nativeEvent: {
       key: 'Enter' | 'Backspace' | string
@@ -117,9 +117,9 @@ class SearchFilter extends React.PureComponent<Props, State> {
   private onHotkey = (cmd: string) => {
     this.props.hotkey && cmd.endsWith('+' + this.props.hotkey) && this.focus()
   }
-  private onKeyDown = (e: React.KeyboardEvent, isComposingIME: boolean) => {
-    e.key === 'Escape' && !isComposingIME && this.cancel(e)
-    this.props.onKeyDown && this.props.onKeyDown(e, isComposingIME)
+  private onKeyDown = (e: React.KeyboardEvent) => {
+    e.key === 'Escape' && this.cancel(e)
+    this.props.onKeyDown && this.props.onKeyDown(e)
   }
   private typing = () => this.state.focused || !!this.text()
   // RN fails at tracking this keyboard if we don't delay this, making it get stuck open.


### PR DESCRIPTION
Initially I did this by always checking `isComposingIME`, but realized we actually never want these events when composing IME. So here's the version I personally prefer, where we just don't trigger those events from the input component when composing. If in the future somehow we need to know key events during composing, we can add a flag to opt-in in those places.