### PR TITLE
add web-of-trust vouch_with_revoke

### DIFF
--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -344,6 +345,190 @@ func TestWebOfTrustReject(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(vouches))
 	t.Log("bob cannot see it")
+}
+
+func TestWebOfTrustRevoke(t *testing.T) {
+	var err error
+	tcAlice := SetupEngineTest(t, "wot")
+	defer tcAlice.Cleanup()
+	tcBob := SetupEngineTest(t, "wot")
+	defer tcBob.Cleanup()
+	alice := CreateAndSignupFakeUser(tcAlice, "wot")
+	uisA := libkb.UIs{
+		LogUI:    tcAlice.G.UI.GetLogUI(),
+		SecretUI: alice.NewSecretUI(),
+	}
+	mctxA := NewMetaContextForTest(tcAlice).WithUIs(uisA)
+	bob := CreateAndSignupFakeUser(tcBob, "wot")
+	uisB := libkb.UIs{
+		LogUI:    tcBob.G.UI.GetLogUI(),
+		SecretUI: bob.NewSecretUI(),
+	}
+	mctxB := NewMetaContextForTest(tcBob).WithUIs(uisB)
+	aliceName := alice.NormalizedUsername().String()
+	bobName := bob.NormalizedUsername().String()
+	t.Logf("alice: %s and bob: %s exist", aliceName, bobName)
+	sigVersion := libkb.GetDefaultSigVersion(tcAlice.G)
+	trackUser(tcBob, bob, alice.NormalizedUsername(), sigVersion)
+	trackUser(tcAlice, alice, bob.NormalizedUsername(), sigVersion)
+	err = bob.LoadUser(tcBob)
+	require.NoError(tcBob.T, err)
+	err = alice.LoadUser(tcAlice)
+	require.NoError(tcAlice.T, err)
+	t.Log("alice and bob follow each other")
+
+	bobVouchesForAlice := func(version int) {
+		vouchTexts := []string{fmt.Sprintf("alice is wondibar v%d", version)}
+		arg := &WotVouchArg{
+			Vouchee:    alice.User.ToUserVersion(),
+			VouchTexts: vouchTexts,
+			Confidence: confidence,
+		}
+		eng := NewWotVouch(tcBob.G, arg)
+		err = RunEngine2(mctxB, eng)
+		require.NoError(t, err)
+	}
+	aliceAccepts := func(sigID keybase1.SigID) error {
+		arg := &WotReactArg{
+			Voucher:  bob.User.ToUserVersion(),
+			Proof:    sigID,
+			Reaction: keybase1.WotReactionType_ACCEPT,
+		}
+		eng := NewWotReact(tcAlice.G, arg)
+		return RunEngine2(mctxA, eng)
+	}
+	aliceRejects := func(sigID keybase1.SigID) error {
+		arg := &WotReactArg{
+			Voucher:  bob.User.ToUserVersion(),
+			Proof:    sigID,
+			Reaction: keybase1.WotReactionType_REJECT,
+		}
+		eng := NewWotReact(tcAlice.G, arg)
+		return RunEngine2(mctxA, eng)
+	}
+	assertFetch := func(mctx libkb.MetaContext, version int, expectedStatus keybase1.WotStatusType) keybase1.WotVouch {
+		vouches, err := libkb.FetchWotVouches(mctx, libkb.FetchWotVouchesArg{Voucher: bobName, Vouchee: aliceName})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(vouches))
+		vouch := vouches[0]
+		require.Equal(t, expectedStatus, vouch.Status)
+		require.Equal(t, bob.User.GetUID(), vouch.Voucher.Uid)
+		require.Equal(t, alice.User.GetUID(), vouch.Vouchee.Uid)
+		expectedVouchText := []string{fmt.Sprintf("alice is wondibar v%d", version)}
+		require.Equal(t, expectedVouchText, vouch.VouchTexts)
+		require.NotNil(t, vouch.Confidence)
+		return vouch
+	}
+	revokeSig := func(mctx libkb.MetaContext, sigID string) {
+		eng := NewRevokeSigsEngine(mctx.G(), []string{sigID})
+		err := RunEngine2(mctx, eng)
+		require.NoError(t, err)
+	}
+
+	// bob vouches for alice
+	vouchVersion := 1
+	bobVouchesForAlice(vouchVersion)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	wotVouchOne := assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	t.Log("bob vouches for alice and everything looks good")
+
+	// bob revokes the attestation
+	revokeSig(mctxB, wotVouchOne.VouchProof.String())
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_REVOKED)
+	_ = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_REVOKED)
+	t.Log("bob revokes the chainlink with the attestation, and it comes back `revoked` for both of them")
+
+	// bob vouches again
+	vouchVersion++
+	bobVouchesForAlice(vouchVersion)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	wotVouchTwo := assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+
+	// alice cannot accept the revoked proof
+	err = aliceAccepts(wotVouchOne.VouchProof)
+	require.Error(t, err)
+	// alice accepts the new proposed proof
+	err = aliceAccepts(wotVouchTwo.VouchProof)
+	require.NoError(t, err)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_ACCEPTED)
+	_ = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_ACCEPTED)
+
+	// alice revokes her acceptance
+	err = alice.LoadUser(tcAlice)
+	require.NoError(t, err)
+	aliceLastLink := alice.User.GetLastLink()
+	tlink, w := libkb.NewTypedChainLink(aliceLastLink)
+	require.Nil(t, w)
+	reactionLink, ok := tlink.(*libkb.WotReactChainLink)
+	require.True(t, ok)
+	revokeSig(mctxA, reactionLink.GetSigID().String())
+	// it goes back to proposed
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	_ = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	// and now she accepts it and it looks accepted to both of them
+	err = aliceAccepts(wotVouchTwo.VouchProof)
+	require.NoError(t, err)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_ACCEPTED)
+	_ = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_ACCEPTED)
+
+	// bob revokes and it shows up as revoked
+	revokeSig(mctxB, wotVouchTwo.VouchProof.String())
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_REVOKED)
+	_ = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_REVOKED)
+
+	///////////
+	// VouchWithRevoke
+	///////////
+	assertUserLastLinkAsVouchWithRevoke := func(user *FakeUser, tc libkb.TestContext) *libkb.WotVouchWithRevokeChainLink {
+		err := user.LoadUser(tc)
+		require.NoError(t, err)
+		lastLink := user.User.GetLastLink()
+		tlink, warning := libkb.NewTypedChainLink(lastLink)
+		require.Nil(t, warning)
+		vouchLink, ok := tlink.(*libkb.WotVouchWithRevokeChainLink)
+		require.True(t, ok)
+		return vouchLink
+	}
+	vouchVersion++
+	bobVouchesForAlice(vouchVersion)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	vouchToRevoke := assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	// another vouch on top of an unrevoked previous one should be of type vouchWithRevoke
+	vouchVersion++
+	bobVouchesForAlice(vouchVersion)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	vouchToAccept := assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	vwrLink := assertUserLastLinkAsVouchWithRevoke(bob, tcBob)
+	require.Contains(t, vwrLink.Revocations, vouchToRevoke.VouchProof)
+	err = aliceAccepts(vouchToRevoke.VouchProof)
+	require.Error(t, err)
+
+	// can vouchWithRevoke an accepted vouch, and then accept it
+	err = aliceAccepts(vouchToAccept.VouchProof)
+	vouchToRevoke = vouchToAccept
+	require.NoError(t, err)
+	vouchVersion++
+	bobVouchesForAlice(vouchVersion)
+	vouchToAccept = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	_ = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	vwrLink = assertUserLastLinkAsVouchWithRevoke(bob, tcBob)
+	require.Contains(t, vwrLink.Revocations, vouchToRevoke.VouchProof)
+	err = aliceAccepts(vouchToAccept.VouchProof)
+	require.NoError(t, err)
+	// it is significant that bob has not loaded alice between these two steps
+	// see comment in sig_chain.go#GetLinkFromSigID
+	err = aliceRejects(vouchToAccept.VouchProof)
+	require.NoError(t, err)
+
+	// can vouchWithRevoke a rejected vouch, and then accept it
+	vouchToRevoke = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_REJECTED)
+	bobVouchesForAlice(vouchVersion)
+	_ = assertFetch(mctxA, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	vouchToAccept = assertFetch(mctxB, vouchVersion, keybase1.WotStatusType_PROPOSED)
+	vwrLink = assertUserLastLinkAsVouchWithRevoke(bob, tcBob)
+	require.Contains(t, vwrLink.Revocations, vouchToRevoke.VouchProof)
+	err = aliceAccepts(vouchToAccept.VouchProof)
+	require.NoError(t, err)
 }
 
 // perhaps revisit after Y2K-1494

--- a/go/engine/wot_vouch.go
+++ b/go/engine/wot_vouch.go
@@ -131,8 +131,6 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 		return err
 	}
 
-	linkType := libkb.LinkTypeWotVouch
-	var sigHasRevokes bool
 	sigIDsToRevoke, err := getSigIDsToRevoke(mctx, them)
 	if err != nil {
 		return err
@@ -144,8 +142,6 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 		if err != nil {
 			return err
 		}
-		linkType = libkb.LinkTypeWotVouchWithRevoke
-		sigHasRevokes = true
 		defer func() {
 			// not sure if this is necessary or not
 			err := libkb.CancelDowngradeLease(ctx, g, lease.LeaseID)
@@ -174,13 +170,12 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 		if err != nil {
 			return err
 		}
-
 		sig, _, linkID, err = libkb.MakeSig(
 			mctx,
 			signingKey,
-			linkType,
+			libkb.LinkTypeWotVouch,
 			inner,
-			libkb.SigHasRevokes(sigHasRevokes),
+			libkb.SigHasRevokes(len(sigIDsToRevoke) > 0),
 			keybase1.SeqType_PUBLIC,
 			libkb.SigIgnoreIfUnsupported(true),
 			me,

--- a/go/libkb/chain_link.go
+++ b/go/libkb/chain_link.go
@@ -1623,6 +1623,7 @@ func (c ChainLink) IsHighUserLink(mctx MetaContext, uid keybase1.UID) (bool, err
 		v2Type == SigchainV2TypeWebServiceBindingWithRevoke ||
 		v2Type == SigchainV2TypeCryptocurrencyWithRevoke ||
 		v2Type == SigchainV2TypeSibkey ||
+		v2Type == SigchainV2TypeWotVouchWithRevoke ||
 		v2Type == SigchainV2TypePGPUpdate
 	return isNewHighLink, nil
 }

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -551,9 +551,11 @@ func SigchainV2TypeFromV1TypeAndRevocations(s string, hasRevocations SigHasRevok
 	case string(LinkTypeWalletStellar):
 		ret = SigchainV2TypeWalletStellar
 	case string(LinkTypeWotVouch):
-		ret = SigchainV2TypeWotVouch
-	case string(LinkTypeWotVouchWithRevoke):
-		ret = SigchainV2TypeWotVouchWithRevoke
+		if hasRevocations {
+			ret = SigchainV2TypeWotVouchWithRevoke
+		} else {
+			ret = SigchainV2TypeWotVouch
+		}
 	case string(LinkTypeWotReact):
 		ret = SigchainV2TypeWotReact
 	default:

--- a/go/libkb/chain_link_v2.go
+++ b/go/libkb/chain_link_v2.go
@@ -34,6 +34,7 @@ const (
 	SigchainV2TypePerUserKey                  SigchainV2Type = 14
 	SigchainV2TypeWalletStellar               SigchainV2Type = 15
 	SigchainV2TypeWotVouch                    SigchainV2Type = 16
+	SigchainV2TypeWotVouchWithRevoke          SigchainV2Type = 17
 	SigchainV2TypeWotReact                    SigchainV2Type = 18
 
 	// Team link types
@@ -104,6 +105,7 @@ func (t SigchainV2Type) IsSupportedUserType() bool {
 		SigchainV2TypeSubkey,
 		SigchainV2TypePGPUpdate,
 		SigchainV2TypePerUserKey,
+		SigchainV2TypeWotVouchWithRevoke,
 		SigchainV2TypeWalletStellar:
 		return true
 	default:
@@ -550,6 +552,8 @@ func SigchainV2TypeFromV1TypeAndRevocations(s string, hasRevocations SigHasRevok
 		ret = SigchainV2TypeWalletStellar
 	case string(LinkTypeWotVouch):
 		ret = SigchainV2TypeWotVouch
+	case string(LinkTypeWotVouchWithRevoke):
+		ret = SigchainV2TypeWotVouchWithRevoke
 	case string(LinkTypeWotReact):
 		ret = SigchainV2TypeWotReact
 	default:

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -401,18 +401,19 @@ type LinkType string
 type DelegationType LinkType
 
 const (
-	LinkTypeAuthentication    LinkType = "auth"
-	LinkTypeCryptocurrency    LinkType = "cryptocurrency"
-	LinkTypeRevoke            LinkType = "revoke"
-	LinkTypeTrack             LinkType = "track"
-	LinkTypeUntrack           LinkType = "untrack"
-	LinkTypeUpdatePassphrase  LinkType = "update_passphrase_hash"
-	LinkTypeUpdateSettings    LinkType = "update_settings"
-	LinkTypeWebServiceBinding LinkType = "web_service_binding"
-	LinkTypePerUserKey        LinkType = "per_user_key"
-	LinkTypeWalletStellar     LinkType = "wallet.stellar"
-	LinkTypeWotVouch          LinkType = "wot.vouch"
-	LinkTypeWotReact          LinkType = "wot.react"
+	LinkTypeAuthentication     LinkType = "auth"
+	LinkTypeCryptocurrency     LinkType = "cryptocurrency"
+	LinkTypeRevoke             LinkType = "revoke"
+	LinkTypeTrack              LinkType = "track"
+	LinkTypeUntrack            LinkType = "untrack"
+	LinkTypeUpdatePassphrase   LinkType = "update_passphrase_hash"
+	LinkTypeUpdateSettings     LinkType = "update_settings"
+	LinkTypeWebServiceBinding  LinkType = "web_service_binding"
+	LinkTypePerUserKey         LinkType = "per_user_key"
+	LinkTypeWalletStellar      LinkType = "wallet.stellar"
+	LinkTypeWotVouch           LinkType = "wot.vouch"
+	LinkTypeWotReact           LinkType = "wot.react"
+	LinkTypeWotVouchWithRevoke LinkType = "wot.vouch_with_revoke"
 
 	// team links
 	LinkTypeTeamRoot         LinkType = "team.root"

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -401,19 +401,18 @@ type LinkType string
 type DelegationType LinkType
 
 const (
-	LinkTypeAuthentication     LinkType = "auth"
-	LinkTypeCryptocurrency     LinkType = "cryptocurrency"
-	LinkTypeRevoke             LinkType = "revoke"
-	LinkTypeTrack              LinkType = "track"
-	LinkTypeUntrack            LinkType = "untrack"
-	LinkTypeUpdatePassphrase   LinkType = "update_passphrase_hash"
-	LinkTypeUpdateSettings     LinkType = "update_settings"
-	LinkTypeWebServiceBinding  LinkType = "web_service_binding"
-	LinkTypePerUserKey         LinkType = "per_user_key"
-	LinkTypeWalletStellar      LinkType = "wallet.stellar"
-	LinkTypeWotVouch           LinkType = "wot.vouch"
-	LinkTypeWotReact           LinkType = "wot.react"
-	LinkTypeWotVouchWithRevoke LinkType = "wot.vouch_with_revoke"
+	LinkTypeAuthentication    LinkType = "auth"
+	LinkTypeCryptocurrency    LinkType = "cryptocurrency"
+	LinkTypeRevoke            LinkType = "revoke"
+	LinkTypeTrack             LinkType = "track"
+	LinkTypeUntrack           LinkType = "untrack"
+	LinkTypeUpdatePassphrase  LinkType = "update_passphrase_hash"
+	LinkTypeUpdateSettings    LinkType = "update_settings"
+	LinkTypeWebServiceBinding LinkType = "web_service_binding"
+	LinkTypePerUserKey        LinkType = "per_user_key"
+	LinkTypeWalletStellar     LinkType = "wallet.stellar"
+	LinkTypeWotVouch          LinkType = "wot.vouch"
+	LinkTypeWotReact          LinkType = "wot.react"
 
 	// team links
 	LinkTypeTeamRoot         LinkType = "team.root"

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -151,6 +151,29 @@ func ParseWotVouch(base GenericChainLink) (ret *WotVouchChainLink, err error) {
 	}, nil
 }
 
+type WotVouchWithRevokeChainLink struct {
+	GenericChainLink
+	ExpansionID string
+	Revocations []keybase1.SigID
+}
+
+func (cl *WotVouchWithRevokeChainLink) DoOwnNewLinkFromServerNotifications(g *GlobalContext) {}
+
+var _ TypedChainLink = (*WotVouchWithRevokeChainLink)(nil)
+
+func ParseWotVouchWithRevoke(base GenericChainLink) (ret *WotVouchWithRevokeChainLink, err error) {
+	body := base.UnmarshalPayloadJSON()
+	expansionID, err := body.AtPath("body.wot_vouch").GetString()
+	if err != nil {
+		return nil, err
+	}
+	return &WotVouchWithRevokeChainLink{
+		GenericChainLink: base,
+		ExpansionID:      expansionID,
+		Revocations:      base.GetRevocations(),
+	}, nil
+}
+
 type WotReactChainLink struct {
 	GenericChainLink
 	ExpansionID string
@@ -1439,6 +1462,8 @@ func NewTypedChainLink(cl *ChainLink) (ret TypedChainLink, w Warning) {
 			ret, err = ParseWotVouch(base)
 		case string(LinkTypeWotReact):
 			ret, err = ParseWotReact(base)
+		case string(LinkTypeWotVouchWithRevoke):
+			ret, err = ParseWotVouchWithRevoke(base)
 		default:
 			err = fmt.Errorf("Unknown signature type %s @%s", s, base.ToDebugString())
 		}

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -133,6 +133,7 @@ func CanonicalProofName(t TypedChainLink) string {
 type WotVouchChainLink struct {
 	GenericChainLink
 	ExpansionID string
+	Revocations []keybase1.SigID
 }
 
 func (cl *WotVouchChainLink) DoOwnNewLinkFromServerNotifications(g *GlobalContext) {}
@@ -146,28 +147,6 @@ func ParseWotVouch(base GenericChainLink) (ret *WotVouchChainLink, err error) {
 		return nil, err
 	}
 	return &WotVouchChainLink{
-		GenericChainLink: base,
-		ExpansionID:      expansionID,
-	}, nil
-}
-
-type WotVouchWithRevokeChainLink struct {
-	GenericChainLink
-	ExpansionID string
-	Revocations []keybase1.SigID
-}
-
-func (cl *WotVouchWithRevokeChainLink) DoOwnNewLinkFromServerNotifications(g *GlobalContext) {}
-
-var _ TypedChainLink = (*WotVouchWithRevokeChainLink)(nil)
-
-func ParseWotVouchWithRevoke(base GenericChainLink) (ret *WotVouchWithRevokeChainLink, err error) {
-	body := base.UnmarshalPayloadJSON()
-	expansionID, err := body.AtPath("body.wot_vouch").GetString()
-	if err != nil {
-		return nil, err
-	}
-	return &WotVouchWithRevokeChainLink{
 		GenericChainLink: base,
 		ExpansionID:      expansionID,
 		Revocations:      base.GetRevocations(),
@@ -1462,8 +1441,6 @@ func NewTypedChainLink(cl *ChainLink) (ret TypedChainLink, w Warning) {
 			ret, err = ParseWotVouch(base)
 		case string(LinkTypeWotReact):
 			ret, err = ParseWotReact(base)
-		case string(LinkTypeWotVouchWithRevoke):
-			ret, err = ParseWotVouchWithRevoke(base)
 		default:
 			err = fmt.Errorf("Unknown signature type %s @%s", s, base.ToDebugString())
 		}

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -699,13 +699,9 @@ func (u *User) ServiceProof(m MetaContext, signingKey GenericKey, typ ServiceTyp
 }
 
 func (u *User) WotVouchProof(m MetaContext, signingKey GenericKey, sigVersion SigVersion, mac []byte, merkleRoot *MerkleRoot, sigIDsToRevoke []keybase1.SigID) (*ProofMetadataRes, error) {
-	linkType := LinkTypeWotVouch
-	if len(sigIDsToRevoke) > 0 {
-		linkType = LinkTypeWotVouchWithRevoke
-	}
 	md := ProofMetadata{
 		Me:                  u,
-		LinkType:            linkType,
+		LinkType:            LinkTypeWotVouch,
 		MerkleRoot:          merkleRoot,
 		SigningKey:          signingKey,
 		SigVersion:          sigVersion,

--- a/go/libkb/kbsig.go
+++ b/go/libkb/kbsig.go
@@ -698,7 +698,7 @@ func (u *User) ServiceProof(m MetaContext, signingKey GenericKey, typ ServiceTyp
 	return ret, nil
 }
 
-func (u *User) WotVouchProof(m MetaContext, signingKey GenericKey, sigVersion SigVersion, mac []byte, merkleRoot *MerkleRoot, sigIDsToRevoke []keybase1.SigID) (*ProofMetadataRes, error) {
+func (u *User) WotVouchProof(m MetaContext, signingKey GenericKey, sigVersion SigVersion, mac []byte, merkleRoot *MerkleRoot, sigIDToRevoke *keybase1.SigID) (*ProofMetadataRes, error) {
 	md := ProofMetadata{
 		Me:                  u,
 		LinkType:            LinkTypeWotVouch,
@@ -717,12 +717,9 @@ func (u *User) WotVouchProof(m MetaContext, signingKey GenericKey, sigVersion Si
 		return nil, err
 	}
 
-	if len(sigIDsToRevoke) > 1 {
-		return nil, fmt.Errorf("cannot revoke more than one previous attestation at a time")
-	}
-	if len(sigIDsToRevoke) > 0 {
+	if sigIDToRevoke != nil {
 		revokeSection := jsonw.NewDictionary()
-		err := revokeSection.SetKey("sig_id", jsonw.NewString(sigIDsToRevoke[0].String()))
+		err := revokeSection.SetKey("sig_id", jsonw.NewString(sigIDToRevoke.String()))
 		if err != nil {
 			return nil, err
 		}

--- a/go/libkb/sig_chain.go
+++ b/go/libkb/sig_chain.go
@@ -1052,6 +1052,12 @@ func (sc *SigChain) GetLinkFromSeqno(seqno keybase1.Seqno) *ChainLink {
 
 func (sc *SigChain) GetLinkFromSigID(id keybase1.SigID) *ChainLink {
 	for _, link := range sc.chainLinks {
+		if len(link.GetSigID()) == 0 {
+			// sigID might not be set for stubbed links on other users. If you're looking
+			// for a specific link by sigID of another user (e.g. for web-of-trust), then
+			// an intermediate stubbed link might otherwise cause a panic if it's not skipped.
+			continue
+		}
 		if link.GetSigID().Eq(id) {
 			return link
 		}

--- a/go/libkb/wot.go
+++ b/go/libkb/wot.go
@@ -25,12 +25,6 @@ func getWotVouchChainLink(mctx MetaContext, uid keybase1.UID, sigID keybase1.Sig
 	if w != nil {
 		return nil, nil, fmt.Errorf("Could not get typed chain link: %v", w.Warning())
 	}
-	if vwrlink, ok := tlink.(*WotVouchWithRevokeChainLink); ok {
-		return &WotVouchChainLink{
-			GenericChainLink: vwrlink.GenericChainLink,
-			ExpansionID:      vwrlink.ExpansionID,
-		}, user, nil
-	}
 	vlink, ok := tlink.(*WotVouchChainLink)
 	if !ok {
 		return nil, nil, fmt.Errorf("Link is not a WotVouchChainLink: %v", tlink)

--- a/go/systests/wot_test.go
+++ b/go/systests/wot_test.go
@@ -126,4 +126,13 @@ func TestWotNotifications(t *testing.T) {
 		badges := getBadgeState(t, bob)
 		return len(badges.WotUpdates) == 0
 	})
+
+	// vouch_with_revoke resets the state of the attestation to PROPOSED
+	aliceVouchesForBob()
+	bobAccepts()
+	aliceVouchesForBob()
+	wotUpdate = getWotUpdate(bob)
+	require.Equal(t, wotUpdate.Status, keybase1.WotStatusType_PROPOSED)
+	require.Equal(t, wotUpdate.Voucher, alice.username)
+	require.Equal(t, wotUpdate.Vouchee, bob.username)
 }


### PR DESCRIPTION
during the web of trust vouch flow, check if there's already a non-revoked attestation by this voucher for this vouchee. if so, do a vouch_with_revoke instead. this revokes the signature with the previous attestation and does the normal vouching. 

this PR also adds more nuanced behavior around revocations of web-of-trust signatures including reactions. if someone revokes their reaction, then that attestation will appear as `PROPOSED` again. this is entirely on the client though, the server is not set up to send another notification. which seems fine to me. 

this will fail on CI until https://github.com/keybase/keybase/pull/5337

_note_: this was pretty confusing. turns out the link type, the signature type, and the signature type in the database are really similar to one another but... subtly different. i'm not at all convinced that this is correct (especially the link type stuff on the server), but it does seem to work. it follows a similar pattern to `cryptocurrency` and `cryptocurrency_with_revoke`. 