### PR TITLE
web of trust fix iknowthem button

### DIFF
--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -153,13 +153,8 @@ func TestWebOfTrustPending(t *testing.T) {
 	t.Log("alice sees one pending vouch")
 	vouches, err = libkb.FetchWotVouches(mctxB, libkb.FetchWotVouchesArg{Vouchee: aliceName})
 	require.NoError(t, err)
-	// TODO: alex will uncomment this imminently
-	// require.Empty(t, vouches)
-	t.Log("bob sees no vouches for Alice")
-	vouches, err = libkb.FetchWotVouches(mctxB, libkb.FetchWotVouchesArg{Vouchee: aliceName, Voucher: bobName})
-	require.NoError(t, err)
 	require.Equal(t, 1, len(vouches))
-	t.Log("bob sees pending vouch for Alice")
+	t.Log("bob also sees his pending vouch for Alice")
 
 	tcCharlie := SetupEngineTest(t, "wot")
 	defer tcCharlie.Cleanup()
@@ -349,9 +344,9 @@ func TestWebOfTrustReject(t *testing.T) {
 
 	vouches, err = libkb.FetchWotVouches(mctxB, libkb.FetchWotVouchesArg{Vouchee: aliceName})
 	require.NoError(t, err)
-	// TODO: alex will uncomment this imminently
-	// require.Equal(t, 0, len(vouches))
-	t.Log("bob cannot see it")
+	require.Equal(t, 1, len(vouches))
+	require.Equal(t, keybase1.WotStatusType_REJECTED, vouches[0].Status)
+	t.Log("bob can also see it as rejected")
 }
 
 func TestWebOfTrustRevoke(t *testing.T) {

--- a/shared/constants/tracker2.tsx
+++ b/shared/constants/tracker2.tsx
@@ -212,3 +212,7 @@ export const guiIDToUsername = (state: Types.State, guiID: string) => {
   const det = [...state.usernameToDetails.values()].find(d => d.guiID === guiID)
   return det ? det.username : null
 }
+
+// when suggestions are implemented, we'll probably want to show rejected entries if they have a suggestion
+export const showableWotEntry = (entry: Types.WebOfTrustEntry): boolean =>
+  entry.status in [RPCTypes.WotStatusType.accepted, RPCTypes.WotStatusType.proposed]

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -94,11 +94,6 @@ export type WebOfTrustEntry = {
   vouchedAt: number
 }
 
-export const showableWotEntry = (entry: WebOfTrustEntry): boolean => {
-  // when suggestions are implemented, we'll also want to show rejected entries that have a suggestion
-  return entry.status in [RPCTypes.WotStatusType.accepted, RPCTypes.WotStatusType.proposed]
-}
-
 export type State = {
   readonly usernameToDetails: Map<string, Details>
   readonly usernameToNonUserDetails: Map<string, NonUserDetails>

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -94,6 +94,11 @@ export type WebOfTrustEntry = {
   vouchedAt: number
 }
 
+export const showableWotEntry = (entry: WebOfTrustEntry): boolean => {
+  // when suggestions are implemented, we'll also want to show rejected entries that have a suggestion
+  return entry.status in [RPCTypes.WotStatusType.accepted, RPCTypes.WotStatusType.proposed]
+}
+
 export type State = {
   readonly usernameToDetails: Map<string, Details>
   readonly usernameToNonUserDetails: Map<string, NonUserDetails>

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -49,14 +49,12 @@ const connected = Container.namedConnect(
     if (!notAUser) {
       // Keybase user
       const followThem = Constants.followThem(state, username)
-      const {followersCount, followingCount, followers, following, reason} = d
-      const webOfTrustEntries = (d.webOfTrustEntries || []).filter(entry => Types.showableWotEntry(entry))
+      const {followersCount, followingCount, followers, following, reason, webOfTrustEntries = []} = d
+      const filteredWot = webOfTrustEntries.filter(Constants.showableWotEntry)
 
       const mutualFollow = followThem && Constants.followsYou(state, username)
-      const hasntAlreadyVouched = webOfTrustEntries.every(
-        entry => entry.attestingUser !== state.config.username
-      )
-      const promptForVouch = mutualFollow && hasntAlreadyVouched
+      const hasNotAlreadyVouched = filteredWot.every(entry => entry.attestingUser !== state.config.username)
+      const promptForVouch = mutualFollow && hasNotAlreadyVouched
 
       return {
         ...commonProps,
@@ -73,7 +71,7 @@ const connected = Container.namedConnect(
         sbsAvatarUrl: undefined,
         serviceIcon: undefined,
         title: username,
-        webOfTrustEntries,
+        webOfTrustEntries: filteredWot,
       }
     } else {
       // SBS profile. But `nonUserDetails` might not have arrived yet,

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -51,6 +51,12 @@ const connected = Container.namedConnect(
       const followThem = Constants.followThem(state, username)
       const {followersCount, followingCount, followers, following, reason, webOfTrustEntries} = d
 
+      const mutualFollow = followThem && Constants.followsYou(state, username)
+      const hasntAlreadyVouched = (webOfTrustEntries || []).every(
+        entry => entry.attestingUser !== state.config.username
+      )
+      const promptForVouch = mutualFollow && hasntAlreadyVouched
+
       return {
         ...commonProps,
         _assertions: d.assertions,
@@ -61,6 +67,7 @@ const connected = Container.namedConnect(
         followersCount,
         following,
         followingCount,
+        promptForVouch,
         reason,
         sbsAvatarUrl: undefined,
         serviceIcon: undefined,
@@ -83,6 +90,7 @@ const connected = Container.namedConnect(
         backgroundColorType: headerBackgroundColorType(d.state, false),
         fullName: nonUserDetails.fullName,
         name,
+        promptForVouch: false,
         sbsAvatarUrl: nonUserDetails.pictureUrl || undefined,
         service,
         serviceIcon: Styles.isDarkMode() ? nonUserDetails.siteIconFullDarkmode : nonUserDetails.siteIconFull,
@@ -154,7 +162,9 @@ const connected = Container.namedConnect(
       onAddIdentity,
       onBack: dispatchProps.onBack,
       onEditAvatar: stateProps.userIsYou ? dispatchProps._onEditAvatar : undefined,
-      onIKnowThem: stateProps.userIsYou ? undefined : () => dispatchProps._onIKnowThem(stateProps.username),
+      onIKnowThem: stateProps.promptForVouch
+        ? () => dispatchProps._onIKnowThem(stateProps.username)
+        : undefined,
       onReload: () => dispatchProps._onReload(stateProps.username, stateProps.userIsYou, stateProps.state),
       reason: stateProps.reason,
       sbsAvatarUrl: stateProps.sbsAvatarUrl,

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -49,10 +49,11 @@ const connected = Container.namedConnect(
     if (!notAUser) {
       // Keybase user
       const followThem = Constants.followThem(state, username)
-      const {followersCount, followingCount, followers, following, reason, webOfTrustEntries} = d
+      const {followersCount, followingCount, followers, following, reason} = d
+      const webOfTrustEntries = (d.webOfTrustEntries || []).filter(entry => Types.showableWotEntry(entry))
 
       const mutualFollow = followThem && Constants.followsYou(state, username)
-      const hasntAlreadyVouched = (webOfTrustEntries || []).every(
+      const hasntAlreadyVouched = webOfTrustEntries.every(
         entry => entry.attestingUser !== state.config.username
       )
       const promptForVouch = mutualFollow && hasntAlreadyVouched

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -403,11 +403,13 @@ class User extends React.Component<Props, State> {
 
   _renderWebOfTrust = ({item}) =>
     item.type === 'IKnowThem' ? (
-      <Kb.Box2 key="iknowthem" direction="horizontal" fullWidth={true} style={styles.knowThemBox}>
-        <Kb.Button key="iknowthembtn" onClick={this.props.onIKnowThem} type="Default" label={item.text}>
-          <Kb.Icon type="iconfont-proof-good" style={styles.knowThemIcon} />
-        </Kb.Button>
-      </Kb.Box2>
+      this.props.onIKnowThem && (
+        <Kb.Box2 key="iknowthem" direction="horizontal" fullWidth={true} style={styles.knowThemBox}>
+          <Kb.Button key="iknowthembtn" onClick={this.props.onIKnowThem} type="Default" label={item.text}>
+            <Kb.Icon type="iconfont-proof-good" style={styles.knowThemIcon} />
+          </Kb.Button>
+        </Kb.Box2>
+      )
     ) : (
       <WebOfTrust webOfTrustAttestation={item} username={this.props.username} />
     )

--- a/shared/profile/user/weboftrust/container.tsx
+++ b/shared/profile/user/weboftrust/container.tsx
@@ -44,18 +44,21 @@ const Connected = Container.connect(
           : null,
     }
   },
-  (stateProps, dispatchProps) => ({
-    attestation: stateProps.attestation,
-    attestingUser: stateProps.attestingUser,
-    onAccept: dispatchProps._onAccept,
-    onReject: dispatchProps._onReject,
-    reactWaitingKey: wotReactWaitingKey,
-    status: stateProps.status,
-    userIsYou: stateProps.userIsYou,
-    username: stateProps.username,
-    verificationType: stateProps.verificationType,
-    vouchedAt: stateProps.vouchedAt,
-  })
+  (stateProps, dispatchProps) => {
+    const noop = () => null
+    return {
+      attestation: stateProps.attestation,
+      attestingUser: stateProps.attestingUser,
+      onAccept: stateProps.userIsYou ? dispatchProps._onAccept : noop,
+      onReject: stateProps.userIsYou ? dispatchProps._onReject : noop,
+      reactWaitingKey: wotReactWaitingKey,
+      status: stateProps.status,
+      userIsYou: stateProps.userIsYou,
+      username: stateProps.username,
+      verificationType: stateProps.verificationType,
+      vouchedAt: stateProps.vouchedAt,
+    }
+  }
 )(WebOfTrust)
 
 export default Connected

--- a/shared/profile/user/weboftrust/container.tsx
+++ b/shared/profile/user/weboftrust/container.tsx
@@ -5,6 +5,8 @@ import {WebOfTrustVerificationType} from '../../../constants/types/more'
 import {wotReactWaitingKey} from '../../../constants/users'
 import {WotReactionType, WotStatusType} from '../../../constants/types/rpc-gen'
 
+const noop = () => null
+
 type OwnProps = {
   webOfTrustAttestation: {
     attestation: string
@@ -45,7 +47,6 @@ const Connected = Container.connect(
     }
   },
   (stateProps, dispatchProps) => {
-    const noop = () => null
     return {
       attestation: stateProps.attestation,
       attestingUser: stateProps.attestingUser,

--- a/shared/profile/user/weboftrust/index.tsx
+++ b/shared/profile/user/weboftrust/index.tsx
@@ -19,7 +19,7 @@ type Props = {
   vouchedAt: number
 }
 
-const entry = (props: Props) => (
+const entry = (props: Props, statusStatement: string) => (
   <>
     <Kb.Box2 direction="horizontal" fullWidth={true}>
       <Kb.Box2 direction="vertical" style={styles.avatarContainer} centerChildren={true}>
@@ -31,6 +31,9 @@ const entry = (props: Props) => (
         />
       </Kb.Box2>
       <Kb.Box2 direction="vertical" fullWidth={true} style={styles.textContainer} centerChildren={false}>
+        <Kb.Text style={styles.attestationText} type="BodySmall">
+          {statusStatement}
+        </Kb.Text>
         <Kb.Text style={styles.attestationText} type="Body">
           {props.attestation}
         </Kb.Text>
@@ -81,13 +84,10 @@ const entry = (props: Props) => (
 const WebOfTrust = (props: Props) => {
   switch (props.status) {
     case WotStatusType.proposed: {
-      if (props.userIsYou) {
-        return entry(props)
-      }
-      return null
+      return entry(props, props.userIsYou ? 'Pending your approval:' : 'You proposed:')
     }
     case WotStatusType.accepted: {
-      return entry(props)
+      return entry(props, 'Accepted:')
     }
     default: {
       return null


### PR DESCRIPTION
depends on https://github.com/keybase/keybase/pull/5381 which depends on https://github.com/keybase/client/pull/23540
I expect this to fail CI until those PRs are in. 

show the iKnowThem button (i.e. prompt for a vouch) iff the viewer and the profile mutually follow one another AND the viewer has not already written a vouch. 