### PR TITLE
Mobile "Share a link" popup

### DIFF
--- a/shared/actions/config-gen.tsx
+++ b/shared/actions/config-gen.tsx
@@ -157,7 +157,11 @@ type _SetUseNativeFramePayload = {readonly useNativeFrame: boolean}
 type _SetUserSwitchingPayload = {readonly userSwitching: boolean}
 type _SetWhatsNewLastSeenVersionPayload = {readonly lastSeenVersion: string}
 type _ShowMainPayload = void
-type _ShowShareActionSheetPayload = {readonly filePath: string; readonly mimeType: string}
+type _ShowShareActionSheetPayload = {
+  readonly filePath?: string
+  readonly message?: string
+  readonly mimeType: string
+}
 type _StartHandshakePayload = void
 type _ToggleRuntimeStatsPayload = void
 type _UpdateCriticalCheckStatusPayload = {

--- a/shared/actions/json/config.json
+++ b/shared/actions/json/config.json
@@ -162,7 +162,8 @@
       "phase": "'initialStartupAsEarlyAsPossible' | 'connectedToDaemonForFirstTime' | 'reloggedIn' | 'startupOrReloginButNotInARush'"
     },
     "showShareActionSheet": {
-      "filePath": "string",
+      "filePath?": "string",
+      "message?": "string",
       "mimeType": "string"
     },
     "androidShare": {

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -155,8 +155,8 @@ export async function saveAttachmentToCameraRoll(filePath: string, mimeType: str
 }
 
 const onShareAction = async (action: ConfigGen.ShowShareActionSheetPayload) => {
-  const {filePath, mimeType} = action.payload
-  await showShareActionSheet({filePath, mimeType})
+  const {filePath, message, mimeType} = action.payload
+  await showShareActionSheet({filePath, message, mimeType})
 }
 
 export const showShareActionSheet = async (options: {

--- a/shared/common-adapters/copy-text.tsx
+++ b/shared/common-adapters/copy-text.tsx
@@ -21,6 +21,7 @@ type Props = {
   text?: string
   textType?: TextType
   placeholderText?: string
+  shareSheet?: boolean // (mobile only) show share sheet instead of copying
   loadText?: () => void
 }
 
@@ -29,6 +30,7 @@ const CopyText = (props: Props) => {
   const [revealed, setRevealed] = React.useState(!props.withReveal)
   const [showingToast, setShowingToast] = React.useState(false)
   const [requestedCopy, setRequestedCopy] = React.useState(false)
+  const shareSheet = props.shareSheet && Styles.isMobile
   const setShowingToastFalseLater = useTimeout(() => setShowingToast(false), 1500)
   React.useEffect(() => {
     showingToast && setShowingToastFalseLater()
@@ -58,15 +60,19 @@ const CopyText = (props: Props) => {
       }
       setRequestedCopy(true)
     } else {
-      setShowingToast(true)
-      textRef.current && textRef.current.highlightText()
-      dispatch(ConfigGen.createCopyToClipboard({text}))
+      if (shareSheet) {
+        dispatch(ConfigGen.createShowShareActionSheet({message: text, mimeType: 'text/plain'}))
+      } else {
+        setShowingToast(true)
+        textRef.current && textRef.current.highlightText()
+        dispatch(ConfigGen.createCopyToClipboard({text}))
+      }
       onCopy && onCopy()
       if (hideOnCopy) {
         setRevealed(false)
       }
     }
-  }, [text, loadText, setRequestedCopy, setShowingToast, dispatch, onCopy, hideOnCopy])
+  }, [text, loadText, shareSheet, dispatch, onCopy, hideOnCopy])
 
   React.useEffect(() => {
     if (requestedCopy && loadText) {
@@ -136,7 +142,11 @@ const CopyText = (props: Props) => {
         onClick={copy}
         labelContainerStyle={styles.buttonLabelContainer}
       >
-        <Icon type="iconfont-clipboard" color={Styles.globalColors.white} sizeType="Small" />
+        <Icon
+          type={shareSheet ? 'iconfont-share' : 'iconfont-clipboard'}
+          color={Styles.globalColors.white}
+          sizeType="Small"
+        />
       </Button>
     </Box2>
   )

--- a/shared/common-adapters/toast.native.tsx
+++ b/shared/common-adapters/toast.native.tsx
@@ -50,7 +50,7 @@ const Toast = (props: Props) => {
     return noop
   }, [shouldRender])
   return shouldRender ? (
-    <Kb.FloatingBox>
+    <Kb.FloatingBox dest="keyboard-avoiding-root">
       <Kb.Box pointerEvents="none" style={styles.wrapper}>
         <NativeAnimated.View
           style={Styles.collapseStyles([

--- a/shared/people/invite-friends/modal.tsx
+++ b/shared/people/invite-friends/modal.tsx
@@ -100,6 +100,8 @@ const ShareLinkPopup = ({onClose}: {onClose: () => void}) => (
   <Kb.MobilePopup>
     <Kb.Box2 direction="vertical" style={styles.linkPopupContainer} gap="small" fullWidth={true}>
       <Kb.Text type="Header">Share a link to Keybase</Kb.Text>
+      <Kb.CopyText text={shareURL} shareSheet={true} />
+      <Kb.Button type="Dim" label="Close" fullWidth={true} onClick={onClose} />
     </Kb.Box2>
   </Kb.MobilePopup>
 )

--- a/shared/people/invite-friends/modal.tsx
+++ b/shared/people/invite-friends/modal.tsx
@@ -5,6 +5,8 @@ import * as Container from '../../util/container'
 import * as SettingsGen from '../../actions/settings-gen'
 import {usePhoneNumberList} from '../../teams/common'
 
+const shareURL = 'https://keybase.io/download'
+
 const InviteFriendsModal = () => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
@@ -26,6 +28,10 @@ const InviteFriendsModal = () => {
     (!emails && phoneNumbers.every(pn => !pn.phoneNumber)) ||
     phoneNumbers.some(pn => pn.phoneNumber && !pn.valid)
 
+  const {popup, setShowingPopup} = Kb.usePopup(() => (
+    <ShareLinkPopup onClose={() => setShowingPopup(false)} />
+  ))
+
   return (
     <Kb.Modal
       mode="DefaultFullHeight"
@@ -40,15 +46,15 @@ const InviteFriendsModal = () => {
                 <Kb.Text type="BodySmall" center={true}>
                   or share a link:
                 </Kb.Text>
-                <Kb.CopyText textType="BodySemibold" text="https://keybase.io/download" />
+                <Kb.CopyText textType="BodySemibold" text={shareURL} />
               </Kb.Box2>
             )}
           </Kb.Box2>
         ),
       }}
     >
-      <Kb.Box2 direction="vertical" gap="small" style={styles.container}>
-        <Kb.Icon type="icon-illustration-invite-friends-460-96" style={{width: '100%'}} />
+      <Kb.Box2 direction="vertical" gap="small" fullWidth={true} style={styles.container}>
+        <Kb.Icon type="icon-illustration-invite-friends-460-96" style={styles.illustration} />
         <Kb.Box2 direction="vertical" gap="small" fullWidth={true} style={styles.content}>
           <Kb.Box2 direction="vertical" gap={Styles.isMobile ? 'xtiny' : 'tiny'} fullWidth={true}>
             <Kb.Text type="BodySmallSemibold">By email address (separate with commas)</Kb.Text>
@@ -76,11 +82,12 @@ const InviteFriendsModal = () => {
             </Kb.Box2>
           </Kb.Box2>
           {Styles.isMobile && (
-            <Kb.ClickableBox style={styles.shareALink}>
+            <Kb.ClickableBox style={styles.shareALink} onClick={() => setShowingPopup(true)}>
               <Kb.Box2 direction="horizontal" gap="tiny" alignItems="center" alignSelf="flex-start">
                 <Kb.Icon type="iconfont-link" color={Styles.globalColors.blueDark} />
                 <Kb.Text type="BodyPrimaryLink">or share a link</Kb.Text>
               </Kb.Box2>
+              {popup}
             </Kb.ClickableBox>
           )}
         </Kb.Box2>
@@ -89,6 +96,14 @@ const InviteFriendsModal = () => {
   )
 }
 
+const ShareLinkPopup = ({onClose}: {onClose: () => void}) => (
+  <Kb.MobilePopup>
+    <Kb.Box2 direction="vertical" style={styles.linkPopupContainer} gap="small" fullWidth={true}>
+      <Kb.Text type="Header">Share a link to Keybase</Kb.Text>
+    </Kb.Box2>
+  </Kb.MobilePopup>
+)
+
 const styles = Styles.styleSheetCreate(() => ({
   container: {
     backgroundColor: Styles.globalColors.blueGrey,
@@ -96,6 +111,12 @@ const styles = Styles.styleSheetCreate(() => ({
   },
   content: {
     ...Styles.padding(0, Styles.globalMargins.small, Styles.globalMargins.small),
+  },
+  illustration: {
+    width: '100%',
+  },
+  linkPopupContainer: {
+    ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.tiny),
   },
   shareALink: {
     ...Styles.padding(10, 0),


### PR DESCRIPTION
- Fix layout issues with invite popup on mobile
  - There is still one issue with the header image, left it for now
- Add `shareSheet` prop to `CopyText` to show share sheet instead of copying
- Make `Toast` gateway into `keyboard-avoiding-root`, it's further down in the layout than `popup-root` and we probably never want it to go behind the keyboard

![image](https://user-images.githubusercontent.com/11968340/77106817-185f6e00-69f6-11ea-848e-a6bc89f52b9d.png)
![image](https://user-images.githubusercontent.com/11968340/77106827-1c8b8b80-69f6-11ea-86cd-c9bf285313aa.png)

cc @keybase/y2ksquad 