### PR TITLE
add debug log helper

### DIFF
--- a/shared/app/preload.native.tsx
+++ b/shared/app/preload.native.tsx
@@ -6,10 +6,13 @@ const invalidPreload = () => {
   throw new Error('invalid preload call on RN')
 }
 
+const debugConsoleLog: () => void = console.log.bind(console) as any
+
 global.KB = {
   get __dirname() {
     return invalidPreload()
   },
+  debugConsoleLog,
   electron: {
     app: {
       get appPath() {

--- a/shared/desktop/renderer/preload-main.shared.desktop.tsx
+++ b/shared/desktop/renderer/preload-main.shared.desktop.tsx
@@ -119,6 +119,9 @@ const showOpenDialog = async (opts: KBElectronOpenDialogOptions) => {
   }
 }
 
+// A helper to allow console logs while building but have TS catch it
+const debugConsoleLog: () => void = console.log.bind(console) as any
+
 const showSaveDialog = async (opts: KBElectronSaveDialogOptions) => {
   try {
     const {title, message, buttonLabel, defaultPath} = opts
@@ -145,6 +148,7 @@ const showSaveDialog = async (opts: KBElectronSaveDialogOptions) => {
 
 target.KB = {
   __dirname: __dirname,
+  debugConsoleLog,
   electron: {
     app: {
       appPath: __STORYSHOT__ ? '' : isRenderer ? Electron.remote.app.getAppPath() : Electron.app.getAppPath(),

--- a/shared/globals.d.ts
+++ b/shared/globals.d.ts
@@ -63,6 +63,8 @@ interface Console {
 declare var KB: {
   __dirname: string
   DEV?: any
+  /** Use this for debug logs you don't want commited **/
+  debugConsoleLog: (nope: never) => void
   electron: {
     app: {
       appPath: string


### PR DESCRIPTION
While devving instead of a regular console log please use this global helper

```
KB.debugConsoleLog('hi')
```