### PR TITLE
libkbfs: fix two panics

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1912,17 +1912,26 @@ func (fbo *folderBranchOps) makeObfuscator() data.Obfuscator {
 func (fbo *folderBranchOps) setHeadLocked(
 	ctx context.Context, lState *kbfssync.LockState,
 	md ImmutableRootMetadata, headStatus headTrustStatus,
-	ct mdCommitType) error {
+	ct mdCommitType) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
 
 	isFirstHead := fbo.head == ImmutableRootMetadata{}
 	wasReadable := false
 	if isFirstHead {
-		err := fbo.setObfuscatorSecret(ctx, md.ReadOnly())
+		err = fbo.setObfuscatorSecret(ctx, md.ReadOnly())
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err != nil && fbo.head == (ImmutableRootMetadata{}) {
+				// If we didn't successfully set the head, we need to
+				// unset the secret.
+				fbo.obLock.Lock()
+				defer fbo.obLock.Unlock()
+				fbo.obSecret = nil
+			}
+		}()
 	} else {
 		if headStatus == headUntrusted {
 			panic("setHeadLocked: Trying to set an untrusted head over an existing head")


### PR DESCRIPTION
* config_local: avoid panic when cleaning sync cache in background
  * There could be a race where the cache is quickly reset multiple times.
* folder_branch_ops: un-set the obfuscator secret on error
  * If we fail to set the first MD of a TLF, we need to un-set the secret, or else it will panic the next time we try to set the first MD.

Issue: HOTPOT-2335

