### PR TITLE
tlfhandle: handle identify errors correctly on single assertions

### DIFF
--- a/go/kbfs/tlfhandle/resolve.go
+++ b/go/kbfs/tlfhandle/resolve.go
@@ -696,8 +696,8 @@ func (ra resolvableAssertion) resolve(ctx context.Context) (
 		}
 		reason := fmt.Sprintf("You accessed a folder with %s.", ra.assertion)
 		var resName kbname.NormalizedUsername
-		resName, _, err = ra.identifier.Identify(
-			ctx, ra.assertion, reason, ra.offline)
+		resName, err = IdentifySingleAssertion(
+			ctx, ra.assertion, reason, ra.identifier, ra.offline)
 		if err == nil && resName != name {
 			return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID,
 				fmt.Errorf(


### PR DESCRIPTION
When identifying a single assertion before resolving it (e.g., because it contained a "+" character), and when extended identify behavior was set, we weren't calling `makeTlfBreaksIfNeeded()`.  So if there was an error, reporting the error would hang because there was nothing waiting on the extended identify `userBreaks` channel.

So this commit wraps that behavior into a util function and makes sure it won't hang.

Issue: HOTPOT-2141