### PR TITLE
tablet wallet settings maxwidth

### DIFF
--- a/shared/wallets/wallet/settings/index.tsx
+++ b/shared/wallets/wallet/settings/index.tsx
@@ -85,7 +85,7 @@ class AccountSettings extends React.Component<SettingsProps> {
   render() {
     const props = this.props
     return (
-      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
+      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
         {Styles.isMobile && <Kb.NavigationEvents onWillBlur={this.clearKey} />}
         <Kb.HeaderHocHeader
           customComponent={<AccountPageHeader accountName={props.name} title="Settings" />}
@@ -320,6 +320,9 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       alignSelfFlexStart: {alignSelf: 'flex-start'},
+      container: Styles.platformStyles({
+        isTablet: {maxWidth: Styles.dimensionWidth - 240},
+      }),
       copyTextContainer: {
         alignSelf: 'flex-start',
         maxWidth: '100%',


### PR DESCRIPTION
Fix wallet settings screen.
<img width="989" alt="image" src="https://user-images.githubusercontent.com/705646/77341002-7648ca00-6d04-11ea-974b-64836ee2b793.png">

I tried to do without maxWidth but got stymied by deep usage of fullWidth in various contained components which blow out the container width. Also Text doesn't wrap until it's too wide. I'm curious if someone else can do it inside out.