### PR TITLE
incoming share to kbfs tweaks

### DIFF
--- a/shared/constants/fs.tsx
+++ b/shared/constants/fs.tsx
@@ -971,3 +971,14 @@ export const hasSpecialFileElement = (path: Types.Path): boolean =>
 
 export const sfmiInfoLoaded = (settings: Types.Settings, driverStatus: Types.DriverStatus): boolean =>
   settings.loaded && driverStatus !== driverStatusUnknown
+
+// This isn't perfect since it doesn't cover the case of multi-writer public
+// TLFs or where a team TLF is readonly to the user. But to do that we'd need
+// some new caching in KBFS to plumb it into the Tlfs structure without
+// awful overhead.
+export const hideOrDisableInDestinationPicker = (
+  tlfType: Types.TlfType,
+  name: string,
+  username: string,
+  destinationPickerIndex?: number
+) => typeof destinationPickerIndex === 'number' && tlfType === Types.TlfType.Public && name !== username

--- a/shared/fs/browser/destination-picker/container.tsx
+++ b/shared/fs/browser/destination-picker/container.tsx
@@ -86,19 +86,29 @@ const ConnectedDestinationPicker = (ownProps: OwnProps) => {
     },
     _onNewFolder: destinationParentPath =>
       dispatch(FsGen.createNewFolderRow({parentPath: destinationParentPath})),
+    onBack: () => {
+      dispatch(RouteTreeGen.createNavigateUp())
+    },
     onCancel: () => {
       dispatch(RouteTreeGen.createClearModals())
     },
   }
 
+  const index = getIndex(ownProps)
+  const showHeaderBackInsteadOfCancel = isShare && index > 0
   const targetName = Constants.getDestinationPickerPathName(destPicker)
   const props = {
-    index: getIndex(ownProps),
+    index,
     isShare,
-    onBackUp: canBackUp(destPicker, ownProps)
-      ? () => dispatchProps._onBackUp(getDestinationParentPath(destPicker, ownProps))
-      : undefined,
-    onCancel: dispatchProps.onCancel,
+    // If we are are dealing with incoming share, the first view is root,
+    // so rely on the header back burtton instead of showing a separate row
+    // for going to parent directory.
+    onBack: showHeaderBackInsteadOfCancel ? dispatchProps.onBack : undefined,
+    onBackUp:
+      isShare || !canBackUp(destPicker, ownProps)
+        ? undefined
+        : () => dispatchProps._onBackUp(getDestinationParentPath(destPicker, ownProps)),
+    onCancel: showHeaderBackInsteadOfCancel ? undefined : dispatchProps.onCancel,
     onCopyHere: canCopy(destPicker, pathItems, ownProps)
       ? () => dispatchProps._onCopyHere(getDestinationParentPath(destPicker, ownProps))
       : undefined,

--- a/shared/fs/browser/destination-picker/index.tsx
+++ b/shared/fs/browser/destination-picker/index.tsx
@@ -14,6 +14,7 @@ type Props = {
   isShare: boolean
   parentPath: Types.Path
   targetName: string
+  onBack?: () => void
   onCancel?: () => void
   onCopyHere?: () => void
   onMoveHere?: () => void
@@ -57,6 +58,7 @@ const DestinationPicker = (props: Props) => {
   FsCommon.useFsOnlineStatus()
   return (
     <Kb.PopupWrapper
+      onBack={props.onBack}
       onCancel={props.onCancel}
       customComponent={props.customComponent}
       headerStyle={props.headerStyle}
@@ -128,11 +130,18 @@ const DestinationPicker = (props: Props) => {
 const HighOrderDestinationPickerMobile = (props: Props) => {
   const otherProps = {
     customComponent: (
-      <Kb.Box2 direction="horizontal" fullWidth={true}>
-        <Kb.ClickableBox style={styles.mobileHeaderButton} onClick={props.onCancel || undefined}>
-          <Kb.Text type="BodyBigLink">Cancel</Kb.Text>
-        </Kb.ClickableBox>
-        <Kb.Box2 direction="vertical" centerChildren={true} style={styles.mobileHeaderContent}>
+      <Kb.Box2 direction="horizontal" fullWidth={true} style={{position: 'relative'}} centerChildren={true}>
+        {!!props.onCancel && (
+          <Kb.ClickableBox style={styles.mobileHeaderButton} onClick={props.onCancel}>
+            <Kb.Text type="BodyBigLink">Cancel</Kb.Text>
+          </Kb.ClickableBox>
+        )}
+        {!!props.onBack && (
+          <Kb.ClickableBox style={styles.mobileHeaderButton} onClick={props.onBack}>
+            <Kb.Text type="BodyBigLink">Back</Kb.Text>
+          </Kb.ClickableBox>
+        )}
+        <Kb.Box2 direction="vertical" centerChildren={true}>
           <Kb.Box2 direction="horizontal" centerChildren={true} gap="xtiny">
             <FsCommon.ItemIcon size={16} path={Types.pathConcat(props.parentPath, props.targetName)} />
             <FsCommon.Filename type="BodySmallSemibold" filename={props.targetName} />
@@ -194,13 +203,9 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       mobileHeaderButton: {
-        paddingBottom: 8,
-        paddingLeft: Styles.globalMargins.small,
-        paddingRight: Styles.globalMargins.small,
-        paddingTop: 8,
-      },
-      mobileHeaderContent: {
-        paddingRight: 90, // width of the "Cancel" button
+        left: 0,
+        padding: Styles.globalMargins.small,
+        position: 'absolute',
       },
       newFolderBox: {
         ...Styles.globalStyles.flexBoxRow,

--- a/shared/fs/browser/rows/index.stories.tsx
+++ b/shared/fs/browser/rows/index.stories.tsx
@@ -342,6 +342,7 @@ const load = () => {
         </WrapRow>
         <WrapRow key="19">
           <TlfRow
+            disabled={false}
             path={Types.stringToPath('/keybase/private/alice,bob,charlie')}
             isIgnored={false}
             onOpen={Sb.action('onOpen')}
@@ -350,6 +351,7 @@ const load = () => {
         </WrapRow>
         <WrapRow key="20">
           <TlfRow
+            disabled={false}
             path={Types.stringToPath('/keybase/private/alice,bob,charlie')}
             isIgnored={false}
             onOpen={Sb.action('onOpen')}
@@ -358,6 +360,16 @@ const load = () => {
         </WrapRow>
         <WrapRow key="21">
           <TlfRow
+            disabled={false}
+            path={Types.stringToPath('/keybase/private/alice,bob,charlie,david,eve,felicity,george')}
+            isIgnored={false}
+            onOpen={Sb.action('onOpen')}
+            usernames={['bob', 'charlie', 'david', 'eve', 'felicity', 'george']}
+          />
+        </WrapRow>
+        <WrapRow key="22">
+          <TlfRow
+            disabled={true}
             path={Types.stringToPath('/keybase/private/alice,bob,charlie,david,eve,felicity,george')}
             isIgnored={false}
             onOpen={Sb.action('onOpen')}

--- a/shared/fs/browser/rows/rows.tsx
+++ b/shared/fs/browser/rows/rows.tsx
@@ -45,9 +45,11 @@ class Rows extends React.PureComponent<Props> {
           </WrapRow>
         )
       case RowTypes.RowType.Tlf:
+        console.log({songgao: 'rows', ...item})
         return (
           <WrapRow>
             <Tlf
+              disabled={item.disabled}
               name={item.name}
               tlfType={item.tlfType}
               destinationPickerIndex={this.props.destinationPickerIndex}

--- a/shared/fs/browser/rows/rows.tsx
+++ b/shared/fs/browser/rows/rows.tsx
@@ -45,7 +45,6 @@ class Rows extends React.PureComponent<Props> {
           </WrapRow>
         )
       case RowTypes.RowType.Tlf:
-        console.log({songgao: 'rows', ...item})
         return (
           <WrapRow>
             <Tlf

--- a/shared/fs/browser/rows/tlf-container.tsx
+++ b/shared/fs/browser/rows/tlf-container.tsx
@@ -7,6 +7,7 @@ import Tlf from './tlf'
 
 export type OwnProps = {
   destinationPickerIndex?: number
+  disabled: boolean
   mixedMode?: boolean
   name: string
   tlfType: Types.TlfType
@@ -17,11 +18,16 @@ const mapStateToProps = (state, {tlfType, name}: OwnProps) => ({
   _username: state.config.username,
 })
 
-const mergeProps = (stateProps, _, {tlfType, name, mixedMode, destinationPickerIndex}: OwnProps) => {
+const mergeProps = (
+  stateProps,
+  _,
+  {tlfType, name, mixedMode, destinationPickerIndex, disabled}: OwnProps
+) => {
   const path = Constants.tlfTypeAndNameToPath(tlfType, name)
   const usernames = Constants.getUsernamesFromTlfName(name).filter(name => name !== stateProps._username)
   return {
     destinationPickerIndex,
+    disabled,
     isIgnored: stateProps._tlf.isIgnored,
     loadPathMetadata:
       stateProps._tlf.syncConfig && stateProps._tlf.syncConfig.mode !== Types.TlfSyncMode.Disabled,

--- a/shared/fs/browser/rows/tlf.tsx
+++ b/shared/fs/browser/rows/tlf.tsx
@@ -13,11 +13,17 @@ type TlfProps = StillCommonProps & {
   isIgnored: boolean
   mixedMode?: boolean
   usernames: Array<string>
+  disabled: boolean
 }
 
 const Content = (props: TlfProps) => (
   <Kb.BoxGrow>
-    <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.leftBox}>
+    <Kb.Box2
+      direction="vertical"
+      fullWidth={true}
+      fullHeight={true}
+      style={Styles.collapseStyles([styles.leftBox, props.disabled && rowStyles.opacity30])}
+    >
       <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.minWidth}>
         <Filename
           type={Constants.pathTypeToTextType(Types.PathType.Folder)}
@@ -49,7 +55,7 @@ const Tlf = (props: TlfProps) => (
     {!!props.loadPathMetadata && <FsPathMetadataLoader path={props.path} />}
     <StillCommon
       path={props.path}
-      onOpen={props.onOpen}
+      onOpen={props.disabled ? undefined : props.onOpen}
       inDestinationPicker={props.inDestinationPicker}
       mixedMode={props.mixedMode}
       writingToJournal={false}

--- a/shared/fs/browser/rows/types.tsx
+++ b/shared/fs/browser/rows/types.tsx
@@ -19,6 +19,7 @@ export type TlfTypeRowItem = {
 }
 
 export type TlfRowItem = {
+  disabled: boolean
   isNew: boolean
   key: string
   name: string


### PR DESCRIPTION
changes to KBFS destination picker for incoming shares:

* hide non-self public TLFs in recent TLFs section
* gray out and disable non-self public TLFs under public list
* get rid of the back up button, and replace that with a back button in header area. We need that for move/copy because user could start from a non-root position and they need to be able to back out. That's not true for incoming shares where user always starts from /keybase.