### PR TITLE
fix: remove tooltip, fix sizing and alignment on deskotp

### DIFF
--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -133,7 +133,7 @@ const emojiRenderer = (item: EmojiData, selected: boolean) => (
     gap="small"
   >
     {item.source ? (
-      <Kb.CustomEmoji size="Medium" src={item.source} />
+      <Kb.CustomEmoji size="MediumLarge" src={item.source} />
     ) : (
       <Kb.Emoji emojiName={item.short_name} size={24} />
     )}

--- a/shared/chat/conversation/messages/react-button/emoji-picker/index.tsx
+++ b/shared/chat/conversation/messages/react-button/emoji-picker/index.tsx
@@ -226,7 +226,7 @@ class EmojiPicker extends React.PureComponent<Props, State> {
         key={emoji.short_name}
       >
         {emoji.source ? (
-          <Kb.CustomEmoji size="Medium" src={emoji.source} alias={emoji.short_name} />
+          <Kb.CustomEmoji size="MediumLarge" src={emoji.source} />
         ) : (
           <Kb.Emoji size={singleEmojiWidth} emojiName={emojiStr} />
         )}

--- a/shared/common-adapters/custom-emoji.d.ts
+++ b/shared/common-adapters/custom-emoji.d.ts
@@ -1,6 +1,6 @@
 import {Component} from 'react'
 
-type emojiSize = 'Small' | 'Medium' | 'Big'
+type emojiSize = 'Small' | 'Medium' | 'MediumLarge' | 'Big'
 export type Props = {
   size: emojiSize
   src: string

--- a/shared/common-adapters/custom-emoji.desktop.tsx
+++ b/shared/common-adapters/custom-emoji.desktop.tsx
@@ -15,7 +15,8 @@ const Kb = {
 
 const emojiTypes = {
   Big: 32,
-  Medium: 20,
+  MediumLarge: 26,
+  Medium: 18,
   Small: 16,
 }
 
@@ -24,6 +25,7 @@ const CustomEmoji = (props: Props) => {
   return (
     <Kb.Box2
       direction="horizontal"
+      alignItems="center"
       style={Styles.collapseStyles([
         styles.emoji,
         {
@@ -36,8 +38,9 @@ const CustomEmoji = (props: Props) => {
         <Kb.Image
           src={src}
           style={Styles.collapseStyles([
+            styles.image,
             {
-              height: emojiTypes[size],
+              maxHeight: emojiTypes[size],
               width: emojiTypes[size],
             },
           ])}
@@ -52,7 +55,13 @@ const styles = Styles.styleSheetCreate(
     ({
       emoji: Styles.platformStyles({
         isElectron: {
-          display: 'inline-block',
+          display: 'inline-flex',
+          justifyContent: 'center',
+        },
+      }),
+      image: Styles.platformStyles({
+        isElectron: {
+          display: 'inline',
           verticalAlign: 'middle',
         },
       }),

--- a/shared/common-adapters/custom-emoji.desktop.tsx
+++ b/shared/common-adapters/custom-emoji.desktop.tsx
@@ -15,8 +15,8 @@ const Kb = {
 
 const emojiTypes = {
   Big: 32,
-  MediumLarge: 26,
   Medium: 18,
+  MediumLarge: 26,
   Small: 16,
 }
 

--- a/shared/common-adapters/custom-emoji.native.tsx
+++ b/shared/common-adapters/custom-emoji.native.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
 import Image from './image'
+import {Box2} from './box'
 import Text from './text'
 import WithTooltip from './with-tooltip'
 import {Props} from './custom-emoji'
 
 const Kb = {
+  Box2,
   Image,
   Text,
   WithTooltip,
@@ -13,19 +15,22 @@ const Kb = {
 const emojiTypes = {
   Big: 32,
   Medium: 24,
+  MediumLarge: 24,
   Small: 20,
 }
 
 const CustomEmoji = (props: Props) => {
   const {size, src} = props
   return (
-    <Kb.Image
-      src={src}
-      style={{
-        height: emojiTypes[size],
-        width: emojiTypes[size],
-      }}
-    />
+    <Kb.Box2 direction="horizontal">
+      <Kb.Image
+        src={src}
+        style={{
+          height: emojiTypes[size],
+          width: emojiTypes[size],
+        }}
+      />
+    </Kb.Box2>
   )
 }
 

--- a/shared/common-adapters/markdown/service-decoration.tsx
+++ b/shared/common-adapters/markdown/service-decoration.tsx
@@ -238,10 +238,14 @@ const ServiceDecoration = (props: Props) => {
       return (
         <CustomEmoji
           size={
-            parsed.emoji.isBig && !props.disableBigEmojis ? 'Big' : parsed.emoji.isReacji ? 'Medium' : 'Small'
+            parsed.emoji.isBig && !props.disableBigEmojis
+              ? 'Big'
+              : parsed.emoji.isReacji && !Styles.isMobile
+              ? 'Medium'
+              : 'Small'
           }
           src={parsed.emoji.source.httpsrv}
-          alias={parsed.emoji.alias}
+          alias={!parsed.emoji.isReacji ? parsed.emoji.alias : undefined}
         />
       )
     } else if (parsed.emoji.source.typ === RPCChatTypes.EmojiLoadSourceTyp.str) {


### PR DESCRIPTION
Removes unneeded tooltips for custom emojis on desktop and makes sizing a little more consistent with stock emoji.