### PR TITLE
Show error text when a device name choice is invalid

### DIFF
--- a/shared/constants/provision.tsx
+++ b/shared/constants/provision.tsx
@@ -65,3 +65,12 @@ export const decodeForgotUsernameError = (error: RPCError) => {
 export const cleanDeviceName = (name: string) =>
   // map 'smart apostrophes' to ASCII (typewriter apostrophe)
   name.replace(/[\u2018\u2019\u0060\u00B4]/g, "'")
+
+// Copied from go/libkb/checkers.go
+export const goodDeviceRE = /^[a-zA-Z0-9][ _'a-zA-Z0-9+‘’—–-]*$/
+// eslint-disable-next-line
+export const badDeviceRE = /  |[ '_-]$|['_-][ ]?['_-]/
+export const normalizeDeviceRE = /[^a-zA-Z0-9]/
+
+export const deviceNameInstructions =
+  'Your device name must have 3-64 characters and not end with punctuation.'

--- a/shared/constants/provision.tsx
+++ b/shared/constants/provision.tsx
@@ -74,3 +74,5 @@ export const normalizeDeviceRE = /[^a-zA-Z0-9]/
 
 export const deviceNameInstructions =
   'Your device name must have 3-64 characters and not end with punctuation.'
+
+export const badDeviceChars = /[^a-zA-Z0-9-_' ]/g

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -19,6 +19,15 @@ type Props = {
 const SetPublicName = (props: Props) => {
   const [deviceName, setDeviceName] = React.useState(defaultDevicename)
   const cleanDeviceName = Constants.cleanDeviceName(deviceName)
+  const disabled = React.useMemo(() => {
+    const normalized = deviceName.replace(Constants.normalizeDeviceRE, '')
+    return (
+      normalized.length < 3 ||
+      normalized.length > 64 ||
+      !Constants.goodDeviceRE.test(deviceName) ||
+      Constants.badDeviceRE.test(deviceName)
+    )
+  }, [deviceName])
   const _onSubmit = props.onSubmit
   const onSubmit = React.useCallback(() => {
     _onSubmit(Constants.cleanDeviceName(cleanDeviceName))
@@ -41,7 +50,7 @@ const SetPublicName = (props: Props) => {
       banners={errorBanner(props.error)}
       buttons={[
         {
-          disabled: deviceName.length < 3 || deviceName.length > 64,
+          disabled,
           label: 'Continue',
           onClick: onSubmit,
           type: 'Success',
@@ -62,13 +71,21 @@ const SetPublicName = (props: Props) => {
         <Kb.Box2 direction="vertical" style={styles.wrapper} gap="xsmall">
           <Kb.NewInput
             autoFocus={true}
+            error={disabled}
             placeholder="Pick a device name"
             onEnterKeyDown={onSubmit}
             onChangeText={setDeviceName}
             value={cleanDeviceName}
             style={styles.nameInput}
           />
-          <Kb.Text type="BodySmall">Your device name will be public.</Kb.Text>
+          {disabled && (
+            <Kb.Text type="BodySmall" style={styles.deviceNameError}>
+              {Constants.deviceNameInstructions}
+            </Kb.Text>
+          )}
+          <Kb.Text type="BodySmall">
+            Your device name will be public and can not be changed in the future.
+          </Kb.Text>
         </Kb.Box2>
       </Kb.Box2>
     </SignupScreen>
@@ -90,6 +107,9 @@ const styles = Styles.styleSheetCreate(() => ({
     common: {width: '100%'},
     isTablet: {width: undefined},
   }),
+  deviceNameError: {
+    color: Styles.globalColors.redDark,
+  },
   nameInput: Styles.platformStyles({
     common: {
       padding: Styles.globalMargins.tiny,

--- a/shared/provision/set-public-name/index.tsx
+++ b/shared/provision/set-public-name/index.tsx
@@ -19,19 +19,18 @@ type Props = {
 const SetPublicName = (props: Props) => {
   const [deviceName, setDeviceName] = React.useState(defaultDevicename)
   const cleanDeviceName = Constants.cleanDeviceName(deviceName)
-  const disabled = React.useMemo(() => {
-    const normalized = deviceName.replace(Constants.normalizeDeviceRE, '')
-    return (
-      normalized.length < 3 ||
-      normalized.length > 64 ||
-      !Constants.goodDeviceRE.test(deviceName) ||
-      Constants.badDeviceRE.test(deviceName)
-    )
-  }, [deviceName])
+  const normalized = cleanDeviceName.replace(Constants.normalizeDeviceRE, '')
+  const disabled =
+    normalized.length < 3 ||
+    normalized.length > 64 ||
+    !Constants.goodDeviceRE.test(cleanDeviceName) ||
+    Constants.badDeviceRE.test(cleanDeviceName)
   const _onSubmit = props.onSubmit
   const onSubmit = React.useCallback(() => {
     _onSubmit(Constants.cleanDeviceName(cleanDeviceName))
   }, [cleanDeviceName, _onSubmit])
+  const _setDeviceName = (deviceName: string) =>
+    setDeviceName(deviceName.replace(Constants.badDeviceChars, ''))
 
   const maybeIcon = Styles.isMobile
     ? Platform.isLargeScreen
@@ -72,9 +71,10 @@ const SetPublicName = (props: Props) => {
           <Kb.NewInput
             autoFocus={true}
             error={disabled}
+            maxLength={64}
             placeholder="Pick a device name"
             onEnterKeyDown={onSubmit}
-            onChangeText={setDeviceName}
+            onChangeText={_setDeviceName}
             value={cleanDeviceName}
             style={styles.nameInput}
           />

--- a/shared/signup/device-name/index.tsx
+++ b/shared/signup/device-name/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as Kb from '../../common-adapters'
+import * as Constants from '../../constants/provision'
 import * as Styles from '../../styles'
 import * as Platform from '../../constants/platform'
 import {SignupScreen, errorBanner, InfoIcon} from '../common'
@@ -13,21 +14,15 @@ type Props = {
   waiting: boolean
 }
 
-// Copied from go/libkb/checkers.go
-const deviceRE = /^[a-zA-Z0-9][ _'a-zA-Z0-9+‘’—–-]*$/
-// eslint-disable-next-line
-const badDeviceRE = /  |[ '_-]$|['_-][ ]?['_-]/
-const normalizeDeviceRE = /[^a-zA-Z0-9]/
-
 const EnterDevicename = (props: Props) => {
   const [devicename, onChangeDevicename] = React.useState(props.initialDevicename || '')
   const disabled = React.useMemo(() => {
-    const normalized = devicename.replace(normalizeDeviceRE, '')
+    const normalized = devicename.replace(Constants.normalizeDeviceRE, '')
     return (
       normalized.length < 3 ||
       normalized.length > 64 ||
-      !deviceRE.test(devicename) ||
-      badDeviceRE.test(devicename)
+      !Constants.goodDeviceRE.test(devicename) ||
+      Constants.badDeviceRE.test(devicename)
     )
   }, [devicename])
   const onContinue = () => (disabled ? {} : props.onContinue(devicename))
@@ -64,11 +59,17 @@ const EnterDevicename = (props: Props) => {
           <Kb.LabeledInput
             autoFocus={true}
             containerStyle={styles.input}
+            error={disabled}
             placeholder={Styles.isMobile ? 'Phone 1' : 'Computer 1'}
             onChangeText={onChangeDevicename}
             onEnterKeyDown={onContinue}
             value={devicename}
           />
+          {disabled && (
+            <Kb.Text type="BodySmall" style={styles.deviceNameError}>
+              {Constants.deviceNameInstructions}
+            </Kb.Text>
+          )}
           <Kb.Text type="BodySmall" style={styles.inputSub}>
             Your device name will be public and can not be changed in the future.
           </Kb.Text>
@@ -92,6 +93,10 @@ EnterDevicename.navigationOptions = {
 }
 
 const styles = Styles.styleSheetCreate(() => ({
+  deviceNameError: {
+    color: Styles.globalColors.redDark,
+    marginLeft: 2,
+  },
   input: Styles.platformStyles({
     isElectron: {
       width: 368,

--- a/shared/signup/device-name/index.tsx
+++ b/shared/signup/device-name/index.tsx
@@ -15,17 +15,17 @@ type Props = {
 }
 
 const EnterDevicename = (props: Props) => {
-  const [devicename, onChangeDevicename] = React.useState(props.initialDevicename || '')
-  const disabled = React.useMemo(() => {
-    const normalized = devicename.replace(Constants.normalizeDeviceRE, '')
-    return (
-      normalized.length < 3 ||
-      normalized.length > 64 ||
-      !Constants.goodDeviceRE.test(devicename) ||
-      Constants.badDeviceRE.test(devicename)
-    )
-  }, [devicename])
-  const onContinue = () => (disabled ? {} : props.onContinue(devicename))
+  const [deviceName, setDeviceName] = React.useState(props.initialDevicename || '')
+  const cleanDeviceName = Constants.cleanDeviceName(deviceName)
+  const normalized = cleanDeviceName.replace(Constants.normalizeDeviceRE, '')
+  const disabled =
+    normalized.length < 3 ||
+    normalized.length > 64 ||
+    !Constants.goodDeviceRE.test(cleanDeviceName) ||
+    Constants.badDeviceRE.test(cleanDeviceName)
+  const _setDeviceName = (deviceName: string) =>
+    setDeviceName(deviceName.replace(Constants.badDeviceChars, ''))
+  const onContinue = () => (disabled ? {} : props.onContinue(cleanDeviceName))
   return (
     <SignupScreen
       banners={errorBanner(props.error)}
@@ -60,10 +60,11 @@ const EnterDevicename = (props: Props) => {
             autoFocus={true}
             containerStyle={styles.input}
             error={disabled}
+            maxLength={64}
             placeholder={Styles.isMobile ? 'Phone 1' : 'Computer 1'}
-            onChangeText={onChangeDevicename}
+            onChangeText={_setDeviceName}
             onEnterKeyDown={onContinue}
-            value={devicename}
+            value={cleanDeviceName}
           />
           {disabled && (
             <Kb.Text type="BodySmall" style={styles.deviceNameError}>


### PR DESCRIPTION
@keybase/react-hackers 

The error message I used ("Your device name must have 3-64 characters and not end with punctuation.") is not precise, since there are some punctuation characters that can't be used at all, but the actual rules seem too complex to try to explain in a sentence.

![Screen Shot 2020-03-17 at 11 43 23 AM](https://user-images.githubusercontent.com/21217/76890447-a09e1180-6844-11ea-93da-b70ff1623e0e.png)