### PR TITLE
Tablet tab bar label colors

### DIFF
--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -210,7 +210,13 @@ const VanillaTabNavigator = createBottomTabNavigator(
             <Kb.Text
               // @ts-ignore expecting a literal color, not a getter
               style={{
-                color: focused ? Styles.globalColors.whiteOrWhite : Styles.globalColors.blueDarkerOrBlack,
+                color: Styles.isDarkMode()
+                  ? focused
+                    ? Styles.globalColors.black
+                    : Styles.globalColors.black_50
+                  : focused
+                  ? Styles.globalColors.white
+                  : Styles.globalColors.blueLighter,
                 marginLeft: Styles.globalMargins.medium,
               }}
               type="BodyBig"

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -209,16 +209,16 @@ const VanillaTabNavigator = createBottomTabNavigator(
           ) : (
             <Kb.Text
               // @ts-ignore expecting a literal color, not a getter
-              style={{
-                color: Styles.isDarkMode()
+              style={Styles.collapseStyles([
+                tabStyles.label,
+                Styles.isDarkMode()
                   ? focused
-                    ? Styles.globalColors.black
-                    : Styles.globalColors.black_50
+                    ? tabStyles.labelDarkModeFocused
+                    : tabStyles.labelDarkMode
                   : focused
-                  ? Styles.globalColors.white
-                  : Styles.globalColors.blueLighter,
-                marginLeft: Styles.globalMargins.medium,
-              }}
+                  ? tabStyles.labelLightModeFocused
+                  : tabStyles.labelLightMode,
+              ])}
               type="BodyBig"
             >
               {data[navigation.state.routeName].label}
@@ -278,6 +278,11 @@ const tabStyles = Styles.styleSheetCreate(
       container: {
         justifyContent: 'center',
       },
+      label: {marginLeft: Styles.globalMargins.medium},
+      labelDarkMode: {color: Styles.globalColors.black_50},
+      labelDarkModeFocused: {color: Styles.globalColors.black},
+      labelLightMode: {color: Styles.globalColors.blueLighter},
+      labelLightModeFocused: {color: Styles.globalColors.white},
       tab: Styles.platformStyles({
         common: {
           paddingBottom: 6,


### PR DESCRIPTION
Change ipad tab bar colors to match desktop labels.

![image](https://user-images.githubusercontent.com/705646/76979465-597c5300-690e-11ea-8271-b0497bcfe966.png)
![image](https://user-images.githubusercontent.com/705646/76979481-5e410700-690e-11ea-90a0-5f6d12f7e1f5.png)
