### PR TITLE
Move destructive menu items to the bottom of the list.

### DIFF
--- a/shared/chat/blocking/block-modal/index.tsx
+++ b/shared/chat/blocking/block-modal/index.tsx
@@ -358,13 +358,18 @@ class BlockModal extends React.PureComponent<Props, State> {
         header={header}
         footer={{
           content: (
-            <Kb.WaitingButton
-              label="Finish"
-              onClick={this.onFinish}
-              fullWidth={true}
-              type="Danger"
-              waitingKey={null}
-            />
+            <Kb.ButtonBar fullWidth={true} style={styles.buttonBar}>
+              {!Styles.isMobile && (
+                <Kb.Button fullWidth={true} label="Cancel" onClick={this.props.onClose} type="Dim" />
+              )}
+              <Kb.WaitingButton
+                label="Finish"
+                onClick={this.onFinish}
+                fullWidth={true}
+                type="Danger"
+                waitingKey={null}
+              />
+            </Kb.ButtonBar>
           ),
         }}
         noScrollView={true}
@@ -408,6 +413,7 @@ const getListHeightStyle = (numOthers: number, expanded: boolean) => ({
 })
 
 const styles = Styles.styleSheetCreate(() => ({
+  buttonBar: {minHeight: undefined},
   checkBoxRow: Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small),
   feedback: Styles.padding(Styles.globalMargins.tiny, Styles.globalMargins.small, 0),
   feedbackPaddingBottom: {paddingBottom: Styles.globalMargins.small},

--- a/shared/chat/conversation/messages/message-popup/attachment/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment/index.tsx
@@ -35,32 +35,7 @@ type Props = {
 
 const AttachmentPopupMenu = (props: Props) => {
   const items: MenuItems = [
-    ...(props.isDeleteable
-      ? ([
-          'Divider' as const,
-          {
-            danger: true,
-            disabled: !props.onDelete,
-            icon: 'iconfont-trash',
-            onClick: props.onDelete,
-            subTitle: 'Deletes this attachment for everyone',
-            title: 'Delete',
-          },
-        ] as const)
-      : []),
-    ...(props.isKickable
-      ? ([
-          {
-            danger: true,
-            disabled: !props.onKick,
-            icon: 'iconfont-block-user',
-            onClick: props.onKick,
-            subTitle: 'Removes the user from the team',
-            title: 'Kick user',
-          },
-        ] as const)
-      : []),
-    'Divider' as const,
+    'Divider',
     ...(props.onShowInFinder
       ? [{icon: 'iconfont-finder', onClick: props.onShowInFinder, title: `Show in ${fileUIName}`}]
       : []),
@@ -97,6 +72,31 @@ const AttachmentPopupMenu = (props: Props) => {
     ...(props.onReply ? [{icon: 'iconfont-reply', onClick: props.onReply, title: 'Reply'}] : []),
     ...(props.onPinMessage
       ? [{icon: 'iconfont-pin', onClick: props.onPinMessage, title: 'Pin message'}]
+      : []),
+    ...(props.isDeleteable
+      ? ([
+          {
+            danger: true,
+            disabled: !props.onDelete,
+            icon: 'iconfont-trash',
+            onClick: props.onDelete,
+            subTitle: 'Deletes this attachment for everyone',
+            title: 'Delete',
+          },
+        ] as const)
+      : []),
+    ...(props.isKickable
+      ? ([
+          'Divider' as const,
+          {
+            danger: true,
+            disabled: !props.onKick,
+            icon: 'iconfont-block-user',
+            onClick: props.onKick,
+            subTitle: 'Removes the user from the team',
+            title: 'Kick user',
+          },
+        ] as const)
       : []),
   ].reduce<MenuItems>((arr, i) => {
     i && arr.push(i as MenuItem)

--- a/shared/chat/conversation/messages/message-popup/text/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/index.tsx
@@ -42,33 +42,6 @@ type Props = {
 const TextPopupMenu = (props: Props) => {
   const items: Kb.MenuItems = [
     ...(props.showDivider ? (['Divider'] as const) : []),
-    ...(props.isDeleteable
-      ? [
-          {
-            danger: true,
-            disabled: !props.onDelete,
-            icon: 'iconfont-trash',
-            onClick: props.onDelete,
-            subTitle: 'Deletes this message for everyone',
-            title: 'Delete',
-          },
-        ]
-      : []),
-    ...(props.isKickable
-      ? [
-          {
-            danger: true,
-            disabled: !props.onKick,
-            icon: 'iconfont-block-user',
-            onClick: props.onKick,
-            subTitle: 'Removes the user from the team',
-            title: 'Kick user',
-          },
-        ]
-      : []),
-    ...((props.yourMessage && (props.isDeleteable || props.isKickable)) || props.onDeleteMessageHistory
-      ? (['Divider'] as const)
-      : []),
     ...(props.onViewMap
       ? [{icon: 'iconfont-location', onClick: props.onViewMap, title: 'View on Google Maps'}]
       : []),
@@ -101,8 +74,33 @@ const TextPopupMenu = (props: Props) => {
     ...(props.onPinMessage
       ? [{icon: 'iconfont-pin', onClick: props.onPinMessage, title: 'Pin message'}]
       : []),
+    ...(props.isDeleteable
+      ? [
+          {
+            danger: true,
+            disabled: !props.onDelete,
+            icon: 'iconfont-trash',
+            onClick: props.onDelete,
+            subTitle: 'Deletes this message for everyone',
+            title: 'Delete',
+          },
+        ]
+      : []),
+    ...(props.onViewProfile || props.isKickable || !props.yourMessage ? ['Divider' as const] : []),
     ...(props.onViewProfile
       ? [{icon: 'iconfont-person', onClick: props.onViewProfile, title: 'View profile'}]
+      : []),
+    ...(props.isKickable
+      ? [
+          {
+            danger: true,
+            disabled: !props.onKick,
+            icon: 'iconfont-block-user',
+            onClick: props.onKick,
+            subTitle: 'Removes the user from the team',
+            title: 'Kick user',
+          },
+        ]
       : []),
     ...(!props.yourMessage
       ? [

--- a/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.native.tsx
@@ -23,6 +23,7 @@ type MenuRowProps = {
 } & MenuItem
 
 const itemContainerHeight = 48
+const itemContainerHeightWithSubTitle = itemContainerHeight + 18 // lineHeight of subTitle
 
 const MenuRow = (props: MenuRowProps) => (
   <NativeTouchableOpacity
@@ -34,6 +35,7 @@ const MenuRow = (props: MenuRowProps) => (
     style={Styles.collapseStyles([
       styles.itemContainer,
       !props.unWrapped && styles.itemContainerWrapped,
+      !!props.subTitle && styles.itemContainerWithSubTitle,
       props.backgroundColor && {backgroundColor: props.backgroundColor},
     ])}
   >
@@ -90,8 +92,8 @@ const MenuRow = (props: MenuRowProps) => (
 )
 
 const MenuLayout = (props: MenuLayoutProps) => {
-  const menuItemsNoDividers: MenuItem[] = props.items.filter((x): x is MenuItem =>
-    x ? x !== 'Divider' : false
+  const menuItemsWithDividers = props.items.filter((x): x is MenuItem | 'Divider' =>
+    x ? x === 'Divider' : false
   )
   const beginningDivider = props.items[0] === 'Divider'
   const firstIsUnWrapped = props.items[0] !== 'Divider' && props.items[0]?.unWrapped
@@ -118,17 +120,23 @@ const MenuLayout = (props: MenuLayoutProps) => {
           style={Styles.collapseStyles([styles.scrollView, firstIsUnWrapped && styles.firstIsUnWrapped])}
           contentContainerStyle={styles.menuGroup}
         >
-          {menuItemsNoDividers.map((mi, idx) => (
-            <MenuRow
-              key={mi.title}
-              {...mi}
-              index={idx}
-              numItems={menuItemsNoDividers.length}
-              onHidden={props.closeOnClick ? props.onHidden : undefined}
-              textColor={props.textColor}
-              backgroundColor={props.backgroundColor}
-            />
-          ))}
+          {menuItemsWithDividers.map((mi, idx) =>
+            mi === 'Divider' ? (
+              idx !== 0 && idx !== props.items.length ? (
+                <Divider style={styles.dividerInScrolleView} />
+              ) : null
+            ) : (
+              <MenuRow
+                key={mi.title}
+                {...mi}
+                index={idx}
+                numItems={menuItemsWithDividers.length}
+                onHidden={props.closeOnClick ? props.onHidden : undefined}
+                textColor={props.textColor}
+                backgroundColor={props.backgroundColor}
+              />
+            )
+          )}
         </ScrollView>
         <Divider style={styles.divider} />
         <Box style={Styles.collapseStyles([styles.menuGroup, props.listStyle])}>
@@ -169,6 +177,10 @@ const styles = Styles.styleSheetCreate(
       divider: {
         marginBottom: Styles.globalMargins.tiny,
       },
+      dividerInScrolleView: {
+        marginBottom: Styles.globalMargins.tiny,
+        marginTop: Styles.globalMargins.tiny,
+      },
       firstIsUnWrapped: {paddingTop: 0},
       flexOne: {
         flex: 1,
@@ -193,6 +205,9 @@ const styles = Styles.styleSheetCreate(
         height: itemContainerHeight,
         justifyContent: 'center',
         position: 'relative',
+      },
+      itemContainerWithSubTitle: {
+        height: itemContainerHeightWithSubTitle,
       },
       itemContainerWrapped: {
         paddingBottom: Styles.globalMargins.tiny,
@@ -225,8 +240,8 @@ const styles = Styles.styleSheetCreate(
       },
       scrollView: {
         flexGrow: 1,
-        paddingBottom: Styles.globalMargins.tiny,
-        paddingTop: Styles.globalMargins.tiny,
+        marginBottom: Styles.globalMargins.tiny,
+        marginTop: Styles.globalMargins.tiny,
       },
     } as const)
 )


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. It moves destructive chat message menu items to the bottom of menus (think, Delete message/attachment, Kick user, Block user, etc.). It also cleans up some styles and adds a Cancel button to Kick/Block modal on desktop.