### PR TITLE
libkbfs: fix conflict resolution when logs are obfuscated

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver.go
+++ b/go/kbfs/libkbfs/conflict_resolver.go
@@ -863,8 +863,9 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 	currOriginal := unmergedOriginal
 	currPath := unmergedPath
 	mergedPath := data.Path{
-		FolderBranch: unmergedPath.FolderBranch,
-		Path:         nil, // fill in backwards, and reverse at the end
+		FolderBranch:    unmergedPath.FolderBranch,
+		Path:            nil, // fill in backwards, and reverse at the end
+		ChildObfuscator: cr.fbo.makeObfuscator(),
 	}
 
 	// First find the earliest merged parent.
@@ -1136,6 +1137,7 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 			Path: []data.PathNode{
 				{BlockPointer: unmergedChain.mostRecent},
 			},
+			ChildObfuscator: cr.fbo.makeObfuscator(),
 		}
 		chainsToSearchFor[mergedChain.mostRecent] =
 			append(chainsToSearchFor[mergedChain.mostRecent],
@@ -1793,8 +1795,9 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 				mergedLen := len(mergedPath.Path)
 				pLen := mergedLen + unmergedWalkBack
 				p := data.Path{
-					FolderBranch: mergedPath.FolderBranch,
-					Path:         make([]data.PathNode, pLen),
+					FolderBranch:    mergedPath.FolderBranch,
+					Path:            make([]data.PathNode, pLen),
+					ChildObfuscator: cr.fbo.makeObfuscator(),
 				}
 				unmergedStart := len(unmergedPath.Path) -
 					unmergedWalkBack
@@ -2359,6 +2362,7 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 		}
 	}
 
+	cr.log.CDebugf(ctx, "putTopBlock: %s", name)
 	err = blocks.putTopBlock(ctx, mergedMostRecent, name, fblock)
 	if err != nil {
 		return data.BlockPointer{}, err
@@ -2511,6 +2515,7 @@ func (cr *ConflictResolver) doOneAction(
 						FolderBranch: mergedPath.FolderBranch,
 						Path: []data.PathNode{{
 							BlockPointer: newPtr, Name: mergedPath.TailName()}},
+						ChildObfuscator: cr.fbo.makeObfuscator(),
 					}
 					uDir = cr.fbo.blocks.newDirDataWithDBMLocked(
 						lState, newPath, chargedTo,
@@ -2806,6 +2811,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 							FolderBranch: cr.fbo.folderBranch,
 							Path: []data.PathNode{{
 								BlockPointer: chain.mostRecent}},
+							ChildObfuscator: cr.fbo.makeObfuscator(),
 						})
 						added = true
 					}
@@ -2933,8 +2939,9 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 		// Reset the resolved path
 		newPathLen := len(parentPath.Path) + len(resolvedPath.Path) - i
 		newResolvedPath := data.Path{
-			FolderBranch: resolvedPath.FolderBranch,
-			Path:         make([]data.PathNode, newPathLen),
+			FolderBranch:    resolvedPath.FolderBranch,
+			Path:            make([]data.PathNode, newPathLen),
+			ChildObfuscator: cr.fbo.makeObfuscator(),
 		}
 		copy(newResolvedPath.Path[:len(parentPath.Path)], parentPath.Path)
 		copy(newResolvedPath.Path[len(parentPath.Path):], resolvedPath.Path[i:])

--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -1496,11 +1496,11 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 			mergedRootPath.TailPointer())
 	} else if len(blocks) != 1 {
 		t.Errorf("Unexpected number of blocks")
-	} else if fblock, ok := blocks[data.NewPathPartString(mergedName, nil)]; !ok {
+	} else if info, ok := blocks[mergedName]; !ok {
 		t.Errorf("No block for name %s", mergedName)
-	} else if fblock.IsInd {
+	} else if info.block.IsInd {
 		t.Errorf("Unexpected indirect block")
-	} else if g, e := fblock.Contents, unmergedData; !reflect.DeepEqual(g, e) {
+	} else if g, e := info.block.Contents, unmergedData; !reflect.DeepEqual(g, e) {
 		t.Errorf("Unexpected block contents: %v vs %v", g, e)
 	}
 

--- a/go/kbfs/libkbfs/folder_update_prepper.go
+++ b/go/kbfs/libkbfs/folder_update_prepper.go
@@ -990,8 +990,9 @@ func (fup *folderUpdatePrepper) setChildrenNodes(
 			ctx, libkb.VLog1, "Creating child node for name %s for parent %v",
 			name, pnode.BlockPointer)
 		childPath := data.Path{
-			FolderBranch: p.FolderBranch,
-			Path:         make([]data.PathNode, indexInPath+2),
+			FolderBranch:    p.FolderBranch,
+			Path:            make([]data.PathNode, indexInPath+2),
+			ChildObfuscator: p.Path[indexInPath].Name.Obfuscator(),
 		}
 		copy(childPath.Path[0:indexInPath+1], p.Path[0:indexInPath+1])
 		childPath.Path[indexInPath+1] = data.PathNode{Name: name}

--- a/go/kbfs/test/cr_basic_conflicts_test.go
+++ b/go/kbfs/test/cr_basic_conflicts_test.go
@@ -7,12 +7,15 @@
 package test
 
 import (
+	"os"
 	"testing"
 	"time"
+
+	"github.com/keybase/client/go/kbfs/libkbfs"
 )
 
 // bob and alice both write(to the same file),
-func TestCrConflictWriteFile(t *testing.T) {
+func testCrConflictWriteFile(t *testing.T) {
 	test(t,
 		users("alice", "bob"),
 		as(alice,
@@ -37,6 +40,19 @@ func TestCrConflictWriteFile(t *testing.T) {
 			read(crname("a/b", bob), "uh oh"),
 		),
 	)
+}
+
+func TestCrConflictWriteFile(t *testing.T) {
+	testCrConflictWriteFile(t)
+}
+
+func TestCrConflictWriteFileWithObfuscation(t *testing.T) {
+	oldEnv := os.Getenv(libkbfs.EnvKeybaseTestObfuscateLogsForTest)
+	os.Setenv(libkbfs.EnvKeybaseTestObfuscateLogsForTest, "1")
+	defer func() {
+		os.Setenv(libkbfs.EnvKeybaseTestObfuscateLogsForTest, oldEnv)
+	}()
+	testCrConflictWriteFile(t)
 }
 
 // bob and alice both create the same entry with different types


### PR DESCRIPTION
A previous "fix" for leaked file names ended up breaking conflict resolution in some scenarios when logs are obfuscated.  Because our tests run without obfuscation, we never noticed.  Also, some filenames were still being leaked.

This PR fixes it by:
* Fix the implementations of `fileBlockMap` so that they index names using plaintext, rather than the `PathPartString`, as the latter could have different obfuscator fields and might not match.
* Fix the `conflictResolver` to always add an obfuscator to every path it makes, so the names will always be obfuscated.
* Add a DSL CR test that turns on log obfuscation, so we can catch this in the future if it happens again.

Issue: HOTPOT-2418