### PR TITLE
Fix user service summary cache refreshers

### DIFF
--- a/go/libkb/remote_proof_links.go
+++ b/go/libkb/remote_proof_links.go
@@ -184,12 +184,9 @@ func (p ProofLinkWithState) GetProofType() keybase1.ProofType { return p.link.Ge
 
 func (r *RemoteProofLinks) toServiceSummary() (ret UserServiceSummary) {
 	ret = make(UserServiceSummary, len(r.links))
-	for _, list := range r.links {
-		if len(list) == 0 {
-			continue
-		}
-		// Get most recent proof for the type
-		key, val := list[len(list)-1].ToKeyValuePair()
+	activeProofs := r.Active()
+	for _, proof := range activeProofs {
+		key, val := proof.ToKeyValuePair()
 		ret[key] = val
 	}
 	return ret

--- a/go/systests/sbs_test.go
+++ b/go/systests/sbs_test.go
@@ -112,21 +112,7 @@ func (p *userSBSRooter) Verify() {
 }
 
 func (p *userSBSRooter) Revoke() {
-	tctx := p.u.tc
-	arg := libkb.NewLoadUserArg(tctx.G).WithUID(p.u.uid).WithPublicKeyOptional().WithForcePoll(true)
-	_, user, err := tctx.G.GetUPAKLoader().LoadV2(arg)
-	require.NoError(tctx.T, err)
-
-	st := tctx.G.GetProofServices().GetServiceType(context.TODO(), "rooter")
-	ret := user.IDTable().GetActiveProofsFor(st)
-	require.Len(tctx.T, len(ret), 1)
-	sigID := ret[0].GetSigID()
-
-	revokeClient := keybase1.RevokeClient{Cli: p.u.teamsClient.Cli}
-	err = revokeClient.RevokeSigs(context.TODO(), keybase1.RevokeSigsArg{
-		SigIDQueries: []string{sigID.String()},
-	})
-	require.NoError(tctx.T, err)
+	p.u.revokeServiceProof("rooter")
 }
 
 // ------------------

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -754,6 +754,25 @@ func (u *userPlusDevice) proveGubbleSocial() {
 	proveGubbleUniverse(u.tc, "gubble.social", "gubble_social", u.username, u.newSecretUI())
 }
 
+func (u *userPlusDevice) revokeServiceProof(serviceType string) {
+	tctx := u.tc
+	arg := libkb.NewLoadUserArg(tctx.G).WithUID(u.uid).WithForcePoll(true)
+	user, err := libkb.LoadUser(arg)
+	require.NoError(tctx.T, err)
+	require.NotNil(tctx.T, user)
+
+	st := tctx.G.GetProofServices().GetServiceType(context.TODO(), "rooter")
+	ret := user.IDTable().GetActiveProofsFor(st)
+	require.Len(tctx.T, ret, 1)
+	sigID := ret[0].GetSigID()
+
+	revokeClient := keybase1.RevokeClient{Cli: u.teamsClient.Cli}
+	err = revokeClient.RevokeSigs(context.TODO(), keybase1.RevokeSigsArg{
+		SigIDQueries: []string{sigID.String()},
+	})
+	require.NoError(tctx.T, err)
+}
+
 func (u *userPlusDevice) track(username string) {
 	trackCmd := client.NewCmdTrackRunner(u.tc.G)
 	trackCmd.SetUser(username)

--- a/go/uidmap/servicemap_test.go
+++ b/go/uidmap/servicemap_test.go
@@ -163,7 +163,6 @@ func TestServiceMapBecomesEmpty(t *testing.T) {
 
 	tc.G.API = apiMock
 
-	const zeroFreshness = time.Duration(0)
 	const freshness = 24 * time.Hour
 	serviceMapper := NewServiceSummaryMap(10)
 	uids := []keybase1.UID{tTracy}

--- a/go/uidmap/servicemap_test.go
+++ b/go/uidmap/servicemap_test.go
@@ -2,9 +2,11 @@ package uidmap
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/clockwork"
@@ -123,4 +125,82 @@ func TestServiceMapLookupEmpty(t *testing.T) {
 		// should not hit the API due to freshness parameter.
 		require.Equal(t, 0, timeoutAPI.callCount)
 	}
+}
+
+type mockAPI struct {
+	libkb.API
+	t       *testing.T
+	results map[keybase1.UID]libkb.UserServiceSummary
+}
+
+func (m *mockAPI) PostDecodeCtx(ctx context.Context, arg libkb.APIArg, resp libkb.APIResponseWrapper) error {
+	require.Equal(m.t, "user/service_maps", arg.Endpoint)
+
+	ps := reflect.ValueOf(resp)
+	elem := ps.Elem()
+	field := elem.FieldByName("ServiceMaps")
+	field.Set(reflect.ValueOf(m.results))
+
+	m.t.Logf("mockAPI is returning for user/service_maps: %s", spew.Sdump(m.results))
+	return nil
+}
+
+func TestServiceMapBecomesEmpty(t *testing.T) {
+	tc := libkb.SetupTest(t, "TestLookup", 1)
+	defer tc.Cleanup()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Now())
+	tc.G.SetClock(fakeClock)
+
+	now := keybase1.ToTime(fakeClock.Now())
+
+	results := make(map[keybase1.UID]libkb.UserServiceSummary)
+	sumsum := make(libkb.UserServiceSummary)
+	sumsum["twitter"] = "tracy"
+	sumsum["github"] = "tracerz"
+	results[tTracy] = sumsum
+	apiMock := &mockAPI{nil, t, results}
+
+	tc.G.API = apiMock
+
+	const zeroFreshness = time.Duration(0)
+	const freshness = 24 * time.Hour
+	serviceMapper := NewServiceSummaryMap(10)
+	uids := []keybase1.UID{tTracy}
+	pkgs := serviceMapper.MapUIDsToServiceSummaries(context.TODO(), tc.G, uids,
+		freshness, DefaultNetworkBudget)
+
+	require.Len(t, pkgs, 1)
+	require.Contains(t, pkgs, tTracy)
+	require.True(t, pkgs[tTracy].CachedAt >= now)
+	require.Equal(t, sumsum, pkgs[tTracy].ServiceMap)
+
+	// Now the service returns empty service map because someone has revoked
+	// all their proofs (or reset).
+
+	fakeClock.Advance(30 * time.Hour)
+
+	// Server returns empty result because user's proofs are all gone.
+	results = make(map[keybase1.UID]libkb.UserServiceSummary)
+	apiMock.results = results
+
+	// Do a normal call with network budget to allow for cache refresh.
+	pkgs = serviceMapper.MapUIDsToServiceSummaries(context.TODO(), tc.G, uids,
+		freshness, DefaultNetworkBudget)
+
+	require.Len(t, pkgs, 1)
+	require.Contains(t, pkgs, tTracy)
+	require.True(t, pkgs[tTracy].CachedAt >= now)
+	require.Equal(t, make(libkb.UserServiceSummary), pkgs[tTracy].ServiceMap)
+
+	fakeClock.Advance(1 * time.Hour)
+
+	// Now do a call without network budget to force read from cache.
+	pkgs = serviceMapper.MapUIDsToServiceSummaries(context.TODO(), tc.G, uids,
+		freshness, DisallowNetworkBudget)
+
+	require.Len(t, pkgs, 1)
+	require.Contains(t, pkgs, tTracy)
+	require.True(t, pkgs[tTracy].CachedAt >= now)
+	require.Equal(t, make(libkb.UserServiceSummary), pkgs[tTracy].ServiceMap)
 }

--- a/go/uidmap/servicemap_test.go
+++ b/go/uidmap/servicemap_test.go
@@ -188,10 +188,12 @@ func TestServiceMapBecomesEmpty(t *testing.T) {
 	pkgs = serviceMapper.MapUIDsToServiceSummaries(context.TODO(), tc.G, uids,
 		freshness, DefaultNetworkBudget)
 
+	var nilMap libkb.UserServiceSummary
+
 	require.Len(t, pkgs, 1)
 	require.Contains(t, pkgs, tTracy)
 	require.True(t, pkgs[tTracy].CachedAt >= now)
-	require.Equal(t, make(libkb.UserServiceSummary), pkgs[tTracy].ServiceMap)
+	require.Equal(t, nilMap, pkgs[tTracy].ServiceMap)
 
 	fakeClock.Advance(1 * time.Hour)
 
@@ -202,5 +204,5 @@ func TestServiceMapBecomesEmpty(t *testing.T) {
 	require.Len(t, pkgs, 1)
 	require.Contains(t, pkgs, tTracy)
 	require.True(t, pkgs[tTracy].CachedAt >= now)
-	require.Equal(t, make(libkb.UserServiceSummary), pkgs[tTracy].ServiceMap)
+	require.Equal(t, nilMap, pkgs[tTracy].ServiceMap)
 }


### PR DESCRIPTION
The refresher from loaduser was poisoning service summary cache with bad values.

Service summary cache is used for things like icons in "interesting people" and contact list.