### PR TITLE
libkbfs: put fetched archived blocks in the sync cache

### DIFF
--- a/go/kbfs/kbfstool/md_check.go
+++ b/go/kbfs/kbfstool/md_check.go
@@ -41,7 +41,9 @@ func checkDirBlock(ctx context.Context, config libkbfs.Config,
 	}()
 
 	var dirBlock data.DirBlock
-	err = config.BlockOps().Get(ctx, kmd, info.BlockPointer, &dirBlock, data.NoCacheEntry)
+	err = config.BlockOps().Get(
+		ctx, kmd, info.BlockPointer, &dirBlock, data.NoCacheEntry,
+		data.MasterBranch)
 	if err != nil {
 		return err
 	}
@@ -87,7 +89,9 @@ func checkFileBlock(ctx context.Context, config libkbfs.Config,
 	}()
 
 	var fileBlock data.FileBlock
-	err = config.BlockOps().Get(ctx, kmd, info.BlockPointer, &fileBlock, data.NoCacheEntry)
+	err = config.BlockOps().Get(
+		ctx, kmd, info.BlockPointer, &fileBlock, data.NoCacheEntry,
+		data.MasterBranch)
 	if err != nil {
 		return err
 	}
@@ -139,7 +143,8 @@ func mdCheckChain(ctx context.Context, config libkbfs.Config,
 				currRev, rootPtr.Ref())
 			var dirBlock data.DirBlock
 			err := config.BlockOps().Get(
-				ctx, irmd, rootPtr, &dirBlock, data.NoCacheEntry)
+				ctx, irmd, rootPtr, &dirBlock, data.NoCacheEntry,
+				data.MasterBranch)
 			if err != nil {
 				fmt.Printf("Got error while checking root "+
 					"for rev %d: %v\n",

--- a/go/kbfs/kbfstool/md_reset.go
+++ b/go/kbfs/kbfstool/md_reset.go
@@ -29,7 +29,8 @@ func mdResetOne(
 		if rootPtr.Ref().IsValid() {
 			var dirBlock data.DirBlock
 			err = config.BlockOps().Get(
-				ctx, irmd, rootPtr, &dirBlock, data.NoCacheEntry)
+				ctx, irmd, rootPtr, &dirBlock, data.NoCacheEntry,
+				data.MasterBranch)
 			if err == nil {
 				fmt.Printf("Got no error when getting root block %s; not doing anything\n", rootPtr)
 				return nil

--- a/go/kbfs/libkbfs/block_ops.go
+++ b/go/kbfs/libkbfs/block_ops.go
@@ -69,7 +69,8 @@ func NewBlockOpsStandard(
 
 // Get implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) Get(ctx context.Context, kmd libkey.KeyMetadata,
-	blockPtr data.BlockPointer, block data.Block, lifetime data.BlockCacheLifetime) error {
+	blockPtr data.BlockPointer, block data.Block,
+	lifetime data.BlockCacheLifetime, branch data.BranchName) error {
 	// Check the journal explicitly first, so we don't get stuck in
 	// the block-fetching queue.
 	if journalBServer, ok := b.config.BlockServer().(journalBlockServer); ok {
@@ -87,9 +88,13 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd libkey.KeyMetadata,
 
 	b.log.LazyTrace(ctx, "BOps: Requesting %s", blockPtr.ID)
 
+	action := b.config.Mode().DefaultBlockRequestAction()
+	if branch != data.MasterBranch {
+		action = action.AddNonMasterBranch()
+	}
 	errCh := b.queue.Request(
 		ctx, defaultOnDemandRequestPriority, kmd,
-		blockPtr, block, lifetime, b.config.Mode().DefaultBlockRequestAction())
+		blockPtr, block, lifetime, action)
 	err := <-errCh
 
 	b.log.LazyTrace(ctx, "BOps: Request fulfilled for %s (err=%v)", blockPtr.ID, err)

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -368,7 +368,7 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	err = bops.Get(ctx, kmd2,
 		data.BlockPointer{ID: id, DataVer: data.FirstValidVer,
 			KeyGen: keyGen, Context: bCtx},
-		decryptedBlock, data.NoCacheEntry)
+		decryptedBlock, data.NoCacheEntry, data.MasterBranch)
 	require.NoError(t, err)
 	require.Equal(t, block, decryptedBlock)
 }
@@ -396,7 +396,7 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 	err = bops.Get(ctx, kmd,
 		data.BlockPointer{ID: id, DataVer: data.FirstValidVer,
 			KeyGen: latestKeyGen, Context: bCtx},
-		&decryptedBlock, data.NoCacheEntry)
+		&decryptedBlock, data.NoCacheEntry, data.MasterBranch)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
 }
 
@@ -446,7 +446,7 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 	err = bops.Get(ctx, kmd,
 		data.BlockPointer{ID: id, DataVer: data.FirstValidVer,
 			KeyGen: latestKeyGen, Context: bCtx},
-		&decryptedBlock, data.NoCacheEntry)
+		&decryptedBlock, data.NoCacheEntry, data.MasterBranch)
 	require.IsType(t, kbfshash.HashMismatchError{}, errors.Cause(err))
 }
 
@@ -478,7 +478,7 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	err = bops.Get(ctx, kmd,
 		data.BlockPointer{ID: id, DataVer: data.FirstValidVer,
 			KeyGen: latestKeyGen + 1, Context: bCtx},
-		&decryptedBlock, data.NoCacheEntry)
+		&decryptedBlock, data.NoCacheEntry, data.MasterBranch)
 	require.EqualError(t, err, fmt.Sprintf(
 		"no key for block decryption (keygen=%d)", latestKeyGen+1))
 }
@@ -551,7 +551,7 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 	err = bops.Get(ctx, kmd,
 		data.BlockPointer{ID: id, DataVer: data.FirstValidVer,
 			KeyGen: latestKeyGen, Context: bCtx},
-		&decryptedBlock, data.NoCacheEntry)
+		&decryptedBlock, data.NoCacheEntry, data.MasterBranch)
 	require.Equal(t, decodeErr, err)
 }
 
@@ -594,7 +594,7 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	err = bops.Get(ctx, kmd,
 		data.BlockPointer{ID: id, DataVer: data.FirstValidVer,
 			KeyGen: latestKeyGen, Context: bCtx},
-		&decryptedBlock, data.NoCacheEntry)
+		&decryptedBlock, data.NoCacheEntry, data.MasterBranch)
 	require.EqualError(t, err, "could not decrypt block")
 }
 

--- a/go/kbfs/libkbfs/block_retrieval_queue.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue.go
@@ -581,7 +581,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	priority int, kmd libkey.KeyMetadata, ptr data.BlockPointer, block data.Block,
 	lifetime data.BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	if brq.config.IsSyncedTlf(kmd.TlfID()) {
+	if !action.NonMasterBranch() && brq.config.IsSyncedTlf(kmd.TlfID()) {
 		action = action.AddSync()
 	}
 	return brq.request(ctx, priority, kmd, ptr, block, lifetime, action)

--- a/go/kbfs/libkbfs/bserver_remote.go
+++ b/go/kbfs/libkbfs/bserver_remote.go
@@ -418,8 +418,12 @@ func (b *BlockServerRemote) Get(
 				ctx, "Get id=%s tlf=%s context=%s sz=%d err=%v",
 				id, tlfID, context, len(buf), err)
 		} else {
-			// But don't cache it if it's archived data.
-			if res.Status == keybase1.BlockStatus_ARCHIVED {
+			// But don't cache it if it's archived data, except if
+			// it's going to the sync cache.  Blocks marked for the
+			// sync cache must be cached, otherwise prefetching will
+			// never complete.
+			if res.Status == keybase1.BlockStatus_ARCHIVED &&
+				cacheType != DiskBlockSyncCache {
 				return
 			}
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1463,6 +1463,11 @@ type BlockOps interface {
 	// object with its contents, if the logged-in user has read
 	// permission for that block. cacheLifetime controls the behavior of the
 	// write-through cache once a Get completes.
+	//
+	// TODO: Make a `BlockRequestParameters` object to encapsulate the
+	// cache lifetime and branch name, to avoid future plumbing.  Or
+	// maybe just get rid of the `Get()` method entirely and have
+	// everyone use the block retrieval queue directly.
 	Get(ctx context.Context, kmd libkey.KeyMetadata, blockPtr data.BlockPointer,
 		block data.Block, cacheLifetime data.BlockCacheLifetime,
 		branch data.BranchName) error

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -1464,7 +1464,8 @@ type BlockOps interface {
 	// permission for that block. cacheLifetime controls the behavior of the
 	// write-through cache once a Get completes.
 	Get(ctx context.Context, kmd libkey.KeyMetadata, blockPtr data.BlockPointer,
-		block data.Block, cacheLifetime data.BlockCacheLifetime) error
+		block data.Block, cacheLifetime data.BlockCacheLifetime,
+		branch data.BranchName) error
 
 	// GetEncodedSizes gets the encoded sizes and statuses of the
 	// block associated with the given block pointers (which belongs

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -566,9 +566,10 @@ func TestKBFSOpsGetRootNodeCacheIdentifyFail(t *testing.T) {
 
 func expectBlock(config *ConfigMock, kmd libkey.KeyMetadata, blockPtr data.BlockPointer, block data.Block, err error) {
 	config.mockBops.EXPECT().Get(gomock.Any(), kmdMatcher{kmd},
-		ptrMatcher{blockPtr}, gomock.Any(), gomock.Any()).
+		ptrMatcher{blockPtr}, gomock.Any(), gomock.Any(), gomock.Any()).
 		Do(func(ctx context.Context, kmd libkey.KeyMetadata,
-			blockPtr data.BlockPointer, getBlock data.Block, lifetime data.BlockCacheLifetime) {
+			blockPtr data.BlockPointer, getBlock data.Block,
+			lifetime data.BlockCacheLifetime, _ data.BranchName) {
 			getBlock.Set(block)
 			_ = config.BlockCache().Put(
 				blockPtr, kmd.TlfID(), getBlock, lifetime, data.DoCacheHash)
@@ -4699,7 +4700,8 @@ func waitForIndirectPtrBlocksInTest(
 		newBlock := block.NewEmpty()
 		t.Logf("Waiting for block %s", info.BlockPointer)
 		err := config.BlockOps().Get(
-			ctx, kmd, info.BlockPointer, newBlock, data.TransientEntry)
+			ctx, kmd, info.BlockPointer, newBlock, data.TransientEntry,
+			data.MasterBranch)
 		require.NoError(t, err)
 	}
 }

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -92,17 +92,17 @@ func (mr *MockBlockOpsMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // Get mocks base method.
-func (m *MockBlockOps) Get(arg0 context.Context, arg1 libkey.KeyMetadata, arg2 data.BlockPointer, arg3 data.Block, arg4 data.BlockCacheLifetime) error {
+func (m *MockBlockOps) Get(arg0 context.Context, arg1 libkey.KeyMetadata, arg2 data.BlockPointer, arg3 data.Block, arg4 data.BlockCacheLifetime, arg5 data.BranchName) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockBlockOpsMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockBlockOpsMockRecorder) Get(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockOps)(nil).Get), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockOps)(nil).Get), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // GetEncodedSizes mocks base method.

--- a/go/kbfs/libkbfs/md_util.go
+++ b/go/kbfs/libkbfs/md_util.go
@@ -472,7 +472,8 @@ func encryptMDPrivateData(
 	return nil
 }
 
-func getFileBlockForMD(ctx context.Context, bcache data.BlockCacheSimple, bops BlockOps,
+func getFileBlockForMD(
+	ctx context.Context, bcache data.BlockCacheSimple, bops BlockOps,
 	ptr data.BlockPointer, tlfID tlf.ID, rmdWithKeys libkey.KeyMetadata) (
 	*data.FileBlock, error) {
 	// We don't have a convenient way to fetch the block from here via
@@ -482,7 +483,15 @@ func getFileBlockForMD(ctx context.Context, bcache data.BlockCacheSimple, bops B
 	block, err := bcache.Get(ptr)
 	if err != nil {
 		block = data.NewFileBlock()
-		if err := bops.Get(ctx, rmdWithKeys, ptr, block, data.TransientEntry); err != nil {
+		// TODO: eventually we should plumb the correct branch name
+		// here, but that would impact a huge number of functions that
+		// fetch MD.  For now, the worst thing that can happen is that
+		// MD blocks for historical MD revisions sneak their way into
+		// the sync cache.
+		branch := data.MasterBranch
+		if err := bops.Get(
+			ctx, rmdWithKeys, ptr, block, data.TransientEntry,
+			branch); err != nil {
 			return nil, err
 		}
 	}

--- a/go/kbfs/search/indexer_test.go
+++ b/go/kbfs/search/indexer_test.go
@@ -369,12 +369,6 @@ func TestFullIndexSyncedTlf(t *testing.T) {
 	sendToIndexer(nil) // beta
 	err = errors.New("STOP")
 	sendToIndexer(err)
-	// The `SetInitialHeadFromServer` call when the indexer constructs
-	// its read-only FS ends up causing two more sync requests that
-	// need to be stopped.  (In production, these should be no-ops
-	// once the first pass of the indexer is done.)
-	sendToIndexer(err)
-	sendToIndexer(err)
 
 	err = i.waitForSyncs(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
[@jzila, I think/hope this will fix your syncing issue...]

If a block has been mistakenly marked as archived on the server due to an old KBFS bug, but it is still reachable through the master view of the TLF, and that TLF has been configured to sync on the local device, we still want to put that archived block into the disk sync cache. Otherwise, the prefetcher will get confused and prefetching will never complete.  (Also, the data wouldn't be available offline.)

This would be a relatively simple fix to `bserver_remote.go`, except that we _don't_ want to cache these archived blocks if we're reading an old revision of the TLF where the blocks are supposed to be archived.  In that case, we don't want to set the cache type for the fetch to be the sync cache.  So all the places that set the cache type now need to be aware of the "branch name" of the local view of the TLF, instead of just knowing the TLF ID.

To accomplish that, we pass the branch name into the `BlockOps.Get()` call, and add a new block request action type to indicate that the fetch is for a non-master branch.

I punted on passing the branch name around for the specific case of fetching MD blocks for a historical version of a TLF -- the call stack size was too overwhelming for such little benefit, for now.

Issue: HOTPOT-2253