### PR TITLE
force purepack to not resolve

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -278,6 +278,7 @@
     "**/minimist": "1.2.5",
     "**/os-locale": "3.1.0",
     "babel-core": "7.0.0-bridge.0",
+    "**/purepack": "git://github.com/keybase/nullModule",
     "react-native-screens": "git://github.com/keybase/react-native-screens#keybase-changes-off-alpha-23"
   }
 }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -9333,7 +9333,7 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-"msgpack@git://github.com/keybase/nullModule", "net@git://github.com/keybase/nullModule", "purepack@git://github.com/keybase/nullModule", "tls@git://github.com/keybase/nullModule":
+"msgpack@git://github.com/keybase/nullModule", "net@git://github.com/keybase/nullModule", purepack@>=1, "purepack@git://github.com/keybase/nullModule", "tls@git://github.com/keybase/nullModule":
   version "0.0.0"
   resolved "git://github.com/keybase/nullModule#e0d7d7874eb4d1fd82056f92f146589186fe94f0"
 


### PR DESCRIPTION
i think upstream should use `peerDependency` instead of optional (my bad advice) but this is fine for now. maybe if we touch that dep again

cc: @joshblum 