### PR TITLE
libkbfs: add a few performance logs to KBFS

### DIFF
--- a/go/kbfs/env/context.go
+++ b/go/kbfs/env/context.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 )
@@ -57,6 +58,7 @@ type Context interface {
 	GetKBFSSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
 	BindToKBFSSocket() (net.Listener, error)
 	GetVDebugSetting() string
+	GetPerfLog() logger.Logger
 }
 
 // KBFSContext is an implementation for libkbfs.Context
@@ -151,6 +153,11 @@ func (c *KBFSContext) GetEnv() *libkb.Env {
 // GetRunMode returns run mode
 func (c *KBFSContext) GetRunMode() kbconst.RunMode {
 	return c.g.GetRunMode()
+}
+
+// GetPerfLog returns the perf log.
+func (c *KBFSContext) GetPerfLog() logger.Logger {
+	return c.g.GetPerfLog()
 }
 
 // NextAppStateUpdate implements AppStateUpdater.

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1234,6 +1234,15 @@ func (c *ConfigLocal) GetQuotaUsage(
 	return quota
 }
 
+// GetPerfLog returns the performance logger for KBFS.
+func (c *ConfigLocal) GetPerfLog() logger.Logger {
+	perfLog := c.kbCtx.GetPerfLog()
+	if perfLog != nil {
+		return perfLog
+	}
+	return c.MakeLogger("")
+}
+
 // EnableDiskLimiter fills in c.diskLimiter for use in journaling and
 // disk caching. It returns the EventuallyConsistentQuotaUsage object
 // used by the disk limiter.
@@ -1518,6 +1527,8 @@ func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {
 			// case, since the cleaning behavior depends on it being
 			// nil if there has been an error.
 			c.syncedTlfs = nil
+			c.GetPerfLog().CDebugf(
+				context.TODO(), "Failed to open database: %v", err)
 		}
 	}()
 	syncedTlfs := make(map[tlf.ID]FolderSyncConfig)

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1528,7 +1528,8 @@ func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {
 			// nil if there has been an error.
 			c.syncedTlfs = nil
 			c.GetPerfLog().CDebugf(
-				context.TODO(), "Failed to open database: %v", err)
+				context.TODO(),
+				"KBFS failed to open synced TLFs database: %v", err)
 		}
 	}()
 	syncedTlfs := make(map[tlf.ID]FolderSyncConfig)

--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -3441,6 +3441,8 @@ func (cr *ConflictResolver) recordFinishResolve(
 		cr.config.Reporter().NotifyFavoritesChanged(ctx)
 		cr.config.SubscriptionManagerPublisher().PublishChange(
 			keybase1.SubscriptionTopic_FILES_TAB_BADGE)
+		cr.config.GetPerfLog().CDebugf(
+			ctx, "Conflict resolution failed too many times for %v", err)
 	}
 }
 
@@ -3525,6 +3527,8 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	case ErrTooManyCRAttempts:
 		cr.log.CWarningf(ctx,
 			"Too many failed CR attempts for folder: %v", cr.fbo.id())
+		cr.config.GetPerfLog().CDebugf(
+			ctx, "Conflict resolution failed too many times for %v", err)
 		return
 	case nil:
 		defer func() {

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -645,29 +645,27 @@ func getInitMode(
 
 	switch modeString {
 	case InitDefaultString:
-		log.CDebugf(ctx, "Initializing in default mode")
 		// Already the default
 	case InitMinimalString:
-		log.CDebugf(ctx, "Initializing in minimal mode")
 		mode = InitMinimal
 	case InitSingleOpString:
-		log.CDebugf(ctx, "Initializing in singleOp mode")
 		mode = InitSingleOp
 	case InitConstrainedString:
-		log.CDebugf(ctx, "Initializing in constrained mode")
 		mode = InitConstrained
 	case InitMemoryLimitedString:
-		log.CDebugf(ctx, "Initializing in memoryLimited mode")
 		mode = InitMemoryLimited
 	case InitTestSearchString:
-		log.CDebugf(ctx, "Initializing in testSearch mode")
 		mode = InitTestSearch
 	case InitSingleOpWithQRString:
-		log.CDebugf(ctx, "Initializing in singleOpWithQR mode")
 		mode = InitSingleOpWithQR
 	default:
 		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}
+
+	log.CDebugf(ctx, "Initializing in %s mode", modeString)
+	kbCtx.GetPerfLog().CDebugf(
+		ctx, "KBFS initializing in %s mode, version %s", modeString,
+		VersionString())
 
 	return NewInitModeFromType(mode), nil
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2225,6 +2225,7 @@ type Config interface {
 	// PrefetchStatus returns the prefetch status of a block.
 	PrefetchStatus(context.Context, tlf.ID, data.BlockPointer) PrefetchStatus
 	GetQuotaUsage(keybase1.UserOrTeamID) *EventuallyConsistentQuotaUsage
+	GetPerfLog() logger.Logger
 
 	// GracePeriod specifies a grace period for which a delayed cancellation
 	// waits before actual cancels the context. This is useful for giving

--- a/go/kbfs/libkbfs/reporter_kbpki.go
+++ b/go/kbfs/libkbfs/reporter_kbpki.go
@@ -174,6 +174,7 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 	if code >= 0 {
 		n := errorNotification(err, code, tlfName, t, mode, filename, params)
 		r.Notify(ctx, n)
+		r.config.GetPerfLog().CDebugf(ctx, "KBFS error: %v", err)
 	}
 }
 


### PR DESCRIPTION
I just added some logs for starting KBFS, hitting notifiable errors, and maxing out on conflict resolution attempts.  We can add more later as we remember or learn about situations where it could be useful.

Issue: HOTPOT-2085