### PR TITLE
fix calling action all the time if mode set to 0

### DIFF
--- a/shared/chat/conversation/input-area/normal/container.tsx
+++ b/shared/chat/conversation/input-area/normal/container.tsx
@@ -358,11 +358,11 @@ export default Container.namedConnect(
       },
 
       setUnsentText: (text: string) => {
-        const unset = text.length <= 0
-        if (stateProps._isExplodingModeLocked ? unset : !unset) {
+        const set = text.length > 0
+        if (stateProps._isExplodingModeLocked !== set) {
           // if it's locked and we want to unset, unset it
           // alternatively, if it's not locked and we want to set it, set it
-          dispatchProps.onSetExplodingModeLock(stateProps.conversationIDKey, unset)
+          dispatchProps.onSetExplodingModeLock(stateProps.conversationIDKey, !set)
         }
         // The store text only lasts until we change it, so blow it away now
         if (stateProps.unsentText) {

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -401,9 +401,9 @@ export const explodingModeGregorKeyPrefix = 'exploding:'
 export const explodingModeGregorKey = (c: Types.ConversationIDKey): string =>
   `${explodingModeGregorKeyPrefix}${c}`
 export const getConversationExplodingMode = (state: TypedState, c: Types.ConversationIDKey): number => {
-  let mode = state.chat2.explodingModeLocks.get(c) || null
-  if (mode === null) {
-    mode = state.chat2.explodingModes.get(c) || 0
+  let mode = state.chat2.explodingModeLocks.get(c)
+  if (mode === undefined) {
+    mode = state.chat2.explodingModes.get(c) ?? 0
   }
   const meta = getMeta(state, c)
   const convRetention = getEffectiveRetentionPolicy(meta)
@@ -411,7 +411,7 @@ export const getConversationExplodingMode = (state: TypedState, c: Types.Convers
   return mode || 0
 }
 export const isExplodingModeLocked = (state: TypedState, c: Types.ConversationIDKey) =>
-  (state.chat2.explodingModeLocks.get(c) || null) !== null
+  state.chat2.explodingModeLocks.get(c) !== undefined
 
 export const getTeamMentionName = (name: string, channel: string) => {
   return name + (channel ? `#${channel}` : '')

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -1179,9 +1179,9 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
   [Chat2Gen.setExplodingModeLock]: (draftState, action) => {
     const {conversationIDKey, unset} = action.payload
     const {explodingModes, explodingModeLocks} = draftState
-    const mode = explodingModes.get(conversationIDKey) || 0
+    const mode = explodingModes.get(conversationIDKey) ?? 0
     // we already have the new mode in `explodingModes`, if we've already locked it we shouldn't update
-    const alreadyLocked = (explodingModeLocks.get(conversationIDKey) || null) !== null
+    const alreadyLocked = explodingModeLocks.get(conversationIDKey) !== undefined
     if (unset) {
       explodingModeLocks.delete(conversationIDKey)
     } else if (!alreadyLocked) {


### PR DESCRIPTION
noticed while debugging something else this action kept on being disaptched as i typed. 
turns out the value of 0 makes the `|| null` fallback keep on happening