### PR TITLE
TypeScript: remove unnecessary ts-ignore, part two

### DIFF
--- a/shared/actions/__tests__/add-new-device.tsx
+++ b/shared/actions/__tests__/add-new-device.tsx
@@ -53,7 +53,6 @@ const startReduxSaga = (initialStore?: TypedState) => {
       throw e
     },
   })
-  // @ts-ignore
   const store = createStore(rootReducer, initialStore, applyMiddleware(sagaMiddleware))
   const getState = store.getState
   const dispatch = store.dispatch

--- a/shared/actions/fs/common.native.tsx
+++ b/shared/actions/fs/common.native.tsx
@@ -47,7 +47,6 @@ const finishedDownloadWithIntent = async (
         await saveAttachmentToCameraRoll(localPath, mimeType)
         return FsGen.createDismissDownload({downloadID})
       case Types.DownloadIntent.Share:
-        // @ts-ignore codemod-issue probably a real issue
         await showShareActionSheet({filePath: localPath, mimeType})
         return FsGen.createDismissDownload({downloadID})
       case Types.DownloadIntent.None:

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -39,7 +39,6 @@ const rpcConflictStateToConflictState = (
       const nv = rpcConflictState.normalview
       return Constants.makeConflictStateNormalView({
         localViewTlfPaths: ((nv && nv.localViews) || []).reduce<Array<Types.Path>>((arr, p) => {
-          // @ts-ignore TODO fix p.kbfs.path is a path already
           p.PathType === RPCTypes.PathType.kbfs && arr.push(Constants.rpcPathToPath(p.kbfs))
           return arr
         }, []),

--- a/shared/actions/fs/platform-specific.android.tsx
+++ b/shared/actions/fs/platform-specific.android.tsx
@@ -47,7 +47,6 @@ const finishedRegularDownload = async (state: TypedState, action: FsGen.Finished
     return null
   }
   try {
-    // @ts-ignore codemod-issue
     await require('rn-fetch-blob').default.android.addCompleteDownload({
       description: `Keybase downloaded ${downloadInfo.filename}`,
       mime: mimeType,

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -30,6 +30,7 @@ import {
 } from 'react-native'
 import CameraRoll from '@react-native-community/cameraroll'
 import NetInfo from '@react-native-community/netinfo'
+// @ts-ignore strict
 import * as PushNotifications from 'react-native-push-notification'
 import {isIOS, isAndroid} from '../../constants/platform'
 import pushSaga, {getStartupDetailsFromInitialPush, getStartupDetailsFromInitialShare} from './push.native'
@@ -37,6 +38,7 @@ import * as Container from '../../util/container'
 import * as Contacts from 'expo-contacts'
 import {launchImageLibraryAsync} from '../../util/expo-image-picker'
 import Geolocation from '@react-native-community/geolocation'
+// @ts-ignore strict
 import {AudioRecorder} from 'react-native-audio'
 import * as Haptics from 'expo-haptics'
 

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -30,7 +30,6 @@ import {
 } from 'react-native'
 import CameraRoll from '@react-native-community/cameraroll'
 import NetInfo from '@react-native-community/netinfo'
-// @ts-ignore
 import * as PushNotifications from 'react-native-push-notification'
 import {isIOS, isAndroid} from '../../constants/platform'
 import pushSaga, {getStartupDetailsFromInitialPush, getStartupDetailsFromInitialShare} from './push.native'
@@ -38,7 +37,6 @@ import * as Container from '../../util/container'
 import * as Contacts from 'expo-contacts'
 import {launchImageLibraryAsync} from '../../util/expo-image-picker'
 import Geolocation from '@react-native-community/geolocation'
-// @ts-ignore
 import {AudioRecorder} from 'react-native-audio'
 import * as Haptics from 'expo-haptics'
 

--- a/shared/actions/platform-specific/push.native.tsx
+++ b/shared/actions/platform-specific/push.native.tsx
@@ -5,7 +5,6 @@ import * as Types from '../../constants/types/push'
 import * as NotificationsGen from '../notifications-gen'
 import * as ProfileGen from '../profile-gen'
 import * as PushGen from '../push-gen'
-// @ts-ignore
 import * as PushNotifications from 'react-native-push-notification'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../../constants/types/rpc-gen'

--- a/shared/actions/platform-specific/push.native.tsx
+++ b/shared/actions/platform-specific/push.native.tsx
@@ -5,6 +5,7 @@ import * as Types from '../../constants/types/push'
 import * as NotificationsGen from '../notifications-gen'
 import * as ProfileGen from '../profile-gen'
 import * as PushGen from '../push-gen'
+// @ts-ignore strict
 import * as PushNotifications from 'react-native-push-notification'
 import * as RPCChatTypes from '../../constants/types/rpc-chat-gen'
 import * as RPCTypes from '../../constants/types/rpc-gen'

--- a/shared/app/runtime-stats.tsx
+++ b/shared/app/runtime-stats.tsx
@@ -4,7 +4,6 @@ import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import {isIPhoneX} from '../constants/platform'
 import * as RPCTypes from '../constants/types/rpc-gen'
-// @ts-ignore
 import lagRadar from 'lag-radar'
 
 type Props = {

--- a/shared/app/runtime-stats.tsx
+++ b/shared/app/runtime-stats.tsx
@@ -4,6 +4,7 @@ import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import {isIPhoneX} from '../constants/platform'
 import * as RPCTypes from '../constants/types/rpc-gen'
+// @ts-ignore strict
 import lagRadar from 'lag-radar'
 
 type Props = {

--- a/shared/chat/conversation/attachment-fullscreen/index.native.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.native.tsx
@@ -145,7 +145,6 @@ class _Fullscreen extends React.Component<Props & Kb.OverlayParentProps, {loaded
         </Kb.BoxGrow>
         <Kb.Icon
           type="iconfont-ellipsis"
-          // @ts-ignore TODO fix styles
           style={styles.headerFooter}
           color={Styles.globalColors.blueDark}
           onClick={this.props.toggleShowingMenu}

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -128,7 +128,6 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
       // @ts-ignore thinks this is ready only: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065
       this._attachmentRef.current = r
       if (typeof this.props.forwardedRef === 'function') {
-        // @ts-ignore this function probably needs some cleanup
         this.props.forwardedRef(r)
       } else if (this.props.forwardedRef && typeof this.props.forwardedRef !== 'string') {
         // @ts-ignore we probably shouldn't be doing this
@@ -205,7 +204,6 @@ const AddSuggestors = <WrappedOwnProps extends {}>(
         for (let [suggestor, marker]: [string, string | RegExp] of Object.entries(
           this.props.suggestorToMarker
         )) {
-          // @ts-ignore
           const matchInfo = matchesMarker(word, marker)
           if (matchInfo.matches && this._inputRef.current && this._inputRef.current.isFocused()) {
             this.setState({active: suggestor, filter: word.substring(matchInfo.marker.length)})

--- a/shared/chat/conversation/messages/account-payment/pending-background/index.desktop.tsx
+++ b/shared/chat/conversation/messages/account-payment/pending-background/index.desktop.tsx
@@ -9,7 +9,6 @@ const bgScroll = Styles.styledKeyframes({
   to: {transform: 'translateY(-80px)'},
 })
 
-// @ts-ignore
 const BackgroundBox = Styles.styled.div(() => ({
   animation: `${bgScroll} 2s linear infinite`,
   backgroundImage: patternImage,

--- a/shared/chat/conversation/messages/react-button/emoji-picker/__test__/data.test.tsx
+++ b/shared/chat/conversation/messages/react-button/emoji-picker/__test__/data.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import {categories, categoryOrder, emojiNameMap, emojiIndex} from '../data'
-// @ts-ignore
 import emojidata from 'emoji-datasource'
 
 const searchIndexOmissions = [

--- a/shared/chat/conversation/messages/react-button/emoji-picker/data.tsx
+++ b/shared/chat/conversation/messages/react-button/emoji-picker/data.tsx
@@ -1,5 +1,4 @@
 import {emojiIndex} from 'emoji-mart'
-// @ts-ignore
 import emojidata from 'emoji-datasource'
 import groupBy from 'lodash/groupBy'
 import {EmojiData} from '../../../../../util/emoji'
@@ -9,7 +8,6 @@ const sorted: typeof categorized = {}
 for (const cat in categorized) {
   sorted[cat] = categorized[cat].sort((a, b) => a.sort_order - b.sort_order)
 }
-// @ts-ignore
 delete sorted.undefined
 const categoryOrder = [
   'Smileys & People',

--- a/shared/chat/conversation/messages/react-button/index.tsx
+++ b/shared/chat/conversation/messages/react-button/index.tsx
@@ -36,24 +36,22 @@ if (!Styles.isMobile) {
 
 const ButtonBox = Styles.styled(ClickableBox, {
   shouldForwardProp: prop => prop !== 'noEffect' && prop !== 'border',
-})(
-  // @ts-ignore
-  (props: ClickableBoxProps & {border: boolean; noEffect: boolean}) =>
-    Styles.isMobile || props.noEffect
-      ? {borderColor: Styles.globalColors.black_10}
-      : {
-          ...(props.border
-            ? {
-                ':hover': {
-                  backgroundColor: Styles.globalColors.blueLighter2,
-                  borderColor: Styles.globalColors.blue,
-                },
-              }
-            : {}),
-          '& .centered': {animation: `${bounceIn} 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards`},
-          '& .offscreen': {animation: `${bounceOut} 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards`},
-          borderColor: Styles.globalColors.black_10,
-        }
+})((props: ClickableBoxProps & {border: boolean; noEffect: boolean}) =>
+  Styles.isMobile || props.noEffect
+    ? {borderColor: Styles.globalColors.black_10}
+    : {
+        ...(props.border
+          ? {
+              ':hover': {
+                backgroundColor: Styles.globalColors.blueLighter2,
+                borderColor: Styles.globalColors.blue,
+              },
+            }
+          : {}),
+        '& .centered': {animation: `${bounceIn} 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards`},
+        '& .offscreen': {animation: `${bounceOut} 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards`},
+        borderColor: Styles.globalColors.black_10,
+      }
 )
 
 const ReactButton = (props: Props) => (

--- a/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-height-retainer/index.desktop.tsx
@@ -236,7 +236,6 @@ const styles = Styles.styleSheetCreate(
     } as const)
 )
 
-// @ts-ignore
 const AshBox = Styles.styled.div(
   {
     '&.full-width': {

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -51,7 +51,6 @@ export const newModalRoutes = {
       },
   chatAttachmentFullscreen: {
     getScreen: (): typeof ChatAttachmentFullscreen =>
-      // @ts-ignore TODO fix
       require('./conversation/attachment-fullscreen/container').default,
   },
   chatAttachmentGetTitles: {

--- a/shared/common-adapters/animation.native.tsx
+++ b/shared/common-adapters/animation.native.tsx
@@ -11,7 +11,6 @@ const Animation = (props: Props) => {
         autoPlay={true}
         loop={true}
         source={animationData[props.animationType]}
-        // @ts-ignore TODO fix styles
         style={props.style || {}}
       />
     </Box>

--- a/shared/common-adapters/dropdown.tsx
+++ b/shared/common-adapters/dropdown.tsx
@@ -224,7 +224,6 @@ const ItemBox = Styles.styled(Box)(() => ({
   width: '100%',
 }))
 
-// @ts-ignore styled can have more than one argument
 const ButtonBox = Styles.styled(Box, {shouldForwardProp: prop => prop !== 'inline'})(props => ({
   ...Styles.globalStyles.flexBoxRow,
   ...(!props.disabled && !Styles.isMobile

--- a/shared/common-adapters/floating-box/index.desktop.tsx
+++ b/shared/common-adapters/floating-box/index.desktop.tsx
@@ -31,7 +31,6 @@ class FloatingBox extends React.Component<Props, State> {
         console.warn('Non html element passed to floating box, deprecate this soon')
         let node
         try {
-          // @ts-ignore this is fine
           node = findDOMNode(attachTo)
         } catch (e) {
           logger.error(`FloatingBox: unable to find rect to attach to. Error: ${e.message}`)

--- a/shared/common-adapters/icon.native.tsx
+++ b/shared/common-adapters/icon.native.tsx
@@ -69,9 +69,7 @@ const Text = React.forwardRef<NativeText, TextProps>((p, ref) => {
   const fontSizeStyle = {fontSize: p.fontSize || Shared.typeToFontSize(p.sizeType)}
 
   return (
-    // @ts-ignore TODO fix styles
     <Kb.NativeText
-      // @ts-ignore TODO fix styles
       style={[styles.text, style, fontSizeStyle, p.style]}
       allowFontScaling={false}
       ref={ref}

--- a/shared/common-adapters/image.native.tsx
+++ b/shared/common-adapters/image.native.tsx
@@ -7,12 +7,7 @@ const Image = ({onLoad, src, style}: Props) => (
 )
 
 const RequireImage = ({src, style}: ReqProps) => (
-  <NativeImage
-    source={src}
-    resizeMode="contain"
-    // @ts-ignore TODO fix styles
-    style={style}
-  />
+  <NativeImage source={src} resizeMode="contain" style={style} />
 )
 
 export default Image

--- a/shared/common-adapters/kb-text-input.native.tsx
+++ b/shared/common-adapters/kb-text-input.native.tsx
@@ -76,7 +76,6 @@ if (isAndroid) {
       )
 
       return (
-        // @ts-ignore
         <TouchableWithoutFeedback
           onLayout={p.onLayout}
           accessible={p.accessible}
@@ -87,7 +86,6 @@ if (isAndroid) {
           accessibilityStates={p.accessibilityStates}
           // @ts-ignore no RN types
           nativeID={this.props.nativeID}
-          // @ts-ignore no RN types
           testID={this.props.testID}
         >
           {textContainer}

--- a/shared/common-adapters/list.native.tsx
+++ b/shared/common-adapters/list.native.tsx
@@ -45,7 +45,6 @@ class List<Item> extends PureComponent<Props<Item>> {
         <View style={Styles.globalStyles.fillAbsolute}>
           <List
             bounces={this.props.bounces}
-            // @ts-ignore TODO styles
             contentContainerStyle={this.props.contentContainerStyle}
             renderItem={this._itemRender}
             data={this.props.items}

--- a/shared/common-adapters/list2.native.tsx
+++ b/shared/common-adapters/list2.native.tsx
@@ -61,7 +61,6 @@ class List2<T> extends PureComponent<Props<T>> {
           onEndReached={this.props.onEndReached}
           windowSize={this.props.windowSize || 10}
           debug={false /* set to true to debug the list */}
-          // @ts-ignore TODO fix styles
           contentContainerStyle={this.props.style}
         />
       </View>

--- a/shared/common-adapters/markdown/generate-emoji-parser.tsx
+++ b/shared/common-adapters/markdown/generate-emoji-parser.tsx
@@ -1,7 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-// TODO: is there something better to do that ignore this?
-// @ts-ignore
 import emojiData from 'emoji-datasource'
 // MUST be lodash for node to work simply
 // eslint-disable-next-line

--- a/shared/common-adapters/oriented-image.desktop.tsx
+++ b/shared/common-adapters/oriented-image.desktop.tsx
@@ -264,7 +264,6 @@ class OrientedImage extends React.Component<Props, State> {
     return (
       <>
         {this.state.srcTransformed && (
-          // @ts-ignore codemod issue
           <ImageRef
             ref={this.props.forwardedRef}
             // @ts-ignore TODO type

--- a/shared/common-adapters/radio-button.desktop.tsx
+++ b/shared/common-adapters/radio-button.desktop.tsx
@@ -31,7 +31,6 @@ const StyledRadio: any = Styles.styled.div(
 
 const RadioButton = ({disabled, label, onSelect, selected, style}: Props) => (
   <div
-    // @ts-ignore clash between StylesCrossPlatform and React.CSSProperties
     style={{...styles.container, ...(disabled ? {} : Styles.desktopStyles.clickable), ...style}}
     onClick={disabled ? undefined : () => onSelect(!selected)}
   >

--- a/shared/common-adapters/reload.stories.tsx
+++ b/shared/common-adapters/reload.stories.tsx
@@ -58,7 +58,6 @@ const load = () => {
       </Kb.Reloadable>
     ))
     .add('Reload with back', () => (
-      // @ts-ignore need that helper thats not merged yet
       <Kb.Reloadable
         {...props}
         onBack={Sb.action('onBack')}

--- a/shared/common-adapters/section-list.native.tsx
+++ b/shared/common-adapters/section-list.native.tsx
@@ -19,7 +19,6 @@ const SectionList = React.forwardRef<NativeSectionList, Props<any>>(
         }
       : undefined
 
-    // @ts-ignore I tried but eventually gave up typing this.
     const NativeSectionListAny = NativeSectionList as any
     return (
       <NativeSectionListAny

--- a/shared/common-adapters/text.desktop.tsx
+++ b/shared/common-adapters/text.desktop.tsx
@@ -74,7 +74,6 @@ class Text extends React.Component<Props> {
         ref={this.props.allowHighlightText ? this._spanRef : null}
         className={this._className(this.props)}
         onClick={this.props.onClick || (this.props.onClickURL && this._urlClick) || undefined}
-        // @ts-ignore TODO CrossPlatformStyles isn't compat with the underlying components
         style={Styles.collapseStyles([this.props.style])}
       >
         {this.props.children}

--- a/shared/common-adapters/toast.desktop.tsx
+++ b/shared/common-adapters/toast.desktop.tsx
@@ -7,10 +7,8 @@ const Kb = {
   FloatingBox,
 }
 
-// @ts-ignore codemod-issue
 const FadeBox = Styles.styled.div(() => ({
   ...Styles.transition('opacity'),
-  // @ts-ignore
   '&.active': {opacity: 1},
   '&.visible': {display: 'flex', opacity: 1},
   opacity: 0,

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -1415,9 +1415,7 @@ export const mergeMessage = (old: Types.Message | null, m: Types.Message): Types
         }
         break
       default:
-        // @ts-ignore key is just a string here so TS doesn't like it
         if (old[key] === m[key]) {
-          // @ts-ignore
           toRet[key] = old[key]
         }
     }

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -1415,7 +1415,9 @@ export const mergeMessage = (old: Types.Message | null, m: Types.Message): Types
         }
         break
       default:
+        // @ts-ignore strict: key is just a string here so TS doesn't like it
         if (old[key] === m[key]) {
+          // @ts-ignore strict
           toRet[key] = old[key]
         }
     }

--- a/shared/constants/people.tsx
+++ b/shared/constants/people.tsx
@@ -118,8 +118,6 @@ export function makeDescriptionForTodoItem(todo: RPCTypes.HomeScreenTodo) {
       return `Your number *${p ? e164ToDisplay(p) : ''}* is unverified.`
     }
     default: {
-      // @ts-ignore this variant compilation seems wrong. ts todo.t can only be
-      // of 3 types but that's not what we do in avdl.
       const type = todoTypeEnumToType[todo.t]
       return todoTypeToInstructions[type]
     }

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -82,7 +82,6 @@ export const rpcDetailsToMemberInfos = (
   }
   types.forEach(type => {
     const key = typeToKey[type]
-    // @ts-ignore
     const members: Array<RPCTypes.TeamMemberDetails> = (allRoleMembers[key] || []) as any
     members.forEach(({fullName, joinTime, status, username}) => {
       infos.push([

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -82,6 +82,7 @@ export const rpcDetailsToMemberInfos = (
   }
   types.forEach(type => {
     const key = typeToKey[type]
+    // @ts-ignore strict
     const members: Array<RPCTypes.TeamMemberDetails> = (allRoleMembers[key] || []) as any
     members.forEach(({fullName, joinTime, status, username}) => {
       infos.push([

--- a/shared/desktop/renderer/preload-main.shared.desktop.tsx
+++ b/shared/desktop/renderer/preload-main.shared.desktop.tsx
@@ -1,7 +1,6 @@
 import path from 'path'
 import os from 'os'
 import * as Electron from 'electron'
-// @ts-ignore
 import fse from 'fs-extra'
 
 const isRenderer = typeof process !== 'undefined' && process.type === 'renderer'
@@ -11,7 +10,6 @@ const isDarwin = platform === 'darwin'
 const isWindows = platform === 'win32'
 const isLinux = platform === 'linux'
 
-// @ts-ignore
 const pid = isRenderer ? Electron.remote.process.pid : process.pid
 
 const kbProcess = {

--- a/shared/desktop/renderer/preload-main.shared.desktop.tsx
+++ b/shared/desktop/renderer/preload-main.shared.desktop.tsx
@@ -1,6 +1,7 @@
 import path from 'path'
 import os from 'os'
 import * as Electron from 'electron'
+// @ts-ignore strict
 import fse from 'fs-extra'
 
 const isRenderer = typeof process !== 'undefined' && process.type === 'renderer'
@@ -10,6 +11,7 @@ const isDarwin = platform === 'darwin'
 const isWindows = platform === 'win32'
 const isLinux = platform === 'linux'
 
+// @ts-ignore strict
 const pid = isRenderer ? Electron.remote.process.pid : process.pid
 
 const kbProcess = {

--- a/shared/engine/index.platform.native.tsx
+++ b/shared/engine/index.platform.native.tsx
@@ -2,7 +2,6 @@ import {NativeModules, NativeEventEmitter} from 'react-native'
 import logger from '../logger'
 import {TransportShared, sharedCreateClient, rpcLog} from './transport-shared'
 import {toByteArray, fromByteArray} from 'base64-js'
-// @ts-ignore
 import {encode} from '@msgpack/msgpack'
 import toBuffer from 'typedarray-to-buffer'
 import {printRPCBytes} from '../local-debug'

--- a/shared/fs/browser/index.stories.tsx
+++ b/shared/fs/browser/index.stories.tsx
@@ -33,7 +33,6 @@ const storeShowingSfmi = produce(storeCommon, draftStoreCommon => {
   draftStoreCommon.fs.sfmi.driverStatus = {...Constants.emptyDriverStatusEnabled}
 })
 const storeOthersReset = produce(storeCommon, draftStore => {
-  // @ts-ignore
   draftStore.fs.tlfs.private.set(
     'others,reset',
     Constants.makeTlf({

--- a/shared/login/reset/password.tsx
+++ b/shared/login/reset/password.tsx
@@ -103,13 +103,11 @@ const EnterPassword = () => {
   )
 }
 
-// @ts-ignore
 KnowPassword.navigationOptions = {
   header: null,
   headerBottomStyle: {height: undefined},
   headerLeft: null, // no back button
 }
-// @ts-ignore
 EnterPassword.navigationOptions = {
   header: null,
   headerBottomStyle: {height: undefined},

--- a/shared/profile/pgp/index.stories.desktop.tsx
+++ b/shared/profile/pgp/index.stories.desktop.tsx
@@ -59,9 +59,7 @@ const load = () => {
         })}
       />
     ))
-    // @ts-ignore
     .add('Import', () => <Import />)
-    // @ts-ignore
     .add('Finished Generated Pgp', () => <Finished />)
     .add('Generating', () => <Generate />)
 }

--- a/shared/router-v2/modal-helper.tsx
+++ b/shared/router-v2/modal-helper.tsx
@@ -18,7 +18,6 @@ function Modal<P extends {}>(
     () => ({}),
     dispatchProps,
     (_, dp, op: P) => ({...dp, ...op})
-    // @ts-ignore TODO figure out this types
   )(withPopup)
 }
 

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -79,7 +79,6 @@ class AppView extends React.PureComponent<NavigationViewProps<any>> {
             {/*
           // @ts-ignore Header typing not finished yet */}
             <Header
-              // @ts-ignore
               loggedIn={!!selectedTab}
               options={descriptor.options}
               onPop={() => childNav.goBack(activeKey)}

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -215,7 +215,6 @@ const VanillaTabNavigator = createBottomTabNavigator(
             <></>
           ) : (
             <Kb.Text
-              // @ts-ignore expecting a literal color, not a getter
               style={Styles.collapseStyles([
                 tabStyles.label,
                 Styles.isDarkMode()

--- a/shared/settings/landing/index.stories.tsx
+++ b/shared/settings/landing/index.stories.tsx
@@ -20,7 +20,6 @@ const defaultPlanProps = {
 const load = () => {
   storiesOf('Settings/Landing', module)
     .add('Normal', () => (
-      // @ts-ignore plan
       <Landing
         account={{
           ...defaultAccountProps,
@@ -33,7 +32,6 @@ const load = () => {
       />
     ))
     .add('Unknown HasRandomPW', () => (
-      // @ts-ignore plan
       <Landing
         account={{
           ...defaultAccountProps,
@@ -43,7 +41,6 @@ const load = () => {
       />
     ))
     .add('Random PW', () => (
-      // @ts-ignore plan
       <Landing
         account={{
           ...defaultAccountProps,
@@ -55,7 +52,6 @@ const load = () => {
       />
     ))
     .add('No e-mail', () => (
-      // @ts-ignore plan
       <Landing
         account={{
           ...defaultAccountProps,
@@ -66,7 +62,6 @@ const load = () => {
       />
     ))
     .add('Both no-email and random pw', () => (
-      // @ts-ignore plan
       <Landing
         account={{
           ...defaultAccountProps,

--- a/shared/stories/prop-providers.tsx
+++ b/shared/stories/prop-providers.tsx
@@ -123,7 +123,6 @@ const Mention = ({username, key, style}: any) => ({
   key,
   onClick: action('onClick Mention'),
   style,
-  // @ts-ignore
   theme: usernameToTheme[username] || (isSpecialMention(username) ? 'highlight' : 'none'),
   username,
 })

--- a/shared/stories/prop-providers.tsx
+++ b/shared/stories/prop-providers.tsx
@@ -123,6 +123,7 @@ const Mention = ({username, key, style}: any) => ({
   key,
   onClick: action('onClick Mention'),
   style,
+  // @ts-ignore strict
   theme: usernameToTheme[username] || (isSpecialMention(username) ? 'highlight' : 'none'),
   username,
 })

--- a/shared/stories/storybook.shared.tsx
+++ b/shared/stories/storybook.shared.tsx
@@ -60,7 +60,6 @@ const createPropProvider = (...maps: SelectorMap[]) => {
    * children to GatewayProvider which only takes one child
    */
   return (story: () => React.ReactNode) => (
-    // @ts-ignore complains about merged
     <Provider
       key={`provider:${uniqueProviderKey++}`}
       store={
@@ -88,7 +87,6 @@ const actionLog = () => (next: any) => (a: any) => {
 
 // Includes common old-style propProvider temporarily
 export const MockStore = ({store, children}: any): any => (
-  // @ts-ignore
   <Provider
     key={`storyprovider:${uniqueProviderKey++}`}
     store={createStore(state => state, {...store, ...PP.Common()}, applyMiddleware(actionLog))}
@@ -238,7 +236,6 @@ class PerfBox extends React.Component<
   }
 
   _getTime = () => {
-    // @ts-ignore
     const perf: any = window ? window.performance : undefined
     if (typeof perf !== 'undefined') {
       return perf.now()

--- a/shared/unlock-folders/main.desktop.tsx
+++ b/shared/unlock-folders/main.desktop.tsx
@@ -5,7 +5,6 @@ import load from '../desktop/remote/component-loader.desktop'
 import {deserialize} from './remote-serializer.desktop'
 
 load({
-  // @ts-ignore codemod issue
   child: <UnlockFolders />,
   deserialize,
   name: 'unlock-folders',

--- a/shared/util/bootstrapable.tsx
+++ b/shared/util/bootstrapable.tsx
@@ -17,7 +17,6 @@ export default function Bootstrapable<P extends Object>(
 ): React.ComponentClass<BootstrapableProp<P>, void> {
   return class extends React.Component<BootstrapableProp<P>, void> {
     componentDidMount() {
-      // @ts-ignore codemod-issue
       !this.props.bootstrapDone && this.props.onBootstrap()
     }
 

--- a/shared/util/phone-numbers/index.tsx
+++ b/shared/util/phone-numbers/index.tsx
@@ -38,7 +38,6 @@ const load = () => {
       curr.countryCallingCodes.length &&
       supported.includes(curr.alpha2)
     ) {
-      // @ts-ignore
       const emojiText: string = emojiIndexByChar[curr.emoji || -1] || ''
       // see here for why we check status is 'assigned'
       // https://github.com/OpenBookPrices/country-data/tree/011dbb6658b0df5a36690af7086baa3e5c20c30c#status-notes

--- a/shared/util/safe-submit.tsx
+++ b/shared/util/safe-submit.tsx
@@ -20,6 +20,7 @@ export function safeSubmit(submitProps: Array<string>, resetSafeProps: Array<str
       }, {})
 
       componentDidUpdate(prevProps: P) {
+        // @ts-ignore strict: Fundamentally unsafe, but we don't actually care about the types
         if (resetSafeProps.some(k => this.props[k] !== prevProps[k])) {
           // reset safe settings
           Object.keys(this._safeToCallWrappedMap).forEach(n => (this._safeToCallWrappedMap[n] = true))
@@ -28,6 +29,7 @@ export function safeSubmit(submitProps: Array<string>, resetSafeProps: Array<str
 
       render() {
         const wrapped = submitProps.reduce<{[key: string]: unknown}>((map, name) => {
+          // @ts-ignore strict
           const old: unknown = this.props[name]
           if (old) {
             map[name] = (...args: Array<unknown>) => {

--- a/shared/util/safe-submit.tsx
+++ b/shared/util/safe-submit.tsx
@@ -20,7 +20,6 @@ export function safeSubmit(submitProps: Array<string>, resetSafeProps: Array<str
       }, {})
 
       componentDidUpdate(prevProps: P) {
-        // @ts-ignore. Fundamentally unsafe, but we don't actually care about the types
         if (resetSafeProps.some(k => this.props[k] !== prevProps[k])) {
           // reset safe settings
           Object.keys(this._safeToCallWrappedMap).forEach(n => (this._safeToCallWrappedMap[n] = true))
@@ -29,7 +28,6 @@ export function safeSubmit(submitProps: Array<string>, resetSafeProps: Array<str
 
       render() {
         const wrapped = submitProps.reduce<{[key: string]: unknown}>((map, name) => {
-          // @ts-ignore
           const old: unknown = this.props[name]
           if (old) {
             map[name] = (...args: Array<unknown>) => {

--- a/shared/util/saga.tsx
+++ b/shared/util/saga.tsx
@@ -87,7 +87,6 @@ function* chainAction2Impl<Actions extends {readonly type: string}>(
   pattern: Types.Pattern<any>,
   f: (state: TypedState, action: Actions, logger: SagaLogger) => ChainActionReturn
 ) {
-  // @ts-ignore
   return yield Effects.takeEvery<TypedActions>(pattern as Types.Pattern<any>, function* chainAction2Helper(
     action: TypedActions
   ) {
@@ -134,7 +133,6 @@ function* chainActionImpl<Actions extends {readonly type: string}>(
   pattern: Types.Pattern<any>,
   f: (action: Actions, logger: SagaLogger) => ChainActionReturn
 ) {
-  // @ts-ignore
   return yield Effects.takeEvery<TypedActions>(pattern as Types.Pattern<any>, function* chainActionHelper(
     action: TypedActions
   ) {

--- a/shared/wallets/send-form/participants/container.tsx
+++ b/shared/wallets/send-form/participants/container.tsx
@@ -128,13 +128,10 @@ const ConnectedParticipantsOtherAccount = namedConnect(
 const ParticipantsChooser = props => {
   switch (props.recipientType) {
     case 'keybaseUser':
-      // @ts-ignore not sure what's up here
       return <ConnectedParticipantsKeybaseUser />
     case 'stellarPublicKey':
-      // @ts-ignore not sure what's up here
       return <ConnectedParticipantsStellarPublicKey />
     case 'otherAccount':
-      // @ts-ignore not sure what's up here
       return <ConnectedParticipantsOtherAccount />
 
     default:


### PR DESCRIPTION
@keybase/react-hackers 

To prepare this:

* installed TS 3.9 beta
* changed all @ts-ignore to @ts-expect-error
* removed all erroring @ts-expect-error lines
* changed back to @ts-ignore
* back to TS 3.8.3
* verified no errors
* now when we go to TS 3.9, we can switch to using @ts-expect-error if we want to