### PR TITLE
iPad: don't flash blue background while rotating

### DIFF
--- a/shared/ios/Keybase/AppDelegate.m
+++ b/shared/ios/Keybase/AppDelegate.m
@@ -75,7 +75,7 @@
   AppearanceRootView *rootView = [[AppearanceRootView alloc] initWithBridge:bridge
                                                    moduleName:@"Keybase"
                                             initialProperties:nil];
-  rootView.backgroundColor = [[UIColor alloc] initWithRed:71/255.0f green:139/255.f blue:1.0f alpha:1];
+  rootView.backgroundColor = [UIColor colorWithWhite:0.f alpha:0.f];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];


### PR DESCRIPTION
@keybase/react-hackers 

With rotation on, the new screen area being created during an iPad rotation is first filled in blue by iOS, and then rendered by JS, so there's a momentary observable flash of blue.

Setting the rootView's background color to transparent seems to work fine as a fix -- dark mode and light mode both have no visible glitch on rotation.  Initial app startup and splash screen look good to me too.  But maybe there's a reason I'm missing for why we want a colored bg?