### PR TITLE
wot vouch cli fills in failing_proofs

### DIFF
--- a/go/client/cmd_wot_vouch.go
+++ b/go/client/cmd_wot_vouch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keybase/client/go/libcmdline"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
 
@@ -80,12 +81,15 @@ func (c *cmdWotVouch) ParseArgv(ctx *cli.Context) error {
 }
 
 func (c *cmdWotVouch) Run() error {
+	protocols := []rpc.Protocol{NewIdentifyUIProtocol(c.G())}
+	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
+		return err
+	}
 	arg := keybase1.WotVouchCLIArg{
 		Assertion:  c.assertion,
 		VouchTexts: []string{c.message},
 		Confidence: c.confidence,
 	}
-
 	cli, err := GetWebOfTrustClient(c.G())
 	if err != nil {
 		return err

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -155,6 +155,13 @@ func (e *ResolveThenIdentify2) Result(m libkb.MetaContext) (*keybase1.Identify2R
 	return e.i2eng.Result(m)
 }
 
+func (e *ResolveThenIdentify2) ResultWotFailingProofs(mctx libkb.MetaContext) (failingProofs []keybase1.WotProof, err error) {
+	if e.i2eng == nil {
+		return nil, errors.New("ResolveThenIdentify2#ResultWotFailingProofs: no result available if the engine did not run")
+	}
+	return e.i2eng.ResultWotFailingProofs(mctx)
+}
+
 func (e *ResolveThenIdentify2) SetResponsibleGregorItem(item gregor.Item) {
 	e.responsibleGregorItem = item
 }

--- a/go/engine/wot_vouch.go
+++ b/go/engine/wot_vouch.go
@@ -13,9 +13,10 @@ import (
 )
 
 type WotVouchArg struct {
-	Vouchee    keybase1.UserVersion
-	Confidence keybase1.Confidence
-	VouchTexts []string
+	Vouchee       keybase1.UserVersion
+	Confidence    keybase1.Confidence
+	FailingProofs []keybase1.WotProof
+	VouchTexts    []string
 }
 
 // WotVouch is an engine.
@@ -85,14 +86,23 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 	if err := statement.SetKey("user", them.ToWotStatement()); err != nil {
 		return err
 	}
-	if err := statement.SetKey("vouch_text", libkb.JsonwStringArray(e.arg.VouchTexts)); err != nil {
-		return err
-	}
 	confidenceJw, err := jsonw.WrapperFromObject(e.arg.Confidence)
 	if err != nil {
 		return err
 	}
 	if err := statement.SetKey("confidence", confidenceJw); err != nil {
+		return err
+	}
+	if len(e.arg.FailingProofs) > 0 {
+		failingProofsJw, err := jsonw.WrapperFromObject(e.arg.FailingProofs)
+		if err != nil {
+			return err
+		}
+		if err := statement.SetKey("failing_proofs", failingProofsJw); err != nil {
+			return err
+		}
+	}
+	if err := statement.SetKey("vouch_text", libkb.JsonwStringArray(e.arg.VouchTexts)); err != nil {
 		return err
 	}
 	expansions, sum, err := libkb.EmbedExpansionObj(statement)

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -159,7 +159,7 @@ func (o WotVouch) DeepCopy() WotVouch {
 
 type WotVouchArg struct {
 	SessionID  int         `codec:"sessionID" json:"sessionID"`
-	Uv         UserVersion `codec:"uv" json:"uv"`
+	Vouchee    UserVersion `codec:"vouchee" json:"vouchee"`
 	VouchTexts []string    `codec:"vouchTexts" json:"vouchTexts"`
 	Confidence Confidence  `codec:"confidence" json:"confidence"`
 }
@@ -173,7 +173,7 @@ type WotVouchCLIArg struct {
 
 type WotReactArg struct {
 	SessionID int             `codec:"sessionID" json:"sessionID"`
-	Uv        UserVersion     `codec:"uv" json:"uv"`
+	Voucher   UserVersion     `codec:"voucher" json:"voucher"`
 	Proof     SigID           `codec:"proof" json:"proof"`
 	Reaction  WotReactionType `codec:"reaction" json:"reaction"`
 }

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -27,7 +28,7 @@ func (h *WebOfTrustHandler) WotVouch(ctx context.Context, arg keybase1.WotVouchA
 	mctx := libkb.NewMetaContext(ctx, h.G())
 
 	earg := &engine.WotVouchArg{
-		Vouchee:    arg.Uv,
+		Vouchee:    arg.Vouchee,
 		VouchTexts: arg.VouchTexts,
 		Confidence: arg.Confidence,
 	}
@@ -40,21 +41,49 @@ func (h *WebOfTrustHandler) WotVouchCLI(ctx context.Context, arg keybase1.WotVou
 	ctx = libkb.WithLogTag(ctx, "WOT")
 	mctx := libkb.NewMetaContext(ctx, h.G())
 
-	// TODO PICNIC-875 fill in FailingProofs by ID-ing the vouchee.
-
 	upak, _, err := h.G().GetUPAKLoader().Load(libkb.NewLoadUserArg(h.G()).WithName(arg.Assertion))
 	if err != nil {
 		return err
 	}
 
-	earg := &engine.WotVouchArg{
-		Vouchee:    upak.Base.ToUserVersion(),
-		VouchTexts: arg.VouchTexts,
-		Confidence: arg.Confidence,
+	eng := engine.NewResolveThenIdentify2(mctx.G(), &keybase1.Identify2Arg{
+		Uid:              upak.GetUID(),
+		UserAssertion:    arg.Assertion,
+		NeedProofSet:     true,
+		UseDelegateUI:    true,
+		Reason:           keybase1.IdentifyReason{Reason: fmt.Sprintf("Vouch for %v", arg.Assertion)},
+		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
+	})
+	err = engine.RunEngine2(mctx.WithUIs(libkb.UIs{
+		IdentifyUI: h.NewRemoteIdentifyUI(arg.SessionID, mctx.G()),
+	}), eng)
+	if err != nil {
+		return err
 	}
-
-	eng := engine.NewWotVouch(h.G(), earg)
-	return engine.RunEngine2(mctx, eng)
+	idRes, err := eng.Result(mctx)
+	if err != nil {
+		return err
+	}
+	if idRes == nil {
+		return fmt.Errorf("missing identify result")
+	}
+	if idRes.TrackBreaks != nil {
+		mctx.Debug("WotVouchCLI TrackBreaks: %+v", idRes.TrackBreaks)
+		return libkb.TrackingBrokeError{}
+	}
+	failingProofs, err := eng.ResultWotFailingProofs(mctx)
+	if err != nil {
+		return err
+	}
+	for i, proof := range failingProofs {
+		mctx.Debug("WotVouchCLI failingProofs %v/%v %+v", i+1, len(failingProofs), proof)
+	}
+	return engine.RunEngine2(mctx, engine.NewWotVouch(h.G(), &engine.WotVouchArg{
+		Vouchee:       idRes.Upk.Current.ToUserVersion(),
+		Confidence:    arg.Confidence,
+		FailingProofs: failingProofs,
+		VouchTexts:    arg.VouchTexts,
+	}))
 }
 
 func (h *WebOfTrustHandler) WotListCLI(ctx context.Context, arg keybase1.WotListCLIArg) (res []keybase1.WotVouch, err error) {
@@ -71,7 +100,7 @@ func (h *WebOfTrustHandler) WotReact(ctx context.Context, arg keybase1.WotReactA
 	mctx := libkb.NewMetaContext(ctx, h.G())
 
 	earg := &engine.WotReactArg{
-		Voucher:  arg.Uv,
+		Voucher:  arg.Voucher,
 		Proof:    arg.Proof,
 		Reaction: arg.Reaction,
 	}
@@ -123,9 +152,41 @@ func (h *WebOfTrustHandler) WotReactCLI(ctx context.Context, arg keybase1.WotRea
 
 	rarg := keybase1.WotReactArg{
 		SessionID: arg.SessionID,
-		Uv:        expectedVoucher,
+		Voucher:   expectedVoucher,
 		Proof:     reactingVouch.VouchProof,
 		Reaction:  arg.Reaction,
 	}
 	return h.WotReact(ctx, rarg)
+}
+
+// Just get a list of proof results.
+type identifyUIResultShim struct {
+	libkb.IdentifyUI
+	mu   sync.Mutex
+	rows []identifyUIResultShimRow
+}
+
+type identifyUIResultShimRow struct {
+	Proof  keybase1.RemoteProof
+	Result keybase1.LinkCheckResult
+}
+
+func (i *identifyUIResultShim) FinishWebProofCheck(mctx libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.rows = append(i.rows, identifyUIResultShimRow{p, l})
+	return i.IdentifyUI.FinishWebProofCheck(mctx, p, l)
+}
+
+func (i *identifyUIResultShim) FinishSocialProofCheck(mctx libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.rows = append(i.rows, identifyUIResultShimRow{p, l})
+	return i.IdentifyUI.FinishSocialProofCheck(mctx, p, l)
+}
+
+func (i *identifyUIResultShim) ProofResults() []identifyUIResultShimRow {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.rows
 }

--- a/go/service/wot.go
+++ b/go/service/wot.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/keybase/client/go/engine"
 	"github.com/keybase/client/go/libkb"
@@ -157,36 +156,4 @@ func (h *WebOfTrustHandler) WotReactCLI(ctx context.Context, arg keybase1.WotRea
 		Reaction:  arg.Reaction,
 	}
 	return h.WotReact(ctx, rarg)
-}
-
-// Just get a list of proof results.
-type identifyUIResultShim struct {
-	libkb.IdentifyUI
-	mu   sync.Mutex
-	rows []identifyUIResultShimRow
-}
-
-type identifyUIResultShimRow struct {
-	Proof  keybase1.RemoteProof
-	Result keybase1.LinkCheckResult
-}
-
-func (i *identifyUIResultShim) FinishWebProofCheck(mctx libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.rows = append(i.rows, identifyUIResultShimRow{p, l})
-	return i.IdentifyUI.FinishWebProofCheck(mctx, p, l)
-}
-
-func (i *identifyUIResultShim) FinishSocialProofCheck(mctx libkb.MetaContext, p keybase1.RemoteProof, l keybase1.LinkCheckResult) error {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	i.rows = append(i.rows, identifyUIResultShimRow{p, l})
-	return i.IdentifyUI.FinishSocialProofCheck(mctx, p, l)
-}
-
-func (i *identifyUIResultShim) ProofResults() []identifyUIResultShimRow {
-	i.mu.Lock()
-	defer i.mu.Unlock()
-	return i.rows
 }

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -40,14 +40,14 @@ protocol wot {
     string other;
   }
 
-  void wotVouch(int sessionID, UserVersion uv /* vouchee */, array<string> vouchTexts, Confidence confidence);
+  void wotVouch(int sessionID, UserVersion vouchee, array<string> vouchTexts, Confidence confidence);
   void wotVouchCLI(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);
 
   enum WotReactionType {
     ACCEPT_0,
     REJECT_1
   }
-  void wotReact(int sessionID, UserVersion uv /* voucher */, SigID proof, WotReactionType reaction);
+  void wotReact(int sessionID, UserVersion voucher, SigID proof, WotReactionType reaction);
   void wotReactCLI(int sessionID, string username /* voucher */, WotReactionType reaction);
 
   record WotVouch {

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -137,7 +137,7 @@
           "type": "int"
         },
         {
-          "name": "uv",
+          "name": "vouchee",
           "type": "UserVersion"
         },
         {
@@ -185,7 +185,7 @@
           "type": "int"
         },
         {
-          "name": "uv",
+          "name": "voucher",
           "type": "UserVersion"
         },
         {


### PR DESCRIPTION
`keybase wot vouch` fills in failing_proofs. A tracker popup pops up, which is suboptimal. The tracker popup probably isn't too hard to hide, but I'd rather write Identify4 than wrangle it. This is CLI only. The gui flow on the other hand should use the proof results seen on screen before hitting "send".