### PR TITLE
enable vibration by default for notification

### DIFF
--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KBPushNotifier.java
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KBPushNotifier.java
@@ -158,7 +158,7 @@ public class KBPushNotifier implements PushNotifier {
         .setContentIntent(pending_intent)
         .setAutoCancel(true);
 
-    int notificationDefaults = NotificationCompat.DEFAULT_LIGHTS;
+    int notificationDefaults = NotificationCompat.DEFAULT_LIGHTS | NotificationCompat.DEFAULT_VIBRATE;
 
     // Set notification sound
     if (chatNotification.getSoundName().equals("default")) {


### PR DESCRIPTION
Following #22963, enable vibration by default for notifications.