### PR TITLE
member page: close when removed

### DIFF
--- a/shared/teams/team/member/index.tsx
+++ b/shared/teams/team/member/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Types from '../../../constants/types/teams'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
+import * as Container from '../../../util/container'
 import {FloatingRolePicker, roleIconMap} from '../../role-picker'
 import {useTeamDetailsSubscribe} from '../../subscriber'
 
@@ -38,10 +39,22 @@ export type MemberProps = {
 
 export type Props = MemberProps & RolePickerSpecificProps
 
+const useCloseIfNoLongerInTeam = (type: Types.TeamRoleType | null) => {
+  const prevType = Container.usePrevious(type)
+  const dispatch = Container.useDispatch()
+  const nav = Container.useSafeNavigation()
+  React.useEffect(() => {
+    if (type === null && prevType !== null) {
+      dispatch(nav.safeNavigateUpPayload())
+    }
+  })
+}
+
 export const TeamMember = (props: Props) => {
   useTeamDetailsSubscribe(props.teamID)
   const {user, you} = props
   const iconType = user.type && roleIconMap[user.type]
+  useCloseIfNoLongerInTeam(user.type)
   return (
     <Kb.Box style={{...Styles.globalStyles.flexBoxColumn, alignItems: 'center', flex: 1}}>
       <Kb.Box


### PR DESCRIPTION
Close the member page when you get removed from the team (test with flags.teamsRedesign off)

cc @keybase/y2ksquad 