### PR TITLE
Handle showing team we're not in

### DIFF
--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -283,6 +283,7 @@
   "keybase.1.teams.getTeamAndMemberShowcase": {"promise": true},
   "keybase.1.teams.getTeamID": {"promise": true},
   "keybase.1.teams.getTeamRoleMap": {"promise": true},
+  "keybase.1.teams.getUntrustedTeamInfo": {"promise": true},
   "keybase.1.teams.getUserSubteamMemberships": {"promise": true},
   "keybase.1.teams.setTarsDisabled": {"promise": true},
   "keybase.1.teams.setTeamMemberShowcase": {"promise": true},

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1258,6 +1258,11 @@ async function showTeamByName(action: TeamsGen.ShowTeamByNamePayload, logger: Sa
     teamID = await RPCTypes.teamsGetTeamIDRpcPromise({teamName: teamname})
   } catch (err) {
     logger.info(`team="${teamname}" cannot be loaded:`, err)
+    if (flags.teamsRedesign) {
+      // navigate to team page for team we're not in
+      logger.info('showing external team page')
+      return RouteTreeGen.createNavigateAppend({path: [{props: {teamname}, selected: 'teamExternalTeam'}]})
+    }
     return null
   }
 

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1355,6 +1355,10 @@ export type MessageTypes = {
     inParam: void
     outParam: TeamRoleMapAndVersion
   }
+  'keybase.1.teams.getUntrustedTeamInfo': {
+    inParam: {readonly teamName: TeamName}
+    outParam: UntrustedTeamInfo
+  }
   'keybase.1.teams.getUserSubteamMemberships': {
     inParam: {readonly teamID: TeamID; readonly username: String}
     outParam: Array<AnnotatedSubteamMemberDetails> | null
@@ -3770,6 +3774,7 @@ export const teamsGetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.t
 export const teamsGetTeamAndMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamAndMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamAndMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamIDRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamID']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamID']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamID', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTeamRoleMapRpcPromise = (params: MessageTypes['keybase.1.teams.getTeamRoleMap']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTeamRoleMap']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTeamRoleMap', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
+export const teamsGetUntrustedTeamInfoRpcPromise = (params: MessageTypes['keybase.1.teams.getUntrustedTeamInfo']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getUntrustedTeamInfo']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getUntrustedTeamInfo', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetUserSubteamMembershipsRpcPromise = (params: MessageTypes['keybase.1.teams.getUserSubteamMemberships']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getUserSubteamMemberships']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getUserSubteamMemberships', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.setTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsSetTeamMemberShowcaseRpcPromise = (params: MessageTypes['keybase.1.teams.setTeamMemberShowcase']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.setTeamMemberShowcase']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.setTeamMemberShowcase', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
@@ -4183,7 +4188,6 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'
 // 'keybase.1.streamUi.write'
-// 'keybase.1.teams.getUntrustedTeamInfo'
 // 'keybase.1.teams.teamCreateWithSettings'
 // 'keybase.1.teams.teamImplicitAdmins'
 // 'keybase.1.teams.teamListTeammates'

--- a/shared/teams/external-team.tsx
+++ b/shared/teams/external-team.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import * as Kb from '../common-adapters'
+import * as Styles from '../styles'
+import * as Container from '../util/container'
+
+type Props = Container.RouteProps<{teamname: string}>
+
+const ExternalTeam = (props: Props) => {
+  const teamname = Container.getRouteProps(props, 'teamname', '')
+  return <Kb.Text type="Header">{teamname}</Kb.Text>
+}
+
+export default ExternalTeam

--- a/shared/teams/external-team.tsx
+++ b/shared/teams/external-team.tsx
@@ -2,12 +2,56 @@ import * as React from 'react'
 import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import * as Container from '../util/container'
+import * as RPCGen from '../constants/types/rpc-gen'
 
 type Props = Container.RouteProps<{teamname: string}>
 
 const ExternalTeam = (props: Props) => {
   const teamname = Container.getRouteProps(props, 'teamname', '')
-  return <Kb.Text type="Header">{teamname}</Kb.Text>
+
+  const getTeamInfo = Container.useRPC(RPCGen.teamsGetUntrustedTeamInfoRpcPromise)
+  const [teamInfo, setTeamInfo] = React.useState<RPCGen.UntrustedTeamInfo | null>(null)
+  const [waiting, setWaiting] = React.useState(false)
+
+  React.useEffect(() => {
+    setWaiting(true)
+    getTeamInfo(
+      [{teamName: {parts: teamname.split('.')}}], // TODO this should just take a string
+      result => {
+        // Note: set all state variables in both of these cases even if they're
+        // not changing from defaults. The user might be stacking these pages on
+        // top of one another, in which case react will preserve state from
+        // previously rendered teams.
+        setWaiting(false)
+        setTeamInfo(result)
+      },
+      _ => {
+        setWaiting(false)
+        setTeamInfo(null)
+      }
+    )
+  }, [getTeamInfo, teamname])
+
+  return (
+    <Kb.Box2 direction="vertical" gap="small" style={styles.container}>
+      <Kb.Text type="Header">{teamname}</Kb.Text>
+      {waiting ? (
+        <Kb.ProgressIndicator />
+      ) : teamInfo ? (
+        <Kb.Box2 direction="vertical" gap="small" fullWidth={true}>
+          <Kb.Text type="BodySmall">{teamInfo?.description}</Kb.Text>
+        </Kb.Box2>
+      ) : (
+        <Kb.Text type="BodySmallError">There is no public information available for this team.</Kb.Text>
+      )}
+    </Kb.Box2>
+  )
 }
+
+const styles = Styles.styleSheetCreate(() => ({
+  container: {
+    padding: Styles.globalMargins.small,
+  },
+}))
 
 export default ExternalTeam

--- a/shared/teams/routes.tsx
+++ b/shared/teams/routes.tsx
@@ -23,6 +23,7 @@ import TeamAddToTeamFromWhere from './add-members-wizard/add-from-where'
 import TeamAddToTeamPhone from './add-members-wizard/add-phone'
 import TeamAddToTeamEmail from './add-members-wizard/add-email'
 import TeamAddToTeamConfirm from './add-members-wizard/confirm'
+import ExternalTeam from './external-team'
 import flags from '../util/feature-flags'
 
 export const newRoutes = {
@@ -30,6 +31,7 @@ export const newRoutes = {
   teamChannel: {
     getScreen: (): typeof TeamEditChannel => require('./channel').default,
   },
+  teamExternalTeam: {getScreen: (): typeof ExternalTeam => require('./external-team').default},
   teamMember: flags.teamsRedesign
     ? {getScreen: (): typeof TeamMemberNew => require('./team/member/index.new').default}
     : {getScreen: (): typeof TeamMember => require('./team/member/container').default},


### PR DESCRIPTION
Test with `teamsRedesign` on
```
DEBUGStore.dispatch({type: 'teams:showTeamByName', payload: {teamname: 'someTeamname'}})
```
cc @keybase/y2ksquad 