### PR TITLE
Fixes around kick team prompt

### DIFF
--- a/shared/teams/confirm-modals/confirm-kick-out.tsx
+++ b/shared/teams/confirm-modals/confirm-kick-out.tsx
@@ -40,7 +40,7 @@ const ConfirmKickOut = (props: Props) => {
   const [subteams, subteamIDs] = Container.useSelector(state => getSubteamNames(state, teamID))
   const teamname = Container.useSelector(state => Constants.getTeamMeta(state, teamID).teamname)
   const waitingKeys = ([] as string[]).concat.apply(
-    [],
+    members.map(member => Constants.removeMemberWaitingKey(teamID, member)),
     members.map(member => subteamIDs.map(subteamID => Constants.removeMemberWaitingKey(subteamID, member)))
   )
   const waiting = Container.useAnyWaiting(...waitingKeys)
@@ -97,7 +97,7 @@ const ConfirmKickOut = (props: Props) => {
             They will lose access to all the {teamname} chats and folders, and they won’t be able to get back
             unless an admin invites them.
           </Kb.Text>
-          {subteams.length && (
+          {!!subteams.length && (
             <Kb.Checkbox
               checked={subteamsToo}
               onCheck={setSubteamsToo}


### PR DESCRIPTION
also in master (without modern team management feature flag) exiting the modal leaves you on this screen:

![image](https://user-images.githubusercontent.com/451974/77515394-c47eda00-6e78-11ea-87c2-6e6abb56e656.png)

which is invalid because that person is not in the team anymore. but I don't know how to fix that