### PR TITLE
Skip tests

### DIFF
--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -8,7 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func skipWebOfTrustTest(t *testing.T) {
+	t.Skip("skipping web-of-trust test until PICNIC-875")
+}
+
 func TestWebOfTrustVouch(t *testing.T) {
+	skipWebOfTrustTest(t)
 	tc1 := SetupEngineTest(t, "wot")
 	tc2 := SetupEngineTest(t, "wot")
 	tc3 := SetupEngineTest(t, "wot")
@@ -96,6 +101,7 @@ func TestWebOfTrustVouch(t *testing.T) {
 }
 
 func TestWebOfTrustPending(t *testing.T) {
+	skipWebOfTrustTest(t)
 	tcAlice := SetupEngineTest(t, "wot")
 	tcBob := SetupEngineTest(t, "wot")
 	defer tcAlice.Cleanup()
@@ -196,6 +202,7 @@ func TestWebOfTrustPending(t *testing.T) {
 }
 
 func TestWebOfTrustAccept(t *testing.T) {
+	skipWebOfTrustTest(t)
 	tcAlice := SetupEngineTest(t, "wot")
 	tcBob := SetupEngineTest(t, "wot")
 	defer tcAlice.Cleanup()
@@ -270,6 +277,7 @@ func TestWebOfTrustAccept(t *testing.T) {
 }
 
 func TestWebOfTrustReject(t *testing.T) {
+	skipWebOfTrustTest(t)
 	tcAlice := SetupEngineTest(t, "wot")
 	tcBob := SetupEngineTest(t, "wot")
 	defer tcAlice.Cleanup()
@@ -337,6 +345,7 @@ func TestWebOfTrustReject(t *testing.T) {
 
 // perhaps revisit after Y2K-1494
 func TestWebOfTrustSigBug(t *testing.T) {
+	skipWebOfTrustTest(t)
 	tcAlice := SetupEngineTest(t, "wot")
 	tcBob := SetupEngineTest(t, "wot")
 	defer tcAlice.Cleanup()


### PR DESCRIPTION
Don't break CI while getting server and client changes to line up.