### PR TITLE
Unset line height on reacji.

### DIFF
--- a/shared/chat/conversation/messages/react-button/index.tsx
+++ b/shared/chat/conversation/messages/react-button/index.tsx
@@ -73,6 +73,7 @@ const ReactButton = (props: Props) => (
     <Box2 centerChildren={true} fullHeight={true} direction="horizontal" gap="xtiny" style={styles.container}>
       <Box2 direction="horizontal" style={styles.emojiWrapper}>
         <EmojiIfExists
+          paragraphTextClassName="noLineHeight"
           size={Styles.isMobile ? 16 : 18}
           lineClamp={1}
           emojiName={props.decorated.length ? props.decorated : props.emoji}

--- a/shared/common-adapters/custom-emoji.native.tsx
+++ b/shared/common-adapters/custom-emoji.native.tsx
@@ -1,18 +1,29 @@
 import * as React from 'react'
+import * as Styles from '../styles'
 import {Props} from './custom-emoji'
 import {FastImage} from './native-image.native'
+import {Box2} from './box'
 
 const CustomEmoji = (props: Props) => {
   const {size, src} = props
   return (
-    <FastImage
-      source={{uri: src}}
-      style={{
-        height: size,
-        width: size,
-      }}
-    />
+    <Box2 direction="vertical" style={styles.container}>
+      <FastImage
+        source={{uri: src}}
+        style={{
+          height: size,
+          width: size,
+        }}
+      />
+    </Box2>
   )
 }
+
+const styles = Styles.styleSheetCreate(() => ({
+  container: {
+    justifyContent: 'flex-end',
+    marginTop: Styles.globalMargins.tiny,
+  },
+}))
 
 export default CustomEmoji

--- a/shared/common-adapters/custom-emoji.native.tsx
+++ b/shared/common-adapters/custom-emoji.native.tsx
@@ -7,7 +7,7 @@ import {Box2} from './box'
 const CustomEmoji = (props: Props) => {
   const {size, src} = props
   return (
-    <Box2 direction="vertical" style={styles.container}>
+    <Box2 direction="vertical" style={Styles.collapseStyles([{height: size}, styles.container])}>
       <FastImage
         source={{uri: src}}
         style={{

--- a/shared/common-adapters/custom-emoji.native.tsx
+++ b/shared/common-adapters/custom-emoji.native.tsx
@@ -6,15 +6,13 @@ import {Box2} from './box'
 
 const CustomEmoji = (props: Props) => {
   const {size, src} = props
+  const dimensions = {
+    height: size,
+    width: size,
+  }
   return (
-    <Box2 direction="vertical" style={Styles.collapseStyles([{height: size}, styles.container])}>
-      <FastImage
-        source={{uri: src}}
-        style={{
-          height: size,
-          width: size,
-        }}
-      />
+    <Box2 direction="vertical" style={Styles.collapseStyles([dimensions, styles.container])}>
+      <FastImage source={{uri: src}} style={dimensions} />
     </Box2>
   )
 }

--- a/shared/common-adapters/markdown/index.d.ts
+++ b/shared/common-adapters/markdown/index.d.ts
@@ -48,6 +48,7 @@ export type Props = {
   lineClamp?: LineClampType
   selectable?: boolean // desktop - applies to outer container only
   smallStandaloneEmoji?: boolean // don't increase font size for a standalone emoji
+  paragraphTextClassName?: string
   preview?: boolean // if true render a simplified version
   serviceOnly?: boolean // only render stuff from the service
 

--- a/shared/common-adapters/markdown/react.tsx
+++ b/shared/common-adapters/markdown/react.tsx
@@ -138,6 +138,7 @@ const markdownStyles = Styles.styleSheetCreate(
 const EmojiIfExists = React.memo(
   (
     props: EmojiProps & {
+      paragraphTextClassName?: string
       style?: any
       allowFontScaling?: boolean
       lineClamp?: LineClampType
@@ -148,7 +149,12 @@ const EmojiIfExists = React.memo(
     return exists ? (
       <Emoji emojiName={emojiNameLower} size={props.size} allowFontScaling={props.allowFontScaling} />
     ) : (
-      <Markdown style={props.style} lineClamp={props.lineClamp} allowFontScaling={props.allowFontScaling}>
+      <Markdown
+        paragraphTextClassName={props.paragraphTextClassName}
+        style={props.style}
+        lineClamp={props.lineClamp}
+        allowFontScaling={props.allowFontScaling}
+      >
         {props.emojiName}
       </Markdown>
     )
@@ -306,6 +312,7 @@ const reactComponentsForMarkdownType = {
       state: SimpleMarkdown.State
     ) => (
       <Text
+        className={state.paragraphTextClassName}
         type="Body"
         key={state.key}
         style={Styles.collapseStyles([markdownStyles.textBlockStyle, state.styleOverride.paragraph])}

--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -284,7 +284,7 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
         </Text>
       )
     }
-    const {allowFontScaling, styleOverride = {}} = this.props
+    const {allowFontScaling, styleOverride = {}, paragraphTextClassName} = this.props
     let parseTree: Array<SimpleMarkdown.SingleASTNode>
     let output: SimpleMarkdown.Output<any>
     try {
@@ -298,6 +298,7 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
 
       const state = {
         allowFontScaling,
+        paragraphTextClassName,
         markdownMeta: this.props.meta,
         styleOverride,
       }
@@ -319,11 +320,17 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
       )
     }
     const inner = this.props.serviceOnly ? (
-      <Text type="Body" style={this.props.style} lineClamp={this.props.lineClamp}>
+      <Text
+        className={this.props.paragraphTextClassName}
+        type="Body"
+        style={this.props.style}
+        lineClamp={this.props.lineClamp}
+      >
         {output}
       </Text>
     ) : this.props.preview ? (
       <Text
+        className={this.props.paragraphTextClassName}
         type={Styles.isMobile ? 'Body' : 'BodySmall'}
         style={Styles.collapseStyles([
           markdownStyles.neutralPreviewStyle,
@@ -343,6 +350,7 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
       inner
     ) : (
       <Text
+        className={this.props.paragraphTextClassName}
         type="Body"
         lineClamp={this.props.lineClamp}
         style={Styles.collapseStyles([styles.rootWrapper, this.props.style])}

--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -298,8 +298,8 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
 
       const state = {
         allowFontScaling,
-        paragraphTextClassName,
         markdownMeta: this.props.meta,
+        paragraphTextClassName,
         styleOverride,
       }
 


### PR DESCRIPTION
@keybase/hotpotatosquad, there's probably a better way to do this. I'm open to suggestions. It removes the line height from reacji to fully center them in the container. It's most obvious on square emoji (`all-the-things` in this example).

Before:
<img width="222" alt="Screen Shot 2020-04-08 at 11 47 58" src="https://user-images.githubusercontent.com/30595/78805320-44379900-798f-11ea-9d6d-2236c47a1970.png">

After:
<img width="230" alt="Screen Shot 2020-04-08 at 11 47 42" src="https://user-images.githubusercontent.com/30595/78805336-48fc4d00-798f-11ea-9d57-51dd5abc779e.png">