### PR TITLE
Add 30s timeout to nonblock RPC calls

### DIFF
--- a/go/protocol/chat1/local.go
+++ b/go/protocol/chat1/local.go
@@ -8853,7 +8853,7 @@ func (c LocalClient) GetThreadLocal(ctx context.Context, __arg GetThreadLocalArg
 }
 
 func (c LocalClient) GetThreadNonblock(ctx context.Context, __arg GetThreadNonblockArg) (res NonblockFetchRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.getThreadNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.getThreadNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
@@ -8910,32 +8910,32 @@ func (c LocalClient) GenerateOutboxID(ctx context.Context) (res OutboxID, err er
 }
 
 func (c LocalClient) PostLocalNonblock(ctx context.Context, __arg PostLocalNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postLocalNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postLocalNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostTextNonblock(ctx context.Context, __arg PostTextNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postTextNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postTextNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostDeleteNonblock(ctx context.Context, __arg PostDeleteNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postDeleteNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postDeleteNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostEditNonblock(ctx context.Context, __arg PostEditNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postEditNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postEditNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostReactionNonblock(ctx context.Context, __arg PostReactionNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postReactionNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postReactionNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
 func (c LocalClient) PostHeadlineNonblock(ctx context.Context, __arg PostHeadlineNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postHeadlineNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postHeadlineNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
@@ -8945,7 +8945,7 @@ func (c LocalClient) PostHeadline(ctx context.Context, __arg PostHeadlineArg) (r
 }
 
 func (c LocalClient) PostMetadataNonblock(ctx context.Context, __arg PostMetadataNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postMetadataNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postMetadataNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 
@@ -9007,7 +9007,7 @@ func (c LocalClient) PostFileAttachmentLocal(ctx context.Context, __arg PostFile
 }
 
 func (c LocalClient) PostFileAttachmentLocalNonblock(ctx context.Context, __arg PostFileAttachmentLocalNonblockArg) (res PostLocalNonblockRes, err error) {
-	err = c.Cli.Call(ctx, "chat.1.local.postFileAttachmentLocalNonblock", []interface{}{__arg}, &res, 0*time.Millisecond)
+	err = c.Cli.Call(ctx, "chat.1.local.postFileAttachmentLocalNonblock", []interface{}{__arg}, &res, 30000*time.Millisecond)
 	return
 }
 

--- a/protocol/avdl/chat1/local.avdl
+++ b/protocol/avdl/chat1/local.avdl
@@ -748,6 +748,7 @@ protocol local {
     DEFAULT_0,
     SERVER_1
   }
+  @timeout_msec(30000) // 30 seconds
   NonblockFetchRes getThreadNonblock(int sessionID, ConversationID conversationID, GetThreadNonblockCbMode cbMode, GetThreadReason reason, GetThreadNonblockPgMode pgmode, union { null, GetThreadQuery} query, array<string> knownRemotes, union { null, UIPagination } pagination, keybase1.TLFIdentifyBehavior identifyBehavior);
 
 
@@ -823,6 +824,7 @@ protocol local {
   }
 
   OutboxID generateOutboxID();
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postLocalNonblock(int sessionID, ConversationID conversationID, MessagePlaintext msg, MessageID clientPrev, union { null, OutboxID } outboxID, union { null, MessageID }  replyTo, keybase1.TLFIdentifyBehavior identifyBehavior);
   record PostLocalNonblockRes {
     array<RateLimit> rateLimits;
@@ -830,18 +832,28 @@ protocol local {
     array<keybase1.TLFIdentifyFailure> identifyFailures;
   }
 
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postTextNonblock(int sessionID, ConversationID conversationID, string tlfName, boolean tlfPublic, string body, MessageID clientPrev, union { null, MessageID } replyTo, union { null, OutboxID } outboxID, keybase1.TLFIdentifyBehavior identifyBehavior, union {null, gregor1.DurationSec} ephemeralLifetime);
+
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postDeleteNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes,MessageID clientPrev, union { null, OutboxID } outboxID,  keybase1.TLFIdentifyBehavior identifyBehavior);
 
   record EditTarget {
     union { null, MessageID } messageID;
     union { null, OutboxID } outboxID;
   }
+
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postEditNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, EditTarget target, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
 
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postReactionNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic, MessageID supersedes, string body, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
+
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postHeadlineNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string headline, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postHeadline(ConversationID conversationID, string tlfName, boolean tlfPublic, string headline, keybase1.TLFIdentifyBehavior identifyBehavior);
+
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postMetadataNonblock(ConversationID conversationID, string tlfName, boolean tlfPublic,  string channelName, union { null, OutboxID } outboxID, MessageID clientPrev, keybase1.TLFIdentifyBehavior identifyBehavior);
   PostLocalRes postMetadata(ConversationID conversationID, string tlfName, boolean tlfPublic, string channelName, keybase1.TLFIdentifyBehavior identifyBehavior);
 
@@ -960,6 +972,8 @@ protocol local {
 
   // Post an attachment from file source to conversationID.
   PostLocalRes postFileAttachmentLocal(int sessionID, PostFileAttachmentArg arg);
+
+  @timeout_msec(30000) // 30 seconds
   PostLocalNonblockRes postFileAttachmentLocalNonblock(int sessionID, PostFileAttachmentArg arg, MessageID clientPrev);
 
   record GetNextAttachmentMessageLocalRes  {

--- a/protocol/json/chat1/local.json
+++ b/protocol/json/chat1/local.json
@@ -4157,7 +4157,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "NonblockFetchRes"
+      "response": "NonblockFetchRes",
+      "timeout_msec": 30000
     },
     "getUnreadline": {
       "request": [
@@ -4341,7 +4342,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postTextNonblock": {
       "request": [
@@ -4395,7 +4397,8 @@
           ]
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postDeleteNonblock": {
       "request": [
@@ -4431,7 +4434,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postEditNonblock": {
       "request": [
@@ -4471,7 +4475,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postReactionNonblock": {
       "request": [
@@ -4511,7 +4516,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postHeadlineNonblock": {
       "request": [
@@ -4547,7 +4553,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postHeadline": {
       "request": [
@@ -4608,7 +4615,8 @@
           "type": "keybase1.TLFIdentifyBehavior"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "postMetadata": {
       "request": [
@@ -4847,7 +4855,8 @@
           "type": "MessageID"
         }
       ],
-      "response": "PostLocalNonblockRes"
+      "response": "PostLocalNonblockRes",
+      "timeout_msec": 30000
     },
     "getNextAttachmentMessageLocal": {
       "request": [


### PR DESCRIPTION
Prevents non-block calls from hanging indefinitely at the RPC level.  Relates to https://github.com/keybase/client/pull/23530

cc @strib 