### PR TITLE
Add a spinner to 'Add to Team' dialog

### DIFF
--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -309,7 +309,10 @@ const addToTeam = async (action: TeamsGen.AddToTeamPayload) => {
           role: RPCTypes.TeamRole[role],
         })),
       },
-      Constants.addMemberWaitingKey(teamID, ...users.map(({assertion}) => assertion))
+      [
+        Constants.teamWaitingKey(teamID),
+        Constants.addMemberWaitingKey(teamID, ...users.map(({assertion}) => assertion)),
+      ]
     )
     if (res.notAdded && res.notAdded.length > 0) {
       const usernames = res.notAdded.map(elem => elem.username)

--- a/shared/team-building/go-button.tsx
+++ b/shared/team-building/go-button.tsx
@@ -6,16 +6,11 @@ import {GoButtonLabel} from '../constants/types/team-building'
 export type Props = {
   onClick: () => void
   label: GoButtonLabel
+  waitingKey: string | null
 }
 
-const Go = (props: {label: GoButtonLabel}) => (
-  <Kb.Text type="BodyBig" style={styles.go}>
-    {props.label}
-  </Kb.Text>
-)
-
 const GoButton = (props: Props) => (
-  <Kb.ClickableBox onClick={() => props.onClick()} style={styles.container}>
+  <Kb.Box style={styles.container}>
     <Kb.WithTooltip
       tooltip={
         <Kb.Box2 direction="horizontal">
@@ -30,26 +25,26 @@ const GoButton = (props: Props) => (
       }
       containerStyle={styles.goTooltipIconContainer}
     >
-      <Kb.Box2 direction="vertical" fullHeight={true} centerChildren={true}>
-        <Go label={props.label} />
-      </Kb.Box2>
+      <Kb.WaitingButton
+        type="Success"
+        narrow={true}
+        label={props.label}
+        onClick={props.onClick}
+        style={styles.button}
+        waitingKey={props.waitingKey}
+      />
     </Kb.WithTooltip>
-  </Kb.ClickableBox>
+  </Kb.Box>
 )
 
 const styles = Styles.styleSheetCreate(() => ({
-  container: Styles.platformStyles({
-    common: {
-      backgroundColor: Styles.globalColors.green,
-      ...Styles.globalStyles.rounded,
-      marginLeft: Styles.globalMargins.tiny,
-    },
-    isElectron: {
-      marginBottom: Styles.globalMargins.tiny,
-      marginTop: Styles.globalMargins.tiny,
-      width: 62,
-    },
-  }),
+  button: {
+    height: '100%',
+  },
+  container: {
+    marginBottom: Styles.globalMargins.tiny,
+    marginTop: Styles.globalMargins.tiny,
+  },
   go: Styles.platformStyles({
     common: {color: Styles.globalColors.white},
     isElectron: {lineHeight: 40},

--- a/shared/team-building/index.stories.tsx
+++ b/shared/team-building/index.stories.tsx
@@ -681,9 +681,10 @@ const load = () => {
             username: 'marcopolo',
           },
         ]}
+        waitingKey={null}
       />
     ))
-    .add('Go Button', () => <GoButton label="Start" onClick={Sb.action('onClick')} />)
+    .add('Go Button', () => <GoButton label="Start" onClick={Sb.action('onClick')} waitingKey={null} />)
 
   Sb.storiesOf('Team-Building/User Bubble', module)
     .addDecorator(provider)

--- a/shared/team-building/index.tsx
+++ b/shared/team-building/index.tsx
@@ -3,6 +3,7 @@ import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import * as Container from '../util/container'
 import * as Constants from '../constants/team-building'
+import * as TeamConstants from '../constants/teams'
 import TeamBox from './team-box'
 import Input from './input'
 import {ServiceTabBar} from './service-tab-bar'
@@ -738,6 +739,7 @@ class TeamBuilding extends React.PureComponent<Props> {
         searchString={props.searchString}
         rolePickerProps={props.rolePickerProps}
         goButtonLabel={props.goButtonLabel}
+        waitingKey={props.teamID ? TeamConstants.teamWaitingKey(props.teamID) : null}
       />
     )
 

--- a/shared/team-building/team-box.tsx
+++ b/shared/team-building/team-box.tsx
@@ -23,6 +23,7 @@ type Props = {
   searchString: string
   rolePickerProps?: RolePickerProps
   goButtonLabel?: GoButtonLabel
+  waitingKey: string | null
 }
 
 const formatNameForUserBubble = (u: SelectedUser) => {
@@ -129,10 +130,15 @@ const TeamBox = (props: Props) => {
               <GoButton
                 label={props.goButtonLabel ?? 'Add'}
                 onClick={() => props.rolePickerProps && props.rolePickerProps.changeShowRolePicker(true)}
+                waitingKey={props.waitingKey}
               />
             </FloatingRolePicker>
           ) : (
-            <GoButton label={props.goButtonLabel ?? 'Start'} onClick={props.onFinishTeamBuilding} />
+            <GoButton
+              label={props.goButtonLabel ?? 'Start'}
+              onClick={props.onFinishTeamBuilding}
+              waitingKey={props.waitingKey}
+            />
           ))}
       </Kb.Box2>
     </Kb.Box2>

--- a/shared/teams/team/rows/member-row/container.tsx
+++ b/shared/teams/team/rows/member-row/container.tsx
@@ -29,7 +29,7 @@ export default connect(
       fullName: state.config.username === username ? 'You' : info.fullName,
       roleType: info.type,
       status: info.status,
-      teamID: teamID,
+      teamID,
       teamname,
       username: info.username,
       waitingForAdd: anyWaiting(state, Constants.addMemberWaitingKey(teamID, username)),


### PR DESCRIPTION
@keybase/react-hackers 

We want to add a spinner while users are being added to a team.  The GoButton component was just text in a green box, so first that's converted to be a Kb.WaitingButton.  Then that button's hooked up to the `teamWaitingKey` for the team being used by the team builder.

(As a result of becoming a button, the "Add" text becomes white foreground color instead of black foreground color.. confirmed with @keybase/design that the black was a bug.)