### PR TITLE
prefetcher: pause prefetching when on a cell network 

### DIFF
--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -404,6 +404,11 @@ func (s SimpleFSMock) SimpleFSSetSfmiBannerDismissed(ctx context.Context, dismis
 	return nil
 }
 
+func (s SimpleFSMock) SimpleFSSetSyncOnCellular(
+	_ context.Context, _ bool) error {
+	return nil
+}
+
 func (s SimpleFSMock) SimpleFSSearch(
 	_ context.Context, _ keybase1.SimpleFSSearchArg) (
 	keybase1.SimpleFSSearchResults, error) {

--- a/go/kbfs/env/context.go
+++ b/go/kbfs/env/context.go
@@ -30,6 +30,9 @@ type AppStateUpdater interface {
 	// NextAppStateUpdate returns a channel that app state changes
 	// are sent to.
 	NextAppStateUpdate(lastState *keybase1.MobileAppState) <-chan keybase1.MobileAppState
+	// NextNetworkStateUpdate returns a channel that mobile network
+	// state changes are sent to.
+	NextNetworkStateUpdate(lastState *keybase1.MobileNetworkState) <-chan keybase1.MobileNetworkState
 }
 
 // EmptyAppStateUpdater is an implementation of AppStateUpdater that
@@ -38,6 +41,13 @@ type EmptyAppStateUpdater struct{}
 
 // NextAppStateUpdate implements AppStateUpdater.
 func (easu EmptyAppStateUpdater) NextAppStateUpdate(lastState *keybase1.MobileAppState) <-chan keybase1.MobileAppState {
+	// Receiving on a nil channel blocks forever.
+	return nil
+}
+
+// NextNetworkStateUpdate implements AppStateUpdater.
+func (easu EmptyAppStateUpdater) NextNetworkStateUpdate(
+	lastState *keybase1.MobileNetworkState) <-chan keybase1.MobileNetworkState {
 	// Receiving on a nil channel blocks forever.
 	return nil
 }
@@ -163,6 +173,12 @@ func (c *KBFSContext) GetPerfLog() logger.Logger {
 // NextAppStateUpdate implements AppStateUpdater.
 func (c *KBFSContext) NextAppStateUpdate(lastState *keybase1.MobileAppState) <-chan keybase1.MobileAppState {
 	return c.g.MobileAppState.NextUpdate(lastState)
+}
+
+// NextNetworkStateUpdate implements AppStateUpdater.
+func (c *KBFSContext) NextNetworkStateUpdate(
+	lastState *keybase1.MobileNetworkState) <-chan keybase1.MobileNetworkState {
+	return c.g.MobileNetState.NextUpdate(lastState)
 }
 
 // CheckService checks if the service is running and returns nil if

--- a/go/kbfs/env/context.go
+++ b/go/kbfs/env/context.go
@@ -172,12 +172,18 @@ func (c *KBFSContext) GetPerfLog() logger.Logger {
 
 // NextAppStateUpdate implements AppStateUpdater.
 func (c *KBFSContext) NextAppStateUpdate(lastState *keybase1.MobileAppState) <-chan keybase1.MobileAppState {
+	if c.g.MobileAppState == nil {
+		return nil
+	}
 	return c.g.MobileAppState.NextUpdate(lastState)
 }
 
 // NextNetworkStateUpdate implements AppStateUpdater.
 func (c *KBFSContext) NextNetworkStateUpdate(
 	lastState *keybase1.MobileNetworkState) <-chan keybase1.MobileNetworkState {
+	if c.g.MobileNetState == nil {
+		return nil
+	}
 	return c.g.MobileNetState.NextUpdate(lastState)
 }
 

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/libkey"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -47,14 +48,16 @@ var _ BlockOps = (*BlockOpsStandard)(nil)
 // NewBlockOpsStandard creates a new BlockOpsStandard
 func NewBlockOpsStandard(
 	config blockOpsConfig, queueSize, prefetchQueueSize int,
-	throttledPrefetchPeriod time.Duration) *BlockOpsStandard {
+	throttledPrefetchPeriod time.Duration,
+	appStateUpdater env.AppStateUpdater) *BlockOpsStandard {
 	bg := &realBlockGetter{config: config}
 	qConfig := &realBlockRetrievalConfig{
 		blockRetrievalPartialConfig: config,
-		bg:                          bg,
+		bg: bg,
 	}
 	q := newBlockRetrievalQueue(
-		queueSize, prefetchQueueSize, throttledPrefetchPeriod, qConfig)
+		queueSize, prefetchQueueSize, throttledPrefetchPeriod, qConfig,
+		appStateUpdater)
 	bops := &BlockOpsStandard{
 		config: config,
 		log:    traceLogger{config.MakeLogger("")},

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -32,6 +32,7 @@ type blockOpsConfig interface {
 	clockGetter
 	reporterGetter
 	settingsDBGetter
+	subscriptionManagerGetter
 	subscriptionManagerPublisherGetter
 }
 
@@ -53,7 +54,7 @@ func NewBlockOpsStandard(
 	bg := &realBlockGetter{config: config}
 	qConfig := &realBlockRetrievalConfig{
 		blockRetrievalPartialConfig: config,
-		bg: bg,
+		bg:                          bg,
 	}
 	q := newBlockRetrievalQueue(
 		queueSize, prefetchQueueSize, throttledPrefetchPeriod, qConfig,

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -93,6 +93,7 @@ type testBlockOpsConfig struct {
 	initModeGetter
 	clock                       Clock
 	reporter                    Reporter
+	subsciptionManager          SubscriptionManager
 	subsciptionManagerPublisher SubscriptionManagerPublisher
 }
 
@@ -134,6 +135,10 @@ func (config testBlockOpsConfig) GetSettingsDB() *SettingsDB {
 	return nil
 }
 
+func (config testBlockOpsConfig) SubscriptionManager() SubscriptionManager {
+	return config.subsciptionManager
+}
+
 func (config testBlockOpsConfig) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
 	return config.subsciptionManagerPublisher
 }
@@ -151,7 +156,7 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	mockPublisher.EXPECT().PublishChange(gomock.Any()).AnyTimes()
 	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, dbcg,
 		stgs, testInitModeGetter{InitDefault}, clock,
-		NewReporterSimple(clock, 1), mockPublisher}
+		NewReporterSimple(clock, 1), nil, mockPublisher}
 }
 
 func testBlockOpsShutdown(

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
@@ -132,6 +133,7 @@ func (config testBlockOpsConfig) Reporter() Reporter {
 func (config testBlockOpsConfig) GetSettingsDB() *SettingsDB {
 	return nil
 }
+
 func (config testBlockOpsConfig) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
 	return config.subsciptionManagerPublisher
 }
@@ -165,7 +167,7 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -207,7 +209,7 @@ func TestBlockOpsReadyFailKeyGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -235,7 +237,7 @@ func TestBlockOpsReadyFailServerHalfGet(t *testing.T) {
 	config.cp = badServerHalfMaker{config.cryptoPure()}
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -264,7 +266,7 @@ func TestBlockOpsReadyFailEncryption(t *testing.T) {
 	config.cp = badBlockEncryptor{config.cryptoPure()}
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -290,7 +292,7 @@ func TestBlockOpsReadyFailEncode(t *testing.T) {
 	config.testCodecGetter.codec = badEncoder{config.codec}
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -317,7 +319,7 @@ func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 	config.codec = tooSmallEncoder{config.codec}
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -335,7 +337,7 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -373,7 +375,7 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -418,7 +420,7 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 	config.bserver = badGetBlockServer{config.bserver}
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -450,7 +452,7 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -520,7 +522,7 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 	config.codec = &badDecoder
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -566,7 +568,7 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	config.cp = badBlockDecryptor{config.cryptoPure()}
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -602,7 +604,7 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 	config.bserver = bserver
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	// Expect one call to delete several blocks.
@@ -640,7 +642,7 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 	config.bserver = bserver
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	b1 := data.BlockPointer{ID: kbfsblock.FakeID(1)}
@@ -676,7 +678,7 @@ func TestBlockOpsArchiveSuccess(t *testing.T) {
 	config.bserver = bserver
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	// Expect one call to archive several blocks.
@@ -711,7 +713,7 @@ func TestBlockOpsArchiveFail(t *testing.T) {
 	config.bserver = bserver
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	defer testBlockOpsShutdown(ctx, t, bops)
 
 	b1 := data.BlockPointer{ID: kbfsblock.FakeID(1)}

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -91,10 +91,10 @@ type testBlockOpsConfig struct {
 	diskBlockCacheGetter
 	*testSyncedTlfGetterSetter
 	initModeGetter
-	clock                       Clock
-	reporter                    Reporter
-	subsciptionManager          SubscriptionManager
-	subsciptionManagerPublisher SubscriptionManagerPublisher
+	clock                        Clock
+	reporter                     Reporter
+	subscriptionManager          SubscriptionManager
+	subscriptionManagerPublisher SubscriptionManagerPublisher
 }
 
 var _ blockOpsConfig = (*testBlockOpsConfig)(nil)
@@ -136,11 +136,11 @@ func (config testBlockOpsConfig) GetSettingsDB() *SettingsDB {
 }
 
 func (config testBlockOpsConfig) SubscriptionManager() SubscriptionManager {
-	return config.subsciptionManager
+	return config.subscriptionManager
 }
 
 func (config testBlockOpsConfig) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
-	return config.subsciptionManagerPublisher
+	return config.subscriptionManagerPublisher
 }
 
 func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/eapache/channels"
 	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/libkey"
 	"github.com/keybase/client/go/kbfs/tlf"
@@ -124,8 +125,9 @@ type blockRetrievalQueue struct {
 	ptrs map[blockPtrLookup]*blockRetrieval
 	// global counter of insertions to queue
 	// capacity: ~584 years at 1 billion requests/sec
-	insertionCount uint64
-	heap           *blockRetrievalHeap
+	insertionCount  uint64
+	heap            *blockRetrievalHeap
+	appStateUpdater env.AppStateUpdater
 
 	// These are notification channels to maximize the time that each request
 	// is in the heap, allowing preemption as long as possible. This way, a
@@ -160,7 +162,8 @@ var _ BlockRetriever = (*blockRetrievalQueue)(nil)
 func newBlockRetrievalQueue(
 	numWorkers int, numPrefetchWorkers int,
 	throttledPrefetchPeriod time.Duration,
-	config blockRetrievalConfig) *blockRetrievalQueue {
+	config blockRetrievalConfig,
+	appStateUpdater env.AppStateUpdater) *blockRetrievalQueue {
 	var throttledWorkCh channels.Channel
 	if numPrefetchWorkers > 0 {
 		throttledWorkCh = NewInfiniteChannelWrapper()
@@ -173,6 +176,7 @@ func newBlockRetrievalQueue(
 		vlog:               config.MakeVLogger(log),
 		ptrs:               make(map[blockPtrLookup]*blockRetrieval),
 		heap:               &blockRetrievalHeap{},
+		appStateUpdater:    appStateUpdater,
 		workerCh:           NewInfiniteChannelWrapper(),
 		prefetchWorkerCh:   NewInfiniteChannelWrapper(),
 		throttledWorkCh:    throttledWorkCh,
@@ -181,7 +185,7 @@ func newBlockRetrievalQueue(
 		workers: make([]*blockRetrievalWorker, 0,
 			numWorkers+numPrefetchWorkers),
 	}
-	q.prefetcher = newBlockPrefetcher(q, config, nil, nil)
+	q.prefetcher = newBlockPrefetcher(q, config, nil, nil, appStateUpdater)
 	for i := 0; i < numWorkers; i++ {
 		q.workers = append(q.workers, newBlockRetrievalWorker(
 			config.blockGetter(), q, q.workerCh))
@@ -738,7 +742,7 @@ func (brq *blockRetrievalQueue) TogglePrefetcher(enable bool,
 	ch := brq.prefetcher.Shutdown()
 	if enable {
 		brq.prefetcher = newBlockPrefetcher(
-			brq, brq.config, testSyncCh, testDoneCh)
+			brq, brq.config, testSyncCh, testDoneCh, brq.appStateUpdater)
 	}
 	return ch
 }

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -46,6 +46,7 @@ type blockRetrievalPartialConfig interface {
 	clockGetter
 	reporterGetter
 	settingsDBGetter
+	subscriptionManagerGetter
 	subscriptionManagerPublisherGetter
 }
 

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eapache/channels"
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/libkey"
 	libkeytest "github.com/keybase/client/go/kbfs/libkey/test"
@@ -106,7 +107,8 @@ func makeKMD() libkey.KeyMetadata {
 
 func initBlockRetrievalQueueTest(t *testing.T) *blockRetrievalQueue {
 	q := newBlockRetrievalQueue(
-		0, 0, 0, newTestBlockRetrievalConfig(t, nil, nil))
+		0, 0, 0, newTestBlockRetrievalConfig(t, nil, nil),
+		env.EmptyAppStateUpdater{})
 	<-q.TogglePrefetcher(false, nil, nil)
 	return q
 }

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -32,10 +32,10 @@ type testBlockRetrievalConfig struct {
 	*testDiskBlockCacheGetter
 	*testSyncedTlfGetterSetter
 	initModeGetter
-	clock                       Clock
-	reporter                    Reporter
-	subsciptionManager          SubscriptionManager
-	subsciptionManagerPublisher SubscriptionManagerPublisher
+	clock                        Clock
+	reporter                     Reporter
+	subscriptionManager          SubscriptionManager
+	subscriptionManagerPublisher SubscriptionManagerPublisher
 }
 
 func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter,
@@ -83,11 +83,11 @@ func (c testBlockRetrievalConfig) GetSettingsDB() *SettingsDB {
 }
 
 func (c testBlockRetrievalConfig) SubscriptionManager() SubscriptionManager {
-	return c.subsciptionManager
+	return c.subscriptionManager
 }
 
 func (c testBlockRetrievalConfig) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
-	return c.subsciptionManagerPublisher
+	return c.subscriptionManagerPublisher
 }
 
 func makeRandomBlockPointer(t *testing.T) data.BlockPointer {

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -34,6 +34,7 @@ type testBlockRetrievalConfig struct {
 	initModeGetter
 	clock                       Clock
 	reporter                    Reporter
+	subsciptionManager          SubscriptionManager
 	subsciptionManagerPublisher SubscriptionManagerPublisher
 }
 
@@ -52,6 +53,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter,
 		testInitModeGetter{InitDefault},
 		clock,
 		NewReporterSimple(clock, 1),
+		nil,
 		mockPublisher,
 	}
 }
@@ -78,6 +80,10 @@ func (c testBlockRetrievalConfig) blockGetter() blockGetter {
 
 func (c testBlockRetrievalConfig) GetSettingsDB() *SettingsDB {
 	return nil
+}
+
+func (c testBlockRetrievalConfig) SubscriptionManager() SubscriptionManager {
+	return c.subsciptionManager
 }
 
 func (c testBlockRetrievalConfig) SubscriptionManagerPublisher() SubscriptionManagerPublisher {

--- a/go/kbfs/libkbfs/block_retrieval_worker_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/kbfscodec"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
 	"github.com/keybase/client/go/kbfs/libkey"
@@ -108,7 +109,8 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -130,7 +132,8 @@ func TestBlockRetrievalWorkerBasicSoloCached(t *testing.T) {
 	t.Log("Test the worker fetching and caching a solo block.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -154,7 +157,8 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	t.Log("Test the ability of multiple workers to retrieve concurrently.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		2, 0, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		2, 0, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -202,7 +206,8 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	t.Log("Test the ability of a worker and queue to work correctly together.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		1, 0, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		1, 0, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -267,7 +272,8 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	t.Log("Test the ability of a worker to handle a request cancelation.")
 	bg := newFakeBlockGetter(true)
 	q := newBlockRetrievalQueue(
-		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		0, 1, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -289,7 +295,8 @@ func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	t.Log("Test that worker shutdown works.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		1, 0, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		1, 0, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -337,7 +344,8 @@ func TestBlockRetrievalWorkerPrefetchedPriorityElevation(t *testing.T) {
 		"correctly switches workers.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		1, 1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+		1, 1, 0, newTestBlockRetrievalConfig(t, bg, nil),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 
@@ -393,7 +401,8 @@ func TestBlockRetrievalWorkerStopIfFull(t *testing.T) {
 
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		1, 1, 0, newTestBlockRetrievalConfig(t, bg, dbc))
+		1, 1, 0, newTestBlockRetrievalConfig(t, bg, dbc),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	<-q.TogglePrefetcher(false, nil, nil)
 	defer endBlockRetrievalQueueTest(t, q)

--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbfs/data"
+	"github.com/keybase/client/go/kbfs/env"
 	"github.com/keybase/client/go/kbfs/ioutil"
 	"github.com/keybase/client/go/kbfs/kbfsblock"
 	"github.com/keybase/client/go/kbfs/kbfscrypto"
@@ -547,7 +548,8 @@ func TestDiskBlockCacheWithRetrievalQueue(t *testing.T) {
 	t.Log("Create a queue with 0 workers to rule it out from serving blocks.")
 	bg := newFakeBlockGetter(false)
 	q := newBlockRetrievalQueue(
-		0, 0, 0, newTestBlockRetrievalConfig(t, bg, cache))
+		0, 0, 0, newTestBlockRetrievalConfig(t, bg, cache),
+		env.EmptyAppStateUpdater{})
 	require.NotNil(t, q)
 	defer endBlockRetrievalQueueTest(t, q)
 

--- a/go/kbfs/libkbfs/init.go
+++ b/go/kbfs/libkbfs/init.go
@@ -753,7 +753,7 @@ func doInit(
 	prefetchWorkers := config.Mode().PrefetchWorkers()
 	throttledPrefetchPeriod := config.Mode().ThrottledPrefetchPeriod()
 	config.SetBlockOps(NewBlockOpsStandard(
-		config, workers, prefetchWorkers, throttledPrefetchPeriod))
+		config, workers, prefetchWorkers, throttledPrefetchPeriod, kbCtx))
 
 	bsplitter, err := data.NewBlockSplitterSimple(
 		data.MaxBlockSizeBytesDefault, 8*1024, config.Codec())

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2124,6 +2124,11 @@ type SubscriptionManagerPublisher interface {
 	PublishChange(topic keybase1.SubscriptionTopic)
 }
 
+type kbContextGetter interface {
+	// KbContext returns the Keybase Context.
+	KbContext() Context
+}
+
 // Config collects all the singleton instance instantiations needed to
 // run KBFS in one place.  The methods below are self-explanatory and
 // do not require comments.
@@ -2315,8 +2320,8 @@ type Config interface {
 	SubscriptionManagerPublisher() SubscriptionManagerPublisher
 	// KbEnv returns the *libkb.Env.
 	KbEnv() *libkb.Env
-	// KbContext returns the Keybase Context.
-	KbContext() Context
+
+	kbContextGetter
 }
 
 // NodeCache holds Nodes, and allows libkbfs to update them when

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -145,6 +145,12 @@ type settingsDBGetter interface {
 	GetSettingsDB() *SettingsDB
 }
 
+type subscriptionManagerGetter interface {
+	// SubscriptionManager returns a subscription manager that can be used to
+	// subscribe to events.
+	SubscriptionManager() SubscriptionManager
+}
+
 type subscriptionManagerPublisherGetter interface {
 	SubscriptionManagerPublisher() SubscriptionManagerPublisher
 }
@@ -2312,9 +2318,8 @@ type Config interface {
 	// "mobile", "vlog1", "vlog2", etc.
 	VLogLevel() string
 
-	// SubscriptionManager returns a subscription manager that can be used to
-	// subscribe to events.
-	SubscriptionManager() SubscriptionManager
+	subscriptionManagerGetter
+
 	// SubscriptionManagerPublisher retursn a publisher that can be used to
 	// publish events to the subscription manager.
 	SubscriptionManagerPublisher() SubscriptionManagerPublisher

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -146,7 +146,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 		testInitModeGetter{InitDefault}, clock, NewReporterSimple(clock, 1),
 		mockPublisher,
 	}
-	brq := newBlockRetrievalQueue(0, 0, 0, brc)
+	brq := newBlockRetrievalQueue(0, 0, 0, brc, env.EmptyAppStateUpdater{})
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
 	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(brq.prefetcher)
 

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -144,7 +144,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 		nil, newTestLogMaker(t), config.BlockCache(), nil,
 		newTestDiskBlockCacheGetter(t, nil), newTestSyncedTlfGetterSetter(),
 		testInitModeGetter{InitDefault}, clock, NewReporterSimple(clock, 1),
-		mockPublisher,
+		nil, mockPublisher,
 	}
 	brq := newBlockRetrievalQueue(0, 0, 0, brc, env.EmptyAppStateUpdater{})
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1332,7 +1332,10 @@ func (ps prefetcherSubscriber) OnPathChange(
 
 func (ps prefetcherSubscriber) OnNonPathChange(
 	_ SubscriptionID, _ keybase1.SubscriptionTopic) {
-	ps.ch <- struct{}{}
+	select {
+	case ps.ch <- struct{}{}:
+	default:
+	}
 }
 
 func (p *blockPrefetcher) handleNetStateChange(
@@ -1431,7 +1434,7 @@ func (p *blockPrefetcher) run(
 	subMan := p.config.SubscriptionManager()
 	var subCh chan struct{}
 	if subMan != nil {
-		subCh = make(chan struct{}, 10)
+		subCh = make(chan struct{}, 1)
 
 		const prefetcherSubKey = "prefetcherSettings"
 		sub := subMan.Subscriber(prefetcherSubscriber{subCh})

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1392,6 +1392,9 @@ func (p *blockPrefetcher) run(
 				select {
 				case appState = <-p.appStateUpdater.NextAppStateUpdate(
 					&appState):
+				case req := <-p.prefetchStatusCh.Out():
+					p.handleStatusRequest(req.(*prefetchStatusRequest))
+					continue
 				case <-p.almostDoneCh:
 					break pauseLoop
 				}
@@ -1405,6 +1408,9 @@ func (p *blockPrefetcher) run(
 				select {
 				case netState = <-p.appStateUpdater.NextNetworkStateUpdate(
 					&netState):
+				case req := <-p.prefetchStatusCh.Out():
+					p.handleStatusRequest(req.(*prefetchStatusRequest))
+					continue
 				case <-p.almostDoneCh:
 					break pauseLoop2
 				}

--- a/go/kbfs/libkbfs/settings_db.go
+++ b/go/kbfs/libkbfs/settings_db.go
@@ -28,6 +28,7 @@ const (
 	spaceAvailableNotificationThresholdKey = "spaceAvailableNotificationThreshold"
 
 	sfmiBannerDismissedKey = "sfmiBannerDismissed"
+	syncOnCellularKey      = "syncOnCellular"
 )
 
 // ErrNoSettingsDB is returned when there is no settings DB potentially due to
@@ -194,9 +195,28 @@ func (db *SettingsDB) Settings(ctx context.Context) (keybase1.FSSettings, error)
 		return keybase1.FSSettings{}, err
 	}
 
+	var syncOnCellular bool
+	syncOnCellularBytes, err :=
+		db.Get(getSettingsDbKey(uid, syncOnCellularKey), nil)
+	switch errors.Cause(err) {
+	case leveldb.ErrNotFound:
+		db.vlogger.CLogf(ctx, libkb.VLog1,
+			"syncOnCellular not set; using default value")
+	case nil:
+		syncOnCellular, err = strconv.ParseBool(string(syncOnCellularBytes))
+		if err != nil {
+			return keybase1.FSSettings{}, err
+		}
+	default:
+		db.logger.CWarningf(ctx,
+			"reading syncOnCellular from leveldb error: %+v", err)
+		return keybase1.FSSettings{}, err
+	}
+
 	return keybase1.FSSettings{
 		SpaceAvailableNotificationThreshold: notificationThreshold,
 		SfmiBannerDismissed:                 sfmiBannerDismissed,
+		SyncOnCellular:                      syncOnCellular,
 	}, nil
 }
 
@@ -212,7 +232,7 @@ func (db *SettingsDB) SetNotificationThreshold(
 		[]byte(strconv.FormatInt(threshold, 10)), nil)
 }
 
-// SetSfmiBannerDismissed hello from this comment
+// SetSfmiBannerDismissed sets whether the smfi banner has been dismissed.
 func (db *SettingsDB) SetSfmiBannerDismissed(
 	ctx context.Context, dismissed bool) error {
 	uid := db.getUID(ctx)
@@ -221,4 +241,16 @@ func (db *SettingsDB) SetSfmiBannerDismissed(
 	}
 	return db.Put(getSettingsDbKey(uid, sfmiBannerDismissedKey),
 		[]byte(strconv.FormatBool(dismissed)), nil)
+}
+
+// SetSyncOnCellular sets whether we should do TLF syncing on a
+// cellular network.
+func (db *SettingsDB) SetSyncOnCellular(
+	ctx context.Context, syncOnCellular bool) error {
+	uid := db.getUID(ctx)
+	if uid == keybase1.UID("") {
+		return errNoSession
+	}
+	return db.Put(getSettingsDbKey(uid, syncOnCellularKey),
+		[]byte(strconv.FormatBool(syncOnCellular)), nil)
 }

--- a/go/kbfs/libkbfs/test_common.go
+++ b/go/kbfs/libkbfs/test_common.go
@@ -61,7 +61,7 @@ func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger
 
 	bops := NewBlockOpsStandard(
 		config, testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize,
-		0)
+		0, env.EmptyAppStateUpdater{})
 	config.SetBlockOps(bops)
 
 	bsplit, err := data.NewBlockSplitterSimpleExact(

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -84,26 +84,26 @@ type testTLFJournalConfig struct {
 	codecGetter
 	logMaker
 	*testSyncedTlfGetterSetter
-	t                           *testing.T
-	tlfID                       tlf.ID
-	splitter                    data.BlockSplitter
-	crypto                      *CryptoLocal
-	bcache                      data.BlockCache
-	bops                        BlockOps
-	mdcache                     MDCache
-	ver                         kbfsmd.MetadataVer
-	reporter                    Reporter
-	uid                         keybase1.UID
-	verifyingKey                kbfscrypto.VerifyingKey
-	ekg                         singleEncryptionKeyGetter
-	nug                         idutil.NormalizedUsernameGetter
-	mdserver                    MDServer
-	dlTimeout                   time.Duration
-	subsciptionManagerPublisher SubscriptionManagerPublisher
+	t                            *testing.T
+	tlfID                        tlf.ID
+	splitter                     data.BlockSplitter
+	crypto                       *CryptoLocal
+	bcache                       data.BlockCache
+	bops                         BlockOps
+	mdcache                      MDCache
+	ver                          kbfsmd.MetadataVer
+	reporter                     Reporter
+	uid                          keybase1.UID
+	verifyingKey                 kbfscrypto.VerifyingKey
+	ekg                          singleEncryptionKeyGetter
+	nug                          idutil.NormalizedUsernameGetter
+	mdserver                     MDServer
+	dlTimeout                    time.Duration
+	subscriptionManagerPublisher SubscriptionManagerPublisher
 }
 
 func (c testTLFJournalConfig) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
-	return c.subsciptionManagerPublisher
+	return c.subscriptionManagerPublisher
 }
 
 func (c testTLFJournalConfig) BlockSplitter() data.BlockSplitter {

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -3339,6 +3339,24 @@ func (k *SimpleFS) SimpleFSSetSfmiBannerDismissed(
 	return nil
 }
 
+// SimpleFSSetSyncOnCellular implements the SimpleFSInterface.
+func (k *SimpleFS) SimpleFSSetSyncOnCellular(
+	ctx context.Context, syncOnCellular bool) (err error) {
+	defer func() {
+		k.log.CDebugf(ctx, "SimpleFSSetSyncOnCellular err=%+v", err)
+	}()
+	db := k.config.GetSettingsDB()
+	if db == nil {
+		return libkbfs.ErrNoSettingsDB
+	}
+	if err = db.SetSyncOnCellular(ctx, syncOnCellular); err != nil {
+		return err
+	}
+	k.config.SubscriptionManagerPublisher().PublishChange(
+		keybase1.SubscriptionTopic_SETTINGS)
+	return nil
+}
+
 // SimpleFSSearch implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSSearch(
 	ctx context.Context, arg keybase1.SimpleFSSearchArg) (

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1293,12 +1293,14 @@ func (e KbfsOnlineStatus) String() string {
 type FSSettings struct {
 	SpaceAvailableNotificationThreshold int64 `codec:"spaceAvailableNotificationThreshold" json:"spaceAvailableNotificationThreshold"`
 	SfmiBannerDismissed                 bool  `codec:"sfmiBannerDismissed" json:"sfmiBannerDismissed"`
+	SyncOnCellular                      bool  `codec:"syncOnCellular" json:"syncOnCellular"`
 }
 
 func (o FSSettings) DeepCopy() FSSettings {
 	return FSSettings{
 		SpaceAvailableNotificationThreshold: o.SpaceAvailableNotificationThreshold,
 		SfmiBannerDismissed:                 o.SfmiBannerDismissed,
+		SyncOnCellular:                      o.SyncOnCellular,
 	}
 }
 
@@ -1870,6 +1872,10 @@ type SimpleFSSetSfmiBannerDismissedArg struct {
 	Dismissed bool `codec:"dismissed" json:"dismissed"`
 }
 
+type SimpleFSSetSyncOnCellularArg struct {
+	SyncOnCellular bool `codec:"syncOnCellular" json:"syncOnCellular"`
+}
+
 type SimpleFSObfuscatePathArg struct {
 	Path Path `codec:"path" json:"path"`
 }
@@ -2084,6 +2090,7 @@ type SimpleFSInterface interface {
 	SimpleFSSettings(context.Context) (FSSettings, error)
 	SimpleFSSetNotificationThreshold(context.Context, int64) error
 	SimpleFSSetSfmiBannerDismissed(context.Context, bool) error
+	SimpleFSSetSyncOnCellular(context.Context, bool) error
 	SimpleFSObfuscatePath(context.Context, Path) (string, error)
 	SimpleFSDeobfuscatePath(context.Context, Path) ([]string, error)
 	SimpleFSGetStats(context.Context) (SimpleFSStats, error)
@@ -2729,6 +2736,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSSetSyncOnCellular": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSSetSyncOnCellularArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SimpleFSSetSyncOnCellularArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSSetSyncOnCellularArg)(nil), args)
+						return
+					}
+					err = i.SimpleFSSetSyncOnCellular(ctx, typedArgs[0].SyncOnCellular)
+					return
+				},
+			},
 			"simpleFSObfuscatePath": {
 				MakeArg: func() interface{} {
 					var ret [1]SimpleFSObfuscatePathArg
@@ -3364,6 +3386,12 @@ func (c SimpleFSClient) SimpleFSSetNotificationThreshold(ctx context.Context, th
 func (c SimpleFSClient) SimpleFSSetSfmiBannerDismissed(ctx context.Context, dismissed bool) (err error) {
 	__arg := SimpleFSSetSfmiBannerDismissedArg{Dismissed: dismissed}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetSfmiBannerDismissed", []interface{}{__arg}, nil, 0*time.Millisecond)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSSetSyncOnCellular(ctx context.Context, syncOnCellular bool) (err error) {
+	__arg := SimpleFSSetSyncOnCellularArg{SyncOnCellular: syncOnCellular}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetSyncOnCellular", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -787,6 +787,18 @@ func (s *SimpleFSHandler) SimpleFSSetSfmiBannerDismissed(ctx context.Context, di
 	return cli.SimpleFSSetSfmiBannerDismissed(ctx, dismissed)
 }
 
+// SimpleFSSetSfmiBannerDismissed implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSSetSyncOnCellular(
+	ctx context.Context, syncOnCellular bool) error {
+	cli, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := s.wrapContextWithTimeout(ctx)
+	defer cancel()
+	return cli.SimpleFSSetSyncOnCellular(ctx, syncOnCellular)
+}
+
 // SimpleFSSearch implements the SimpleFSInterface.
 func (s *SimpleFSHandler) SimpleFSSearch(
 	ctx context.Context, arg keybase1.SimpleFSSearchArg) (

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -538,7 +538,8 @@ protocol SimpleFS {
     int64 spaceAvailableNotificationThreshold;
     @lint("ignore")
     boolean sfmiBannerDismissed;
-  }
+    boolean syncOnCellular;
+}
 
   // simpleFSSettings retrieves the settings for this client.
   FSSettings simpleFSSettings();
@@ -546,6 +547,7 @@ protocol SimpleFS {
   void simpleFSSetNotificationThreshold(int64 threshold);
   @lint("ignore")
   void simpleFSSetSfmiBannerDismissed(boolean dismissed);
+  void simpleFSSetSyncOnCellular(boolean syncOnCellular);
 
   // simpleFSObfuscatePath returns an obfuscated path for the given KBFS path.
   string simpleFSObfuscatePath(Path path);

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -773,6 +773,10 @@
           "type": "boolean",
           "name": "sfmiBannerDismissed",
           "lint": "ignore"
+        },
+        {
+          "type": "boolean",
+          "name": "syncOnCellular"
         }
       ]
     },
@@ -1578,6 +1582,15 @@
       ],
       "response": null,
       "lint": "ignore"
+    },
+    "simpleFSSetSyncOnCellular": {
+      "request": [
+        {
+          "name": "syncOnCellular",
+          "type": "boolean"
+        }
+      ],
+      "response": null
     },
     "simpleFSObfuscatePath": {
       "request": [

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2836,7 +2836,7 @@ export type FSFolderWriterEdit = {readonly filename: String; readonly notificati
 export type FSFolderWriterEditHistory = {readonly writerName: String; readonly edits?: Array<FSFolderWriterEdit> | null; readonly deletes?: Array<FSFolderWriterEdit> | null}
 export type FSNotification = {readonly filename: String; readonly status: String; readonly statusCode: FSStatusCode; readonly notificationType: FSNotificationType; readonly errorType: FSErrorType; readonly params: {[key: string]: String}; readonly writerUid: UID; readonly localTime: Time; readonly folderType: FolderType}
 export type FSPathSyncStatus = {readonly folderType: FolderType; readonly path: String; readonly syncingBytes: Int64; readonly syncingOps: Int64; readonly syncedBytes: Int64}
-export type FSSettings = {readonly spaceAvailableNotificationThreshold: Int64; readonly sfmiBannerDismissed: Boolean}
+export type FSSettings = {readonly spaceAvailableNotificationThreshold: Int64; readonly sfmiBannerDismissed: Boolean; readonly syncOnCellular: Boolean}
 export type FSSyncStatus = {readonly totalSyncingBytes: Int64; readonly syncingPaths?: Array<String> | null; readonly endEstimate?: Time | null}
 export type FSSyncStatusRequest = {readonly requestID: Int}
 export type FastTeamData = {readonly frozen: Boolean; readonly subversion: Int; readonly tombstoned: Boolean; readonly name: TeamName; readonly chain: FastTeamSigChainState; readonly perTeamKeySeeds: /* perTeamKeySeedsUnverified */ {[key: string]: PerTeamKeySeed}; readonly maxContinuousPTKGeneration: PerTeamKeyGeneration; readonly seedChecks: {[key: string]: PerTeamSeedCheck}; readonly latestKeyGeneration: PerTeamKeyGeneration; readonly readerKeyMasks: {[key: string]: {[key: string]: MaskB64}}; readonly latestSeqnoHint: Seqno; readonly cachedAt: Time; readonly loadedLatest: Boolean}
@@ -4198,6 +4198,7 @@ export const userUserCardRpcPromise = (params: MessageTypes['keybase.1.user.user
 // 'keybase.1.SimpleFS.simpleFSGetUserQuotaUsage'
 // 'keybase.1.SimpleFS.simpleFSGetTeamQuotaUsage'
 // 'keybase.1.SimpleFS.simpleFSReset'
+// 'keybase.1.SimpleFS.simpleFSSetSyncOnCellular'
 // 'keybase.1.SimpleFS.simpleFSObfuscatePath'
 // 'keybase.1.SimpleFS.simpleFSDeobfuscatePath'
 // 'keybase.1.SimpleFS.simpleFSGetStats'


### PR DESCRIPTION
Listen to the mobile network updates (will only work on mobile, while sharing a global with the service), and pause the prefetcher whenever we get a notification about being on a cell network.

While I'm here, I also made the prefetcher pause when the app is backgrounded.

I don't think this pausing will cause the prefetcher queue to grow out of bounds or anything -- for the most part, the prefetcher itself is responsible for enqueuing its own work, so if it's paused, there shouldn't be much new work that's added.

This also adds a way to set whether or not to sync while on cellular.  The default is false, meaning it won't sync if the network becomes cellular.  But the prefetcher subscribes to those sync changes and pauses/unpauses accordingly.

Issue: HOTPOT-2047