### PR TITLE
Fixups for empty inbox state

### DIFF
--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -55,7 +55,7 @@ let Conversation = (p: SwitchProps) => {
       // On iOS it is less noticeable because screen transitions slide away to
       // the right, though it is visible for a small amount of time.
       // To solve this we render a blank screen on mobile conversation views with "noConvo"
-      return Container.isMobile ? null : <NoConversation />
+      return Container.isPhone ? null : <NoConversation />
     case 'normal':
       return <Normal conversationIDKey={conversationIDKey} />
     case 'youAreReset':

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -18,18 +18,28 @@ import shallowEqual from 'shallowequal'
 type RowItem = Types.ChatInboxRowItem
 
 const NoChats = (props: {onNewChat: () => void}) => (
-  <Kb.Box2 direction="vertical" gap="small" style={styles.noChatsContainer}>
-    <Kb.Icon type="icon-fancy-encrypted-phone-mobile-226-96" />
-    <Kb.Box2 direction="vertical">
-      <Kb.Text type="BodySmall" center={true}>
-        All conversations are
-      </Kb.Text>
-      <Kb.Text type="BodySmall" center={true}>
-        end-to-end encrypted.
-      </Kb.Text>
+  <>
+    <Kb.Box2 direction="vertical" gapStart={true} gap="small" style={styles.noChatsContainer}>
+      <Kb.Icon type="icon-fancy-encrypted-phone-mobile-226-96" />
+      <Kb.Box2 direction="vertical">
+        <Kb.Text type="BodySmall" center={true}>
+          All conversations are
+        </Kb.Text>
+        <Kb.Text type="BodySmall" center={true}>
+          end-to-end encrypted.
+        </Kb.Text>
+      </Kb.Box2>
     </Kb.Box2>
-    <Kb.Button onClick={props.onNewChat} mode="Primary" label="Start a new chat" style={styles.button} />
-  </Kb.Box2>
+    <Kb.Box2 direction="vertical" gapStart={true} gap="medium" style={styles.newChat}>
+      <Kb.Button
+        fullWidth={true}
+        onClick={props.onNewChat}
+        mode="Primary"
+        label="Start a new chat"
+        style={styles.button}
+      />
+    </Kb.Box2>
+  </>
 )
 
 type State = {
@@ -231,6 +241,7 @@ class Inbox extends React.PureComponent<T.Props, State> {
       return false
     })
 
+    console.warn(this.props.neverLoaded, this.props.isSearching, this.props.rows.length)
     const noChats = !this.props.neverLoaded && !this.props.isSearching && !this.props.rows.length && (
       <NoChats onNewChat={this.props.onNewChat} />
     )
@@ -280,6 +291,11 @@ class Inbox extends React.PureComponent<T.Props, State> {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      buttonBar: {
+        alignSelf: 'flex-end',
+        alignItems: 'flex-end',
+        justifyContent: 'flex-end',
+      },
       button: {width: '100%'},
       container: Styles.platformStyles({
         common: {
@@ -301,13 +317,19 @@ const styles = Styles.styleSheetCreate(
         top: 0,
         zIndex: 1000,
       },
+      newChat: {
+        ...Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
+        backgroundColor: Styles.globalColors.fastBlank,
+        flexShrink: 0,
+        width: '100%',
+      },
       noChatsContainer: {
-        ...Styles.globalStyles.fillAbsolute,
         alignItems: 'center',
-        flex: 1,
-        justifyContent: 'center',
+        justifyContent: 'flex-end',
         paddingLeft: Styles.globalMargins.small,
         paddingRight: Styles.globalMargins.small,
+        paddingBottom: Styles.globalMargins.xlarge,
+        paddingTop: Styles.globalMargins.xlarge,
       },
     } as const)
 )

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -241,7 +241,6 @@ class Inbox extends React.PureComponent<T.Props, State> {
       return false
     })
 
-    console.warn(this.props.neverLoaded, this.props.isSearching, this.props.rows.length)
     const noChats = !this.props.neverLoaded && !this.props.isSearching && !this.props.rows.length && (
       <NoChats onNewChat={this.props.onNewChat} />
     )

--- a/shared/chat/inbox/index.native.tsx
+++ b/shared/chat/inbox/index.native.tsx
@@ -291,12 +291,12 @@ class Inbox extends React.PureComponent<T.Props, State> {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      button: {width: '100%'},
       buttonBar: {
-        alignSelf: 'flex-end',
         alignItems: 'flex-end',
+        alignSelf: 'flex-end',
         justifyContent: 'flex-end',
       },
-      button: {width: '100%'},
       container: Styles.platformStyles({
         common: {
           ...Styles.globalStyles.flexBoxColumn,
@@ -326,9 +326,9 @@ const styles = Styles.styleSheetCreate(
       noChatsContainer: {
         alignItems: 'center',
         justifyContent: 'flex-end',
+        paddingBottom: Styles.globalMargins.xlarge,
         paddingLeft: Styles.globalMargins.small,
         paddingRight: Styles.globalMargins.small,
-        paddingBottom: Styles.globalMargins.xlarge,
         paddingTop: Styles.globalMargins.xlarge,
       },
     } as const)


### PR DESCRIPTION
@keybase/react-hackers @keybase/design 

This state isn't seen by most users since a hellobot message comes along to replace it, but some quick fixups anyway:

Before:

![Screenshot_20200327-091727](https://user-images.githubusercontent.com/21217/77782507-9f26d300-7014-11ea-8b8b-241e83fac4e7.png)

![image-2020-02-26-13-44-31-211](https://user-images.githubusercontent.com/21217/77782559-b5cd2a00-7014-11ea-95d5-f26c4abeaef4.png)

After:

![Screen Shot 2020-03-27 at 10 13 58 AM](https://user-images.githubusercontent.com/21217/77782666-dc8b6080-7014-11ea-855d-fac24487444c.png)

![Screen Shot 2020-03-25 at 12 57 42 PM](https://user-images.githubusercontent.com/21217/77782650-d5fce900-7014-11ea-86d6-630972f1d848.png)

![Screen Shot 2020-03-25 at 12 59 19 PM](https://user-images.githubusercontent.com/21217/77782609-c7163680-7014-11ea-84e9-711eeb83276c.png)
