### PR TITLE
config_local: add more perf logs for synced TLF stuff

### DIFF
--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1401,6 +1401,7 @@ func (c *ConfigLocal) cleanSyncBlockCache() {
 			continue
 		}
 
+		c.GetPerfLog().CDebugf(ctx, "Clearing KBFS sync blocks for TLF %s", id)
 		c.cleanSyncBlockCacheForTlfInBackgroundLocked(id, make(chan error, 1))
 	}
 }
@@ -1521,15 +1522,18 @@ func (c *ConfigLocal) openConfigLevelDB(configName string) (
 
 func (c *ConfigLocal) loadSyncedTlfsLocked() (err error) {
 	defer func() {
-		c.MakeLogger("").CDebugf(context.TODO(), "Loaded synced TLFs: %+v", err)
+		ctx := context.TODO()
+		c.MakeLogger("").CDebugf(ctx, "Loaded synced TLFs: %+v", err)
 		if err != nil {
 			// Should already be nil, but make it explicit just in
 			// case, since the cleaning behavior depends on it being
 			// nil if there has been an error.
 			c.syncedTlfs = nil
 			c.GetPerfLog().CDebugf(
-				context.TODO(),
-				"KBFS failed to open synced TLFs database: %v", err)
+				ctx, "KBFS failed to open synced TLFs database: %v", err)
+		} else {
+			c.GetPerfLog().CDebugf(
+				ctx, "KBFS loaded %d synced TLFs", len(c.syncedTlfs))
 		}
 	}()
 	syncedTlfs := make(map[tlf.ID]FolderSyncConfig)
@@ -1625,7 +1629,8 @@ func (c *ConfigLocal) OfflineAvailabilityForID(
 	return keybase1.OfflineAvailability_NONE
 }
 
-func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
+func (c *ConfigLocal) setTlfSyncState(
+	ctx context.Context, tlfID tlf.ID, config FolderSyncConfig) (
 	<-chan error, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -1673,6 +1678,8 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 
 	ch := make(chan error, 1)
 	if config.Mode == keybase1.FolderSyncMode_DISABLED {
+		c.GetPerfLog().CDebugf(
+			ctx, "Clearing KBFS sync blocks for disabled TLF %s", tlfID)
 		c.cleanSyncBlockCacheForTlfInBackgroundLocked(tlfID, ch)
 	} else {
 		ch <- nil
@@ -1705,7 +1712,7 @@ func (c *ConfigLocal) SetTlfSyncState(
 			return nil, err
 		}
 	}
-	return c.setTlfSyncState(tlfID, config)
+	return c.setTlfSyncState(ctx, tlfID, config)
 }
 
 // GetAllSyncedTlfs implements the syncedTlfGetterSetter interface for

--- a/go/kbfs/libkbfs/disk_block_cache.go
+++ b/go/kbfs/libkbfs/disk_block_cache.go
@@ -318,6 +318,10 @@ func newDiskBlockCacheLocal(config diskBlockCacheConfig,
 	defer func() {
 		if err != nil {
 			log.Error("Error initializing disk cache: %+v", err)
+			config.GetPerfLog().CDebugf(
+				context.TODO(),
+				"KBFS couldn't initialize disk cache of type %s: %v",
+				cacheType, err)
 		}
 	}()
 	versionPath, err := ldbutils.GetVersionedPathForDb(

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -9380,6 +9380,14 @@ func (fbo *folderBranchOps) SetSyncConfig(
 		return nil, err
 	}
 
+	defer func() {
+		if err == nil && newConfig.Mode != oldConfig.Mode {
+			fbo.config.GetPerfLog().CDebugf(
+				ctx, "Set KBFS sync config for %s, new mode=%s, old mode=%s",
+				tlfID, newConfig.Mode, oldConfig.Mode)
+		}
+	}()
+
 	oldPartial := oldConfig.Mode == keybase1.FolderSyncMode_PARTIAL
 	newPartial := newConfig.Mode == keybase1.FolderSyncMode_PARTIAL
 	switch {

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -885,6 +885,8 @@ func doInit(
 	err = config.MakeDiskBlockCacheIfNotExists()
 	if err != nil {
 		log.CWarningf(ctx, "Could not initialize disk cache: %+v", err)
+		config.GetPerfLog().CDebugf(
+			ctx, "KBFS could not initialize disk cache: %v", err)
 		notification := &keybase1.FSNotification{
 			StatusCode:       keybase1.FSStatusCode_ERROR,
 			NotificationType: keybase1.FSNotificationType_INITIALIZED,

--- a/go/kbfs/libkbfs/interface_test.go
+++ b/go/kbfs/libkbfs/interface_test.go
@@ -52,6 +52,10 @@ func (lm testLogMaker) MakeVLogger(log logger.Logger) *libkb.VDebugLog {
 	return vlog
 }
 
+func (lm testLogMaker) GetPerfLog() logger.Logger {
+	return lm.log
+}
+
 type testClockGetter struct {
 	clock *clocktest.TestClock
 }

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -32,6 +32,7 @@ import (
 type logMaker interface {
 	MakeLogger(module string) logger.Logger
 	MakeVLogger(logger.Logger) *libkb.VDebugLog
+	GetPerfLog() logger.Logger
 }
 
 type blockCacher interface {
@@ -2225,7 +2226,6 @@ type Config interface {
 	// PrefetchStatus returns the prefetch status of a block.
 	PrefetchStatus(context.Context, tlf.ID, data.BlockPointer) PrefetchStatus
 	GetQuotaUsage(keybase1.UserOrTeamID) *EventuallyConsistentQuotaUsage
-	GetPerfLog() logger.Logger
 
 	// GracePeriod specifies a grace period for which a delayed cancellation
 	// waits before actual cancels the context. This is useful for giving


### PR DESCRIPTION
Add some more performance logs for synced TLF events, so we can better debug what happened to a synced TLF if the debug logs have already rotated away.

Issue: HOTPOT-2047