### PR TITLE
wait for nav to startup

### DIFF
--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -419,7 +419,7 @@ export const clearWatchPosition = () => {}
 export const watchPositionForMap = () => Promise.resolve(0)
 
 function* checkNav(
-  state: Container.TypedState,
+  _state: Container.TypedState,
   action: ConfigGen.DaemonHandshakePayload,
   logger: Saga.SagaLogger
 ) {

--- a/shared/actions/platform-specific/index.desktop.tsx
+++ b/shared/actions/platform-specific/index.desktop.tsx
@@ -15,6 +15,7 @@ import {writeLogLinesToFile} from '../../util/forward-logs'
 import InputMonitor from './input-monitor.desktop'
 import {skipAppFocusActions} from '../../local-debug.desktop'
 import * as Container from '../../util/container'
+import {_getNavigator} from '../../constants/router2'
 
 const {resolve} = KB.path
 const {argv, env, pid} = KB.process
@@ -417,6 +418,30 @@ export const requestAudioPermission = () => Promise.resolve()
 export const clearWatchPosition = () => {}
 export const watchPositionForMap = () => Promise.resolve(0)
 
+function* checkNav(
+  state: Container.TypedState,
+  action: ConfigGen.DaemonHandshakePayload,
+  logger: Saga.SagaLogger
+) {
+  // have one
+  if (_getNavigator()) {
+    return
+  }
+
+  const name = 'desktopNav'
+  const {version} = action.payload
+
+  yield Saga.put(ConfigGen.createDaemonHandshakeWait({increment: true, name, version}))
+  while (true) {
+    logger.info('Waiting on nav')
+    yield Saga.take(ConfigGen.setNavigator)
+    if (_getNavigator()) {
+      break
+    }
+  }
+  yield Saga.put(ConfigGen.createDaemonHandshakeWait({increment: false, name, version}))
+}
+
 export function* platformConfigSaga() {
   yield* Saga.chainAction2(ConfigGen.setOpenAtLogin, setOpenAtLogin)
   yield* Saga.chainAction2(ConfigGen.setNotifySound, setNotifySound)
@@ -441,6 +466,7 @@ export function* platformConfigSaga() {
   if (isWindows) {
     yield* Saga.chainGenerator<ConfigGen.DaemonHandshakePayload>(ConfigGen.daemonHandshake, checkRPCOwnership)
   }
+  yield* Saga.chainGenerator<ConfigGen.DaemonHandshakePayload>(ConfigGen.daemonHandshake, checkNav)
 
   yield Saga.spawn(initializeUseNativeFrame)
   yield Saga.spawn(initializeNotifySound)

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -905,7 +905,7 @@ const onPersistRoute = async () => {
 }
 
 function* checkNav(
-  state: Container.TypedState,
+  _state: Container.TypedState,
   action: ConfigGen.DaemonHandshakePayload,
   logger: Saga.SagaLogger
 ) {

--- a/shared/router-v2/router.d.ts
+++ b/shared/router-v2/router.d.ts
@@ -3,6 +3,7 @@ import * as React from 'react'
 export type Props = {
   isDarkMode?: boolean
   onNavigationStateChange: (prev: any, next: any, action: any) => void
+  updateNavigator: (route: Router) => void
 }
 declare class Router extends React.Component<Props> {}
 export default Router

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -308,6 +308,10 @@ const createElectronApp = Component => {
 
     _getScreenProps = () => this.props.screenProps
 
+    private setRef = () => {
+      this.props.updateNavigator(this)
+    }
+
     render() {
       let navigation = this.props.navigation
       const navState = this.state.nav
@@ -327,7 +331,7 @@ const createElectronApp = Component => {
       navigation = this.navigation
       return (
         <NavigationContext.Provider key={this.props.isDarkMode ? 'dark' : 'light'} value={navigation}>
-          <Component {...this.props} navigation={navigation} />
+          <Component {...this.props} navigation={navigation} ref={this.setRef} />
         </NavigationContext.Provider>
       )
     }

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -387,6 +387,7 @@ class RNApp extends React.PureComponent<Props> {
 
   private setNav = (n: any) => {
     this.nav = n
+    this.props.updateNavigator(n && this)
   }
 
   private onNavigationStateChange = (prevNav: any, nav: any, action: any) => {

--- a/shared/router-v2/switcheroo.tsx
+++ b/shared/router-v2/switcheroo.tsx
@@ -30,7 +30,11 @@ const RouterSwitcheroo = React.memo(() => {
   )
 
   return (
-    <Router ref={updateNavigator} onNavigationStateChange={onNavigationStateChange} isDarkMode={isDarkMode} />
+    <Router
+      updateNavigator={updateNavigator}
+      onNavigationStateChange={onNavigationStateChange}
+      isDarkMode={isDarkMode}
+    />
   )
 })
 


### PR DESCRIPTION
I hadn't seen this happen, although it could explain some mysterious logs. 
It's possible the redux / service side is outpacing the render side and the nav could not be booted up before we start firing nav actions, leaving you in a potentially weird state. Instead we make it part of the bootstrap process

Note I did see this in my nav5 branch so this is to ultimately support that but technically possible on master also