### PR TITLE
libpages/libfs: avoid panic in logging

### DIFF
--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -124,7 +124,7 @@ func pathForLogging(
 		childName := n.ChildName(p)
 		ret = path.Join(ret, childName.String())
 		nextNode, _, err := config.KBFSOps().Lookup(ctx, n, childName)
-		if err != nil {
+		if err != nil || nextNode == nil {
 			// Just keep using the parent node to obfuscate.
 			continue
 		}

--- a/go/kbfs/libfs/fs.go
+++ b/go/kbfs/libfs/fs.go
@@ -124,6 +124,11 @@ func pathForLogging(
 		childName := n.ChildName(p)
 		ret = path.Join(ret, childName.String())
 		nextNode, _, err := config.KBFSOps().Lookup(ctx, n, childName)
+		// If filename is a path that includes a symlink, we can get a nil node
+		// here. So just move on if nextNode == nil. In the very rare case of
+		// an entry that gets a duplicated obfuscated name within a directory,
+		// this could give the wrong answer. But it's not worth it at this time
+		// to follow the symlnk for logging.
 		if err != nil || nextNode == nil {
 			// Just keep using the parent node to obfuscate.
 			continue

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -707,7 +707,11 @@ func (mt modeTest) QuotaReclamationMinHeadAge() time.Duration {
 	return 0
 }
 
+// EnvKeybaseTestObfuscateLogsForTest is "KEYBASE_TEST_OBFUSCATE_LOGS" and used
+// to specify if log obfuscation should be enabled for test.
+const EnvKeybaseTestObfuscateLogsForTest = "KEYBASE_TEST_OBFUSCATE_LOGS"
+
 func (mt modeTest) DoLogObfuscation() bool {
-	e := os.Getenv("KEYBASE_TEST_OBFUSCATE_LOGS")
+	e := os.Getenv(EnvKeybaseTestObfuscateLogsForTest)
 	return e != "" && e != "0" && strings.ToLower(e) != "false"
 }

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -1604,9 +1604,8 @@ func (k *SimpleFS) SimpleFSMove(
 			if sameTlf {
 				k.log.CDebugf(ctx, "Renaming within same TLF: %s",
 					tlfHandle.GetCanonicalPath())
-				fs, err := libfs.NewFS(
-					ctx, k.config, tlfHandle, data.MasterBranch, "", "",
-					keybase1.MDPriorityNormal)
+				fs, err := k.newFS(
+					ctx, k.config, tlfHandle, data.MasterBranch, "", false)
 				if err != nil {
 					return err
 				}
@@ -1699,9 +1698,8 @@ func (k *SimpleFS) SimpleFSRename(
 	if err != nil {
 		return err
 	}
-	fs, err := libfs.NewFS(
-		ctx, k.config, tlfHandle, data.MasterBranch, "", "",
-		keybase1.MDPriorityNormal)
+	fs, err := k.newFS(
+		ctx, k.config, tlfHandle, data.MasterBranch, "", false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Somehow `Lookup` returns an empty node and `nil` error here, even though the thing exists. It only happens when the log obfuscator is enabled. I couldn't reproduce it using simple FS, so I added a `libpages` test to cover it. It has to run with `KEYBASE_TEST_OBFUSCATE_LOGS` set though.

This fixes the panic, but it'd be nice to have a real fix. @strib any ideas?