### PR TITLE
Fix a mystery More badge on iPad, due to notifications off not being plumbed through

### DIFF
--- a/shared/settings/nav/split-nav.tsx
+++ b/shared/settings/nav/split-nav.tsx
@@ -68,6 +68,7 @@ const SplitNav = (props: Props) => {
         onClick={() => props.onTabChange(Constants.fsTab)}
       />
       <SettingsItem
+        badgeNumber={props.badgeNotifications ? 1 : 0}
         text="Notifications"
         selected={props.selectedTab === Constants.notificationsTab}
         onClick={() => props.onTabChange(Constants.notificationsTab)}

--- a/shared/settings/render.tsx
+++ b/shared/settings/render.tsx
@@ -24,34 +24,7 @@ const SettingsRender = (props: Props) => {
   React.useEffect(() => {
     loadHasRandomPW()
   }, [loadHasRandomPW])
-  return (
-    <Box style={styles.container}>
-      <Box style={styles.row}>
-        <SettingsNav
-          badgeNumbers={props.badgeNumbers}
-          contactsLabel={props.contactsLabel}
-          logoutInProgress={props.logoutInProgress}
-          selectedTab={props.selectedTab}
-          onTabChange={props.onTabChange}
-          onLogout={props.onLogout}
-          hasRandomPW={props.hasRandomPW || null}
-        />
-        <Box style={styles.overflowRow}>{props.children}</Box>
-      </Box>
-    </Box>
-  )
-}
-SettingsRender.navigationOptions = {
-  header: null,
-}
-
-const PhoneRender = (props: Props) => {
-  const {loadHasRandomPW} = props
-  React.useEffect(() => {
-    loadHasRandomPW()
-  }, [loadHasRandomPW])
-
-  return (
+  const SettingsNavComponent = (
     <SettingsNav
       badgeNotifications={props.badgeNotifications}
       badgeNumbers={props.badgeNumbers}
@@ -63,12 +36,25 @@ const PhoneRender = (props: Props) => {
       hasRandomPW={props.hasRandomPW || null}
     />
   )
+  return Container.isPhone ? (
+    SettingsNavComponent
+  ) : (
+    <Box style={styles.container}>
+      <Box style={styles.row}>
+        {SettingsNavComponent}
+        <Box style={styles.overflowRow}>{props.children}</Box>
+      </Box>
+    </Box>
+  )
 }
-
-PhoneRender.navigationOptions = {
-  header: undefined,
-  title: 'More',
-}
+SettingsRender.navigationOptions = Container.isPhone
+  ? {
+      header: undefined,
+      title: 'More',
+    }
+  : {
+      header: null,
+    }
 
 const styles = Styles.styleSheetCreate(() => ({
   container: {
@@ -93,4 +79,4 @@ const styles = Styles.styleSheetCreate(() => ({
   },
 }))
 
-export default Container.isPhone ? PhoneRender : SettingsRender
+export default SettingsRender


### PR DESCRIPTION
@keybase/react-hackers 

If you don't allow native notifications, we badge the More tab and the Notifications subtab.  But on iPad the Notifications badge wasn't being shown because it's using the desktop settings nav instead of the phone one.  That badge is plumbed through to the split settings nav too now.

We also had two almost identical render components for phone and !phone, merged them into one.