### PR TITLE
fix "not found" software error and other generator error

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -564,13 +564,11 @@ const loadPathMetadata = async (_: Container.TypedState, action: FsGen.LoadPathM
       },
       Constants.statWaitingKey
     )
-    console.log({songgao: 'loadPathMetadata', dirent})
     return FsGen.createPathItemLoaded({
       path,
       pathItem: makeEntry(dirent),
     })
   } catch (err) {
-    console.log({songgao: 'loadPathMetadata', err})
     return makeRetriableErrorHandler(action, path)(err)
   }
 }


### PR DESCRIPTION
The reason why "not found" screen wasn't shown was that the soft error actions from `loadPathMetadata` didn't actually get put. This PR just changes that from  generator to `chainAction2`. Also changed `ignoreFavorite`.

There are still two generator actions in `action/fs/index.tsx`. `pollJournalFlushStatusUntilDone` will be moved to the upload manager in Go (HOTPOT-2134). `folderList` is a bit complicated as it pulls state after getting the result from RPC. Seems like we should move those merging logics into Go as well (made TIRAGE-2344).