### PR TITLE
iPad: tweaks for settings tabs

### DIFF
--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -29,7 +29,12 @@ export type Props = {
 }
 
 export const SettingsSection = ({children}: {children: React.ReactNode}) => (
-  <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
+  <Kb.Box2
+    direction="vertical"
+    gap="tiny"
+    fullWidth={true}
+    style={Styles.isPhone ? styles.sectionPhone : styles.sectionDesktopTablet}
+  >
     {children}
   </Kb.Box2>
 )
@@ -241,8 +246,8 @@ const styles = Styles.styleSheetCreate(() => ({
     height: 16,
     width: 16,
   },
-  section: Styles.platformStyles({
-    isElectron: {
+  sectionDesktopTablet: Styles.platformStyles({
+    common: {
       ...Styles.padding(
         Styles.globalMargins.small,
         Styles.globalMargins.mediumLarge,
@@ -251,10 +256,13 @@ const styles = Styles.styleSheetCreate(() => ({
       ),
       maxWidth: 600,
     },
-    isMobile: {
-      ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.small, Styles.globalMargins.medium),
+    isTablet: {
+      maxWidth: Styles.globalStyles.largeWidthPercent,
     },
   }),
+  sectionPhone: {
+    ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.small, Styles.globalMargins.medium),
+  },
   topButton: {
     marginTop: Styles.globalMargins.xtiny,
   },

--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -253,11 +253,11 @@ const styles = Styles.styleSheetCreate(() => ({
     isElectron: {
       maxWidth: 600,
     },
-    isTablet: {
-      maxWidth: Styles.globalStyles.largeWidthPercent,
-    },
     isPhone: {
       ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.small, Styles.globalMargins.medium),
+    },
+    isTablet: {
+      maxWidth: Styles.globalStyles.largeWidthPercent,
     },
   }),
   topButton: {

--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -29,12 +29,7 @@ export type Props = {
 }
 
 export const SettingsSection = ({children}: {children: React.ReactNode}) => (
-  <Kb.Box2
-    direction="vertical"
-    gap="tiny"
-    fullWidth={true}
-    style={Styles.isPhone ? styles.sectionPhone : styles.sectionDesktopTablet}
-  >
+  <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} style={styles.section}>
     {children}
   </Kb.Box2>
 )
@@ -246,7 +241,7 @@ const styles = Styles.styleSheetCreate(() => ({
     height: 16,
     width: 16,
   },
-  sectionDesktopTablet: Styles.platformStyles({
+  section: Styles.platformStyles({
     common: {
       ...Styles.padding(
         Styles.globalMargins.small,
@@ -254,15 +249,17 @@ const styles = Styles.styleSheetCreate(() => ({
         Styles.globalMargins.medium,
         Styles.globalMargins.small
       ),
+    },
+    isElectron: {
       maxWidth: 600,
     },
     isTablet: {
       maxWidth: Styles.globalStyles.largeWidthPercent,
     },
+    isPhone: {
+      ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.small, Styles.globalMargins.medium),
+    },
   }),
-  sectionPhone: {
-    ...Styles.padding(Styles.globalMargins.small, Styles.globalMargins.small, Styles.globalMargins.medium),
-  },
   topButton: {
     marginTop: Styles.globalMargins.xtiny,
   },

--- a/shared/settings/chat/index.tsx
+++ b/shared/settings/chat/index.tsx
@@ -384,15 +384,17 @@ const styles = Styles.styleSheetCreate(() => ({
       borderRadius: Styles.borderRadius,
       borderStyle: 'solid',
       borderWidth: 1,
+      height: 150,
     },
     isElectron: {
-      height: 150,
       marginLeft: 22,
       minWidth: 305,
     },
-    isMobile: {
-      height: 150,
+    isPhone: {
       width: '100%',
+    },
+    isTablet: {
+      width: Styles.globalStyles.largeWidthPercent,
     },
   }),
   whitelistRowContainer: {

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -143,7 +143,12 @@ class Feedback extends React.Component<Props, State> {
               gap="tiny"
             >
               <Kb.ButtonBar>
-                <Kb.Button label="Send" onClick={this._onSendFeedback} waiting={sending} fullWidth={true} />
+                <Kb.Button
+                  label="Send"
+                  onClick={this._onSendFeedback}
+                  waiting={sending}
+                  fullWidth={!Styles.isTablet}
+                />
               </Kb.ButtonBar>
             </Kb.Box2>
             {sendError && (
@@ -193,8 +198,8 @@ const styles = Styles.styleSheetCreate(
           width: '100%',
         },
         isTablet: {
-          maxWidth: Styles.globalStyles.mediumWidth,
-          width: '100%',
+          alignSelf: 'flex-start',
+          width: Styles.globalStyles.largeWidthPercent,
         },
       }),
       outerStyle: {backgroundColor: Styles.globalColors.white},

--- a/shared/settings/files/index.native.tsx
+++ b/shared/settings/files/index.native.tsx
@@ -71,7 +71,12 @@ const Files = (props: Props) => {
   )
   return (
     <Kb.HeaderHocWrapper title="Files" onBack={props.onBack} skipHeader={!Styles.isPhone}>
-      <Kb.Box2 direction="vertical" fullWidth={true} alignItems="center" gap="small">
+      <Kb.Box2
+        direction="vertical"
+        fullWidth={true}
+        alignItems={Styles.isTablet ? 'flex-start' : 'center'}
+        gap="small"
+      >
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.syncContent} gap="tiny">
           <Kb.Text type="Header">Sync</Kb.Text>
           <Kb.Switch

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -61,6 +61,7 @@ export declare const globalStyles: {
     width: '100%'
   }
   italic: _fakeFontDefSeeCommentsOnThisStyle
+  largeWidthPercent: string
   loadingTextStyle: CSS._StylesCrossPlatform
   mediumWidth: number | string
   opacity0: {opacity: 0}

--- a/shared/styles/index.desktop.tsx
+++ b/shared/styles/index.desktop.tsx
@@ -59,6 +59,7 @@ const font = {
 
 const util = {
   ...Shared.util,
+  largeWidthPercent: '70%',
   loadingTextStyle: {
     // this won't really work with dark mode
     backgroundColor: colors.greyLight,

--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -35,6 +35,7 @@ const font = isIOS
 
 const util = {
   ...Shared.util,
+  largeWidthPercent: '70%',
   loadingTextStyle: {
     backgroundColor: globalColors.greyLight,
     height: 16,


### PR DESCRIPTION
@keybase/react-hackers @keybase/design 

Many iPad settings sub-tabs had their content center-aligned, like it is on phone, instead of left-aligned with a maxWidth (but with dividers still full-width), like it is on desktop.  Examples of fixed screens:

<img width="1311" alt="Screen Shot 2020-03-31 at 4 47 34 PM" src="https://user-images.githubusercontent.com/21217/78085647-68ccb900-7370-11ea-8cd6-b23632becdc1.png">

<img width="1033" alt="Screen Shot 2020-03-31 at 4 55 30 PM" src="https://user-images.githubusercontent.com/21217/78085663-72eeb780-7370-11ea-8e62-d274218a7cad.png">

<img width="1311" alt="Screen Shot 2020-03-31 at 4 47 50 PM" src="https://user-images.githubusercontent.com/21217/78085668-78e49880-7370-11ea-915a-df476a7fd1e5.png">

<img width="1311" alt="Screen Shot 2020-03-31 at 4 57 58 PM" src="https://user-images.githubusercontent.com/21217/78085798-d547b800-7370-11ea-81fc-5060cf7cce74.png">

<img width="1311" alt="Screen Shot 2020-03-31 at 4 47 40 PM" src="https://user-images.githubusercontent.com/21217/78085683-839f2d80-7370-11ea-8d58-3f92c1924823.png">
