### PR TITLE
Fix chat header (and the Usernames component).

### DIFF
--- a/shared/chat/header.tsx
+++ b/shared/chat/header.tsx
@@ -34,11 +34,11 @@ const descColor = Styles.globalColors.black_50
 const descStyleMobile = {
   color: descColor,
   fontSize: 13,
-  lineHeight: 16,
+  lineHeight: 17,
 }
 const descStyleDesktop = {
   fontSize: 13,
-  lineHeight: '16px',
+  lineHeight: '17px',
   wordBreak: 'break-all',
 } as const // approximates BodySmall since markdown does not support text type
 const descStyle = Container.isMobile ? descStyleMobile : descStyleDesktop

--- a/shared/chat/header.tsx
+++ b/shared/chat/header.tsx
@@ -169,6 +169,7 @@ const Header = (p: Props) => {
                     inline={true}
                     commaColor={Styles.globalColors.black_50}
                     type="BodySmallBold"
+                    typeOverride={true}
                     usernames={withoutSelf[0]}
                     onUsernameClicked="profile"
                   />

--- a/shared/chat/header.tsx
+++ b/shared/chat/header.tsx
@@ -169,7 +169,6 @@ const Header = (p: Props) => {
                     inline={true}
                     commaColor={Styles.globalColors.black_50}
                     type="BodySmallBold"
-                    typeOverride={true}
                     usernames={withoutSelf[0]}
                     onUsernameClicked="profile"
                   />

--- a/shared/common-adapters/text.css
+++ b/shared/common-adapters/text.css
@@ -596,3 +596,7 @@
   text-overflow: ellipsis;
   word-break: break-word;
 }
+
+.noLineHeight {
+  line-height: unset !important;
+}

--- a/shared/common-adapters/usernames.tsx
+++ b/shared/common-adapters/usernames.tsx
@@ -102,7 +102,7 @@ const UsernameText = (
           // line height is unset to prevent some text clipping issues
           // in children with larger text styles on Android (HOTPOT-2112)
           // see also https://github.com/keybase/client/pull/22331#discussion_r374224355
-          <Text type="Body" style={{lineHeight: undefined}} key={u.username}>
+          <Text type={props.type} style={{lineHeight: undefined}} key={u.username}>
             {i !== 0 && i === props.users.length - 1 && props.showAnd && (
               <Text type={props.type} negative={isNegative} style={derivedJoinerStyle} underlineNever={true}>
                 {'and '}

--- a/shared/common-adapters/usernames.tsx
+++ b/shared/common-adapters/usernames.tsx
@@ -38,7 +38,6 @@ export type Props = {
   suffixType?: TextType
   title?: string
   type: TextType
-  typeOverride?: boolean
   underline?: boolean
   usernames: Array<string> | string
   withProfileCardPopup?: boolean
@@ -103,11 +102,7 @@ const UsernameText = (
           // line height is unset to prevent some text clipping issues
           // in children with larger text styles on Android (HOTPOT-2112)
           // see also https://github.com/keybase/client/pull/22331#discussion_r374224355
-          <Text
-            type={props.typeOverride ? props.type : 'Body'}
-            style={{lineHeight: undefined}}
-            key={u.username}
-          >
+          <Text className="noLineHeight" type="Body" style={{lineHeight: undefined}} key={u.username}>
             {i !== 0 && i === props.users.length - 1 && props.showAnd && (
               <Text type={props.type} negative={isNegative} style={derivedJoinerStyle} underlineNever={true}>
                 {'and '}

--- a/shared/common-adapters/usernames.tsx
+++ b/shared/common-adapters/usernames.tsx
@@ -38,6 +38,7 @@ export type Props = {
   suffixType?: TextType
   title?: string
   type: TextType
+  typeOverride?: boolean
   underline?: boolean
   usernames: Array<string> | string
   withProfileCardPopup?: boolean
@@ -102,7 +103,11 @@ const UsernameText = (
           // line height is unset to prevent some text clipping issues
           // in children with larger text styles on Android (HOTPOT-2112)
           // see also https://github.com/keybase/client/pull/22331#discussion_r374224355
-          <Text type={props.type} style={{lineHeight: undefined}} key={u.username}>
+          <Text
+            type={props.typeOverride ? props.type : 'Body'}
+            style={{lineHeight: undefined}}
+            key={u.username}
+          >
             {i !== 0 && i === props.users.length - 1 && props.showAnd && (
               <Text type={props.type} negative={isNegative} style={derivedJoinerStyle} underlineNever={true}>
                 {'and '}


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. Every username was wrapped in a `Text type="Body"` instead of `Text type={props.type}`. So, the line-height was often wrong.