### PR TITLE
fix deeplink highlighting

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -652,7 +652,7 @@ func GetSupersedes(msg chat1.MessageUnboxed) ([]chat1.MessageID, error) {
 	}
 }
 
-// Start at the beginng of the line, space, or some hand picked artisanal
+// Start at the beginning of the line, space, or some hand picked artisanal
 // characters
 const ServiceDecorationPrefix = `(?:^|[\s([/{:;.,!?"'])`
 
@@ -2544,7 +2544,7 @@ func DecorateWithLinks(ctx context.Context, body string) string {
 	origBody := body
 
 	// early out of here if there is no dot
-	if !strings.Contains(body, ".") {
+	if !(strings.Contains(body, ".") || strings.Contains(body, "://")) {
 		return body
 	}
 	shouldSkipLink := func(body string) bool {

--- a/go/chat/utils/utils_test.go
+++ b/go/chat/utils/utils_test.go
@@ -853,6 +853,14 @@ func TestDecorateLinks(t *testing.T) {
 			body:   "@keybase.bots.build.macos",
 			result: "@keybase.bots.build.macos",
 		},
+		{
+			body:   "keybase://team-page/keybasefriends",
+			result: "$>kb$eyJ0eXAiOjQsImxpbmsiOnsidXJsIjoia2V5YmFzZTovL3RlYW0tcGFnZS9rZXliYXNlZnJpZW5kcyIsInB1bnljb2RlIjoiIn19$<kb$",
+		},
+		{
+			body:   "keybase://team-page/keybasefriends https://github.com",
+			result: "$>kb$eyJ0eXAiOjQsImxpbmsiOnsidXJsIjoia2V5YmFzZTovL3RlYW0tcGFnZS9rZXliYXNlZnJpZW5kcyIsInB1bnljb2RlIjoiIn19$<kb$ $>kb$eyJ0eXAiOjQsImxpbmsiOnsidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tIiwicHVueWNvZGUiOiIifX0=$<kb$",
+		},
 	}
 	for _, c := range cases {
 		res := DecorateWithLinks(context.TODO(), c.body)


### PR DESCRIPTION
before:
```
 go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/keybase/client/go/chat/utils
BenchmarkDecorateLinks-4              24          49435327 ns/op
PASS
ok      github.com/keybase/client/go/chat/utils 1.667s
```

after:
```
$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/keybase/client/go/chat/utils
BenchmarkDecorateLinks-4              21          54543743 ns/op
PASS
ok      github.com/keybase/client/go/chat/utils 1.618s
```
