### PR TITLE
Fix react native gobuild script for mobile clients

### DIFF
--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -38,6 +38,12 @@ GOPATH0=${GOPATH_ARRAY[0]}
 client_dir="$GOPATH0/src/github.com/keybase/client"
 client_go_dir="$client_dir/go"
 
+if [ ! -d $client_dir ]; then
+  echo "Getting client (via git clone)..."
+  mkdir -p $client_dir
+  (cd "$GOPATH/src/github.com/keybase" && git clone --depth=1 https://github.com/keybase/client)
+fi
+
 echo "Using GOPATH: $GOPATH"
 
 # gomobile looks for gobind in $PATH, so put $GOPATH/bin in $PATH. We


### PR DESCRIPTION
Tried to build the iOS client and was getting the following error when I ran `yarn rn-gobuild-ios`:
```
$ ./react-native/gobuild.sh ios
Using GOPATH: /Users/sergeichestakov/go
Building for iOS (/Users/sergeichestakov/Documents/client/shared/react-native/../ios/keybase.framework)...
Running gomobile init cause: gomobile: package "github.com/keybase/client/go/bind": cannot find package "github.com/keybase/client/go/bind" in any of:
	/usr/local/go/src/github.com/keybase/client/go/bind (from $GOROOT)
	/Users/sergeichestakov/go/src/github.com/keybase/client/go/bind (from $GOPATH)
Build gomobile...
rsync: link_stat "/Users/sergeichestakov/go/src/github.com/keybase/client/go/vendor/golang.org/x" failed: No such file or directory (2)
rsync error: some files could not be transferred (code 23) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-54/rsync/main.c(996) [sender=2.6.9]
error Command failed with exit code 23.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I was able to get it to build by doing the following:
1. Reverting https://github.com/keybase/client/pull/19183 
2. `export LOCAL_CLIENT=0`
3. Rerunning `yarn rn-gobuild-ios`

After doing that I realized that this script expects the client repo to be cloned inside `$GOPATH/src/github.com/keybase` so I thought to add that logic back in (which got removed in https://github.com/keybase/client/pull/19183) and now it works. Alternatively, if recloning the client repo is not an intended side effect, it might be nice to leave a note in the README  specifying that this repo needs to be cloned inside `$GOPATH/src/github.com/keybase` in order to build any of the native clients (happy to add that as well).

cc @thebearjew 