### PR TITLE
add teamname, channelname, or username in platform input hint

### DIFF
--- a/shared/chat/conversation/input-area/normal/container.tsx
+++ b/shared/chat/conversation/input-area/normal/container.tsx
@@ -7,6 +7,7 @@ import * as ConfigGen from '../../../../actions/config-gen'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 import * as RPCChatTypes from '../../../../constants/types/rpc-chat-gen'
 import * as Waiting from '../../../../constants/waiting'
+import * as Platform from '../../../../constants/platform'
 import HiddenString from '../../../../util/hidden-string'
 import * as Container from '../../../../util/container'
 import {memoize} from '../../../../util/memoize'
@@ -107,6 +108,28 @@ const getChannelSuggestions = (
   return _channelSuggestions
 }
 
+const getConversationNameForInput = (
+  state: Container.TypedState,
+  conversationIDKey: Types.ConversationIDKey
+): string => {
+  const meta = Constants.getMeta(state, conversationIDKey)
+  if (meta.teamType === 'big') {
+    return meta.channelname ? `in ${Platform.isMobile ? '' : `@${meta.teamname}`}#${meta.channelname}` : ''
+  }
+  if (meta.teamType === 'small') {
+    return meta.teamname ? `in ${meta.teamname}` : ''
+  }
+  if (meta.teamType === 'adhoc') {
+    const participantInfo = state.chat2.participantMap.get(conversationIDKey) || Constants.noParticipantInfo
+    if (participantInfo.name.length) {
+      return participantInfo.name.length > 2
+        ? 'in the group'
+        : `to @${participantInfo.name.find(n => n !== state.config.username)}`
+    }
+  }
+  return ''
+}
+
 export default Container.namedConnect(
   (state, {conversationIDKey}: OwnProps) => {
     const editInfo = Constants.getEditInfo(state, conversationIDKey)
@@ -115,7 +138,7 @@ export default Container.namedConnect(
     const isSearching = Constants.getThreadSearchInfo(state, conversationIDKey).visible
     // don't include 'small' here to ditch the single #general suggestion
     const teamname = meta.teamType === 'big' ? meta.teamname : ''
-    const conversationName = Constants.getConversationNameForInput(state, conversationIDKey)
+    const conversationName = getConversationNameForInput(state, conversationIDKey)
 
     const _you = state.config.username
 

--- a/shared/chat/conversation/input-area/normal/container.tsx
+++ b/shared/chat/conversation/input-area/normal/container.tsx
@@ -115,6 +115,7 @@ export default Container.namedConnect(
     const isSearching = Constants.getThreadSearchInfo(state, conversationIDKey).visible
     // don't include 'small' here to ditch the single #general suggestion
     const teamname = meta.teamType === 'big' ? meta.teamname : ''
+    const conversationName = Constants.getConversationNameForInput(state, conversationIDKey)
 
     const _you = state.config.username
 
@@ -143,6 +144,7 @@ export default Container.namedConnect(
       _you,
       cannotWrite: meta.cannotWrite,
       conversationIDKey,
+      conversationName,
       editText: editInfo ? editInfo.text : '',
       explodingModeSeconds,
       infoPanelShowing: state.chat2.infoPanelShowing,
@@ -257,6 +259,7 @@ export default Container.namedConnect(
       cannotWrite: stateProps.cannotWrite,
       clearInboxFilter: dispatchProps.clearInboxFilter,
       conversationIDKey: stateProps.conversationIDKey,
+      conversationName: stateProps.conversationName,
       editText: stateProps.editText,
       explodingModeSeconds: stateProps.explodingModeSeconds,
       focusInputCounter: ownProps.focusInputCounter,

--- a/shared/chat/conversation/input-area/normal/index.stories.tsx
+++ b/shared/chat/conversation/input-area/normal/index.stories.tsx
@@ -88,6 +88,7 @@ const InputContainer = (props: Props) => {
     cannotWrite: props.cannotWrite || false,
     clearInboxFilter: Sb.action('clearInboxFilter'),
     conversationIDKey: stringToConversationIDKey('fake conversation id key'),
+    conversationName: '',
     editText: '',
     explodingModeSeconds: props.explodingModeSeconds,
     focusInputCounter: 0,

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -169,18 +169,22 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
     this.props.toggleShowingMenu()
   }
 
-  render() {
-    let hintText = 'Write a message'
+  _getHintText = () => {
     if (this.props.cannotWrite) {
-      hintText = `You must be at least ${indefiniteArticle(this.props.minWriterRole)} ${
+      return `You must be at least ${indefiniteArticle(this.props.minWriterRole)} ${
         this.props.minWriterRole
       } to post.`
     } else if (this.props.isEditing) {
-      hintText = 'Edit your message'
+      return 'Edit your message'
     } else if (this.props.isExploding) {
-      hintText = 'Write an exploding message'
+      return this.props.conversationName
+        ? `Exploding message ${this.props.conversationName}`
+        : 'Eploding message'
     }
+    return this.props.conversationName ? `Message ${this.props.conversationName}` : 'Write a message'
+  }
 
+  render() {
     return (
       <KeyEventHandler
         onKeyDown={this._globalKeyDownPressHandler}
@@ -254,7 +258,7 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
                 disabled={this.props.cannotWrite ?? false}
                 autoFocus={false}
                 ref={this._inputSetRef}
-                placeholder={hintText}
+                placeholder={this._getHintText()}
                 style={Styles.collapseStyles([styles.input, this.props.isEditing && styles.inputEditing])}
                 onChangeText={this._onChangeText}
                 multiline={true}

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -169,7 +169,7 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
     this.props.toggleShowingMenu()
   }
 
-  _getHintText = () => {
+  private getHintText = () => {
     if (this.props.cannotWrite) {
       return `You must be at least ${indefiniteArticle(this.props.minWriterRole)} ${
         this.props.minWriterRole
@@ -258,7 +258,7 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
                 disabled={this.props.cannotWrite ?? false}
                 autoFocus={false}
                 ref={this._inputSetRef}
-                placeholder={this._getHintText()}
+                placeholder={this.getHintText()}
                 style={Styles.collapseStyles([styles.input, this.props.isEditing && styles.inputEditing])}
                 onChangeText={this._onChangeText}
                 multiline={true}

--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -146,19 +146,20 @@ class _PlatformInput extends React.PureComponent<PlatformInputPropsInternal, Sta
   }
 
   private getHintText = () => {
-    let hintText = 'Write a message'
     if (this.props.isExploding && isLargeScreen) {
-      hintText = 'Exploding message'
+      return this.props.conversationName
+        ? `Exploding message ${this.props.conversationName}`
+        : 'Exploding message'
     } else if (this.props.isExploding && !isLargeScreen) {
-      hintText = 'Exploding'
+      return this.props.conversationName ? `Exploding ${this.props.conversationName}` : 'Exploding'
     } else if (this.props.isEditing) {
-      hintText = 'Edit your message'
+      return 'Edit your message'
     } else if (this.props.cannotWrite) {
-      hintText = `You must be at least ${indefiniteArticle(this.props.minWriterRole)} ${
+      return `You must be at least ${indefiniteArticle(this.props.minWriterRole)} ${
         this.props.minWriterRole
       } to post.`
     }
-    return hintText
+    return this.props.conversationName ? `Message ${this.props.conversationName}` : 'Write a message'
   }
 
   private getMenu = () => {

--- a/shared/chat/conversation/input-area/normal/types.tsx
+++ b/shared/chat/conversation/input-area/normal/types.tsx
@@ -8,6 +8,7 @@ type CommonProps = {
   cannotWrite: boolean | null
   clearInboxFilter: () => void
   conversationIDKey: Types.ConversationIDKey
+  conversationName: string
   editText: string
   explodingModeSeconds: number
   focusInputCounter: number
@@ -71,7 +72,6 @@ export type InputProps = {
 } & CommonProps
 
 export type PlatformInputProps = {
-  conversationName: string
   inputSetRef: (r: null | PlainInput) => void
   onChangeText: (newText: string) => void
   onKeyDown: (evt: React.KeyboardEvent) => void

--- a/shared/chat/conversation/input-area/normal/types.tsx
+++ b/shared/chat/conversation/input-area/normal/types.tsx
@@ -71,6 +71,7 @@ export type InputProps = {
 } & CommonProps
 
 export type PlatformInputProps = {
+  conversationName: string
   inputSetRef: (r: null | PlainInput) => void
   onChangeText: (newText: string) => void
   onKeyDown: (evt: React.KeyboardEvent) => void

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -510,30 +510,6 @@ export const getParticipantInfo = (
   return participantInfo ? participantInfo : noParticipantInfo
 }
 
-export const getConversationNameForInput = (
-  state: TypedState,
-  conversationIDKey: Types.ConversationIDKey
-): string => {
-  const meta = getMeta(state, conversationIDKey)
-  console.log({songgao: 'container', meta})
-  if (meta.teamType === 'big') {
-    return meta.channelname ? `in ${isMobile ? '' : `@${meta.teamname}`}#${meta.channelname}` : ''
-  }
-  if (meta.teamType === 'small') {
-    return meta.teamname ? `in ${meta.teamname}` : ''
-  }
-  if (meta.teamType === 'adhoc') {
-    const participantInfo = state.chat2.participantMap.get(conversationIDKey) || noParticipantInfo
-    console.log({songgao: 'container', participantInfo})
-    if (participantInfo.name.length) {
-      return participantInfo.name.length > 2
-        ? 'in the group'
-        : `to @${participantInfo.name.find(n => n !== state.config.username)}`
-    }
-  }
-  return ''
-}
-
 const _getParticipantSuggestionsMemoized = memoize(
   (
     teamMembers: Map<string, TeamTypes.MemberInfo> | undefined,

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -510,6 +510,30 @@ export const getParticipantInfo = (
   return participantInfo ? participantInfo : noParticipantInfo
 }
 
+export const getConversationNameForInput = (
+  state: TypedState,
+  conversationIDKey: Types.ConversationIDKey
+): string => {
+  const meta = getMeta(state, conversationIDKey)
+  console.log({songgao: 'container', meta})
+  if (meta.teamType === 'big') {
+    return meta.channelname ? `in ${isMobile ? '' : `@${meta.teamname}`}#${meta.channelname}` : ''
+  }
+  if (meta.teamType === 'small') {
+    return meta.teamname ? `in ${meta.teamname}` : ''
+  }
+  if (meta.teamType === 'adhoc') {
+    const participantInfo = state.chat2.participantMap.get(conversationIDKey) || noParticipantInfo
+    console.log({songgao: 'container', participantInfo})
+    if (participantInfo.name.length) {
+      return participantInfo.name.length > 2
+        ? 'in the group'
+        : `to @${participantInfo.name.find(n => n !== state.config.username)}`
+    }
+  }
+  return ''
+}
+
 const _getParticipantSuggestionsMemoized = memoize(
   (
     teamMembers: Map<string, TeamTypes.MemberInfo> | undefined,


### PR DESCRIPTION
Discussed in design briefly about this change. 

@cecileboucheron Here's the strategy I ended up using:

1. For adhoc teams, either say "Message to <username>", or "Message in the group"
2. For small teams: "Message in <teamname"
3. For big teams: "Message in @ teamname#channelname" on desktop, and "Message in #channelname"  on mobile.

Since we have an upper bond of 20 for channel names, this hint won't overflow. (Otherwise dealing with overflow seems a bit hard since the input box is multiline.