### PR TITLE
android lifecycle logs. gc on low mem like ios

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.java
@@ -148,6 +148,7 @@ public class MainActivity extends ReactActivity {
   @Override
   @TargetApi(Build.VERSION_CODES.KITKAT)
   protected void onCreate(Bundle savedInstanceState) {
+    NativeLogger.info("Activity onCreate");
     ReactInstanceManager instanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
     if (!this.createdReact) {
       this.createdReact = true;
@@ -202,6 +203,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onPause() {
+    NativeLogger.info("Activity onPause");
     super.onPause();
     if (Keybase.appDidEnterBackground()) {
       Keybase.appBeginBackgroundTaskNonblock(new KBPushNotifier(this, new Bundle()));
@@ -371,6 +373,7 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onResume() {
+    NativeLogger.info("Activity onPause");
     super.onResume();
     Keybase.setAppStateForeground();
 
@@ -383,12 +386,14 @@ public class MainActivity extends ReactActivity {
 
   @Override
   protected void onStart() {
+    NativeLogger.info("Activity onStart");
     super.onStart();
     Keybase.setAppStateForeground();
   }
 
   @Override
   protected void onDestroy() {
+    NativeLogger.info("Activity onDestroy");
     super.onDestroy();
     Keybase.appWillExit(new KBPushNotifier(this, new Bundle()));
   }

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainApplication.java
@@ -36,6 +36,8 @@ import io.keybase.ossifrage.modules.BackgroundSyncJob;
 import io.keybase.ossifrage.modules.NativeLogger;
 import io.keybase.ossifrage.modules.StorybookConstants;
 
+import static keybase.Keybase.forceGC;
+
 public class MainApplication extends Application implements ReactApplication {
     private final ReactModuleRegistryProvider mModuleRegistryProvider = new ReactModuleRegistryProvider(Arrays.<Package>asList(
       new ReactAdapterPackage(),
@@ -72,6 +74,12 @@ public class MainApplication extends Application implements ReactApplication {
             manager.cancelAllForTag(BackgroundSyncJob.TAG);
             BackgroundSyncJob.scheduleJob();
         }
+    }
+
+    @Override
+    public void onLowMemory() {
+        forceGC();
+        super.onLowMemory();
     }
 
     /**


### PR DESCRIPTION
add some logging and force gc on low mem (which ios already does)