### PR TITLE
wot-author passes proofs

### DIFF
--- a/go/client/cmd_wot_vouch.go
+++ b/go/client/cmd_wot_vouch.go
@@ -85,7 +85,7 @@ func (c *CmdWotVouch) Run() error {
 	if err := RegisterProtocolsWithContext(protocols, c.G()); err != nil {
 		return err
 	}
-	arg := keybase1.WotVouchArg{
+	arg := keybase1.WotVouchCLIArg{
 		Assertion:  c.Assertion,
 		VouchTexts: []string{c.Message},
 		Confidence: c.Confidence,
@@ -94,7 +94,7 @@ func (c *CmdWotVouch) Run() error {
 	if err != nil {
 		return err
 	}
-	return cli.WotVouch(context.Background(), arg)
+	return cli.WotVouchCLI(context.Background(), arg)
 }
 
 func (c *CmdWotVouch) GetUsage() libkb.Usage {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -1253,40 +1253,6 @@ func (e *Identify2WithUID) Result(m libkb.MetaContext) (*keybase1.Identify2ResUP
 	return res, nil
 }
 
-func (e *Identify2WithUID) ResultWotFailingProofs(mctx libkb.MetaContext) (failingProofs []keybase1.WotProof, err error) {
-	for _, row := range e.state.Result().ProofChecks {
-		if row.GetError() != nil {
-			proofType := row.GetLink().GetProofType()
-			key, value := row.GetLink().ToKeyValuePair()
-			switch proofType {
-			case keybase1.ProofType_TWITTER, keybase1.ProofType_GITHUB, keybase1.ProofType_REDDIT,
-				keybase1.ProofType_COINBASE, keybase1.ProofType_HACKERNEWS, keybase1.ProofType_FACEBOOK,
-				keybase1.ProofType_GENERIC_SOCIAL, keybase1.ProofType_ROOTER:
-				failingProofs = append(failingProofs, keybase1.WotProof{
-					ProofType: proofType,
-					Name:      key,
-					Username:  value,
-				})
-			case keybase1.ProofType_GENERIC_WEB_SITE:
-				failingProofs = append(failingProofs, keybase1.WotProof{
-					ProofType: proofType,
-					Protocol:  key,
-					Hostname:  value,
-				})
-			case keybase1.ProofType_DNS:
-				failingProofs = append(failingProofs, keybase1.WotProof{
-					ProofType: proofType,
-					Protocol:  key,
-					Domain:    value,
-				})
-			default:
-				return nil, fmt.Errorf("unexpected proof failure of type: %v", proofType)
-			}
-		}
-	}
-	return failingProofs, nil
-}
-
 func (e *Identify2WithUID) GetProofSet() *libkb.ProofSet {
 	return e.remotesReceived
 }

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -155,13 +155,6 @@ func (e *ResolveThenIdentify2) Result(m libkb.MetaContext) (*keybase1.Identify2R
 	return e.i2eng.Result(m)
 }
 
-func (e *ResolveThenIdentify2) ResultWotFailingProofs(mctx libkb.MetaContext) (failingProofs []keybase1.WotProof, err error) {
-	if e.i2eng == nil {
-		return nil, errors.New("ResolveThenIdentify2#ResultWotFailingProofs: no result available if the engine did not run")
-	}
-	return e.i2eng.ResultWotFailingProofs(mctx)
-}
-
 func (e *ResolveThenIdentify2) SetResponsibleGregorItem(item gregor.Item) {
 	e.responsibleGregorItem = item
 }

--- a/go/engine/wot_vouch.go
+++ b/go/engine/wot_vouch.go
@@ -13,10 +13,9 @@ import (
 )
 
 type WotVouchArg struct {
-	Vouchee       keybase1.UserVersion
-	Confidence    keybase1.Confidence
-	FailingProofs []keybase1.WotProof
-	VouchTexts    []string
+	Vouchee    keybase1.UserVersion
+	Confidence keybase1.Confidence
+	VouchTexts []string
 }
 
 // WotVouch is an engine.
@@ -86,6 +85,7 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 	}
 
 	if them.GetCurrentEldestSeqno() != e.arg.Vouchee.EldestSeqno {
+		mctx.Debug("eldest seqno mismatch: loaded %v != %v caller", them.GetCurrentEldestSeqno(), e.arg.Vouchee.EldestSeqno)
 		return errors.New("vouchee has reset, make sure you still know them")
 	}
 
@@ -116,15 +116,6 @@ func (e *WotVouch) Run(mctx libkb.MetaContext) error {
 	}
 	if err := statement.SetKey("confidence", confidenceJw); err != nil {
 		return err
-	}
-	if len(e.arg.FailingProofs) > 0 {
-		failingProofsJw, err := jsonw.WrapperFromObject(e.arg.FailingProofs)
-		if err != nil {
-			return err
-		}
-		if err := statement.SetKey("failing_proofs", failingProofsJw); err != nil {
-			return err
-		}
 	}
 	if err := statement.SetKey("vouch_text", libkb.JsonwStringArray(e.arg.VouchTexts)); err != nil {
 		return err

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -296,6 +296,17 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 	row.SiteIconDarkmode = externals.MakeIcons(mctx, iconKey, externals.IconTypeSmallDarkmode, 16)
 	row.SiteIconFull = externals.MakeIcons(mctx, iconKey, externals.IconTypeFull, 64)
 	row.SiteIconFullDarkmode = externals.MakeIcons(mctx, iconKey, externals.IconTypeFullDarkmode, 64)
+	switch proof.ProofType {
+	case keybase1.ProofType_NONE, keybase1.ProofType_PGP:
+		// These types are not eligible for web-of-trust selection.
+	default:
+		wotProof, err := libkb.NewWotProof(proof.ProofType, proof.Key, proof.Value)
+		if err != nil {
+			mctx.Debug("Error creating web-of-trust proof summary: %v", err)
+		} else {
+			row.WotProof = &wotProof
+		}
+	}
 	return row
 }
 
@@ -364,6 +375,7 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 		SiteIconFull:         externals.MakeIcons(mctx, "pgp", externals.IconTypeFull, 64),
 		SiteIconFullDarkmode: externals.MakeIcons(mctx, "pgp", externals.IconTypeFullDarkmode, 64),
 		Kid:                  &key.KID,
+		// PICNIC-1092 consider adding `WotProof` to support pgp in web-of-trust.
 	}
 
 	switch {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -687,6 +687,7 @@ func (l *TrackChainLink) ToServiceBlocks() (ret []*ServiceBlock) {
 	return ret
 }
 
+// Get the tail of the trackee's sigchain.
 func (l *TrackChainLink) GetTrackedLinkSeqno() (seqno keybase1.Seqno, err error) {
 	seqnoJSON := l.UnmarshalPayloadJSON().AtPath("body.track.seq_tail.seqno")
 	if seqnoJSON.IsNil() {

--- a/go/libkb/identify3.go
+++ b/go/libkb/identify3.go
@@ -73,6 +73,12 @@ func (s *Identify3Session) ResultType() keybase1.Identify3ResultType {
 	}
 }
 
+func (s *Identify3Session) Outcome() *IdentifyOutcome {
+	s.Lock()
+	defer s.Unlock()
+	return s.outcome
+}
+
 func (s *Identify3Session) OutcomeLocked() *IdentifyOutcome {
 	return s.outcome
 }

--- a/go/libkb/identify_outcome.go
+++ b/go/libkb/identify_outcome.go
@@ -16,6 +16,8 @@ import (
 type IdentifyOutcome struct {
 	Contextified
 	Username              NormalizedUsername
+	UID                   keybase1.UID
+	EldestSeqno           keybase1.Seqno
 	Error                 error
 	KeyDiffs              []TrackDiff
 	Revoked               []TrackDiff
@@ -29,8 +31,13 @@ type IdentifyOutcome struct {
 	ResponsibleGregorItem gregor.Item
 }
 
-func NewIdentifyOutcomeWithUsername(g *GlobalContext, u NormalizedUsername) *IdentifyOutcome {
-	return &IdentifyOutcome{Contextified: NewContextified(g), Username: u}
+func NewIdentifyOutcome(g *GlobalContext, username NormalizedUsername, uid keybase1.UID, eldestSeqno keybase1.Seqno) *IdentifyOutcome {
+	return &IdentifyOutcome{
+		Contextified: NewContextified(g),
+		Username:     username,
+		UID:          uid,
+		EldestSeqno:  eldestSeqno,
+	}
 }
 
 func (i *IdentifyOutcome) remoteProofLinks() *RemoteProofLinks {

--- a/go/libkb/identify_state.go
+++ b/go/libkb/identify_state.go
@@ -17,7 +17,7 @@ type IdentifyState struct {
 }
 
 func NewIdentifyStateWithGregorItem(g *GlobalContext, item gregor.Item, u *User) IdentifyState {
-	res := NewIdentifyOutcomeWithUsername(g, u.GetNormalizedName())
+	res := NewIdentifyOutcome(g, u.GetNormalizedName(), u.GetUID(), u.GetCurrentEldestSeqno())
 	res.ResponsibleGregorItem = item
 	return IdentifyState{Contextified: NewContextified(g), res: res, u: u}
 }

--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -1267,3 +1267,31 @@ func ThrottleBatch(f func(interface{}), batcher func(interface{}, interface{}) i
 		close(cancelCh)
 	}
 }
+
+// Format a proof for web-of-trust. Does not support all proof types.
+func NewWotProof(proofType keybase1.ProofType, key, value string) (res keybase1.WotProof, err error) {
+	switch proofType {
+	case keybase1.ProofType_TWITTER, keybase1.ProofType_GITHUB, keybase1.ProofType_REDDIT,
+		keybase1.ProofType_COINBASE, keybase1.ProofType_HACKERNEWS, keybase1.ProofType_FACEBOOK,
+		keybase1.ProofType_GENERIC_SOCIAL, keybase1.ProofType_ROOTER:
+		return keybase1.WotProof{
+			ProofType: proofType,
+			Name:      key,
+			Username:  value,
+		}, nil
+	case keybase1.ProofType_GENERIC_WEB_SITE:
+		return keybase1.WotProof{
+			ProofType: proofType,
+			Protocol:  key,
+			Hostname:  value,
+		}, nil
+	case keybase1.ProofType_DNS:
+		return keybase1.WotProof{
+			ProofType: proofType,
+			Protocol:  key,
+			Domain:    value,
+		}, nil
+	default:
+		return res, fmt.Errorf("unexpected proof type: %v", proofType)
+	}
+}

--- a/go/libkb/wot.go
+++ b/go/libkb/wot.go
@@ -122,9 +122,9 @@ func transformUserVouch(mctx MetaContext, serverVouch serverWotVouch, voucheeUse
 
 	if voucheeUser == nil || voucheeUser.GetUID() != serverVouch.Vouchee {
 		// load vouchee
-		voucheeUser, err = LoadUser(NewLoadUserArgWithMetaContext(mctx).WithUID(serverVouch.Vouchee).WithStubMode(StubModeUnstubbed))
+		voucheeUser, err = LoadUser(NewLoadUserArgWithMetaContext(mctx).WithUID(serverVouch.Vouchee).WithPublicKeyOptional().WithStubMode(StubModeUnstubbed))
 		if err != nil {
-			return res, fmt.Errorf("error loading vouchee: %s", err.Error())
+			return res, fmt.Errorf("error loading vouchee to transform: %s", err.Error())
 		}
 	}
 
@@ -232,7 +232,7 @@ func FetchWotVouches(mctx MetaContext, arg FetchWotVouchesArg) (res []keybase1.W
 	}
 	var voucheeUser *User
 	if len(arg.Vouchee) > 0 {
-		voucheeUser, err = LoadUser(NewLoadUserArgWithMetaContext(mctx).WithName(arg.Vouchee))
+		voucheeUser, err = LoadUser(NewLoadUserArgWithMetaContext(mctx).WithName(arg.Vouchee).WithPublicKeyOptional())
 		if err != nil {
 			return nil, fmt.Errorf("error loading vouchee: %s", err.Error())
 		}

--- a/go/protocol/keybase1/identify3_ui.go
+++ b/go/protocol/keybase1/identify3_ui.go
@@ -147,6 +147,7 @@ type Identify3Row struct {
 	Metas                []Identify3RowMeta `codec:"metas" json:"metas"`
 	Color                Identify3RowColor  `codec:"color" json:"color"`
 	Kid                  *KID               `codec:"kid,omitempty" json:"kid,omitempty"`
+	WotProof             *WotProof          `codec:"wotProof,omitempty" json:"wotProof,omitempty"`
 }
 
 func (o Identify3Row) DeepCopy() Identify3Row {
@@ -223,6 +224,13 @@ func (o Identify3Row) DeepCopy() Identify3Row {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.Kid),
+		WotProof: (func(x *WotProof) *WotProof {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.WotProof),
 	}
 }
 

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -129,6 +129,14 @@ func (o WotVouch) DeepCopy() WotVouch {
 }
 
 type WotVouchArg struct {
+	SessionID  int            `codec:"sessionID" json:"sessionID"`
+	Username   string         `codec:"username" json:"username"`
+	GuiID      Identify3GUIID `codec:"guiID" json:"guiID"`
+	VouchTexts []string       `codec:"vouchTexts" json:"vouchTexts"`
+	Confidence Confidence     `codec:"confidence" json:"confidence"`
+}
+
+type WotVouchCLIArg struct {
 	SessionID  int        `codec:"sessionID" json:"sessionID"`
 	Assertion  string     `codec:"assertion" json:"assertion"`
 	VouchTexts []string   `codec:"vouchTexts" json:"vouchTexts"`
@@ -155,6 +163,7 @@ type WotFetchVouchesArg struct {
 
 type WotInterface interface {
 	WotVouch(context.Context, WotVouchArg) error
+	WotVouchCLI(context.Context, WotVouchCLIArg) error
 	WotReact(context.Context, WotReactArg) error
 	DismissWotNotifications(context.Context, DismissWotNotificationsArg) error
 	WotFetchVouches(context.Context, WotFetchVouchesArg) ([]WotVouch, error)
@@ -176,6 +185,21 @@ func WotProtocol(i WotInterface) rpc.Protocol {
 						return
 					}
 					err = i.WotVouch(ctx, typedArgs[0])
+					return
+				},
+			},
+			"wotVouchCLI": {
+				MakeArg: func() interface{} {
+					var ret [1]WotVouchCLIArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]WotVouchCLIArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]WotVouchCLIArg)(nil), args)
+						return
+					}
+					err = i.WotVouchCLI(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -234,6 +258,11 @@ type WotClient struct {
 
 func (c WotClient) WotVouch(ctx context.Context, __arg WotVouchArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouch", []interface{}{__arg}, nil, 0*time.Millisecond)
+	return
+}
+
+func (c WotClient) WotVouchCLI(ctx context.Context, __arg WotVouchCLIArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.wot.wotVouchCLI", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return
 }
 

--- a/protocol/avdl/keybase1/identify3_ui.avdl
+++ b/protocol/avdl/keybase1/identify3_ui.avdl
@@ -63,6 +63,10 @@ protocol identify3Ui {
     array<Identify3RowMeta> metas; // things like 'upgraded' | 'new' | 'unreachable' | 'pending' | 'deleted' | 'none' | 'ignored', but can be anything
     Identify3RowColor color;       // 'blue' | 'red' | 'black' | 'green' | 'gray' | 'yellow' | 'orange'
     union { null, KID } kid;       // in the case of PGP key, also send the KID so that we can revoke by kid
+
+    // wotProof is a summary of the proof for web-of-trust.
+    // Passed back from gui to service for wot proofs list. If omitted, proof is ineligible (e.g. stellar).
+    union { null, WotProof } wotProof;
   }
 
   record Identify3Summary {

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -32,7 +32,8 @@ protocol wot {
     string other;
   }
 
-  void wotVouch(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);
+  void wotVouch(int sessionID, string username, Identify3GUIID guiID, array<string> vouchTexts, Confidence confidence);
+  void wotVouchCLI(int sessionID, string assertion, array<string> vouchTexts, Confidence confidence);
 
   enum WotReactionType {
     ACCEPT_0,

--- a/protocol/json/keybase1/identify3_ui.json
+++ b/protocol/json/keybase1/identify3_ui.json
@@ -142,6 +142,13 @@
             "KID"
           ],
           "name": "kid"
+        },
+        {
+          "type": [
+            null,
+            "WotProof"
+          ],
+          "name": "wotProof"
         }
       ]
     },

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -138,6 +138,34 @@
           "type": "int"
         },
         {
+          "name": "username",
+          "type": "string"
+        },
+        {
+          "name": "guiID",
+          "type": "Identify3GUIID"
+        },
+        {
+          "name": "vouchTexts",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
+        },
+        {
+          "name": "confidence",
+          "type": "Confidence"
+        }
+      ],
+      "response": null
+    },
+    "wotVouchCLI": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
           "name": "assertion",
           "type": "string"
         },

--- a/shared/actions/json/profile.json
+++ b/shared/actions/json/profile.json
@@ -83,6 +83,7 @@
     "updateUsername": {"username": "string"},
     "wotVouch": {
       "username": "string",
+      "guiID": "string", // Identify3 ID to pin the user version
       "verificationType": "string",
       "statement": "string",
       "otherText": "string",

--- a/shared/actions/json/tracker2.json
+++ b/shared/actions/json/tracker2.json
@@ -26,7 +26,7 @@
     "updateResult": {
       "guiID": "string",
       "result": "Types.DetailsState",
-      "reason?": "string"
+      "reason?": "string",
     },
     "closeTracker": {
       "guiID": "string"

--- a/shared/actions/profile-gen.tsx
+++ b/shared/actions/profile-gen.tsx
@@ -92,6 +92,7 @@ type _UpdateUsernamePayload = {readonly username: string}
 type _UploadAvatarPayload = {readonly filename: string; readonly crop?: RPCTypes.ImageCropRect}
 type _WotVouchPayload = {
   readonly username: string
+  readonly guiID: string
   readonly verificationType: string
   readonly statement: string
   readonly otherText: string

--- a/shared/actions/profile/index.tsx
+++ b/shared/actions/profile/index.tsx
@@ -171,7 +171,7 @@ const backToProfile = (state: TypedState) => [
 ]
 
 const wotVouch = async (state: TypedState, action: ProfileGen.WotVouchPayload, logger: Saga.SagaLogger) => {
-  const { guiID, otherText, proofs, statement, username, verificationType, } = action.payload
+  const {guiID, otherText, proofs, statement, username, verificationType} = action.payload
   const details = state.tracker2.usernameToDetails.get(username)
   if (!details) {
     return ProfileGen.createWotVouchSetError({error: 'Missing user details.'})
@@ -189,7 +189,7 @@ const wotVouch = async (state: TypedState, action: ProfileGen.WotVouchPayload, l
           usernameVerifiedVia: verificationType,
         },
         guiID,
-        username: username,
+        username,
         vouchTexts: [statement],
       },
       Constants.wotAuthorWaitingKey

--- a/shared/actions/profile/index.tsx
+++ b/shared/actions/profile/index.tsx
@@ -170,17 +170,26 @@ const backToProfile = (state: TypedState) => [
   Tracker2Gen.createShowUser({asTracker: false, username: state.config.username}),
 ]
 
-const wotVouch = async (action: ProfileGen.WotVouchPayload, logger: Saga.SagaLogger) => {
-  const {otherText, proofs, statement, username, verificationType} = action.payload
+const wotVouch = async (state: TypedState, action: ProfileGen.WotVouchPayload, logger: Saga.SagaLogger) => {
+  const { guiID, otherText, proofs, statement, username, verificationType, } = action.payload
+  const details = state.tracker2.usernameToDetails.get(username)
+  if (!details) {
+    return ProfileGen.createWotVouchSetError({error: 'Missing user details.'})
+  } else if (details.state !== 'valid') {
+    return ProfileGen.createWotVouchSetError({error: `User is not in a valid state. (${details.state})`})
+  } else if (details.resetBrokeTrack) {
+    return ProfileGen.createWotVouchSetError({error: 'User has reset their account since following.'})
+  }
   try {
     await RPCTypes.wotWotVouchRpcPromise(
       {
-        assertion: username,
         confidence: {
           other: otherText,
           proofs,
           usernameVerifiedVia: verificationType,
         },
+        guiID,
+        username: username,
         vouchTexts: [statement],
       },
       Constants.wotAuthorWaitingKey
@@ -206,7 +215,7 @@ function* _profileSaga() {
   yield* Saga.chainAction(ProfileGen.showUserProfile, showUserProfile)
   yield* Saga.chainAction2(ProfileGen.editAvatar, editAvatar)
   yield* Saga.chainAction2(ProfileGen.hideStellar, hideStellar)
-  yield* Saga.chainAction(ProfileGen.wotVouch, wotVouch)
+  yield* Saga.chainAction2(ProfileGen.wotVouch, wotVouch)
 }
 
 function* profileSaga() {

--- a/shared/constants/tracker2.tsx
+++ b/shared/constants/tracker2.tsx
@@ -126,6 +126,7 @@ export const rpcAssertionToAssertion = (row: RPCTypes.Identify3Row): Types.Asser
   timestamp: row.ctime,
   type: row.key,
   value: row.value,
+  wotProof: row.wotProof ?? undefined,
 })
 
 export const rpcSuggestionToAssertion = (s: RPCTypes.ProofSuggestion): Types.Assertion => {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1636,7 +1636,7 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.wot.wotVouch': {
-    inParam: {readonly assertion: String; readonly vouchTexts?: Array<String> | null; readonly confidence: Confidence}
+    inParam: {readonly username: String; readonly guiID: Identify3GUIID; readonly vouchTexts?: Array<String> | null; readonly confidence: Confidence}
     outParam: void
   }
 }
@@ -2976,7 +2976,7 @@ export type Identify2Res = {readonly upk: UserPlusKeys; readonly identifiedAt: T
 export type Identify2ResUPK2 = {readonly upk: UserPlusKeysV2AllIncarnations; readonly identifiedAt: Time; readonly trackBreaks?: IdentifyTrackBreaks | null}
 export type Identify3Assertion = String
 export type Identify3GUIID = String
-export type Identify3Row = {readonly guiID: Identify3GUIID; readonly key: String; readonly value: String; readonly priority: Int; readonly siteURL: String; readonly siteIcon?: Array<SizedImage> | null; readonly siteIconDarkmode?: Array<SizedImage> | null; readonly siteIconFull?: Array<SizedImage> | null; readonly siteIconFullDarkmode?: Array<SizedImage> | null; readonly proofURL: String; readonly sigID: SigID; readonly ctime: Time; readonly state: Identify3RowState; readonly metas?: Array<Identify3RowMeta> | null; readonly color: Identify3RowColor; readonly kid?: KID | null}
+export type Identify3Row = {readonly guiID: Identify3GUIID; readonly key: String; readonly value: String; readonly priority: Int; readonly siteURL: String; readonly siteIcon?: Array<SizedImage> | null; readonly siteIconDarkmode?: Array<SizedImage> | null; readonly siteIconFull?: Array<SizedImage> | null; readonly siteIconFullDarkmode?: Array<SizedImage> | null; readonly proofURL: String; readonly sigID: SigID; readonly ctime: Time; readonly state: Identify3RowState; readonly metas?: Array<Identify3RowMeta> | null; readonly color: Identify3RowColor; readonly kid?: KID | null; readonly wotProof?: WotProof | null}
 export type Identify3RowMeta = {readonly color: Identify3RowColor; readonly label: String}
 export type Identify3Summary = {readonly guiID: Identify3GUIID; readonly numProofsToCheck: Int}
 export type IdentifyKey = {readonly pgpFingerprint: Bytes; readonly KID: KID; readonly trackDiff?: TrackDiff | null; readonly breaksTracking: Boolean; readonly sigID: SigID}
@@ -4357,3 +4357,4 @@ export const wotWotVouchRpcPromise = (params: MessageTypes['keybase.1.wot.wotVou
 // 'keybase.1.user.findNextMerkleRootAfterRevoke'
 // 'keybase.1.user.findNextMerkleRootAfterReset'
 // 'keybase.1.user.getTeamBlocks'
+// 'keybase.1.wot.wotVouchCLI'

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -42,6 +42,7 @@ export type Assertion = {
   timestamp: number // can be 0,
   type: string // twitter,
   value: string // bob
+  wotProof?: RPCTypes.WotProof
 }
 
 export type DetailsState = 'checking' | 'valid' | 'broken' | 'needsUpgrade' | 'error' | 'notAUserYet'

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -6,6 +6,7 @@ import * as Constants from '../../constants/tracker2'
 import * as Types from '../../constants/types/tracker2'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
+import {memoize} from '../../util/memoize'
 
 export type OwnProps = Container.RouteProps<{username: string}>
 
@@ -18,6 +19,11 @@ const headerBackgroundColorType = (state: Types.DetailsState, followThem: boolea
     return followThem ? 'green' : 'blue'
   }
 }
+
+const filterWebOfTrustEntries = memoize(
+  (webOfTrustEntries: Array<Types.WebOfTrustEntry> | undefined): Array<Types.WebOfTrustEntry> =>
+    webOfTrustEntries ? webOfTrustEntries.filter(Constants.showableWotEntry) : []
+)
 
 const connected = Container.namedConnect(
   (state, ownProps: OwnProps) => {
@@ -54,7 +60,7 @@ const connected = Container.namedConnect(
       const {followersCount, followingCount, followers, following, reason, webOfTrustEntries} = d
       const mutualFollow = followThem && Constants.followsYou(state, username)
 
-      const filteredWot = (webOfTrustEntries ?? []).filter(Constants.showableWotEntry)
+      const filteredWot = filterWebOfTrustEntries(webOfTrustEntries)
       const hasAlreadyVouched = filteredWot.some(entry => entry.attestingUser === myName)
       const vouchShowButton = mutualFollow && !hasAlreadyVouched
       const vouchDisableButton = !vouchShowButton || d.state !== 'valid' || d.resetBrokeTrack
@@ -75,7 +81,7 @@ const connected = Container.namedConnect(
         title: username,
         vouchShowButton,
         vouchDisableButton,
-        webOfTrustEntries: webOfTrustEntries || [],
+        webOfTrustEntries: filteredWot || [],
       }
     } else {
       // SBS profile. But `nonUserDetails` might not have arrived yet,

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -79,8 +79,8 @@ const connected = Container.namedConnect(
         sbsAvatarUrl: undefined,
         serviceIcon: undefined,
         title: username,
-        vouchShowButton,
         vouchDisableButton,
+        vouchShowButton,
         webOfTrustEntries: filteredWot || [],
       }
     } else {
@@ -103,8 +103,8 @@ const connected = Container.namedConnect(
         service,
         serviceIcon: Styles.isDarkMode() ? nonUserDetails.siteIconFullDarkmode : nonUserDetails.siteIconFull,
         title,
-        vouchShowButton: false,
         vouchDisableButton: true,
+        vouchShowButton: false,
         webOfTrustEntries: [],
       }
     }
@@ -113,7 +113,9 @@ const connected = Container.namedConnect(
     _onEditAvatar: () => dispatch(ProfileGen.createEditAvatar()),
     _onIKnowThem: (username: string, guiID: string) =>
       dispatch(
-        RouteTreeGen.createNavigateAppend({path: [{props: {username, guiID}, selected: 'profileWotAuthor'}]})
+        RouteTreeGen.createNavigateAppend({
+          path: [{props: {guiID, username}, selected: 'profileWotAuthor'}],
+        })
       ),
     _onReload: (username: string, isYou: boolean, state: Types.DetailsState) => {
       if (state !== 'valid') {
@@ -188,8 +190,8 @@ const connected = Container.namedConnect(
       title: stateProps.title,
       userIsYou: stateProps.userIsYou,
       username: stateProps.username,
-      vouchShowButton: stateProps.vouchShowButton,
       vouchDisableButton: stateProps.vouchDisableButton,
+      vouchShowButton: stateProps.vouchShowButton,
       webOfTrustEntries: stateProps.webOfTrustEntries,
     }
   },

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -1,11 +1,11 @@
-import * as Constants from '../../constants/tracker2'
-import * as Container from '../../util/container'
 import Profile2, {BackgroundColorType} from '.'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
-import * as Styles from '../../styles'
 import * as Tracker2Gen from '../../actions/tracker2-gen'
+import * as Constants from '../../constants/tracker2'
 import * as Types from '../../constants/types/tracker2'
+import * as Styles from '../../styles'
+import * as Container from '../../util/container'
 
 export type OwnProps = Container.RouteProps<{username: string}>
 
@@ -98,9 +98,9 @@ const connected = Container.namedConnect(
   },
   dispatch => ({
     _onEditAvatar: () => dispatch(ProfileGen.createEditAvatar()),
-    _onIKnowThem: (username: string) =>
+    _onIKnowThem: (username: string, guiID: string) =>
       dispatch(
-        RouteTreeGen.createNavigateAppend({path: [{props: {username}, selected: 'profileWotAuthor'}]})
+        RouteTreeGen.createNavigateAppend({path: [{props: {username, guiID}, selected: 'profileWotAuthor'}]})
       ),
     _onReload: (username: string, isYou: boolean, state: Types.DetailsState) => {
       if (state !== 'valid') {
@@ -163,7 +163,11 @@ const connected = Container.namedConnect(
       onAddIdentity,
       onBack: dispatchProps.onBack,
       onEditAvatar: stateProps.userIsYou ? dispatchProps._onEditAvatar : undefined,
-      onIKnowThem: promptForVouch ? () => dispatchProps._onIKnowThem(stateProps.username) : undefined,
+      // xxx TODO there is more to onIKnowThem/promptForVouch than #23546. See `details` conditions in actions/profile/index.tsx:wotVouch
+      // xxx additional conditions could disable the button.
+      onIKnowThem: promptForVouch
+        ? () => dispatchProps._onIKnowThem(stateProps.username, stateProps.guiID)
+        : undefined,
       onReload: () => dispatchProps._onReload(stateProps.username, stateProps.userIsYou, stateProps.state),
       reason: stateProps.reason,
       sbsAvatarUrl: stateProps.sbsAvatarUrl,

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -81,7 +81,7 @@ const connected = Container.namedConnect(
         title: username,
         vouchDisableButton,
         vouchShowButton,
-        webOfTrustEntries: filteredWot || [],
+        webOfTrustEntries: filteredWot,
       }
     } else {
       // SBS profile. But `nonUserDetails` might not have arrived yet,

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -49,6 +49,8 @@ export type Props = {
   serviceIcon?: Array<Types.SiteIcon>
   fullName?: string // full name from external profile
   title: string
+  vouchShowButton: boolean
+  vouchDisableButton: boolean
   webOfTrustEntries: Array<Types.WebOfTrustEntry>
 }
 
@@ -403,9 +405,15 @@ class User extends React.Component<Props, State> {
 
   _renderWebOfTrust = ({item}) =>
     item.type === 'IKnowThem' ? (
-      this.props.onIKnowThem && (
+      this.props.vouchShowButton && (
         <Kb.Box2 key="iknowthem" direction="horizontal" fullWidth={true} style={styles.knowThemBox}>
-          <Kb.Button key="iknowthembtn" onClick={this.props.onIKnowThem} type="Default" label={item.text}>
+          <Kb.Button
+            key="iknowthembtn"
+            type="Default"
+            label={item.text}
+            onClick={this.props.onIKnowThem}
+            disabled={this.props.vouchDisableButton}
+          >
             <Kb.Icon type="iconfont-proof-good" style={styles.knowThemIcon} />
           </Kb.Button>
         </Kb.Box2>

--- a/shared/profile/wot-author/index.stories.tsx
+++ b/shared/profile/wot-author/index.stories.tsx
@@ -279,8 +279,14 @@ const sampleAssertions = {
 }
 /* eslint-enable sort-keys */
 
-const sampleProofs: Proof[] = sortBy(Object.values(sampleAssertions), x => x.priority).flatMap((x: any) =>
-  x.wotProof && x.state === 'valid' ? [{...x, wotProof: x.wotProof}] : []
+const sampleProofs: Proof[] = sortBy(Object.values(sampleAssertions), x => x.priority).reduce<Array<Proof>>(
+  (acc, x: any) => {
+    if (x.wotProof && x.state === 'valid') {
+      acc.push({...x, wotProof: x.wotProof})
+    }
+    return acc
+  },
+  []
 )
 
 const storyProofs: Proof[] = [

--- a/shared/profile/wot-author/index.stories.tsx
+++ b/shared/profile/wot-author/index.stories.tsx
@@ -9,7 +9,7 @@ const sampleAssertions = {
   'mastodon.social:mlsteele': {
     assertionKey: 'mastodon.social:mlsteele',
     belowFold: false,
-    color: 'blue',
+    color: 'green',
     kid: ',',
     metas: [],
     pickerSubtext: '',
@@ -64,11 +64,19 @@ const sampleAssertions = {
     timestamp: 1554393831000,
     type: 'mastodon.social',
     value: 'mlsteele',
+    wotProof: {
+      domain: '',
+      hostname: '',
+      name: 'mastodon.social',
+      proofType: 9,
+      protocol: '',
+      username: 'mlsteele',
+    },
   },
   'https:milessteele.com': {
     assertionKey: 'https:milessteele.com',
     belowFold: false,
-    color: 'blue',
+    color: 'green',
     kid: ',',
     metas: [],
     pickerSubtext: '',
@@ -100,11 +108,19 @@ const sampleAssertions = {
     timestamp: 1437509684000,
     type: 'https',
     value: 'milessteele.com',
+    wotProof: {
+      domain: '',
+      hostname: 'milessteele.com',
+      name: '',
+      proofType: 1000,
+      protocol: 'https',
+      username: '',
+    },
   },
   'github:mlsteele': {
     assertionKey: 'github:mlsteele',
     belowFold: false,
-    color: 'blue',
+    color: 'green',
     kid: ',',
     metas: [],
     pickerSubtext: '',
@@ -139,11 +155,12 @@ const sampleAssertions = {
     timestamp: 1437509440000,
     type: 'github',
     value: 'mlsteele',
+    wotProof: {domain: '', hostname: '', name: 'github', proofType: 3, protocol: '', username: 'mlsteele'},
   },
   'twitter:mlsteele': {
     assertionKey: 'twitter:mlsteele',
     belowFold: false,
-    color: 'blue',
+    color: 'green',
     kid: ',',
     metas: [],
     pickerSubtext: '',
@@ -178,11 +195,12 @@ const sampleAssertions = {
     timestamp: 1437510817000,
     type: 'twitter',
     value: 'mlsteele',
+    wotProof: {domain: '', hostname: '', name: 'twitter', proofType: 2, protocol: '', username: 'mlsteele'},
   },
   'btc:1BtCWKzmZTmRdH63CZzJeVD1MUMSshniFo': {
     assertionKey: 'btc:1BtCWKzmZTmRdH63CZzJeVD1MUMSshniFo',
     belowFold: false,
-    color: 'blue',
+    color: 'green',
     kid: ',',
     metas: [],
     pickerSubtext: '',
@@ -220,7 +238,7 @@ const sampleAssertions = {
   'stellar:mlsteele*keybase.io': {
     assertionKey: 'stellar:mlsteele*keybase.io',
     belowFold: false,
-    color: 'blue',
+    color: 'green',
     kid: ',',
     metas: [],
     pickerSubtext: '',
@@ -261,8 +279,8 @@ const sampleAssertions = {
 }
 /* eslint-enable sort-keys */
 
-const sampleProofs: Proof[] = sortBy(Object.values(sampleAssertions), x => x.priority).filter(
-  x => x.type !== 'stellar'
+const sampleProofs: Proof[] = sortBy(Object.values(sampleAssertions), x => x.priority).flatMap((x: any) =>
+  x.wotProof && x.state === 'valid' ? [{...x, wotProof: x.wotProof}] : []
 )
 
 const storyProofs: Proof[] = [
@@ -271,6 +289,14 @@ const storyProofs: Proof[] = [
 ].map(x => ({
   siteIcon: sampleProofs[0].siteIcon,
   siteIconDarkmode: sampleProofs[0].siteIcon,
+  wotProof: {
+    domain: '',
+    hostname: '',
+    name: x.type,
+    proofType: 9,
+    protocol: '',
+    username: x.value,
+  },
   ...x,
 }))
 

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -87,7 +87,12 @@ export const Question1Wrapper = (
       proofs = sortBy(
         Array.from(assertions, ([_, assertion]) => assertion),
         x => x.priority
-      ).flatMap(x => (x.wotProof && x.state === 'valid' ? [{...x, wotProof: x.wotProof}] : []))
+      ).reduce<Array<Proof>>((acc, x) => {
+        if (x.wotProof && x.state === 'valid') {
+          acc.push({...x, wotProof: x.wotProof})
+        }
+        return acc
+      }, [])
     }
   } else {
     error = `Proofs not loaded: ${trackerUsername} != ${voucheeUsername}`

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -144,7 +144,7 @@ export const Question2Wrapper = (
       ProfileGen.createWotVouch({
         otherText,
         guiID,
-        proofs: proofs,
+        proofs,
         statement,
         username: voucheeUsername,
         verificationType,

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -9,6 +9,8 @@ import * as Tracker2Types from '../../constants/types/tracker2'
 import {SiteIcon} from '../../profile/generic/shared'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as Tracker2Constants from '../../constants/tracker2'
+import * as RPCTypes from '../../constants/types/rpc-gen'
+import sortBy from 'lodash/sortBy'
 
 // PICNIC-1059 Keep in sync with server limit (yet to be implemented)
 const statementLimit = 700
@@ -24,7 +26,7 @@ export type Question1Props = {
 
 export type Question1Answer = {
   otherText: string
-  proofs: Array<Proof>
+  proofs: Array<RPCTypes.WotProof>
   verificationType: WebOfTrustVerificationType
 }
 
@@ -52,6 +54,7 @@ export type Proof = {
   value: string
   siteIcon?: Tracker2Types.SiteIconSet
   siteIconDarkmode?: Tracker2Types.SiteIconSet
+  wotProof: RPCTypes.WotProof
 }
 
 type Checkboxed = {
@@ -59,8 +62,14 @@ type Checkboxed = {
   onCheck: (_: boolean) => void
 }
 
-export const Question1Wrapper = (props: Container.RouteProps<{username: string}>) => {
+export const Question1Wrapper = (
+  props: Container.RouteProps<{
+    username: string
+    guiID: string
+  }>
+) => {
   const voucheeUsername = Container.getRouteProps(props, 'username', '')
+  const guiID = Container.getRouteProps(props, 'guiID', '')
   const nav = Container.useSafeNavigation()
   const dispatch = Container.useDispatch()
   let error = Container.useSelector(state => state.profile.wotAuthorError)
@@ -73,7 +82,12 @@ export const Question1Wrapper = (props: Container.RouteProps<{username: string}>
   let proofs: Proof[] = []
   if (trackerUsername === voucheeUsername) {
     if (assertions) {
-      proofs = Array.from(assertions, ([_, assertion]) => assertion).filter(x => x.type !== 'stellar')
+      // Pull proofs from the profile they were just looking at.
+      // Only take passing proofs that have a `wotProof` field filled by the service.
+      proofs = sortBy(
+        Array.from(assertions, ([_, assertion]) => assertion),
+        x => x.priority
+      ).flatMap(x => (x.wotProof && x.state === 'valid' ? [{...x, wotProof: x.wotProof}] : []))
     }
   } else {
     error = `Proofs not loaded: ${trackerUsername} != ${voucheeUsername}`
@@ -81,7 +95,12 @@ export const Question1Wrapper = (props: Container.RouteProps<{username: string}>
   const onSubmit = (answer: Question1Answer) => {
     dispatch(
       nav.safeNavigateAppendPayload({
-        path: [{props: {question1Answer: answer, username: voucheeUsername}, selected: 'profileWotAuthorQ2'}],
+        path: [
+          {
+            props: {guiID, question1Answer: answer, username: voucheeUsername},
+            selected: 'profileWotAuthorQ2',
+          },
+        ],
       })
     )
   }
@@ -99,10 +118,12 @@ export const Question1Wrapper = (props: Container.RouteProps<{username: string}>
 export const Question2Wrapper = (
   props: Container.RouteProps<{
     username: string
+    guiID: string
     question1Answer: Question1Answer
   }>
 ) => {
   const voucheeUsername = Container.getRouteProps(props, 'username', '')
+  const guiID = Container.getRouteProps(props, 'guiID', '')
   const question1Answer = Container.getRoutePropsOr(props, 'question1Answer', 'error')
   const nav = Container.useSafeNavigation()
   const dispatch = Container.useDispatch()
@@ -118,11 +139,12 @@ export const Question2Wrapper = (
     if (question1Answer === 'error') {
       return
     }
-    const {otherText, verificationType} = question1Answer
+    const {otherText, proofs, verificationType} = question1Answer
     dispatch(
       ProfileGen.createWotVouch({
         otherText,
-        proofs: [], // PICNIC-1087 TODO
+        guiID,
+        proofs: proofs,
         statement,
         username: voucheeUsername,
         verificationType,
@@ -170,12 +192,7 @@ export const Question1 = (props: Question1Props) => {
   const onSubmit = () => {
     props.onSubmit({
       otherText: selectedVerificationType === 'other' ? otherText : '',
-      proofs: proofs
-        .filter(({checked}) => checked)
-        .map(proof => {
-          const {checked, onCheck, ...rest} = proof
-          return rest
-        }),
+      proofs: proofs.filter(({checked}) => checked).map(proof => proof.wotProof),
       verificationType: selectedVerificationType,
     })
   }

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -142,8 +142,8 @@ export const Question2Wrapper = (
     const {otherText, proofs, verificationType} = question1Answer
     dispatch(
       ProfileGen.createWotVouch({
-        otherText,
         guiID,
+        otherText,
         proofs,
         statement,
         username: voucheeUsername,


### PR DESCRIPTION
- wot-author sends `proofs` to service to when verificationType is 'proofs'
- split wotVouchCLI RPC to lock in vouchee version from Identify3