### PR TITLE
fix: remove channel filter from redux

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -127,7 +127,6 @@ export const setAudioRecordingPostInfo = 'chat2:setAudioRecordingPostInfo'
 export const setBotPublicCommands = 'chat2:setBotPublicCommands'
 export const setBotRoleInConv = 'chat2:setBotRoleInConv'
 export const setBotSettings = 'chat2:setBotSettings'
-export const setChannelSearchText = 'chat2:setChannelSearchText'
 export const setCommandMarkdown = 'chat2:setCommandMarkdown'
 export const setCommandStatusInfo = 'chat2:setCommandStatusInfo'
 export const setContainsLastMessage = 'chat2:setContainsLastMessage'
@@ -645,7 +644,6 @@ type _SetBotSettingsPayload = {
   readonly username: string
   readonly settings: RPCTypes.TeamBotSettings
 }
-type _SetChannelSearchTextPayload = {readonly text: string}
 type _SetCommandMarkdownPayload = {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly md: RPCChatTypes.UICommandMarkdown | null
@@ -1104,12 +1102,6 @@ export const createSetParticipants = (payload: _SetParticipantsPayload): SetPart
   payload,
   type: setParticipants,
 })
-/**
- * Set filter for channel search
- */
-export const createSetChannelSearchText = (
-  payload: _SetChannelSearchTextPayload
-): SetChannelSearchTextPayload => ({payload, type: setChannelSearchText})
 /**
  * Set index percent complete
  */
@@ -2098,10 +2090,6 @@ export type SetBotSettingsPayload = {
   readonly payload: _SetBotSettingsPayload
   readonly type: typeof setBotSettings
 }
-export type SetChannelSearchTextPayload = {
-  readonly payload: _SetChannelSearchTextPayload
-  readonly type: typeof setChannelSearchText
-}
 export type SetCommandMarkdownPayload = {
   readonly payload: _SetCommandMarkdownPayload
   readonly type: typeof setCommandMarkdown
@@ -2415,7 +2403,6 @@ export type Actions =
   | SetBotPublicCommandsPayload
   | SetBotRoleInConvPayload
   | SetBotSettingsPayload
-  | SetChannelSearchTextPayload
   | SetCommandMarkdownPayload
   | SetCommandStatusInfoPayload
   | SetContainsLastMessagePayload

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -781,10 +781,6 @@
       "_description": "Toggle /giphy text to trigger preview window",
       "conversationIDKey": "Types.ConversationIDKey"
     },
-    "setChannelSearchText": {
-      "_description": "Set filter for channel search",
-      "text": "string"
-    },
     "updateBlockButtons": {
       "_description": "Show or hide invitation to block for a given team ID",
       "teamID": "RPCTypes.TeamID",

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -221,7 +221,6 @@ export type TypedActionsMap = {
   'chat2:dismissBottomBanner': chat2.DismissBottomBannerPayload
   'chat2:updateLastCoord': chat2.UpdateLastCoordPayload
   'chat2:toggleGiphyPrefill': chat2.ToggleGiphyPrefillPayload
-  'chat2:setChannelSearchText': chat2.SetChannelSearchTextPayload
   'chat2:updateBlockButtons': chat2.UpdateBlockButtonsPayload
   'chat2:dismissBlockButtons': chat2.DismissBlockButtonsPayload
   'chat2:setInboxNumSmallRows': chat2.SetInboxNumSmallRowsPayload

--- a/shared/chat/manage-channels/container.tsx
+++ b/shared/chat/manage-channels/container.tsx
@@ -68,7 +68,6 @@ type Props = {
   ) => void
   canCreateChannels: boolean
   canEditChannels: boolean
-  onChangeSearch: (text: string) => void
   onClose: () => void
   onCreate: () => void
   onEdit: (convID: ChatTypes.ConversationIDKey) => void
@@ -83,7 +82,7 @@ const Wrapper = (p: Props) => {
   const channelMetas = useAllChannelMetas(_teamID)
   const teamSize = Container.useSelector(state => state.teams.teamIDToMembers.get(_teamID)?.size ?? 0)
   const participantMap = Container.useSelector(state => state.chat2.participantMap)
-  const searchText = Container.useSelector(state => state.chat2.channelSearchText)
+  const [searchText, setSearchText] = React.useState('')
   const channels = getChannels(channelMetas, participantMap, searchText, teamSize)
 
   const oldChannelState = React.useMemo(
@@ -146,7 +145,7 @@ const Wrapper = (p: Props) => {
       waitingForGet={rest.waitingForGet}
       teamname={teamname}
       onEdit={rest.onEdit}
-      onChangeSearch={rest.onChangeSearch}
+      onChangeSearch={setSearchText}
       onClose={rest.onClose}
       onCreate={rest.onCreate}
       canEditChannels={rest.canEditChannels}
@@ -225,12 +224,9 @@ export default Container.connect(
       },
       onBack: () => {
         dispatch(RouteTreeGen.createNavigateUp())
-        dispatch(Chat2Gen.createSetChannelSearchText({text: ''}))
       },
-      onChangeSearch: (text: string) => dispatch(Chat2Gen.createSetChannelSearchText({text})),
       onClose: () => {
         dispatch(RouteTreeGen.createNavigateUp())
-        dispatch(Chat2Gen.createSetChannelSearchText({text: ''}))
       },
       onCreate: () =>
         dispatch(

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -45,7 +45,6 @@ export const makeState = (): Types.State => ({
   botSearchResults: new Map(),
   botSettings: new Map(),
   botTeamRoleInConvMap: new Map(),
-  channelSearchText: '',
   commandMarkdownMap: new Map(),
   commandStatusMap: new Map(),
   containsLatestMessageMap: new Map(),

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -202,7 +202,6 @@ export type State = {
   readonly botSearchResults: Map<string, BotSearchResults | undefined> // Keyed so that we never show results that don't match the user's input (e.g. outdated results)
   readonly botSettings: Map<Common.ConversationIDKey, Map<string, RPCTypes.TeamBotSettings>>
   readonly botTeamRoleInConvMap: Map<Common.ConversationIDKey, Map<string, Team.TeamRoleType | null>>
-  readonly channelSearchText: string
   readonly commandMarkdownMap: Map<Common.ConversationIDKey, RPCChatTypes.UICommandMarkdown>
   readonly commandStatusMap: Map<Common.ConversationIDKey, CommandStatusInfo>
   readonly containsLatestMessageMap: Map<Common.ConversationIDKey, boolean>

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -203,10 +203,6 @@ const paymentActions: Container.ActionHandler<Actions, Types.State> = {
 }
 
 const searchActions: Container.ActionHandler<Actions, Types.State> = {
-  [Chat2Gen.setChannelSearchText]: (draftState, action) => {
-    const {text} = action.payload
-    draftState.channelSearchText = text.toLowerCase()
-  },
   [Chat2Gen.threadSearchResults]: (draftState, action) => {
     const {conversationIDKey, clear, messages} = action.payload
     const {threadSearchInfoMap} = draftState


### PR DESCRIPTION
the channel list filter being in redux was causing issues and wasn't really necessary, so this PR moves it to a hook.