### PR TITLE
bust team cache

### DIFF
--- a/go/teams/storage/std.go
+++ b/go/teams/storage/std.go
@@ -15,7 +15,7 @@ type Storage struct {
 }
 
 // Increment to invalidate the disk cache.
-const diskStorageVersion = 11
+const diskStorageVersion = 12
 const memCacheLRUSize = 200
 
 type DiskStorageItem struct {
@@ -65,27 +65,6 @@ func (s *Storage) Get(mctx libkb.MetaContext, teamID keybase1.TeamID, public boo
 		return nil, false, false
 	}
 
-	// TODO Y2K-1486: old migrations, version is now 11, remove these:
-
-	if diskStorageVersion == 10 && ret.Subversion == 0 {
-		migrateInvites(mctx, ret.ID(), ret.Chain.ActiveInvites)
-		migrateInvites(mctx, ret.ID(), ret.Chain.ObsoleteInvites)
-		ret.Subversion = 1
-	}
-
-	if diskStorageVersion == 10 && (ret.Subversion == 1 || ret.Chain.MaxPerTeamKeyGeneration == keybase1.PerTeamKeyGeneration(0)) {
-		prior := ret.Chain.MaxPerTeamKeyGeneration
-		// 2019-06: We added MaxPerTeamKeyGeneration and can hot-patch existing structures
-		// pretty easily, so do that rather than blasting away the cache.
-		for k := range ret.Chain.PerTeamKeys {
-			if k > ret.Chain.MaxPerTeamKeyGeneration {
-				ret.Chain.MaxPerTeamKeyGeneration = k
-			}
-		}
-		mctx.Debug("Upgraded MaxPerTeamKeyGeneration to %d in version 10.2 (prior: %d, %d)", ret.Chain.MaxPerTeamKeyGeneration, ret.Subversion, prior)
-		ret.Subversion = 2
-	}
-
 	if ret.Frozen {
 		mctx.Debug("returning frozen team data")
 	}
@@ -93,24 +72,4 @@ func (s *Storage) Get(mctx libkb.MetaContext, teamID keybase1.TeamID, public boo
 		mctx.Debug("returning tombstoned team data")
 	}
 	return ret, ret.Frozen, ret.Tombstoned
-}
-
-// migrateInvites converts old 'category unknown' invites into social invites for paramproofs.
-func migrateInvites(mctx libkb.MetaContext, teamID keybase1.TeamID, invites map[keybase1.TeamInviteID]keybase1.TeamInvite) {
-	for key, invite := range invites {
-		category, err := invite.Type.C()
-		if err != nil {
-			continue
-		}
-		if category != keybase1.TeamInviteCategory_UNKNOWN {
-			continue
-		}
-		categoryStr := invite.Type.Unknown()
-		if mctx.G().GetProofServices().GetServiceType(mctx.Ctx(), categoryStr) == nil {
-			continue
-		}
-		mctx.Debug("migrateInvites repairing teamID:%v inviteID:%v cat:%v", teamID, invite.Id, categoryStr)
-		invite.Type = keybase1.NewTeamInviteTypeWithSbs(keybase1.TeamInviteSocialNetwork(categoryStr))
-		invites[key] = invite
-	}
 }


### PR DESCRIPTION
This is so invite links can be processed correctly if one updates kb after loading a team chainlink containing a new invite (which the old version would have ignored)