### PR TITLE
Remove backspace hotkey for removing conversation members.

### DIFF
--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -2,7 +2,6 @@ import logger from '../logger'
 import * as React from 'react'
 import unidecode from 'unidecode'
 import debounce from 'lodash/debounce'
-import throttle from 'lodash/throttle'
 import trim from 'lodash/trim'
 import TeamBuilding, {
   RolePickerProps,
@@ -259,14 +258,6 @@ const mapDispatchToProps = (dispatch: Container.TypedDispatch, {namespace, teamI
   onSelectRole: (role: TeamTypes.TeamRoleType) =>
     namespace === 'teams' && dispatch(TeamBuildingGen.createSelectRole({namespace, role})),
 })
-
-const deriveOnBackspace = throttle(
-  memoize((searchString, teamSoFar, onRemove) => () => {
-    // Check if empty and we have a team so far
-    !searchString && teamSoFar.length && onRemove(teamSoFar[teamSoFar.length - 1].userId)
-  }),
-  100
-)
 
 const deriveOnEnterKeyDown = memoizeShallow(
   (p: {
@@ -598,7 +589,6 @@ const mergeProps = (
     includeContacts: ownProps.namespace === 'chat2',
     namespace: ownProps.namespace,
     onAdd,
-    onBackspace: deriveOnBackspace(ownProps.searchString, teamSoFar, dispatchProps.onRemove),
     onChangeService: deriveOnChangeService(
       ownProps.onChangeService,
       ownProps.incFocusInputCounter,

--- a/shared/team-building/index.stories.tsx
+++ b/shared/team-building/index.stories.tsx
@@ -118,7 +118,6 @@ const contactProps = {
 
 const eventHandlers = {
   incFocusInputCounter: Sb.action('incFocusInputCounter'),
-  onBackspace: Sb.action('onBackspace'),
   onChangeService: Sb.action('onChangeService'),
   onChangeText: Sb.action('onChangeText'),
   onClear: Sb.action('onClear'),
@@ -649,7 +648,6 @@ const load = () => {
       <Input
         placeholder="Type in some input inside"
         searchString=""
-        onBackspace={Sb.action('onBackspace')}
         onChangeText={Sb.action('onChangeText')}
         onClear={Sb.action('onClear')}
         onDownArrowKeyDown={Sb.action('onDownArrowKeyDown')}
@@ -668,7 +666,6 @@ const load = () => {
         onUpArrowKeyDown={Sb.action('onUpArrowKeyDown')}
         onEnterKeyDown={Sb.action('onEnterKeyDown')}
         onFinishTeamBuilding={Sb.action('onFinishTeamBuilding')}
-        onBackspace={Sb.action('onBackspace')}
         onRemove={Sb.action('onRemove')}
         teamSoFar={[
           {

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -104,7 +104,6 @@ export type Props = ContactProps & {
   includeContacts: boolean
   namespace: AllowedNamespace
   onAdd: (userId: string) => void
-  onBackspace: () => void
   onChangeService: (newService: ServiceIdWithContact) => void
   onChangeText: (newText: string) => void
   onClear: () => void
@@ -392,7 +391,6 @@ class TeamBuilding extends React.PureComponent<Props> {
         onDownArrowKeyDown={this.props.onDownArrowKeyDown}
         onUpArrowKeyDown={this.props.onUpArrowKeyDown}
         onEnterKeyDown={this.props.onEnterKeyDown}
-        onBackspace={this.props.onBackspace}
         placeholder={searchPlaceholder}
         searchString={this.props.searchString}
         focusOnMount={!Styles.isMobile || this.props.selectedService !== 'keybase'}
@@ -737,7 +735,6 @@ class TeamBuilding extends React.PureComponent<Props> {
         onFinishTeamBuilding={props.onFinishTeamBuilding}
         onRemove={props.onRemove}
         teamSoFar={props.teamSoFar}
-        onBackspace={props.onBackspace}
         searchString={props.searchString}
         rolePickerProps={props.rolePickerProps}
         goButtonLabel={props.goButtonLabel}

--- a/shared/team-building/input.tsx
+++ b/shared/team-building/input.tsx
@@ -10,7 +10,6 @@ type Props = {
   onEnterKeyDown: () => void
   onDownArrowKeyDown: () => void
   onUpArrowKeyDown: () => void
-  onBackspace: () => void
   placeholder: string
   searchString: string
   focusOnMount: boolean
@@ -43,9 +42,6 @@ const handleKeyDown = (preventDefault: () => void, ctrlKey: boolean, key: string
     case 'ArrowUp':
       preventDefault()
       props.onUpArrowKeyDown()
-      break
-    case 'Backspace':
-      props.onBackspace()
       break
   }
 }

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -19,7 +19,6 @@ type Props = {
   onUpArrowKeyDown: () => void
   teamSoFar: Array<SelectedUser>
   onRemove: (userId: string) => void
-  onBackspace: () => void
   onFinishTeamBuilding: () => void
   searchString: string
   rolePickerProps?: RolePickerProps


### PR DESCRIPTION
@keybase/react-hackers, we decided after a few iterations that this ultimately does more harm than good and are removing it.