### PR TITLE
md_util: fix sorting behavior of MD changes

### DIFF
--- a/go/kbfs/search/indexer.go
+++ b/go/kbfs/search/indexer.go
@@ -1080,9 +1080,9 @@ func (i *Indexer) doIncrementalIndex(
 	ctx context.Context, m tlfMessage, indexedRev, newRev kbfsmd.Revision) (
 	err error) {
 	i.log.CDebugf(
-		ctx, "Incremental index %s: d -> %d", m.tlfID, indexedRev, newRev)
+		ctx, "Incremental index %s: %d -> %d", m.tlfID, indexedRev, newRev)
 	defer func() {
-		i.log.CDebugf(ctx, "Incremental index %s: d -> %d: %+v",
+		i.log.CDebugf(ctx, "Incremental index %s: %d -> %d: %+v",
 			m.tlfID, indexedRev, newRev, err)
 	}()
 


### PR DESCRIPTION
Renames should be processed last, since their pointers could depend on early write changes.  This could cause racy failures in the indexer tests.

(Also, fix a comment typo in indexer.go, found while debugging this issue.)