### PR TITLE
client: allow fs search commands in prod

### DIFF
--- a/go/client/cmd_simplefs.go
+++ b/go/client/cmd_simplefs.go
@@ -53,6 +53,9 @@ func NewCmdSimpleFS(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			NewCmdSimpleFSFinishResolvingConflicts(cl, g),
 			NewCmdSimpleFSSync(cl, g),
 			NewCmdSimpleFSUploads(cl, g),
+			NewCmdSimpleFSSearch(cl, g),
+			NewCmdSimpleFSResetIndex(cl, g),
+			NewCmdSimpleFSIndexProgress(cl, g),
 		}, getBuildSpecificFSCommands(cl, g)...),
 	}
 }

--- a/go/client/cmd_simplefs_index_progress.go
+++ b/go/client/cmd_simplefs_index_progress.go
@@ -23,7 +23,7 @@ type CmdSimpleFSIndexProgress struct {
 func NewCmdSimpleFSIndexProgress(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:  "index-progress",
-		Usage: "print the current progress of the indexer",
+		Usage: "[disabled] print the current progress of the indexer",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdSimpleFSIndexProgress{
 				Contextified: libkb.NewContextified(g)}, "index-progress", c)

--- a/go/client/cmd_simplefs_reset_index.go
+++ b/go/client/cmd_simplefs_reset_index.go
@@ -21,7 +21,7 @@ type CmdSimpleFSResetIndex struct {
 func NewCmdSimpleFSResetIndex(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
 		Name:  "reset-index",
-		Usage: "delete all local index storage, and resets the indexer",
+		Usage: "[disabled] delete all local index storage, and resets the indexer",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdSimpleFSResetIndex{
 				Contextified: libkb.NewContextified(g)}, "reset-index", c)

--- a/go/client/cmd_simplefs_search.go
+++ b/go/client/cmd_simplefs_search.go
@@ -29,8 +29,9 @@ type CmdSimpleFSSearch struct {
 // NewCmdSimpleFSSearch creates a new cli.Command.
 func NewCmdSimpleFSSearch(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
 	return cli.Command{
-		Name:  "search",
-		Usage: "search [flags] <query>",
+		Name:         "search",
+		ArgumentHelp: "<query>",
+		Usage:        "[disabled] search locally-synced folders",
 		Action: func(c *cli.Context) {
 			cl.ChooseCommand(&CmdSimpleFSSearch{
 				Contextified: libkb.NewContextified(g)}, "search", c)

--- a/go/client/commands_devel.go
+++ b/go/client/commands_devel.go
@@ -76,9 +76,6 @@ func getBuildSpecificFSCommands(cl *libcmdline.CommandLine, g *libkb.GlobalConte
 	return []cli.Command{
 		NewCmdSimpleFSUpgrade(cl, g),
 		NewCmdSimpleFSForceConflict(cl, g),
-		NewCmdSimpleFSSearch(cl, g),
-		NewCmdSimpleFSResetIndex(cl, g),
-		NewCmdSimpleFSIndexProgress(cl, g),
 	}
 }
 


### PR DESCRIPTION
This lets internal users test kbfs search if they have enabled the magic mode.  Everyone else will get an error if they try to use them:

```
$ keybase fs search x
▶ ERROR Indexing not enabled

```

In help, it looks like:

```
$ keybase fs -h
...
   search			[disabled] search locally-synced folders
   reset-index			[disabled] delete all local index storage, and resets the indexer
   index-progress		[disabled] print the current progress of the indexer
...
```