### PR TITLE
disk_block_cache: evict blocks in bigger batches when possible

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache_test.go
+++ b/go/kbfs/libkbfs/disk_block_cache_test.go
@@ -477,7 +477,8 @@ func TestDiskBlockCacheStaticLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, int64(standardCache.currBytes) < currBytes)
-	require.Equal(t, 1+numBlocks-defaultNumBlocksToEvict, standardCache.numBlocks)
+	require.Equal(
+		t, 1+numBlocks-minNumBlocksToEvictInBatch, standardCache.numBlocks)
 }
 
 func TestDiskBlockCacheDynamicLimit(t *testing.T) {
@@ -523,7 +524,7 @@ func TestDiskBlockCacheDynamicLimit(t *testing.T) {
 
 	t.Log("Add a round of blocks to the cache. Verify that blocks were" +
 		" evicted each time we went past the limit.")
-	start := numBlocks - defaultNumBlocksToEvict
+	start := numBlocks - minNumBlocksToEvictInBatch
 	for i := 1; i <= numBlocks; i++ {
 		blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 			t, config)
@@ -531,7 +532,8 @@ func TestDiskBlockCacheDynamicLimit(t *testing.T) {
 			ctx, tlf.FakeID(10, tlf.Private), blockPtr.ID, blockEncoded,
 			serverHalf)
 		require.NoError(t, err)
-		require.Equal(t, start+(i%defaultNumBlocksToEvict), standardCache.numBlocks)
+		require.Equal(
+			t, start+(i%minNumBlocksToEvictInBatch), standardCache.numBlocks)
 	}
 
 	require.True(t, int64(standardCache.currBytes) < currBytes)


### PR DESCRIPTION
A user had an issue where their syncs were blocked when suddenly their disk filled up (I think by some external thing) and their disk block cache was suddenly over capacity.  A `SyncAll` started, while they were still doing concurrent writes.  I think one of the writes did a Put into the disk block cache, which caused a bunch of evictions while locked.  So many evictions that the `SyncAll`, which I suspect was blocked on the disk block cache lock (trying to read a block), timed out.

The best solution is probably to release the lock once in a while during eviction, but that seems a bit complicated.  So for now, I'm just trying to calculate a good number of blocks to evict in a single batch based on the average block size, instead of always trying to do 10 at a time.  Hopefully this speeds up the process and makes it less likely to block for long periods of time.

cc: @jzila 

Issue: HOTPOT-2281