### PR TITLE
iPad: don't show extra headerhoc headers on settings subnav pages

### DIFF
--- a/shared/common-adapters/header-hoc/index.d.ts
+++ b/shared/common-adapters/header-hoc/index.d.ts
@@ -52,7 +52,9 @@ type HeaderHocProps = Props
 /**
  * Short term use this instead of the hoc as a regular component
  */
-export declare class HeaderHocWrapper extends React.Component<Props & {children: React.ReactNode}> {}
+export declare class HeaderHocWrapper extends React.Component<
+  Props & {children: React.ReactNode; skipHeader?: boolean}
+> {}
 export declare class HeaderHocHeader extends React.Component<HeaderHocProps> {}
 export declare class LeftAction extends React.Component<LeftActionProps> {}
 // HeaderHoc is deprecated. navigationOptions should be used instead.

--- a/shared/common-adapters/header-hoc/index.native.tsx
+++ b/shared/common-adapters/header-hoc/index.native.tsx
@@ -219,12 +219,12 @@ const renderAction = (action: Action, index: number): React.ReactNode =>
   )
 
 /** TODO likely deprecate this **/
-export const HeaderHocWrapper = (props: Props & {children: React.ReactNode}) => {
-  const {customSafeAreaTopStyle, children, customSafeAreaBottomStyle} = props
+export const HeaderHocWrapper = (props: Props & {children: React.ReactNode; skipHeader?: boolean}) => {
+  const {customSafeAreaTopStyle, children, customSafeAreaBottomStyle, skipHeader} = props
   return (
     <Box style={styles.container}>
       {!!customSafeAreaTopStyle && <SafeAreaViewTop style={customSafeAreaTopStyle} />}
-      <HeaderHocHeader {...props} />
+      {!skipHeader && <HeaderHocHeader {...props} />}
       <Box style={styles.grow}>
         <Box style={styles.innerWrapper}>{children}</Box>
       </Box>

--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -168,7 +168,7 @@ const AccountSettings = (props: Props) => (
     reloadOnMount={true}
     waitingKeys={[Constants.loadSettingsWaitingKey]}
   >
-    <Kb.HeaderHocWrapper onBack={props.onBack} title="Your account">
+    <Kb.HeaderHocWrapper onBack={props.onBack} skipHeader={!Styles.isPhone} title="Your account">
       <Kb.ScrollView style={Styles.globalStyles.fullWidth}>
         {props.addedEmail && (
           <Kb.Banner color="yellow" onClose={props.onClearAddedEmail}>

--- a/shared/settings/chat/index.tsx
+++ b/shared/settings/chat/index.tsx
@@ -130,7 +130,7 @@ class Chat extends React.Component<Props, State> {
 
   render() {
     return (
-      <Kb.HeaderHocWrapper onBack={this.props.onBack} title="Chat">
+      <Kb.HeaderHocWrapper onBack={this.props.onBack} skipHeader={!Styles.isPhone} title="Chat">
         <Kb.Box2 direction="vertical" fullWidth={true}>
           <Kb.ScrollView>
             <Kb.Box2 direction="vertical" fullHeight={true} gap="tiny" style={styles.container}>

--- a/shared/settings/display/index.tsx
+++ b/shared/settings/display/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 }
 
 const Display = (props: Props) => (
-  <Kb.HeaderHocWrapper onBack={props.onBack} title="Display">
+  <Kb.HeaderHocWrapper onBack={props.onBack} skipHeader={!Styles.isPhone} title="Display">
     <Kb.ScrollView style={styles.scrollview}>
       <Kb.Box style={styles.container}>
         <Kb.Box2 direction="vertical" fullWidth={true}>

--- a/shared/settings/files/index.native.tsx
+++ b/shared/settings/files/index.native.tsx
@@ -66,7 +66,7 @@ const Files = (props: Props) => {
     Container.anyWaiting(state, Constants.setSyncOnCellularWaitingKey)
   )
   return (
-    <Kb.HeaderHocWrapper title="Files" onBack={props.onBack}>
+    <Kb.HeaderHocWrapper title="Files" onBack={props.onBack} skipHeader={!Styles.isPhone}>
       <Kb.Box2 direction="vertical" fullWidth={true} alignItems="center" gap="small">
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.syncContent} gap="tiny">
           <Kb.Text type="Header">Sync</Kb.Text>

--- a/shared/settings/nav/split-nav.tsx
+++ b/shared/settings/nav/split-nav.tsx
@@ -12,7 +12,7 @@ const SplitNav = (props: Props) => {
   return (
     <Kb.Box style={styles.container}>
       {Styles.isTablet && (
-        <Kb.Box style={styles.header}>
+        <>
           <SettingsItem
             icon="iconfont-nav-2-crypto"
             text="Crypto"
@@ -42,7 +42,7 @@ const SplitNav = (props: Props) => {
             onClick={() => props.onTabChange(Constants.whatsNewTab)}
           />
           <Kb.SectionDivider label="Settings" />
-        </Kb.Box>
+        </>
       )}
       <SettingsItem
         text="Your account"
@@ -113,18 +113,18 @@ const styles = Styles.styleSheetCreate(() => ({
     common: {
       ...Styles.globalStyles.flexBoxColumn,
       backgroundColor: Styles.globalColors.blueGrey,
-      paddingTop: Styles.globalMargins.small,
     },
     isElectron: {
+      paddingTop: Styles.globalMargins.small,
       width: 160,
+    },
+    isPhone: {
+      paddingTop: Styles.globalMargins.small,
     },
     isTablet: {
       width: Styles.globalStyles.shortWidth,
     },
   }),
-  header: {
-    marginTop: Styles.globalMargins.xlarge,
-  },
 }))
 
 export default SplitNav

--- a/shared/settings/notifications/index.native.tsx
+++ b/shared/settings/notifications/index.native.tsx
@@ -6,7 +6,7 @@ import TurnOnNotifications from './turn-on-notifications.native'
 import {Props} from '.'
 
 const MobileNotifications = (props: Props) => (
-  <Kb.HeaderHocWrapper title="Notifications" onBack={props.onBack}>
+  <Kb.HeaderHocWrapper title="Notifications" onBack={props.onBack} skipHeader={!Styles.isPhone}>
     <Kb.ScrollView style={{...Styles.globalStyles.flexBoxColumn, flex: 1}}>
       {!props.mobileHasPermissions && <TurnOnNotifications />}
       <Notifications {...props} />

--- a/shared/settings/routes.native.tsx
+++ b/shared/settings/routes.native.tsx
@@ -142,6 +142,7 @@ const SettingsSubNavigator = createNavigator(
 )
 
 SettingsSubNavigator.navigationOptions = {
+  header: undefined,
   title: 'More',
 }
 


### PR DESCRIPTION
@keybase/react-hackers @keybase/design 

Changes on iPad only.  Before:

![Screen Shot 2020-03-27 at 12 00 07 PM](https://user-images.githubusercontent.com/21217/77790816-b66cbd00-7022-11ea-9ccb-659cae411d50.png)

After:

![Screen Shot 2020-03-27 at 11 59 35 AM](https://user-images.githubusercontent.com/21217/77790834-bd93cb00-7022-11ea-91c1-c96b3287f95f.png)
