### PR TITLE
Remove on-drag keyboardDismissMode

### DIFF
--- a/shared/common-adapters/scroll-view.native.tsx
+++ b/shared/common-adapters/scroll-view.native.tsx
@@ -4,7 +4,6 @@ import {ScrollView} from 'react-native'
 // changes this behavior: https://github.com/facebook/react-native/issues/4087
 class BetterScrollView extends ScrollView {
   static defaultProps = {
-    keyboardDismissMode: 'on-drag',
     keyboardShouldPersistTaps: 'handled',
   }
 }


### PR DESCRIPTION
This allows you to scroll a large input on mobile/tablet with the keyboard up.

cc @keybase/react-hackers 