### PR TITLE
Tweaks on exploding messages, edit mode, chat input buttons

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -221,13 +221,15 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
                     {formatDurationShort(this.props.explodingModeSeconds * 1000)}
                   </Kb.Text>
                 ) : (
-                  <Kb.Icon
-                    className="timer"
-                    colorOverride={this.props.cannotWrite ? Styles.globalColors.black_20 : null}
-                    onClick={this.props.cannotWrite ? undefined : this._toggleShowingMenu}
-                    padding="xtiny"
-                    type="iconfont-timer"
-                  />
+                  <Kb.WithTooltip tooltip="Timer">
+                    <Kb.Icon
+                      className="timer"
+                      colorOverride={this.props.cannotWrite ? Styles.globalColors.black_20 : null}
+                      onClick={this.props.cannotWrite ? undefined : this._toggleShowingMenu}
+                      padding="xtiny"
+                      type="iconfont-timer"
+                    />
+                  </Kb.WithTooltip>
                 )}
               </HoverBox>
             )}
@@ -277,22 +279,35 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
               />
             )}
             {!this.props.cannotWrite && this.props.showWalletsIcon && (
-              <WalletsIcon
-                size={16}
-                style={styles.walletsIcon}
-                conversationIDKey={this.props.conversationIDKey}
-              />
+              <Kb.WithTooltip tooltip="Lumens">
+                <WalletsIcon
+                  size={16}
+                  style={styles.walletsIcon}
+                  conversationIDKey={this.props.conversationIDKey}
+                />
+              </Kb.WithTooltip>
             )}
             {!this.props.cannotWrite && (
               <>
-                <Kb.Icon onClick={this.props.onGiphyToggle} style={styles.icon} type="iconfont-gif" />
-                <Kb.Icon
-                  color={this.state.emojiPickerOpen ? Styles.globalColors.black : null}
-                  onClick={this._emojiPickerToggle}
-                  style={styles.icon}
-                  type="iconfont-emoji"
-                />
-                <Kb.Icon onClick={this._filePickerOpen} style={styles.icon} type="iconfont-attachment" />
+                <Kb.WithTooltip tooltip="GIF">
+                  <Kb.Box style={styles.icon}>
+                    <Kb.Icon onClick={this.props.onGiphyToggle} type="iconfont-gif" />
+                  </Kb.Box>
+                </Kb.WithTooltip>
+                <Kb.WithTooltip tooltip="Emoji">
+                  <Kb.Box style={styles.icon}>
+                    <Kb.Icon
+                      color={this.state.emojiPickerOpen ? Styles.globalColors.black : null}
+                      onClick={this._emojiPickerToggle}
+                      type="iconfont-emoji"
+                    />
+                  </Kb.Box>
+                </Kb.WithTooltip>
+                <Kb.WithTooltip tooltip="Attachment">
+                  <Kb.Box style={styles.icon}>
+                    <Kb.Icon onClick={this._filePickerOpen} type="iconfont-attachment" />
+                  </Kb.Box>
+                </Kb.WithTooltip>
               </>
             )}
           </Kb.Box>
@@ -417,9 +432,10 @@ const styles = Styles.styleSheetCreate(
         display: 'none',
       },
       icon: {
-        bottom: 6,
-        marginRight: Styles.globalMargins.tiny,
-        position: 'relative',
+        alignSelf: 'flex-end',
+        marginBottom: 2,
+        marginRight: Styles.globalMargins.xtiny,
+        padding: Styles.globalMargins.xtiny,
       },
       input: Styles.platformStyles({
         isElectron: {
@@ -451,11 +467,12 @@ const styles = Styles.styleSheetCreate(
         borderWidth: 1,
         marginLeft: Styles.globalMargins.small,
         marginRight: Styles.globalMargins.small,
+        paddingRight: Styles.globalMargins.xtiny,
       },
       walletsIcon: {
         alignSelf: 'flex-end',
-        marginBottom: 6,
-        marginRight: Styles.globalMargins.tiny,
+        marginBottom: 2,
+        marginRight: Styles.globalMargins.xtiny,
       },
     } as const)
 )

--- a/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.desktop.tsx
@@ -234,11 +234,13 @@ class _PlatformInput extends React.Component<PlatformInputPropsInternal, State> 
               </HoverBox>
             )}
             {this.props.isEditing && (
-              <Kb.Box onClick={this.props.onCancelEditing} style={styles.cancelEditing}>
-                <Kb.Text style={styles.cancelEditingText} type="BodySmallSemibold">
-                  Cancel
-                </Kb.Text>
-              </Kb.Box>
+              <Kb.Button
+                label="Cancel"
+                onClick={this.props.onCancelEditing}
+                small={true}
+                style={styles.cancelEditingBtn}
+                type="Dim"
+              />
             )}
             <input
               type="file"
@@ -356,24 +358,8 @@ const EmojiPicker = ({
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      cancelEditing: Styles.platformStyles({
-        common: {
-          ...Styles.globalStyles.flexBoxColumn,
-          alignSelf: 'stretch',
-          backgroundColor: Styles.globalColors.blackOrBlack,
-          borderRadius: 2,
-          justifyContent: 'center',
-          margin: 2,
-          marginRight: 0,
-          paddingLeft: Styles.globalMargins.tiny,
-          paddingRight: Styles.globalMargins.tiny,
-        },
-        isElectron: {
-          ...Styles.desktopStyles.clickable,
-        },
-      }),
-      cancelEditingText: {
-        color: Styles.globalColors.whiteOrWhite,
+      cancelEditingBtn: {
+        margin: Styles.globalMargins.xtiny,
       },
       container: {
         ...Styles.globalStyles.flexBoxColumn,

--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -378,7 +378,7 @@ const Buttons = (p: ButtonsProps) => {
       alignItems="center"
       style={styles.actionContainer}
     >
-      {isEditing && <Kb.Button mode="Secondary" small={true} onClick={onCancelEditing} label="Cancel" />}
+      {isEditing && <Kb.Button small={true} onClick={onCancelEditing} label="Cancel" type="Dim" />}
       {explodingIcon}
       <Kb.Box2 direction="vertical" style={Styles.globalStyles.flexGrow} />
       {!hasText && (

--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -264,6 +264,7 @@ class _PlatformInput extends React.PureComponent<PlatformInputPropsInternal, Sta
           direction="vertical"
           style={Styles.collapseStyles([
             styles.container,
+            isExploding && styles.explodingContainer,
             (this.state.expanded || this.state.animating) && {height: '100%', minHeight: 0},
           ])}
           fullWidth={true}
@@ -397,6 +398,8 @@ const Buttons = (p: ButtonsProps) => {
           onClick={onSubmit}
           disabled={!hasText}
           label={isEditing ? 'Save' : 'Send'}
+          labelStyle={isExploding ? styles.explodingSendBtnLabel : undefined}
+          style={isExploding ? styles.explodingSendBtn : undefined}
         />
       )}
     </Kb.Box2>
@@ -476,6 +479,15 @@ const styles = Styles.styleSheetCreate(
         borderRadius: Styles.globalMargins.mediumLarge / 2,
         height: 28,
         width: 28,
+      },
+      explodingContainer: {
+        borderTopColor: Styles.globalColors.black,
+      },
+      explodingSendBtn: {
+        backgroundColor: Styles.globalColors.black,
+      },
+      explodingSendBtnLabel: {
+        color: Styles.globalColors.white,
       },
       explodingText: {
         fontSize: 11,

--- a/shared/chat/conversation/input-area/normal/wallets-icon/index.tsx
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/index.tsx
@@ -53,6 +53,7 @@ const styles = Styles.styleSheetCreate(
       }),
       container: {
         position: 'relative',
+        padding: Styles.globalMargins.xtiny,
       },
       menuItemBox: Styles.platformStyles({
         common: {

--- a/shared/chat/conversation/input-area/normal/wallets-icon/index.tsx
+++ b/shared/chat/conversation/input-area/normal/wallets-icon/index.tsx
@@ -52,8 +52,8 @@ const styles = Styles.styleSheetCreate(
         },
       }),
       container: {
-        position: 'relative',
         padding: Styles.globalMargins.xtiny,
+        position: 'relative',
       },
       menuItemBox: Styles.platformStyles({
         common: {

--- a/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
@@ -121,7 +121,7 @@ class ExplodingMeta extends React.Component<Props, State> {
                   <Kb.ProgressIndicator style={{height: 12, width: 12}} />
                 </Kb.Box2>
               ) : (
-                <Kb.WithTooltip containerStyle={styles.explodingTooltip} tooltip="Exploding message">
+                <Kb.WithTooltip toastStyle={styles.explodingTooltip} tooltip="Exploding message">
                   <Kb.Box2
                     className="explodingTimeContainer"
                     direction="horizontal"
@@ -251,7 +251,9 @@ const styles = Styles.styleSheetCreate(
       countdownHighlighted: {
         color: Styles.globalColors.whiteOrWhite,
       },
-      explodingTooltip: {right: -Styles.globalMargins.small},
+      explodingTooltip: {
+        marginRight: -Styles.globalMargins.xxtiny,
+      },
       progressContainer: Styles.platformStyles({
         common: {
           alignItems: 'center',

--- a/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
@@ -121,7 +121,7 @@ class ExplodingMeta extends React.Component<Props, State> {
                   <Kb.ProgressIndicator style={{height: 12, width: 12}} />
                 </Kb.Box2>
               ) : (
-                <Kb.WithTooltip tooltip="Exploding message">
+                <Kb.WithTooltip containerStyle={styles.explodingTooltip} tooltip="Exploding message">
                   <Kb.Box2
                     className="explodingTimeContainer"
                     direction="horizontal"
@@ -251,6 +251,7 @@ const styles = Styles.styleSheetCreate(
       countdownHighlighted: {
         color: Styles.globalColors.whiteOrWhite,
       },
+      explodingTooltip: {right: -Styles.globalMargins.small},
       progressContainer: Styles.platformStyles({
         common: {
           alignItems: 'center',

--- a/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
@@ -229,8 +229,8 @@ const styles = Styles.styleSheetCreate(
           marginLeft: Styles.globalMargins.tiny,
           position: 'relative',
         },
-        isMobile: {height: 24},
         isElectron: {height: 20},
+        isMobile: {height: 24},
       }),
       countdown: Styles.platformStyles({
         common: {color: Styles.globalColors.white, fontWeight: 'bold'},

--- a/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta/index.tsx
@@ -114,7 +114,6 @@ class ExplodingMeta extends React.Component<Props, State> {
     switch (this.state.mode) {
       case 'countdown':
         {
-          const stopWatchIconSize = Styles.isMobile ? 16 : 14
           children = (
             <Kb.Box2 direction="horizontal" gap="xtiny">
               {this.props.pending ? (
@@ -122,39 +121,31 @@ class ExplodingMeta extends React.Component<Props, State> {
                   <Kb.ProgressIndicator style={{height: 12, width: 12}} />
                 </Kb.Box2>
               ) : (
-                <Kb.Box2
-                  className="explodingTimeContainer"
-                  direction="horizontal"
-                  style={Styles.collapseStyles([
-                    styles.countdownContainer,
-                    {
-                      backgroundColor,
-                    },
-                    this.props.isParentHighlighted && styles.countdownContainerHighlighted,
-                  ])}
-                >
-                  <Kb.Text
-                    className="explodingTimeText"
-                    type="Body"
+                <Kb.WithTooltip tooltip="Exploding message">
+                  <Kb.Box2
+                    className="explodingTimeContainer"
+                    direction="horizontal"
                     style={Styles.collapseStyles([
-                      styles.countdown,
-                      this.props.isParentHighlighted && styles.countdownHighlighted,
+                      styles.countdownContainer,
+                      {
+                        backgroundColor,
+                      },
+                      this.props.isParentHighlighted && styles.countdownContainerHighlighted,
                     ])}
                   >
-                    {formatDurationShort(this.props.explodesAt - Date.now())}
-                  </Kb.Text>
-                </Kb.Box2>
+                    <Kb.Text
+                      className="explodingTimeText"
+                      type="Body"
+                      style={Styles.collapseStyles([
+                        styles.countdown,
+                        this.props.isParentHighlighted && styles.countdownHighlighted,
+                      ])}
+                    >
+                      {formatDurationShort(this.props.explodesAt - Date.now())}
+                    </Kb.Text>
+                  </Kb.Box2>
+                </Kb.WithTooltip>
               )}
-              <Kb.Icon
-                className="explodingTimeIcon"
-                type="iconfont-timer"
-                fontSize={stopWatchIconSize}
-                color={
-                  this.props.isParentHighlighted
-                    ? Styles.globalColors.blackOrBlack
-                    : Styles.globalColors.black
-                }
-              />
             </Kb.Box2>
           )
         }
@@ -238,29 +229,21 @@ const styles = Styles.styleSheetCreate(
           marginLeft: Styles.globalMargins.tiny,
           position: 'relative',
         },
-        isMobile: {height: 21},
+        isMobile: {height: 24},
+        isElectron: {height: 20},
       }),
       countdown: Styles.platformStyles({
         common: {color: Styles.globalColors.white, fontWeight: 'bold'},
-        isElectron: {fontSize: 10, lineHeight: 14},
-        isMobile: {fontSize: 11, lineHeight: 16},
+        isElectron: {fontSize: 9, letterSpacing: -0.2, lineHeight: 13},
+        isMobile: {fontSize: 10, letterSpacing: -0.2, lineHeight: 14},
       }),
       countdownContainer: Styles.platformStyles({
         common: {
           alignItems: 'center',
-          borderRadius: 2,
           justifyContent: 'center',
-          paddingLeft: 2,
-          paddingRight: 2,
         },
-        isElectron: {
-          height: 14,
-          width: 28,
-        },
-        isMobile: {
-          height: 16,
-          width: 30,
-        },
+        isElectron: {borderRadius: 10, height: 20, width: 20},
+        isMobile: {borderRadius: 14, height: 24, width: 24},
       }),
       countdownContainerHighlighted: {
         backgroundColor: Styles.globalColors.blackOrBlack,

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -632,12 +632,11 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                   )}
                 <Kb.Box>
                   {this.props.shouldShowPopup && (
-                    <Kb.Icon
-                      type="iconfont-ellipsis"
-                      onClick={this.props.toggleShowingMenu}
-                      style={styles.ellipsis}
-                      fontSize={14}
-                    />
+                    <Kb.WithTooltip tooltip="More actions...">
+                      <Kb.Box style={styles.ellipsis}>
+                        <Kb.Icon type="iconfont-ellipsis" onClick={this.props.toggleShowingMenu} />
+                      </Kb.Box>
+                    </Kb.WithTooltip>
                   )}
                 </Kb.Box>
               </Kb.Box>

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -632,7 +632,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                   )}
                 <Kb.Box>
                   {this.props.shouldShowPopup && (
-                    <Kb.WithTooltip tooltip="More actions...">
+                    <Kb.WithTooltip tooltip="More actions..." toastStyle={styles.moreActionsTooltip}>
                       <Kb.Box style={styles.ellipsis}>
                         <Kb.Icon type="iconfont-ellipsis" onClick={this.props.toggleShowingMenu} />
                       </Kb.Box>
@@ -821,6 +821,9 @@ const styles = Styles.styleSheetCreate(
       }),
       menuButtonsWithAuthor: {marginTop: -16},
       messagePopupContainer: {marginRight: Styles.globalMargins.small},
+      moreActionsTooltip: {
+        marginRight: -Styles.globalMargins.xxtiny,
+      },
       orangeLine: {
         // don't push down content due to orange line
         backgroundColor: Styles.globalColors.orange,

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -437,7 +437,7 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
       this.props.isRevoked ? 24 : 0, // revoked
       this.props.showCoinsIcon ? 24 : 0, // coin stack
       exploded || Styles.isMobile ? 0 : 16, // ... menu
-      exploding ? (Styles.isMobile ? 57 : 46) : 0, // exploding
+      exploding ? (Styles.isMobile ? 24 : 20) : 0, // exploding
       this.getKeyedBot() && !this.props.authorIsBot ? 24 : 0,
     ].filter(Boolean)
     const padding = Styles.globalMargins.tiny
@@ -763,7 +763,10 @@ const styles = Styles.styleSheetCreate(
       }),
       edited: {color: Styles.globalColors.black_20},
       editedHighlighted: {color: Styles.globalColors.black_20OrBlack},
-      ellipsis: {marginLeft: Styles.globalMargins.tiny},
+      ellipsis: {
+        marginLeft: Styles.globalMargins.tiny,
+        paddingTop: 3,
+      },
       emojiRow: Styles.platformStyles({
         isElectron: {
           borderBottomLeftRadius: Styles.borderRadius,
@@ -814,8 +817,8 @@ const styles = Styles.styleSheetCreate(
           justifyContent: 'flex-end',
           overflow: 'hidden',
         },
-        isElectron: {height: 16},
-        isMobile: {height: 21},
+        isElectron: {height: 20},
+        isMobile: {height: 24},
       }),
       menuButtonsWithAuthor: {marginTop: -16},
       messagePopupContainer: {marginRight: Styles.globalMargins.small},

--- a/shared/common-adapters/with-tooltip.d.ts
+++ b/shared/common-adapters/with-tooltip.d.ts
@@ -12,6 +12,7 @@ export type Props = {
   position?: Position // on mobile only 'top center' and 'bottom center' are supported,,
   className?: string
   toastClassName?: string
+  toastStyle?: StylesCrossPlatform
   textStyle?: StylesCrossPlatform
   showOnPressMobile?: boolean | null
 }

--- a/shared/common-adapters/with-tooltip.desktop.tsx
+++ b/shared/common-adapters/with-tooltip.desktop.tsx
@@ -59,6 +59,7 @@ class WithTooltip extends React.Component<Props, State> {
               styles.container,
               this.props.multiline && styles.containerMultiline,
               this.props.backgroundColor && {backgroundColor: this.props.backgroundColor},
+              this.props.toastStyle,
             ])}
             visible={!!this.props.tooltip && this.state.visible}
             attachTo={this._getAttachmentRef}


### PR DESCRIPTION
@adamjspooner Can you try this branch and see if the tooltips on hover feel right? (in the message box and to the right of a message)

This PR:
• replaces the current timestamp + stopwatch icon with a black disk, to the right of exploding messages:
![image](https://user-images.githubusercontent.com/2807426/78091516-e947e580-7381-11ea-9e75-f3691d94e6a2.png)

• changes the color of the Send button for exploding messages from blue to black:
![image](https://user-images.githubusercontent.com/2807426/78091540-fe247900-7381-11ea-9c80-6c04cee53d24.png)

• adds hover tooltips to the desktop input buttons:
![image](https://user-images.githubusercontent.com/2807426/78091580-201dfb80-7382-11ea-84be-03cbb207f2e4.png)





