### PR TITLE
fix: more reliably center spinner on native attachments

### DIFF
--- a/shared/chat/conversation/attachment-fullscreen/index.native.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.native.tsx
@@ -131,10 +131,15 @@ class _Fullscreen extends React.Component<Props & Kb.OverlayParentProps, {loaded
               />
             )}
             {!this.state.loaded && (
-              <Kb.ProgressIndicator
-                style={{alignSelf: 'center', margin: 'auto', position: 'absolute', top: '50%', width: 48}}
-                white={true}
-              />
+              <Kb.Box2
+                direction="vertical"
+                style={styles.progressWrapper}
+                centerChildren={true}
+                fullHeight={true}
+                fullWidth={true}
+              >
+                <Kb.ProgressIndicator style={styles.progressIndicator} white={true} />
+              </Kb.Box2>
             )}
           </Kb.Box2>
         </Kb.BoxGrow>
@@ -192,11 +197,10 @@ const styles = Styles.styleSheetCreate(
       },
       headerWrapper: {backgroundColor: Styles.globalColors.blackOrBlack},
       progressIndicator: {
-        alignSelf: 'center',
-        margin: 'auto',
-        position: 'absolute',
-        top: '50%',
         width: 48,
+      },
+      progressWrapper: {
+        position: 'absolute',
       },
       safeAreaTop: {
         ...Styles.globalStyles.flexBoxColumn,

--- a/shared/chat/conversation/messages/attachment/image/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image/index.tsx
@@ -180,7 +180,21 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                                 />
                               </Kb.Box>
                             )}
-                            {!this.state.loaded && <Kb.ProgressIndicator style={styles.progress} />}
+                            {!this.state.loaded && (
+                              <Kb.Box2
+                                direction="vertical"
+                                centerChildren={true}
+                                style={Styles.collapseStyles([
+                                  styles.spinnerContainer,
+                                  {
+                                    height: this.props.height,
+                                    width: this.props.width,
+                                  },
+                                ])}
+                              >
+                                <Kb.ProgressIndicator style={styles.progress} />
+                              </Kb.Box2>
+                            )}
                           </Kb.Box>
                         )}
                       </Kb.Box2>
@@ -203,7 +217,19 @@ class ImageAttachment extends React.PureComponent<Props, State> {
                   </Kb.Box2>
                 )}
                 {Styles.isMobile && this.state.loadingVideo === 'loading' && (
-                  <Kb.ProgressIndicator style={styles.progress} />
+                  <Kb.Box2
+                    style={Styles.collapseStyles([
+                      styles.spinnerContainer,
+                      {
+                        height: this.props.height,
+                        width: this.props.width,
+                      },
+                    ])}
+                    centerChildren={true}
+                    direction="vertical"
+                  >
+                    <Kb.ProgressIndicator style={styles.progress} />
+                  </Kb.Box2>
                 )}
               </Kb.Box>
               <Kb.Box style={styles.progressContainer}>
@@ -326,15 +352,6 @@ const styles = Styles.styleSheetCreate(
         top: '50%',
       },
       progress: {
-        bottom: '50%',
-        left: '50%',
-        marginBottom: -24,
-        marginLeft: -24,
-        marginRight: -24,
-        marginTop: -24,
-        position: 'absolute',
-        right: '50%',
-        top: '50%',
         width: 48,
       },
       progressContainer: {
@@ -348,6 +365,9 @@ const styles = Styles.styleSheetCreate(
       retry: {
         color: Styles.globalColors.redDark,
         textDecorationLine: 'underline',
+      },
+      spinnerContainer: {
+        position: 'absolute',
       },
       title: Styles.platformStyles({
         common: {


### PR DESCRIPTION
The progress spinners on native attachments keep getting off-centered, so this PR moves them into a full height wrapper element to better match what we do elsewhere in the app.