### PR TITLE
Set initial conversations in add members wizard confirm screen

### DIFF
--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -373,6 +373,11 @@
       "_description": "Remove a pending member from the add members wizard.",
       "assertion": "string"
     },
+    "addMembersWizardSetDefaultChannels": {
+      "_description": "Change the set of default channels we're adding these users to.",
+      "toAdd?": "Array<Types.ChannelNameID>",
+      "toRemove?": "Types.ChannelNameID"
+    },
     "cancelAddMembersWizard": {
       "_description": "Nav away from add members wizard and clear related state."
     },

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -10,6 +10,7 @@ export const resetStore = 'common:resetStore' // not a part of teams but is hand
 export const typePrefix = 'teams:'
 export const addMembersWizardPushMembers = 'teams:addMembersWizardPushMembers'
 export const addMembersWizardRemoveMember = 'teams:addMembersWizardRemoveMember'
+export const addMembersWizardSetDefaultChannels = 'teams:addMembersWizardSetDefaultChannels'
 export const addParticipant = 'teams:addParticipant'
 export const addTeamWithChosenChannels = 'teams:addTeamWithChosenChannels'
 export const addToTeam = 'teams:addToTeam'
@@ -114,6 +115,10 @@ export const uploadTeamAvatar = 'teams:uploadTeamAvatar'
 // Payload Types
 type _AddMembersWizardPushMembersPayload = {readonly members: Array<Types.AddingMember>}
 type _AddMembersWizardRemoveMemberPayload = {readonly assertion: string}
+type _AddMembersWizardSetDefaultChannelsPayload = {
+  readonly toAdd?: Array<Types.ChannelNameID>
+  readonly toRemove?: Types.ChannelNameID
+}
 type _AddParticipantPayload = {
   readonly teamID: Types.TeamID
   readonly conversationIDKey: ChatTypes.ConversationIDKey
@@ -388,6 +393,12 @@ type _UploadTeamAvatarPayload = {
 export const createAddMembersWizardPushMembers = (
   payload: _AddMembersWizardPushMembersPayload
 ): AddMembersWizardPushMembersPayload => ({payload, type: addMembersWizardPushMembers})
+/**
+ * Change the set of default channels we're adding these users to.
+ */
+export const createAddMembersWizardSetDefaultChannels = (
+  payload: _AddMembersWizardSetDefaultChannelsPayload = Object.freeze({})
+): AddMembersWizardSetDefaultChannelsPayload => ({payload, type: addMembersWizardSetDefaultChannels})
 /**
  * Don't eagerly reload team list anymore.
  */
@@ -816,6 +827,10 @@ export type AddMembersWizardRemoveMemberPayload = {
   readonly payload: _AddMembersWizardRemoveMemberPayload
   readonly type: typeof addMembersWizardRemoveMember
 }
+export type AddMembersWizardSetDefaultChannelsPayload = {
+  readonly payload: _AddMembersWizardSetDefaultChannelsPayload
+  readonly type: typeof addMembersWizardSetDefaultChannels
+}
 export type AddParticipantPayload = {
   readonly payload: _AddParticipantPayload
   readonly type: typeof addParticipant
@@ -1165,6 +1180,7 @@ export type UploadTeamAvatarPayload = {
 export type Actions =
   | AddMembersWizardPushMembersPayload
   | AddMembersWizardRemoveMemberPayload
+  | AddMembersWizardSetDefaultChannelsPayload
   | AddParticipantPayload
   | AddTeamWithChosenChannelsPayload
   | AddToTeamPayload

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -984,6 +984,7 @@ export type TypedActionsMap = {
   'teams:setAddMembersWizardIndividualRole': teams.SetAddMembersWizardIndividualRolePayload
   'teams:addMembersWizardPushMembers': teams.AddMembersWizardPushMembersPayload
   'teams:addMembersWizardRemoveMember': teams.AddMembersWizardRemoveMemberPayload
+  'teams:addMembersWizardSetDefaultChannels': teams.AddMembersWizardSetDefaultChannelsPayload
   'teams:cancelAddMembersWizard': teams.CancelAddMembersWizardPayload
   'teams:finishAddMembersWizard': teams.FinishAddMembersWizardPayload
   'teams:setJustFinishedAddMembersWizard': teams.SetJustFinishedAddMembersWizardPayload

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -164,6 +164,7 @@ export const makeRetentionPolicy = (r?: Partial<RetentionPolicy>): RetentionPoli
 
 export const addMembersWizardEmptyState: Types.State['addMembersWizard'] = {
   addingMembers: [],
+  defaultChannels: undefined,
   justFinished: false,
   role: 'writer',
   teamID: Types.noTeamID,

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -154,8 +154,9 @@ export type NewTeamWizardState = {
 
 export type AddingMember = {assertion: string; role: TeamRoleType}
 export type AddMembersWizardState = {
-  justFinished: boolean
   addingMembers: Array<AddingMember>
+  defaultChannels: Array<ChannelNameID> | undefined // undefined -> unchanged from default
+  justFinished: boolean
   role: TeamRoleType | undefined // undefined -> role set individually
   teamID: TeamID
 }

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -347,6 +347,24 @@ export default Container.makeReducer<
   [TeamsGen.finishAddMembersWizard]: draftState => {
     draftState.addMembersWizard = {...Constants.addMembersWizardEmptyState, justFinished: true}
   },
+  [TeamsGen.addMembersWizardSetDefaultChannels]: (draftState, action) => {
+    const {toAdd, toRemove} = action.payload
+    if (!draftState.addMembersWizard.defaultChannels) {
+      // we're definitely setting these manually now
+      draftState.addMembersWizard.defaultChannels = []
+    }
+    const defaultChannels = draftState.addMembersWizard.defaultChannels
+    toAdd?.forEach(channel => {
+      if (!defaultChannels.find(dc => dc.conversationIDKey === channel.conversationIDKey)) {
+        defaultChannels?.push(channel)
+      }
+    })
+    const maybeRemoveIdx =
+      (toRemove && defaultChannels.findIndex(dc => dc.conversationIDKey === toRemove.conversationIDKey)) ?? -1
+    if (maybeRemoveIdx >= 0) {
+      defaultChannels.splice(maybeRemoveIdx, 1)
+    }
+  },
   [TeamsGen.setNewTeamRequests]: (draftState, action) => {
     draftState.newTeamRequests = action.payload.newTeamRequests
   },

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -317,6 +317,10 @@ const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
   const defaultChannelsFromStore = Container.useSelector(s => s.teams.addMembersWizard.defaultChannels)
   const onChangeFromDefault = () =>
     dispatch(TeamsGen.createAddMembersWizardSetDefaultChannels({toAdd: defaultChannels}))
+  const onAdd = (toAdd: Array<Types.ChannelNameID>) =>
+    dispatch(TeamsGen.createAddMembersWizardSetDefaultChannels({toAdd}))
+  const onRemove = (toRemove: Types.ChannelNameID) =>
+    dispatch(TeamsGen.createAddMembersWizardSetDefaultChannels({toRemove}))
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny">
       <Kb.Text type="BodySmallSemibold">Join channels</Kb.Text>
@@ -328,8 +332,8 @@ const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
             disableGeneral={true}
             teamID={teamID}
             channels={defaultChannelsFromStore}
-            onAddChannel={() => {}}
-            onRemoveChannel={() => {}}
+            onAddChannel={onAdd}
+            onRemoveChannel={onRemove}
           />
         ) : (
           <>

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -2,12 +2,14 @@ import * as React from 'react'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
+import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 import * as TeamsGen from '../../actions/teams-gen'
 import * as RPCGen from '../../constants/types/rpc-gen'
 import {appendNewTeamBuilder, appendTeamsContactsTeamBuilder} from '../../actions/typed-routes'
 import capitalize from 'lodash/capitalize'
 import {FloatingRolePicker} from '../role-picker'
+import {useDefaultChannels} from '../team/settings-tab/default-channels'
 import {ModalTitle} from '../common'
 import {pluralize} from '../../util/string'
 import logger from '../../logger'
@@ -17,6 +19,7 @@ const AddMembersConfirm = () => {
 
   const {teamID, addingMembers} = Container.useSelector(s => s.teams.addMembersWizard)
   const fromNewTeamWizard = teamID === Types.newTeamWizardTeamID
+  const isBigTeam = Container.useSelector(s => (fromNewTeamWizard ? false : Constants.isBigTeam(s, teamID)))
   const noun = addingMembers.length === 1 ? 'person' : 'people'
   const onlyEmails = React.useMemo(
     () =>
@@ -91,19 +94,7 @@ const AddMembersConfirm = () => {
             <RoleSelector />
           </Kb.Box2>
         </Kb.Box2>
-        <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny">
-          <Kb.Text type="BodySmallSemibold">Join channels</Kb.Text>
-          <Kb.Box2 direction="vertical" fullWidth={true}>
-            <Kb.Text type="BodySmall">Your invitees will be added to 3 channels.</Kb.Text>
-            <Kb.Text type="BodySmall">
-              {/* TODO: Hook this up when default channels settings are hooked up */}
-              <Kb.Text type="BodySmallBold">#general</Kb.Text>,{' '}
-              <Kb.Text type="BodySmallBold">#random</Kb.Text>, and{' '}
-              <Kb.Text type="BodySmallBold">#hellos</Kb.Text>.{' '}
-              <Kb.Text type="BodySmallPrimaryLink">Change this</Kb.Text>
-            </Kb.Text>
-          </Kb.Box2>
-        </Kb.Box2>
+        {isBigTeam && <DefaultChannels teamID={teamID} />}
         {onlyEmails && (
           <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny">
             <Kb.Text type="BodySmallSemibold">Custom note</Kb.Text>
@@ -315,6 +306,37 @@ const AddingMember = (props: Types.AddingMember & {lastMember?: boolean}) => {
           </FloatingRolePicker>
         )}
         {props.lastMember !== true && <Kb.Icon type="iconfont-remove" sizeType="Small" onClick={onRemove} />}
+      </Kb.Box2>
+    </Kb.Box2>
+  )
+}
+
+const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
+  const {defaultChannels, defaultChannelsWaiting} = useDefaultChannels(teamID)
+  return (
+    <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny">
+      <Kb.Text type="BodySmallSemibold">Join channels</Kb.Text>
+      <Kb.Box2 direction="vertical" fullWidth={true}>
+        {defaultChannelsWaiting ? (
+          <Kb.ProgressIndicator />
+        ) : (
+          <>
+            <Kb.Text type="BodySmall">
+              Your invitees will be added to {defaultChannels.length}{' '}
+              {pluralize('channel', defaultChannels.length)}.
+            </Kb.Text>
+            <Kb.Text type="BodySmall">
+              {defaultChannels.map((channel, index) => (
+                <Kb.Text key={channel.conversationIDKey} type="BodySmallSemibold">
+                  #{channel.channelname}
+                  {defaultChannels.length > 2 && index < defaultChannels.length - 1 && ', '}
+                  {index === defaultChannels.length - 2 && <Kb.Text type="BodySmall"> and </Kb.Text>}
+                </Kb.Text>
+              ))}
+              . <Kb.Text type="BodySmallPrimaryLink">Change this</Kb.Text>
+            </Kb.Text>
+          </>
+        )}
       </Kb.Box2>
     </Kb.Box2>
   )

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -10,7 +10,7 @@ import {appendNewTeamBuilder, appendTeamsContactsTeamBuilder} from '../../action
 import capitalize from 'lodash/capitalize'
 import {FloatingRolePicker} from '../role-picker'
 import {useDefaultChannels} from '../team/settings-tab/default-channels'
-import {ModalTitle} from '../common'
+import {ModalTitle, ChannelsWidget} from '../common'
 import {pluralize} from '../../util/string'
 import logger from '../../logger'
 
@@ -311,14 +311,39 @@ const AddingMember = (props: Types.AddingMember & {lastMember?: boolean}) => {
   )
 }
 
+// keep it in the module so we don't reload if we loop back to this page
+// let defaultChannelsCache: null | {channels: Array<Types.ChannelNameID>; teamID: Types.TeamID} = null
+// const emptyArray = []
 const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
   const {defaultChannels, defaultChannelsWaiting} = useDefaultChannels(teamID)
+  const [changing, setChanging] = React.useState(false)
+  // React.useEffect(() => {
+  //   if (_defaultChannels.length) {
+  //     defaultChannelsCache = {
+  //       channels: _defaultChannels,
+  //       teamID,
+  //     }
+  //   }
+  // }, [_defaultChannels, teamID])
+  // const defaultChannels = _defaultChannels.length
+  //   ? _defaultChannels
+  //   : defaultChannelsCache?.teamID === teamID
+  //   ? defaultChannelsCache.channels
+  //   : emptyArray
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny">
       <Kb.Text type="BodySmallSemibold">Join channels</Kb.Text>
       <Kb.Box2 direction="vertical" fullWidth={true}>
         {defaultChannelsWaiting ? (
           <Kb.ProgressIndicator />
+        ) : changing ? (
+          <ChannelsWidget
+            disableGeneral={true}
+            teamID={teamID}
+            channels={defaultChannels}
+            onAddChannel={() => {}}
+            onRemoveChannel={() => {}}
+          />
         ) : (
           <>
             <Kb.Text type="BodySmall">
@@ -333,7 +358,10 @@ const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
                   {index === defaultChannels.length - 2 && <Kb.Text type="BodySmall"> and </Kb.Text>}
                 </Kb.Text>
               ))}
-              . <Kb.Text type="BodySmallPrimaryLink">Change this</Kb.Text>
+              .{' '}
+              <Kb.Text type="BodySmallPrimaryLink" onClick={() => setChanging(true)}>
+                Change this
+              </Kb.Text>
             </Kb.Text>
           </>
         )}

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -311,36 +311,23 @@ const AddingMember = (props: Types.AddingMember & {lastMember?: boolean}) => {
   )
 }
 
-// keep it in the module so we don't reload if we loop back to this page
-// let defaultChannelsCache: null | {channels: Array<Types.ChannelNameID>; teamID: Types.TeamID} = null
-// const emptyArray = []
 const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
+  const dispatch = Container.useDispatch()
   const {defaultChannels, defaultChannelsWaiting} = useDefaultChannels(teamID)
-  const [changing, setChanging] = React.useState(false)
-  // React.useEffect(() => {
-  //   if (_defaultChannels.length) {
-  //     defaultChannelsCache = {
-  //       channels: _defaultChannels,
-  //       teamID,
-  //     }
-  //   }
-  // }, [_defaultChannels, teamID])
-  // const defaultChannels = _defaultChannels.length
-  //   ? _defaultChannels
-  //   : defaultChannelsCache?.teamID === teamID
-  //   ? defaultChannelsCache.channels
-  //   : emptyArray
+  const defaultChannelsFromStore = Container.useSelector(s => s.teams.addMembersWizard.defaultChannels)
+  const onChangeFromDefault = () =>
+    dispatch(TeamsGen.createAddMembersWizardSetDefaultChannels({toAdd: defaultChannels}))
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} gap="xtiny">
       <Kb.Text type="BodySmallSemibold">Join channels</Kb.Text>
       <Kb.Box2 direction="vertical" fullWidth={true}>
         {defaultChannelsWaiting ? (
           <Kb.ProgressIndicator />
-        ) : changing ? (
+        ) : defaultChannelsFromStore ? (
           <ChannelsWidget
             disableGeneral={true}
             teamID={teamID}
-            channels={defaultChannels}
+            channels={defaultChannelsFromStore}
             onAddChannel={() => {}}
             onRemoveChannel={() => {}}
           />
@@ -359,7 +346,7 @@ const DefaultChannels = ({teamID}: {teamID: Types.TeamID}) => {
                 </Kb.Text>
               ))}
               .{' '}
-              <Kb.Text type="BodySmallPrimaryLink" onClick={() => setChanging(true)}>
+              <Kb.Text type="BodySmallPrimaryLink" onClick={onChangeFromDefault}>
                 Change this
               </Kb.Text>
             </Kb.Text>


### PR DESCRIPTION
Known issue: TRIAGE-2531

Hook up the channels selector in add members confirm. Call `bulkAddToManyConvs` after `addMembersMultiRole` with our selection. cc @keybase/y2ksquad 