### PR TITLE
Add debug render perf

### DIFF
--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -4,6 +4,7 @@ import * as Kb from '../common-adapters/mobile.native'
 import * as React from 'react'
 import * as Shared from './router.shared'
 import * as Shim from './shim.native'
+import {getRenderDebug} from './shim.shared'
 import * as Stack from 'react-navigation-stack'
 import * as Styles from '../styles'
 import * as Tabs from '../constants/tabs'
@@ -254,13 +255,14 @@ const VanillaTabNavigator = createBottomTabNavigator(
 class UnconnectedTabNavigator extends React.PureComponent<any> {
   static router = VanillaTabNavigator.router
   render() {
-    const {navigation, isDarkMode} = this.props
-    return <VanillaTabNavigator navigation={navigation} key={isDarkMode ? 'dark' : 'light'} />
+    const {navigation, isDarkMode, renderDebug} = this.props
+    const key = `${isDarkMode ? 'dark' : 'light'}: ${renderDebug ? 'd' : ''}`
+    return <VanillaTabNavigator navigation={navigation} key={key} />
   }
 }
 
 const TabNavigator = Container.connect(
-  () => ({isDarkMode: Styles.isDarkMode()}),
+  () => ({isDarkMode: Styles.isDarkMode(), renderDebug: getRenderDebug()}),
   undefined,
   (s, _, o: any) => ({
     ...s,

--- a/shared/router-v2/shim.desktop.tsx
+++ b/shared/router-v2/shim.desktop.tsx
@@ -11,7 +11,7 @@ const shimNewRoute = (Original: any) => {
     const original = <Original {...props} />
     let body = original
 
-    const [renderDebug] = Shared.useRenderDebug()
+    const renderDebug = Shared.getRenderDebug()
     if (renderDebug) {
       body = <PerfWrapper style={styles.perf}>{original}</PerfWrapper>
     }

--- a/shared/router-v2/shim.desktop.tsx
+++ b/shared/router-v2/shim.desktop.tsx
@@ -1,3 +1,30 @@
+import * as React from 'react'
 import * as Shared from './shim.shared'
-// We don't wrap our components in anything special
-export const shim = (routes: any) => Shared.shim(routes, c => c)
+import * as Container from '../util/container'
+import * as Styles from '../styles'
+import {PerfWrapper} from '../util/use-perf'
+
+export const shim = (routes: any) => Shared.shim(routes, shimNewRoute)
+
+const shimNewRoute = (Original: any) => {
+  const ShimmedNew = React.memo((props: any) => {
+    const original = <Original {...props} />
+    let body = original
+
+    const [renderDebug] = Shared.useRenderDebug()
+    if (renderDebug) {
+      body = <PerfWrapper style={styles.perf}>{original}</PerfWrapper>
+    }
+
+    return body
+  })
+  Container.hoistNonReactStatic(ShimmedNew, Original)
+  return ShimmedNew
+}
+
+const styles = Styles.styleSheetCreate(() => ({
+  perf: {
+    height: '100%',
+    width: '100%',
+  },
+}))

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -9,6 +9,7 @@ export const shim = (routes: any) => Shared.shim(routes, shimNewRoute)
 
 let isV8 = false
 try {
+  // @ts-ignore
   console.log(`V8 version is ${global._v8runtime().version}`)
   isV8 = true
 } catch (_) {}
@@ -25,7 +26,7 @@ const shimNewRoute = (Original: any) => {
     const original = <Original {...props} key={Styles.isDarkMode ? 'dark' : 'light'} />
     let body = original
 
-    const [renderDebug] = Shared.useRenderDebug()
+    const renderDebug = Shared.getRenderDebug()
     if (renderDebug) {
       body = (
         <PerfWrapper style={styles.perf} prefix={isV8 ? 'V8: ' : 'JSC: '}>

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -3,8 +3,15 @@ import * as React from 'react'
 import * as Styles from '../styles'
 import * as Shared from './shim.shared'
 import * as Container from '../util/container'
+import {PerfWrapper} from '../util/use-perf'
 
 export const shim = (routes: any) => Shared.shim(routes, shimNewRoute)
+
+let isV8 = false
+try {
+  console.log(`V8 version is ${global._v8runtime().version}`)
+  isV8 = true
+} catch (_) {}
 
 const shimNewRoute = (Original: any) => {
   // Wrap everything in a keyboard avoiding view (maybe this is opt in/out?)
@@ -15,7 +22,17 @@ const shimNewRoute = (Original: any) => {
         ? Original.navigationOptions({navigation: props.navigation})
         : Original.navigationOptions
 
-    const body = <Original {...props} key={Styles.isDarkMode ? 'dark' : 'light'} />
+    const original = <Original {...props} key={Styles.isDarkMode ? 'dark' : 'light'} />
+    let body = original
+
+    const [renderDebug] = Shared.useRenderDebug()
+    if (renderDebug) {
+      body = (
+        <PerfWrapper style={styles.perf} prefix={isV8 ? 'V8: ' : 'JSC: '}>
+          {original}
+        </PerfWrapper>
+      )
+    }
 
     // we try and determine the  offset based on seeing if the header exists
     // this isn't perfect and likely we should move where this avoiding view is relative to the stack maybe
@@ -80,6 +97,10 @@ const styles = Styles.styleSheetCreate(
         flexGrow: 1,
         maxHeight: '100%',
         position: 'relative',
+      },
+      perf: {
+        height: '100%',
+        width: '100%',
       },
     } as const)
 )

--- a/shared/router-v2/shim.shared.tsx
+++ b/shared/router-v2/shim.shared.tsx
@@ -1,3 +1,14 @@
+import * as React from 'react'
+
+let _renderDebug = false
+export const useRenderDebug = () => {
+  const [renderDebug, setRenderDebug] = React.useState(_renderDebug)
+  React.useEffect(() => {
+    _renderDebug = renderDebug
+  }, [renderDebug])
+  return [renderDebug, setRenderDebug]
+}
+
 export const shim = (routes: any, platformWrapper: any) => {
   return Object.keys(routes).reduce((map, route) => {
     let _cached = null

--- a/shared/router-v2/shim.shared.tsx
+++ b/shared/router-v2/shim.shared.tsx
@@ -1,13 +1,8 @@
-import * as React from 'react'
-
 let _renderDebug = false
-export const useRenderDebug = () => {
-  const [renderDebug, setRenderDebug] = React.useState(_renderDebug)
-  React.useEffect(() => {
-    _renderDebug = renderDebug
-  }, [renderDebug])
-  return [renderDebug, setRenderDebug]
+export const toggleRenderDebug = () => {
+  _renderDebug = !_renderDebug
 }
+export const getRenderDebug = () => _renderDebug
 
 export const shim = (routes: any, platformWrapper: any) => {
   return Object.keys(routes).reduce((map, route) => {

--- a/shared/settings/advanced.tsx
+++ b/shared/settings/advanced.tsx
@@ -11,7 +11,7 @@ import * as Styles from '../styles'
 import {ProxySettings} from './proxy/container'
 import {anyErrors, anyWaiting} from '../constants/waiting'
 import {isMobile, isLinux, isWindows} from '../constants/platform'
-import {useRenderDebug} from '../router-v2/shim.shared'
+import {toggleRenderDebug} from '../router-v2/shim.shared'
 
 let initialUseNativeFrame: boolean | undefined
 
@@ -222,8 +222,6 @@ const Developer = () => {
     dispatch(SettingsGen.createProcessorProfile({durationSeconds}))
   const onDBNuke = () => dispatch(RouteTreeGen.createNavigateAppend({path: ['dbNukeConfirm']}))
 
-  const [, setRenderDebug] = useRenderDebug()
-
   return (
     <Kb.Box style={styles.developerContainer}>
       <Kb.Text center={true} type="BodySmallSemibold" onClick={onLabelClick} style={styles.text}>
@@ -247,7 +245,7 @@ const Developer = () => {
           />
           <Kb.Button
             label="Toggle Render Stats"
-            onClick={() => setRenderDebug(r => !r)}
+            onClick={toggleRenderDebug}
             mode="Secondary"
             style={styles.developerButtons}
           />

--- a/shared/settings/advanced.tsx
+++ b/shared/settings/advanced.tsx
@@ -11,6 +11,7 @@ import * as Styles from '../styles'
 import {ProxySettings} from './proxy/container'
 import {anyErrors, anyWaiting} from '../constants/waiting'
 import {isMobile, isLinux, isWindows} from '../constants/platform'
+import {useRenderDebug} from '../router-v2/shim.shared'
 
 let initialUseNativeFrame: boolean | undefined
 
@@ -221,6 +222,8 @@ const Developer = () => {
     dispatch(SettingsGen.createProcessorProfile({durationSeconds}))
   const onDBNuke = () => dispatch(RouteTreeGen.createNavigateAppend({path: ['dbNukeConfirm']}))
 
+  const [, setRenderDebug] = useRenderDebug()
+
   return (
     <Kb.Box style={styles.developerContainer}>
       <Kb.Text center={true} type="BodySmallSemibold" onClick={onLabelClick} style={styles.text}>
@@ -239,6 +242,12 @@ const Developer = () => {
           <Kb.Button
             label="Toggle Runtime Stats"
             onClick={onToggleRuntimeStats}
+            mode="Secondary"
+            style={styles.developerButtons}
+          />
+          <Kb.Button
+            label="Toggle Render Stats"
+            onClick={() => setRenderDebug(r => !r)}
             mode="Secondary"
             style={styles.developerButtons}
           />

--- a/shared/util/use-perf.tsx
+++ b/shared/util/use-perf.tsx
@@ -2,63 +2,63 @@ import * as React from 'react'
 import {Box2} from '../common-adapters/box'
 import Text from '../common-adapters/text'
 import * as Styles from '../styles'
-/** 
-A dev only hook to measure rendering perf of a component, use the return value as a key
+/**
+A hook to measure rendering perf of a component, use the return value as a key
  */
 
-export const usePerf = __DEV__
-  ? (count: number = 10) => {
-      const [numRenders, setNumRenders] = React.useState(0)
-      const startTime = React.useRef<number>(0)
-      const runTime = React.useRef<number>(0)
-      const running = React.useRef<boolean>(false)
+export const usePerf = (count: number = 10) => {
+  const [numRenders, setNumRenders] = React.useState(0)
+  const startTime = React.useRef<number>(0)
+  const runTime = React.useRef<number>(0)
+  const running = React.useRef<boolean>(false)
 
-      const reset = React.useCallback(() => {
-        setNumRenders(0)
-      }, [setNumRenders])
+  const reset = React.useCallback(() => {
+    setNumRenders(0)
+  }, [setNumRenders])
 
-      if (numRenders === 0 && !running.current) {
-        running.current = true
-        startTime.current = Date.now()
-        runTime.current = 0
-        console.log('usePerf start:', count)
+  if (numRenders === 0 && !running.current) {
+    running.current = true
+    startTime.current = Date.now()
+    runTime.current = 0
+    console.log('usePerf start:', count)
+  }
+
+  React.useEffect(() => {
+    console.log('usePerf useEffect ran')
+    if (running.current) {
+      runTime.current = Date.now() - startTime.current
+      if (numRenders === count) {
+        // done?
+        running.current = false
+        setNumRenders(-1)
+        console.log('usePerf end: ', runTime.current)
+      } else {
+        // some components defer so lets actually render them
+        setImmediate(() => {
+          console.log('usePerf increment ran')
+          setNumRenders(s => s + 1)
+        })
       }
-
-      React.useEffect(() => {
-        console.log('usePerf useEffect ran')
-        if (running.current) {
-          runTime.current = Date.now() - startTime.current
-          if (numRenders === count) {
-            // done?
-            running.current = false
-            setNumRenders(-1)
-            console.log('usePerf end: ', runTime.current)
-          } else {
-            // some components defer so lets actually render them
-            setImmediate(() => {
-              console.log('usePerf increment ran')
-              setNumRenders(s => s + 1)
-            })
-          }
-        }
-      }, [numRenders, setNumRenders, count])
-
-      return [String(numRenders), runTime.current, reset] as const
     }
-  : (_: number = 1000) => ['prod', 0, () => {}] as const
+  }, [numRenders, setNumRenders, count])
+
+  return [String(numRenders), runTime.current, reset] as const
+}
 
 type Props = {
   perfCount?: number
+  prefix?: string
   children: React.ReactNode
   style?: Styles.StylesCrossPlatform
 }
 const _PerfWrapper = (props: Props) => {
-  const {perfCount, children, style} = props
+  const {perfCount, children, style, prefix} = props
   const [key, time, reset] = usePerf(perfCount)
   return (
     <Box2 direction="vertical" key={key} style={Styles.collapseStyles([styles.container, style])}>
       {children}
       <Text type="Body" style={styles.time} onClick={reset}>
+        {prefix ?? ''}
         {time}
       </Text>
     </Box2>


### PR DESCRIPTION
For awhile i've had a rendering perf counter that I use to compare android builds. instead of setting that ad hoc it now will work in the app.
Settings | Advanced | click 7 times | Toggle render stats
Now you get a yellow overlay that'll render the screen 10 times and time it. Clicking it again will redo it