### PR TITLE
feat: chat button on needsupgrade profile

### DIFF
--- a/shared/profile/user/actions/index.tsx
+++ b/shared/profile/user/actions/index.tsx
@@ -108,6 +108,18 @@ const Actions = (p: Props) => {
         chatButton,
         dropdown,
       ]
+    } else if (p.state === 'needsUpgrade') {
+      buttons = [
+        chatButton,
+        <Kb.WaitingButton
+          key="Accept"
+          type="Success"
+          label="Accept"
+          waitingKey={Constants.waitingKey}
+          onClick={p.onAccept}
+        />,
+        dropdown,
+      ]
     } else {
       buttons = [
         <Kb.WaitingButton


### PR DESCRIPTION
Replaces the "reload" button with a chat button for upgraded profiles of users you follow.