### PR TITLE
block_getter: use local block ID verifier for local blocks

### DIFF
--- a/go/kbfs/libkbfs/block_disk_store.go
+++ b/go/kbfs/libkbfs/block_disk_store.go
@@ -282,7 +282,7 @@ func (s *blockDiskStore) getDataExclusive(id kbfsblock.ID) (
 
 	// Check integrity.
 
-	err = kbfsblock.VerifyID(data, id)
+	err = verifyLocalBlockID(data, id)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}

--- a/go/kbfs/libkbfs/block_disk_store.go
+++ b/go/kbfs/libkbfs/block_disk_store.go
@@ -282,7 +282,7 @@ func (s *blockDiskStore) getDataExclusive(id kbfsblock.ID) (
 
 	// Check integrity.
 
-	err = verifyLocalBlockID(data, id)
+	err = verifyLocalBlockIDMaybe(data, id)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -80,7 +80,7 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd libkey.KeyMetadata,
 			return err
 		}
 		if found {
-			return assembleBlock(
+			return assembleBlockLocal(
 				ctx, b.config.keyGetter(), b.config.Codec(),
 				b.config.cryptoPure(), kmd, blockPtr, block, data, serverHalf)
 		}

--- a/go/kbfs/libkbfs/block_put_state_disk.go
+++ b/go/kbfs/libkbfs/block_put_state_disk.go
@@ -77,7 +77,7 @@ func (bps *blockPutStateDisk) GetBlock(
 	} else {
 		block = data.NewFileBlock()
 	}
-	err = assembleBlock(
+	err = assembleBlockLocal(
 		ctx, bps.config.keyGetter(), bps.config.Codec(),
 		bps.config.cryptoPure(), bps.kmd, blockPtr, block, blockData,
 		serverHalf)

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -424,8 +424,8 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	}
 
 	// Assemble the block from the encrypted block buffer.
-	err = brq.config.blockGetter().assembleBlock(ctx, kmd, ptr, block, blockBuf,
-		serverHalf)
+	err = brq.config.blockGetter().assembleBlockLocal(
+		ctx, kmd, ptr, block, blockBuf, serverHalf)
 	if err == nil {
 		// Cache the block in memory.
 		_ = brq.config.BlockCache().Put(

--- a/go/kbfs/libkbfs/block_retrieval_worker_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_worker_test.go
@@ -105,6 +105,12 @@ func (bg *fakeBlockGetter) assembleBlock(ctx context.Context,
 	return nil
 }
 
+func (bg *fakeBlockGetter) assembleBlockLocal(ctx context.Context,
+	kmd libkey.KeyMetadata, ptr data.BlockPointer, block data.Block, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
+	return bg.assembleBlock(ctx, kmd, ptr, block, buf, serverHalf)
+}
+
 func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
 	bg := newFakeBlockGetter(false)

--- a/go/kbfs/libkbfs/block_util.go
+++ b/go/kbfs/libkbfs/block_util.go
@@ -221,7 +221,7 @@ func assembleBlockLocal(
 	blockServerHalf kbfscrypto.BlockCryptKeyServerHalf) error {
 	// This call only verifies the block ID if we're not running
 	// production mode, for performance reasons.
-	if err := verifyLocalBlockID(buf, blockPtr.ID); err != nil {
+	if err := verifyLocalBlockIDMaybe(buf, blockPtr.ID); err != nil {
 		return err
 	}
 

--- a/go/kbfs/libkbfs/bserver_memory.go
+++ b/go/kbfs/libkbfs/bserver_memory.go
@@ -169,7 +169,7 @@ func validateBlockPut(checkNonzeroRef bool, id kbfsblock.ID, context kbfsblock.C
 		return errors.New("can't Put() a block with a non-zero refnonce")
 	}
 
-	return kbfsblock.VerifyID(buf, id)
+	return verifyLocalBlockID(buf, id)
 }
 
 // doPut consolidates the put logic for implementing both the Put and PutAgain interface.

--- a/go/kbfs/libkbfs/bserver_memory.go
+++ b/go/kbfs/libkbfs/bserver_memory.go
@@ -169,7 +169,7 @@ func validateBlockPut(checkNonzeroRef bool, id kbfsblock.ID, context kbfsblock.C
 		return errors.New("can't Put() a block with a non-zero refnonce")
 	}
 
-	return verifyLocalBlockID(buf, id)
+	return verifyLocalBlockIDMaybe(buf, id)
 }
 
 // doPut consolidates the put logic for implementing both the Put and PutAgain interface.

--- a/go/kbfs/libkbfs/dirty_bcache_disk.go
+++ b/go/kbfs/libkbfs/dirty_bcache_disk.go
@@ -98,7 +98,7 @@ func (d *DirtyBlockCacheDisk) Get(
 	}
 
 	block := info.newBlock()
-	err = assembleBlock(
+	err = assembleBlockLocal(
 		ctx, d.config.keyGetter(), d.config.Codec(),
 		d.config.cryptoPure(), d.kmd, info.tmpPtr, block, data, serverHalf)
 	if err != nil {

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1033,7 +1033,7 @@ func (fbo *folderBranchOps) getProtocolSyncConfig(
 		}
 	} else {
 		block = data.NewFileBlock().(*data.FileBlock)
-		err = assembleBlock(
+		err = assembleBlockLocal(
 			ctx, fbo.config.keyGetter(), fbo.config.Codec(),
 			fbo.config.Crypto(), kmd, config.Paths.Ptr, block,
 			config.Paths.Buf, config.Paths.ServerHalf)

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -443,6 +443,10 @@ func (mso modeSingleOp) TLFEditHistoryEnabled() bool {
 	return false
 }
 
+func (mso modeSingleOp) MetricsEnabled() bool {
+	return false
+}
+
 func (mso modeSingleOp) SendEditNotificationsEnabled() bool {
 	// We don't want git, or other single op writes, showing up in the
 	// notification history.

--- a/go/kbfs/libkbfs/verify_local_block_id_devel.go
+++ b/go/kbfs/libkbfs/verify_local_block_id_devel.go
@@ -1,0 +1,13 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build !production
+
+package libkbfs
+
+import "github.com/keybase/client/go/kbfs/kbfsblock"
+
+func verifyLocalBlockID(data []byte, id kbfsblock.ID) error {
+	return kbfsblock.VerifyID(data, id)
+}

--- a/go/kbfs/libkbfs/verify_local_block_id_devel.go
+++ b/go/kbfs/libkbfs/verify_local_block_id_devel.go
@@ -8,6 +8,6 @@ package libkbfs
 
 import "github.com/keybase/client/go/kbfs/kbfsblock"
 
-func verifyLocalBlockID(data []byte, id kbfsblock.ID) error {
+func verifyLocalBlockIDMaybe(data []byte, id kbfsblock.ID) error {
 	return kbfsblock.VerifyID(data, id)
 }

--- a/go/kbfs/libkbfs/verify_local_block_id_production.go
+++ b/go/kbfs/libkbfs/verify_local_block_id_production.go
@@ -1,0 +1,15 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build production
+
+package libkbfs
+
+import "github.com/keybase/client/go/kbfs/kbfsblock"
+
+func verifyLocalBlockID(_ []byte, _ kbfsblock.ID) error {
+	// Don't bother verifying local block IDs when we're in production
+	// mode, since it's expensive.
+	return nil
+}

--- a/go/kbfs/libkbfs/verify_local_block_id_production.go
+++ b/go/kbfs/libkbfs/verify_local_block_id_production.go
@@ -8,7 +8,7 @@ package libkbfs
 
 import "github.com/keybase/client/go/kbfs/kbfsblock"
 
-func verifyLocalBlockID(_ []byte, _ kbfsblock.ID) error {
+func verifyLocalBlockIDMaybe(_ []byte, _ kbfsblock.ID) error {
 	// Don't bother verifying local block IDs when we're in production
 	// mode, since it's expensive.
 	return nil


### PR DESCRIPTION
It's expensive, and doesn't really protect against anything but local disk corruption (which should be caught anyway during block decryption).


With #23247 and #23274, I think this should eliminate all unnecessary block hashes in prod builds.

Issue: HOTPOT-2024

