### PR TITLE
WIP: simplify orange line

### DIFF
--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -507,38 +507,6 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
     const {threadLoadStatus, containsLatestMessageMap, orangeLineMap} = draftState
     const {metaMap, messageCenterOrdinals} = draftState
 
-    if (conversationIDKey) {
-      const {readMsgID, maxVisibleMsgID} = metaMap.get(conversationIDKey) ?? Constants.makeConversationMeta()
-
-      logger.info(
-        `rootReducer: selectConversation: setting orange line: convID: ${conversationIDKey} maxVisible: ${maxVisibleMsgID} read: ${readMsgID}`
-      )
-      if (maxVisibleMsgID > readMsgID) {
-        // Store the message ID that will display the orange line above it,
-        // which is the first message after the last read message. We can't
-        // just increment `readMsgID` since that msgID might be a
-        // non-visible (edit, delete, reaction...) message so we scan the
-        // ordinals for the appropriate value.
-        const messageMap = draftState.messageMap.get(conversationIDKey)
-        const ordinals = [...(draftState.messageOrdinals.get(conversationIDKey) || [])]
-        const ord =
-          messageMap &&
-          ordinals.find(o => {
-            const message = messageMap.get(o)
-            return !!(message && message.id >= readMsgID + 1)
-          })
-        const message = ord ? messageMap?.get(ord) : null
-        if (message?.id) {
-          orangeLineMap.set(conversationIDKey, message.id)
-        } else {
-          orangeLineMap.delete(conversationIDKey)
-        }
-      } else {
-        // If there aren't any new messages, we don't want to display an
-        // orange line so remove its entry from orangeLineMap
-        orangeLineMap.delete(conversationIDKey)
-      }
-    }
     // blank out draft so we don't flash old data when switching convs
     const meta = metaMap.get(conversationIDKey)
     if (meta) {
@@ -1586,6 +1554,9 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
         })
       )
     })
+
+    // clear all orange lines
+    draftState.orangeLineMap.clear()
   },
   [Chat2Gen.setBotRoleInConv]: (draftState, action) => {
     const roles =


### PR DESCRIPTION
- [ ] this pr is broken due to how the meta is working now. need some help from @mmaxim 

There are 2 pieces that touch the orange map. 
1. when you select a convo we make an rpc call to get the orange line (good)
1. after we select a convo we update the ornage map locally (could even race with 1) to update it based on our messages

seems like 2 above should just go away