### PR TITLE
simplefs: remove timeouts for conflict state operations

### DIFF
--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -510,8 +510,8 @@ func (s *SimpleFSHandler) SimpleFSClearConflictState(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	ctx, cancel := s.wrapContextWithTimeout(ctx)
-	defer cancel()
+	// No timeouts since this can be a long operation if the folder is
+	// large or the disk is slow, and this is a synchronous operation.
 	return cli.SimpleFSClearConflictState(ctx, path)
 }
 
@@ -522,8 +522,8 @@ func (s *SimpleFSHandler) SimpleFSFinishResolvingConflict(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	ctx, cancel := s.wrapContextWithTimeout(ctx)
-	defer cancel()
+	// No timeouts since this can be a long operation if the folder is
+	// large or the disk is slow, and this is a synchronous operation.
 	return cli.SimpleFSFinishResolvingConflict(ctx, path)
 }
 


### PR DESCRIPTION
Several people on slow computers with large conflict folders have hit timeouts trying to clear the conflict.  I think it's fine to just let this go until it completes, since it's so rare.