### PR TITLE
team rows: visual tweaks

### DIFF
--- a/shared/common-adapters/list-item2.css
+++ b/shared/common-adapters/list-item2.css
@@ -30,7 +30,3 @@
 .listItem2:hover .grow {
   max-width: 64px;
 }
-
-.listItem2:hover .checkCircle {
-  color: #4c8eff;
-}

--- a/shared/teams/channel/index.tsx
+++ b/shared/teams/channel/index.tsx
@@ -196,6 +196,7 @@ const Channel = (props: OwnProps) => {
         stickySectionHeadersEnabled={Styles.isMobile}
         sections={sections}
         contentContainerStyle={styles.listContentContainer}
+        style={styles.list}
       />
       <SelectionPopup
         selectedTab={selectedTab === 'members' ? 'channelMembers' : ''}
@@ -240,6 +241,13 @@ const styles = Styles.styleSheetCreate(() => ({
     height: 0,
   },
   header: {height: 40, left: 0, position: 'absolute', right: 0, top: 0},
+  list: Styles.platformStyles({
+    isElectron: {
+      ...Styles.globalStyles.fillAbsolute,
+      ...Styles.globalStyles.flexBoxColumn,
+      alignItems: 'stretch',
+    },
+  }),
   listContentContainer: Styles.platformStyles({
     isElectron: {
       ...Styles.globalStyles.fillAbsolute,

--- a/shared/teams/channel/rows/member-row.tsx
+++ b/shared/teams/channel/rows/member-row.tsx
@@ -110,6 +110,7 @@ const ChannelMemberRow = (props: Props) => {
       onCheck={onSelect}
       key={`check-${username}`}
       selectedColor={Styles.isDarkMode() ? Styles.globalColors.black : undefined}
+      style={styles.widenClickableArea}
     />
   )
 
@@ -257,6 +258,7 @@ const styles = Styles.styleSheetCreate(() => ({
   nameContainer: {...Styles.globalStyles.flexBoxColumn, marginLeft: Styles.globalMargins.small},
   nameContainerInner: {...Styles.globalStyles.flexBoxRow, alignItems: 'center'},
   selected: {backgroundColor: Styles.globalColors.blueLighterOrBlueDarker},
+  widenClickableArea: {margin: -5, padding: 5},
 }))
 
 export default ChannelMemberRow

--- a/shared/teams/team/rows/channel-row/channel.tsx
+++ b/shared/teams/team/rows/channel-row/channel.tsx
@@ -59,6 +59,7 @@ const ChannelRow = (props: ChannelRowProps) => {
       onCheck={onSelect}
       key={`check-${channel.channelname}`}
       selectedColor={Styles.isDarkMode() ? Styles.globalColors.black : undefined}
+      style={styles.widenClickableArea}
     />
   )
   const membersText = hasAllMembers
@@ -143,6 +144,7 @@ const styles = Styles.styleSheetCreate(
       listItemMargin: {marginLeft: 0},
       mobileMarginsHack: Styles.platformStyles({isMobile: {marginRight: 48}}), // ListItem2 is malfunctioning because the checkbox width is unusual
       selected: {backgroundColor: Styles.globalColors.blueLighterOrBlueDarker},
+      widenClickableArea: {margin: -5, padding: 5},
     } as const)
 )
 

--- a/shared/teams/team/rows/index.tsx
+++ b/shared/teams/team/rows/index.tsx
@@ -38,8 +38,12 @@ export const useMembersSections = (
     {
       data: stillLoading ? ['loading'] : getOrderedMemberArray(details.members, yourUsername, yourOperations),
       key: 'member-members',
-      renderItem: ({item}) =>
-        item === 'loading' ? <LoadingRow /> : <MemberRow teamID={teamID} username={item.username} />,
+      renderItem: ({index, item}) =>
+        item === 'loading' ? (
+          <LoadingRow />
+        ) : (
+          <MemberRow teamID={teamID} username={item.username} firstItem={index == 0} />
+        ),
       title: flags.teamsRedesign ? `Already in team (${meta.memberCount})` : '',
     },
   ]

--- a/shared/teams/team/rows/member-row/container.tsx
+++ b/shared/teams/team/rows/member-row/container.tsx
@@ -13,6 +13,7 @@ import {anyWaiting} from '../../../../constants/waiting'
 type OwnProps = {
   teamID: Types.TeamID
   username: string
+  firstItem: boolean
 }
 
 const blankInfo = Constants.initialMemberInfo
@@ -74,7 +75,8 @@ export default connect(
           : Tracker2Gen.createShowUser({asTracker: true, username})
       ),
   }),
-  (stateProps, dispatchProps, _: OwnProps) => ({
+  (stateProps, dispatchProps, ownProps: OwnProps) => ({
+    firstItem: ownProps.firstItem,
     following: stateProps.following,
     fullName: stateProps.fullName,
     onBlock: dispatchProps.onBlock,

--- a/shared/teams/team/rows/member-row/index.tsx
+++ b/shared/teams/team/rows/member-row/index.tsx
@@ -11,6 +11,7 @@ import {BoolTypeMap, MemberStatus, TeamRoleType} from '../../../../constants/typ
 import MenuHeader from '../menu-header.new'
 
 export type Props = {
+  firstItem: boolean
   following: boolean
   fullName: string
   onBlock: () => void
@@ -71,7 +72,6 @@ export const TeamMemberRow = (props: Props) => {
   const isYou = props.you === props.username
 
   if (flags.teamsRedesign) {
-    const isOwner = props.roleType == 'owner'
     const teamID = props.teamID
 
     const dispatch = Container.useDispatch()
@@ -89,6 +89,7 @@ export const TeamMemberRow = (props: Props) => {
         onCheck={onSelect}
         key={`check-${props.username}`}
         selectedColor={Styles.isDarkMode() ? Styles.globalColors.black : undefined}
+        style={styles.widenClickableArea}
       />
     )
 
@@ -207,7 +208,7 @@ export const TeamMemberRow = (props: Props) => {
         containerStyleOverride={styles.listItemMargin}
         type="Large"
         body={body}
-        firstItem={isOwner /*TODO: make this accurate */}
+        firstItem={props.firstItem}
         style={selected ? styles.selected : undefined}
         onClick={anySelected ? () => onSelect(!selected) : props.onClick}
       />
@@ -393,4 +394,5 @@ const styles = Styles.styleSheetCreate(() => ({
   nameContainer: {...Styles.globalStyles.flexBoxColumn, marginLeft: Styles.globalMargins.small},
   nameContainerInner: {...Styles.globalStyles.flexBoxRow, alignItems: 'center'},
   selected: {backgroundColor: Styles.globalColors.blueLighterOrBlueDarker},
+  widenClickableArea: {margin: -5, padding: 5},
 }))


### PR DESCRIPTION
 - embiggen clickable area on check circles
 - fix some list item lines
 - turn off highlighting of the check circle on hover of row, because it makes it look like your click will activate the check circle but it won't.
 - reinstate scrollability of channel page

cc @keybase/y2ksquad 