### PR TITLE
iPad portrait: re-enable for testing

### DIFF
--- a/shared/ios/Keybase/Info.plist
+++ b/shared/ios/Keybase/Info.plist
@@ -100,7 +100,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -109,6 +109,8 @@
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
@keybase/react-hackers 

We've started a PICNIC project for portrait mode iPad.  We don't want to release it until everything's finished, but there's no feature flag ability for plists, so we're going to turn it on in admin builds for testing, and turn it off again before releases.