### PR TITLE
home: handle a badge race

### DIFF
--- a/go/home/home.go
+++ b/go/home/home.go
@@ -456,7 +456,6 @@ func (h *Home) handleUpdateWithVersions(ctx context.Context, homeVersion int, an
 		h.homeCache = nil
 		refreshHome = true
 	}
-	return
 }
 
 func (h *Home) IsAlive() bool {

--- a/go/libkb/homestate.go
+++ b/go/libkb/homestate.go
@@ -1,0 +1,31 @@
+package libkb
+
+import (
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type HomeTodoMap map[keybase1.HomeScreenTodoType]int
+type HomeItemMap map[keybase1.HomeScreenItemType]HomeTodoMap
+
+type HomeStateBody struct {
+	Version              int           `json:"version"`
+	BadgeCountMap        HomeItemMap   `json:"badge_count_map"`
+	LastViewedTime       keybase1.Time `json:"last_viewed_time"`
+	AnnouncementsVersion int           `json:"announcements_version"`
+}
+
+func (a *HomeStateBody) LessThan(b HomeStateBody) bool {
+	if a == nil {
+		return true
+	}
+	if a.Version < b.Version {
+		return true
+	}
+	if a.Version == b.Version && a.LastViewedTime < b.LastViewedTime {
+		return true
+	}
+	if a.AnnouncementsVersion < b.AnnouncementsVersion {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
- the badge race, I believe, happens when you visit home right around the same time an announcement is being introduced
- in this case, your view of home doesn't show the announcement, but the queued rerender of your server-side home state does pick the announcement up
- which drives your badge state +1
- the issue, previously, was that you could keep stale home state even after your badge is driven for up to 1 hours
- so now we clear home cache on badge state, if appropriate
- might result in some flickering, so let's be on the lookout for that and readdress if so