### PR TITLE
bcache: pass cache hash behavior into `CheckForKnownPtr`

### DIFF
--- a/go/kbfs/data/bcache.go
+++ b/go/kbfs/data/bcache.go
@@ -136,8 +136,14 @@ func (b *BlockCacheStandard) onEvict(key interface{}, value interface{}) {
 }
 
 // CheckForKnownPtr implements the BlockCache interface for BlockCacheStandard.
-func (b *BlockCacheStandard) CheckForKnownPtr(tlf tlf.ID, block *FileBlock) (
+func (b *BlockCacheStandard) CheckForKnownPtr(
+	tlf tlf.ID, block *FileBlock, hashBehavior BlockCacheHashBehavior) (
 	BlockPointer, error) {
+	if hashBehavior == SkipCacheHash {
+		// Avoid hashing if we're not caching the hashes.
+		return BlockPointer{}, nil
+	}
+
 	if block.IsInd {
 		return BlockPointer{}, NotDirectFileBlockError{}
 	}

--- a/go/kbfs/data/bcache_test.go
+++ b/go/kbfs/data/bcache_test.go
@@ -82,7 +82,7 @@ func TestBlockCacheCheckPtrSuccess(t *testing.T) {
 	err := bcache.Put(ptr, tlf, block, TransientEntry, DoCacheHash)
 	require.NoError(t, err)
 
-	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block)
+	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block, DoCacheHash)
 	require.NoError(t, err)
 	require.Equal(t, ptr, checkedPtr)
 }
@@ -99,7 +99,7 @@ func TestBlockCacheCheckPtrPermanent(t *testing.T) {
 	err := bcache.Put(ptr, tlf, block, PermanentEntry, SkipCacheHash)
 	require.NoError(t, err)
 
-	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block)
+	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block, DoCacheHash)
 	require.NoError(t, err)
 	require.Equal(t, BlockPointer{}, checkedPtr)
 }
@@ -118,7 +118,7 @@ func TestBlockCacheCheckPtrNotFound(t *testing.T) {
 
 	block2 := NewFileBlock().(*FileBlock)
 	block2.Contents = []byte{4, 3, 2, 1}
-	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block2)
+	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block2, DoCacheHash)
 	require.NoError(t, err)
 	require.False(t, checkedPtr.IsInitialized())
 }
@@ -139,7 +139,7 @@ func TestBlockCacheDeleteTransient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make sure the pointer is gone from the hash cache too.
-	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block)
+	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block, DoCacheHash)
 	require.NoError(t, err)
 	require.False(t, checkedPtr.IsInitialized())
 }
@@ -186,7 +186,7 @@ func TestBlockCacheEmptyTransient(t *testing.T) {
 	err = bcache.DeletePermanent(id)
 	require.NoError(t, err)
 
-	_, err = bcache.CheckForKnownPtr(tlf, block.(*FileBlock))
+	_, err = bcache.CheckForKnownPtr(tlf, block.(*FileBlock), DoCacheHash)
 	require.NoError(t, err)
 }
 
@@ -311,7 +311,7 @@ func TestBlockCachePutNoHashCalculation(t *testing.T) {
 
 	// CheckForKnownPtr() calculates hash only if it's nil. If the block with
 	// invalid hash was put into cache, this will find it.
-	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block)
+	checkedPtr, err := bcache.CheckForKnownPtr(tlf, block, DoCacheHash)
 	require.NoError(t, err)
 	require.Equal(t, ptr, checkedPtr)
 	require.Equal(t, hash, block.hash)

--- a/go/kbfs/data/block_tree.go
+++ b/go/kbfs/data/block_tree.go
@@ -1018,7 +1018,8 @@ func (bt *blockTree) readyWorker(
 	ctx context.Context, id tlf.ID, bcache BlockCache, rp ReadyProvider,
 	bps BlockPutState, pathsFromRoot [][]ParentBlockAndChildIndex,
 	makeSync makeSyncFunc, i int, level int, lock *sync.Mutex,
-	oldPtrs map[BlockInfo]BlockPointer, donePtrs map[BlockPointer]bool) error {
+	oldPtrs map[BlockInfo]BlockPointer, donePtrs map[BlockPointer]bool,
+	hashBehavior BlockCacheHashBehavior) error {
 	// Ready the dirty block.
 	pb := pathsFromRoot[i][level]
 
@@ -1035,7 +1036,7 @@ func (bt *blockTree) readyWorker(
 
 	newInfo, _, readyBlockData, err := ReadyBlock(
 		ctx, bcache, rp, bt.kmd, pb.pblock,
-		bt.chargedTo, bt.rootBlockPointer().GetBlockType())
+		bt.chargedTo, bt.rootBlockPointer().GetBlockType(), hashBehavior)
 	if err != nil {
 		return err
 	}
@@ -1083,7 +1084,8 @@ func (bt *blockTree) readyWorker(
 func (bt *blockTree) readyHelper(
 	ctx context.Context, id tlf.ID, bcache BlockCache,
 	rp ReadyProvider, bps BlockPutState,
-	pathsFromRoot [][]ParentBlockAndChildIndex, makeSync makeSyncFunc) (
+	pathsFromRoot [][]ParentBlockAndChildIndex, makeSync makeSyncFunc,
+	hashBehavior BlockCacheHashBehavior) (
 	map[BlockInfo]BlockPointer, error) {
 	oldPtrs := make(map[BlockInfo]BlockPointer)
 	donePtrs := make(map[BlockPointer]bool)
@@ -1109,7 +1111,7 @@ func (bt *blockTree) readyHelper(
 			for i := range indices {
 				err := bt.readyWorker(
 					groupCtx, id, bcache, rp, bps, pathsFromRoot, makeSync,
-					i, level, &lock, oldPtrs, donePtrs)
+					i, level, &lock, oldPtrs, donePtrs, hashBehavior)
 				if err != nil {
 					return err
 				}
@@ -1139,7 +1141,8 @@ func (bt *blockTree) readyHelper(
 func (bt *blockTree) ready(
 	ctx context.Context, id tlf.ID, bcache BlockCache,
 	dirtyBcache IsDirtyProvider, rp ReadyProvider, bps BlockPutState,
-	topBlock BlockWithPtrs, makeSync makeSyncFunc) (
+	topBlock BlockWithPtrs, makeSync makeSyncFunc,
+	hashBehavior BlockCacheHashBehavior) (
 	map[BlockInfo]BlockPointer, error) {
 	if !topBlock.IsIndirect() {
 		return nil, nil
@@ -1187,7 +1190,8 @@ func (bt *blockTree) ready(
 		return nil, nil
 	}
 
-	return bt.readyHelper(ctx, id, bcache, rp, bps, dirtyLeafPaths, makeSync)
+	return bt.readyHelper(
+		ctx, id, bcache, rp, bps, dirtyLeafPaths, makeSync, hashBehavior)
 }
 
 func (bt *blockTree) getIndirectBlocksForOffsetRange(

--- a/go/kbfs/data/dir_data.go
+++ b/go/kbfs/data/dir_data.go
@@ -361,9 +361,10 @@ func (dd *DirData) RemoveEntry(ctx context.Context, name PathPartString) (
 func (dd *DirData) Ready(ctx context.Context, id tlf.ID,
 	bcache BlockCache, dirtyBcache IsDirtyProvider,
 	rp ReadyProvider, bps BlockPutState,
-	topBlock *DirBlock) (map[BlockInfo]BlockPointer, error) {
+	topBlock *DirBlock, hashBehavior BlockCacheHashBehavior) (
+	map[BlockInfo]BlockPointer, error) {
 	return dd.tree.ready(
-		ctx, id, bcache, dirtyBcache, rp, bps, topBlock, nil)
+		ctx, id, bcache, dirtyBcache, rp, bps, topBlock, nil, hashBehavior)
 }
 
 // GetDirtyChildPtrs returns a set of dirty child pointers (not the

--- a/go/kbfs/data/file_data.go
+++ b/go/kbfs/data/file_data.go
@@ -1000,7 +1000,8 @@ func (fd *FileData) Split(ctx context.Context, id tlf.ID,
 // info from any readied block to its corresponding old block pointer.
 func (fd *FileData) Ready(ctx context.Context, id tlf.ID,
 	bcache BlockCache, dirtyBcache IsDirtyProvider,
-	rp ReadyProvider, bps BlockPutState, topBlock *FileBlock, df *DirtyFile) (
+	rp ReadyProvider, bps BlockPutState, topBlock *FileBlock, df *DirtyFile,
+	hashBehavior BlockCacheHashBehavior) (
 	map[BlockInfo]BlockPointer, error) {
 	return fd.tree.ready(
 		ctx, id, bcache, dirtyBcache, rp, bps, topBlock,
@@ -1009,7 +1010,7 @@ func (fd *FileData) Ready(ctx context.Context, id tlf.ID,
 				return func() error { return df.setBlockSynced(ptr) }
 			}
 			return nil
-		})
+		}, hashBehavior)
 }
 
 // GetIndirectFileBlockInfosWithTopBlock returns the block infos
@@ -1252,7 +1253,8 @@ func (fd *FileData) DeepCopy(ctx context.Context, dataVer Ver) (
 // the BlockInfos for all children.
 func (fd *FileData) UndupChildrenInCopy(ctx context.Context,
 	bcache BlockCache, rp ReadyProvider, bps BlockPutState,
-	topBlock *FileBlock) ([]BlockInfo, error) {
+	topBlock *FileBlock, hashBehavior BlockCacheHashBehavior) (
+	[]BlockInfo, error) {
 	if !topBlock.IsInd {
 		return nil, nil
 	}
@@ -1285,7 +1287,7 @@ func (fd *FileData) UndupChildrenInCopy(ctx context.Context,
 	}
 
 	newInfos, err := fd.tree.readyHelper(
-		ctx, fd.tree.file.Tlf, bcache, rp, bps, pfr, nil)
+		ctx, fd.tree.file.Tlf, bcache, rp, bps, pfr, nil, hashBehavior)
 	if err != nil {
 		return nil, err
 	}
@@ -1303,7 +1305,8 @@ func (fd *FileData) UndupChildrenInCopy(ctx context.Context,
 // BlockInfos for all non-leaf children.
 func (fd *FileData) ReadyNonLeafBlocksInCopy(ctx context.Context,
 	bcache BlockCache, rp ReadyProvider, bps BlockPutState,
-	topBlock *FileBlock) ([]BlockInfo, error) {
+	topBlock *FileBlock, hashBehavior BlockCacheHashBehavior) (
+	[]BlockInfo, error) {
 	if !topBlock.IsInd {
 		return nil, nil
 	}
@@ -1322,7 +1325,7 @@ func (fd *FileData) ReadyNonLeafBlocksInCopy(ctx context.Context,
 	}
 
 	newInfos, err := fd.tree.readyHelper(
-		ctx, fd.tree.file.Tlf, bcache, rp, bps, pfr, nil)
+		ctx, fd.tree.file.Tlf, bcache, rp, bps, pfr, nil, hashBehavior)
 	if err != nil {
 		return nil, err
 	}

--- a/go/kbfs/data/interfaces.go
+++ b/go/kbfs/data/interfaces.go
@@ -161,7 +161,9 @@ type BlockCache interface {
 	// associated with that ID, including key and data versions.
 	// If no ID is known, return an uninitialized BlockPointer and
 	// a nil error.
-	CheckForKnownPtr(tlf tlf.ID, block *FileBlock) (BlockPointer, error)
+	CheckForKnownPtr(
+		tlf tlf.ID, block *FileBlock, hashBehavior BlockCacheHashBehavior) (
+		BlockPointer, error)
 	// DeleteTransient removes the transient entry for the given
 	// ID from the cache, as well as any cached IDs so the block
 	// won't be reused.

--- a/go/kbfs/data/ready.go
+++ b/go/kbfs/data/ready.go
@@ -17,7 +17,7 @@ import (
 func ReadyBlock(
 	ctx context.Context, bcache BlockCache, rp ReadyProvider,
 	kmd libkey.KeyMetadata, block Block, chargedTo keybase1.UserOrTeamID,
-	bType keybase1.BlockType) (
+	bType keybase1.BlockType, hashBehavior BlockCacheHashBehavior) (
 	info BlockInfo, plainSize int, readyBlockData ReadyBlockData, err error) {
 	var ptr BlockPointer
 	directType := DirectBlock
@@ -25,7 +25,7 @@ func ReadyBlock(
 		directType = IndirectBlock
 	} else if fBlock, ok := block.(*FileBlock); ok {
 		// first see if we are duplicating any known blocks in this folder
-		ptr, err = bcache.CheckForKnownPtr(kmd.TlfID(), fBlock)
+		ptr, err = bcache.CheckForKnownPtr(kmd.TlfID(), fBlock, hashBehavior)
 		if err != nil {
 			return BlockInfo{}, 0, ReadyBlockData{}, err
 		}

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -40,6 +40,7 @@ type blockRetrievalPartialConfig interface {
 	data.Versioner
 	logMaker
 	blockCacher
+	blockServerGetter
 	diskBlockCacheGetter
 	syncedTlfGetterSetter
 	initModeGetter
@@ -348,15 +349,18 @@ func (brq *blockRetrievalQueue) setPrefetchStatus(
 	return nil
 }
 
+func (brq *blockRetrievalQueue) cacheHashBehavior(
+	tlfID tlf.ID) data.BlockCacheHashBehavior {
+	return cacheHashBehavior(brq.config, brq.config, tlfID)
+}
+
 // PutInCaches implements the BlockRetriever interface for
 // BlockRetrievalQueue.
 func (brq *blockRetrievalQueue) PutInCaches(ctx context.Context,
 	ptr data.BlockPointer, tlfID tlf.ID, block data.Block, lifetime data.BlockCacheLifetime,
 	prefetchStatus PrefetchStatus, cacheType DiskBlockCacheType) (err error) {
-	// TODO: plumb through whether journaling is enabled for this TLF,
-	// to set the right cache behavior.
 	err = brq.config.BlockCache().Put(
-		ptr, tlfID, block, lifetime, data.DoCacheHash)
+		ptr, tlfID, block, lifetime, brq.cacheHashBehavior(tlfID))
 	switch err.(type) {
 	case nil:
 	case data.CachePutCacheFullError:
@@ -423,11 +427,10 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	err = brq.config.blockGetter().assembleBlock(ctx, kmd, ptr, block, blockBuf,
 		serverHalf)
 	if err == nil {
-		// Cache the block in memory.  TODO: plumb through whether
-		// journaling is enabled for this TLF, to set the right cache
-		// behavior.
+		// Cache the block in memory.
 		_ = brq.config.BlockCache().Put(
-			ptr, kmd.TlfID(), block, data.TransientEntry, data.DoCacheHash)
+			ptr, kmd.TlfID(), block, data.TransientEntry,
+			brq.cacheHashBehavior(kmd.TlfID()))
 	}
 	return prefetchStatus, err
 }

--- a/go/kbfs/libkbfs/data_mocks_test.go
+++ b/go/kbfs/libkbfs/data_mocks_test.go
@@ -37,18 +37,18 @@ func (m *MockBlockCache) EXPECT() *MockBlockCacheMockRecorder {
 }
 
 // CheckForKnownPtr mocks base method.
-func (m *MockBlockCache) CheckForKnownPtr(arg0 tlf.ID, arg1 *data.FileBlock) (data.BlockPointer, error) {
+func (m *MockBlockCache) CheckForKnownPtr(arg0 tlf.ID, arg1 *data.FileBlock, arg2 data.BlockCacheHashBehavior) (data.BlockPointer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckForKnownPtr", arg0, arg1)
+	ret := m.ctrl.Call(m, "CheckForKnownPtr", arg0, arg1, arg2)
 	ret0, _ := ret[0].(data.BlockPointer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckForKnownPtr indicates an expected call of CheckForKnownPtr.
-func (mr *MockBlockCacheMockRecorder) CheckForKnownPtr(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockCacheMockRecorder) CheckForKnownPtr(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckForKnownPtr", reflect.TypeOf((*MockBlockCache)(nil).CheckForKnownPtr), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckForKnownPtr", reflect.TypeOf((*MockBlockCache)(nil).CheckForKnownPtr), arg0, arg1, arg2)
 }
 
 // DeleteKnownPtr mocks base method.

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -873,7 +873,7 @@ func (fbo *folderBlockOps) deepCopyFileLocked(
 }
 
 func (fbo *folderBlockOps) cacheHashBehavior() data.BlockCacheHashBehavior {
-	return cacheHashBehavior(fbo.config, fbo.id())
+	return cacheHashBehavior(fbo.config, fbo.config, fbo.id())
 }
 
 func (fbo *folderBlockOps) UndupChildrenInCopy(ctx context.Context,

--- a/go/kbfs/libkbfs/folder_block_ops.go
+++ b/go/kbfs/libkbfs/folder_block_ops.go
@@ -872,6 +872,10 @@ func (fbo *folderBlockOps) deepCopyFileLocked(
 	return fd.DeepCopy(ctx, dataVer)
 }
 
+func (fbo *folderBlockOps) cacheHashBehavior() data.BlockCacheHashBehavior {
+	return cacheHashBehavior(fbo.config, fbo.id())
+}
+
 func (fbo *folderBlockOps) UndupChildrenInCopy(ctx context.Context,
 	lState *kbfssync.LockState, kmd libkey.KeyMetadata, file data.Path, bps blockPutState,
 	dirtyBcache data.DirtyBlockCacheSimple, topBlock *data.FileBlock) (
@@ -885,7 +889,7 @@ func (fbo *folderBlockOps) UndupChildrenInCopy(ctx context.Context,
 	fd := fbo.newFileDataWithCache(
 		lState, file, chargedTo, kmd, dirtyBcache)
 	return fd.UndupChildrenInCopy(ctx, fbo.config.BlockCache(),
-		fbo.config.BlockOps(), bps, topBlock)
+		fbo.config.BlockOps(), bps, topBlock, fbo.cacheHashBehavior())
 }
 
 func (fbo *folderBlockOps) ReadyNonLeafBlocksInCopy(ctx context.Context,
@@ -902,7 +906,7 @@ func (fbo *folderBlockOps) ReadyNonLeafBlocksInCopy(ctx context.Context,
 	fd := fbo.newFileDataWithCache(
 		lState, file, chargedTo, kmd, dirtyBcache)
 	return fd.ReadyNonLeafBlocksInCopy(ctx, fbo.config.BlockCache(),
-		fbo.config.BlockOps(), bps, topBlock)
+		fbo.config.BlockOps(), bps, topBlock, fbo.cacheHashBehavior())
 }
 
 // getDirLocked retrieves the block pointed to by the tail pointer of
@@ -2810,7 +2814,8 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 
 	// Ready all children blocks, if any.
 	oldPtrs, err := fd.Ready(ctx, fbo.id(), fbo.config.BlockCache(),
-		fbo.config.DirtyBlockCache(), fbo.config.BlockOps(), si.bps, fblock, df)
+		fbo.config.DirtyBlockCache(), fbo.config.BlockOps(), si.bps, fblock, df,
+		fbo.cacheHashBehavior())
 	if err != nil {
 		return nil, nil, syncState, nil, err
 	}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -2715,7 +2715,8 @@ func ResetRootBlock(ctx context.Context, config Config,
 
 	info, plainSize, readyBlockData, err :=
 		data.ReadyBlock(ctx, config.BlockCache(), config.BlockOps(),
-			rmd.ReadOnly(), newDblock, chargedTo, config.DefaultBlockType())
+			rmd.ReadOnly(), newDblock, chargedTo, config.DefaultBlockType(),
+			cacheHashBehavior(config, rmd.TlfID()))
 	if err != nil {
 		return nil, data.BlockInfo{}, data.ReadyBlockData{}, err
 	}
@@ -2745,10 +2746,7 @@ func ResetRootBlock(ctx context.Context, config Config,
 }
 
 func (fbo *folderBranchOps) cacheHashBehavior() data.BlockCacheHashBehavior {
-	if TLFJournalEnabled(fbo.config, fbo.id()) {
-		return data.SkipCacheHash
-	}
-	return data.DoCacheHash
+	return cacheHashBehavior(fbo.config, fbo.id())
 }
 
 func (fbo *folderBranchOps) initMDLocked(
@@ -9194,7 +9192,8 @@ func (fbo *folderBranchOps) makeEncryptedPartialPathsLocked(
 
 	info, _, readyBlockData, err :=
 		data.ReadyBlock(ctx, fbo.config.BlockCache(), fbo.config.BlockOps(),
-			kmd, b, chargedTo, fbo.config.DefaultBlockType())
+			kmd, b, chargedTo, fbo.config.DefaultBlockType(),
+			fbo.cacheHashBehavior())
 	if err != nil {
 		return FolderSyncEncryptedPartialPaths{}, err
 	}

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -2716,7 +2716,7 @@ func ResetRootBlock(ctx context.Context, config Config,
 	info, plainSize, readyBlockData, err :=
 		data.ReadyBlock(ctx, config.BlockCache(), config.BlockOps(),
 			rmd.ReadOnly(), newDblock, chargedTo, config.DefaultBlockType(),
-			cacheHashBehavior(config, rmd.TlfID()))
+			cacheHashBehavior(config, config, rmd.TlfID()))
 	if err != nil {
 		return nil, data.BlockInfo{}, data.ReadyBlockData{}, err
 	}
@@ -2746,7 +2746,7 @@ func ResetRootBlock(ctx context.Context, config Config,
 }
 
 func (fbo *folderBranchOps) cacheHashBehavior() data.BlockCacheHashBehavior {
-	return cacheHashBehavior(fbo.config, fbo.id())
+	return cacheHashBehavior(fbo.config, fbo.config, fbo.id())
 }
 
 func (fbo *folderBranchOps) initMDLocked(

--- a/go/kbfs/libkbfs/journal_block_cache.go
+++ b/go/kbfs/libkbfs/journal_block_cache.go
@@ -18,10 +18,11 @@ var _ data.BlockCache = journalBlockCache{}
 
 // CheckForKnownPtr implements BlockCache.
 func (j journalBlockCache) CheckForKnownPtr(
-	tlfID tlf.ID, block *data.FileBlock) (data.BlockPointer, error) {
+	tlfID tlf.ID, block *data.FileBlock,
+	hashBehavior data.BlockCacheHashBehavior) (data.BlockPointer, error) {
 	_, ok := j.jManager.getTLFJournal(tlfID, nil)
 	if !ok {
-		return j.BlockCache.CheckForKnownPtr(tlfID, block)
+		return j.BlockCache.CheckForKnownPtr(tlfID, block, hashBehavior)
 	}
 
 	// Temporarily disable de-duping for the journal server until

--- a/go/kbfs/libkbfs/journal_manager_util.go
+++ b/go/kbfs/libkbfs/journal_manager_util.go
@@ -17,8 +17,8 @@ import (
 
 // GetJournalManager returns the JournalManager tied to a particular
 // config.
-func GetJournalManager(config Config) (*JournalManager, error) {
-	bserver := config.BlockServer()
+func GetJournalManager(getter blockServerGetter) (*JournalManager, error) {
+	bserver := getter.BlockServer()
 	jbserver, ok := bserver.(journalBlockServer)
 	if !ok {
 		return nil, errors.New("Write journal not enabled")
@@ -28,8 +28,8 @@ func GetJournalManager(config Config) (*JournalManager, error) {
 
 // TLFJournalEnabled returns true if journaling is enabled for the
 // given TLF.
-func TLFJournalEnabled(config Config, tlfID tlf.ID) bool {
-	if jManager, err := GetJournalManager(config); err == nil {
+func TLFJournalEnabled(getter blockServerGetter, tlfID tlf.ID) bool {
+	if jManager, err := GetJournalManager(getter); err == nil {
 		return jManager.JournalEnabled(tlfID)
 	}
 	return false

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -138,13 +138,14 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore BlockRetriever calls
 	clock := clocktest.NewTestClockNow()
-	mockPublisher := NewMockSubscriptionManagerPublisher(gomock.NewController(t))
+	ctlr := gomock.NewController(t)
+	mockPublisher := NewMockSubscriptionManagerPublisher(ctlr)
 	mockPublisher.EXPECT().PublishChange(gomock.Any()).AnyTimes()
 	brc := &testBlockRetrievalConfig{
 		nil, newTestLogMaker(t), config.BlockCache(), nil,
-		newTestDiskBlockCacheGetter(t, nil), newTestSyncedTlfGetterSetter(),
-		testInitModeGetter{InitDefault}, clock, NewReporterSimple(clock, 1),
-		nil, mockPublisher,
+		NewMockBlockServer(ctlr), newTestDiskBlockCacheGetter(t, nil),
+		newTestSyncedTlfGetterSetter(), testInitModeGetter{InitDefault}, clock,
+		NewReporterSimple(clock, 1), nil, mockPublisher,
 	}
 	brq := newBlockRetrievalQueue(0, 0, 0, brc, env.EmptyAppStateUpdater{})
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -427,3 +427,13 @@ func MakeDiskBlockServer(config Config, serverRootDir string) BlockServer {
 	bserverLog := config.MakeLogger("BSD")
 	return NewBlockServerDir(config.Codec(), bserverLog, blockPath)
 }
+
+func cacheHashBehavior(config Config, id tlf.ID) data.BlockCacheHashBehavior {
+	if config.Mode().IsSingleOp() || TLFJournalEnabled(config, id) {
+		// If the journal is enabled, or single-op mode is enabled
+		// (which implies either local or journal writes), then skip
+		// any known-ptr block hash computations.
+		return data.SkipCacheHash
+	}
+	return data.DoCacheHash
+}

--- a/go/kbfs/libkbfs/util.go
+++ b/go/kbfs/libkbfs/util.go
@@ -428,8 +428,10 @@ func MakeDiskBlockServer(config Config, serverRootDir string) BlockServer {
 	return NewBlockServerDir(config.Codec(), bserverLog, blockPath)
 }
 
-func cacheHashBehavior(config Config, id tlf.ID) data.BlockCacheHashBehavior {
-	if config.Mode().IsSingleOp() || TLFJournalEnabled(config, id) {
+func cacheHashBehavior(
+	bsGetter blockServerGetter, modeGetter initModeGetter,
+	id tlf.ID) data.BlockCacheHashBehavior {
+	if modeGetter.Mode().IsSingleOp() || TLFJournalEnabled(bsGetter, id) {
 		// If the journal is enabled, or single-op mode is enabled
 		// (which implies either local or journal writes), then skip
 		// any known-ptr block hash computations.


### PR DESCRIPTION
Since we don't need to calculate the hashes when journaling is enabled.

Issue: HOTPOT-2024