### PR TITLE
search: improve indexing memory usage

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -216,7 +216,7 @@ var _ Config = (*ConfigLocal)(nil)
 
 // getDefaultCleanBlockCacheCapacity returns the default clean block
 // cache capacity. If we can get total RAM of the system, we cap at
-// the smaller of <1/4 of available memory> and
+// the smaller of <1/8 of available memory> and
 // <MaxBlockSizeBytesDefault * DefaultBlocksInMemCache>; otherwise,
 // fallback to latter.
 func getDefaultCleanBlockCacheCapacity(mode InitMode) uint64 {

--- a/go/kbfs/search/init.go
+++ b/go/kbfs/search/init.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"path/filepath"
 
+	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/libcontext"
 	"github.com/keybase/client/go/kbfs/libkbfs"
 	"github.com/keybase/client/go/logger"
@@ -21,6 +22,8 @@ const (
 	mdserverStorageDir = "mdserver"
 
 	currentIndexVersion = "v1"
+
+	indexBlocksInCache = 100
 )
 
 // Params returns a set of default parameters for search-related
@@ -33,6 +36,11 @@ func Params(kbCtx libkbfs.Context, storageRoot string, uid keybase1.UID) (
 
 	params.EnableJournal = false
 	params.DiskCacheMode = libkbfs.DiskCacheModeOff
+
+	// Try to balance not using too much memory vs. the time/CPU it
+	// takes to keep pulling in index blocks from the disk.
+	params.CleanBlockCacheCapacity =
+		uint64(data.MaxBlockSizeBytesDefault) * indexBlocksInCache
 
 	// Make a per-user index for all the TLFs indexed locally by that
 	// user.  This means on one hand that the user can get


### PR DESCRIPTION
Bleve's indexer takes a lot of memory proportional to batch size.  I asked about this on blevesearch/bleve#1347, but haven't yet found a way to reduce memory usage besides just making the batch sizes smaller.

Unfortunately, making the batch sizes smaller increases CPU usage (and indexing time) so we don't want to do this unless we really have to. So this commit is a first attempt to reduce the batch size in the case that there's not much free memory available.  We change the size for each batch, depending on the amount of available memory.

Also, reduce the size of the clean block cache for the indexer.  Don't reduce it too much though, because it would cause a lot of disk and decryption load if it's too small.

Issue; HOTPOT-2205