### PR TITLE
fix miniature menubar icon on Linux

### DIFF
--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -16,7 +16,6 @@ import {ProxyProps, RemoteTlfUpdates} from './remote-serializer.desktop'
 import {mapFilterByKey} from '../util/map'
 import {memoize} from '../util/memoize'
 import shallowEqual from 'shallowequal'
-import {useInterval} from '../common-adapters/use-timers'
 
 const getIcons = (iconType: NotificationTypes.BadgeType, isBadged: boolean) => {
   const devMode = __DEV__ ? '-dev' : ''

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -9,13 +9,14 @@ import * as Electron from 'electron'
 import {intersect} from '../util/set'
 import useSerializeProps from '../desktop/remote/use-serialize-props.desktop'
 import {serialize} from './remote-serializer.desktop'
-import {isDarwin, isWindows} from '../constants/platform'
+import {isDarwin, isWindows, isLinux} from '../constants/platform'
 import {isSystemDarkMode} from '../styles/dark-mode'
 import {uploadsToUploadCountdownHOCProps} from '../fs/footer/upload-container'
 import {ProxyProps, RemoteTlfUpdates} from './remote-serializer.desktop'
 import {mapFilterByKey} from '../util/map'
 import {memoize} from '../util/memoize'
 import shallowEqual from 'shallowequal'
+import {useInterval} from '../common-adapters/use-timers'
 
 const getIcons = (iconType: NotificationTypes.BadgeType, isBadged: boolean) => {
   const devMode = __DEV__ ? '-dev' : ''
@@ -32,9 +33,10 @@ const getIcons = (iconType: NotificationTypes.BadgeType, isBadged: boolean) => {
   }
 
   const size = isWindows ? 16 : 22
-  const icon = `icon-${platform}keybase-menubar-${badged}${iconType}-${color}-${size}${devMode}@2x.png`
+  const x = isLinux ? '' : '@2x'
+  const icon = `icon-${platform}keybase-menubar-${badged}${iconType}-${color}-${size}${devMode}${x}.png`
   // Only used on Darwin
-  const iconSelected = `icon-${platform}keybase-menubar-${iconType}-${colorSelected}-${size}${devMode}@2x.png`
+  const iconSelected = `icon-${platform}keybase-menubar-${iconType}-${colorSelected}-${size}${devMode}${x}.png`
   return [icon, iconSelected]
 }
 


### PR DESCRIPTION
Weirdly if I set the same icon `desktop/app/menu-bar.desktop.tsx` the app crashes right after it starts, with no error message at all. It's as if it didn't start anything.