### PR TITLE
modes: delay background synced TLF initialization for search mode

### DIFF
--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -677,6 +677,12 @@ func (mts modeTestSearch) IndexingEnabled() bool {
 	return true
 }
 
+func (mts modeTestSearch) InitialDelayForBackgroundWork() time.Duration {
+	// Delay background work like loading the synced TLFs, until the
+	// indexer has registered to receive notifications about them.
+	return 5 * time.Second
+}
+
 func (mts modeTestSearch) DelayInitialConnect() bool {
 	return false
 }


### PR DESCRIPTION
If a synced TLF is initialized too early, the indexer might not yet have registered to receive notifications about synced TLFs.  So just delay that background work for a few seconds.  A better, future fix might be to have the indexer itself check for any missed notifications after it has registered itself, but that's a lot more complicated.