### PR TITLE
Fix text desktop style handling

### DIFF
--- a/shared/common-adapters/text.desktop.tsx
+++ b/shared/common-adapters/text.desktop.tsx
@@ -74,8 +74,8 @@ class Text extends React.Component<Props> {
         ref={this.props.allowHighlightText ? this._spanRef : null}
         className={this._className(this.props)}
         onClick={this.props.onClick || (this.props.onClickURL && this._urlClick) || undefined}
-        // @ts-ignore TODO fix styles
-        style={this.props.style}
+        // @ts-ignore TODO CrossPlatformStyles isn't compat with the underlying components
+        style={Styles.collapseStyles([this.props.style])}
       >
         {this.props.children}
       </span>


### PR DESCRIPTION
When making some changes to reduce prop thrashing I removed a bunch of collapse styles. Turns out we need this sort term as the StylesCrossPlatform is a type thats not really compatible with (any) of the underyling components. Now that we have TS we can actually make a correct type and reduce any intermediate types that erase type information. We'll tackle that eventually.
For now this just runs the style through `collapseStyles` so it filters out values like `false` or arrays