### PR TITLE
PICNIC-581: Fix missing error from path not found

### DIFF
--- a/shared/wallets/sep7-confirm/container.tsx
+++ b/shared/wallets/sep7-confirm/container.tsx
@@ -6,12 +6,13 @@ import SEP7Confirm from '.'
 
 const mapStateToProps = (state: Container.TypedState) => ({
   _inputURI: state.wallets.sep7ConfirmURI,
+  builtPaymentAdvancedWaitingKey: Constants.calculateBuildingAdvancedWaitingKey,
   loading: !state.wallets.sep7ConfirmInfo,
   sep7ConfirmFromQR: state.wallets.sep7ConfirmFromQR,
   sep7ConfirmInfo: state.wallets.sep7ConfirmInfo,
   sep7ConfirmPath: state.wallets.sep7ConfirmPath,
   sep7SendError: state.wallets.sep7SendError,
-  waitingKey: Constants.sep7WaitingKey,
+  sep7WaitingKey: Constants.sep7WaitingKey,
 })
 
 const mapDispatchToProps = (dispatch: Container.TypedDispatch) => ({
@@ -29,8 +30,10 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
       amount: null,
       assetCode: '',
       availableToSendNative: '',
+      builtPaymentAdvancedWaitingKey: stateProps.builtPaymentAdvancedWaitingKey,
       callbackURL: null,
       displayAmountFiat: '',
+      findPathError: stateProps.sep7ConfirmPath.findPathError,
       fromQRCode: false,
       loading: true,
       memo: null,
@@ -46,6 +49,7 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
       path: stateProps.sep7ConfirmPath,
       recipient: null,
       sendError: stateProps.sep7SendError,
+      sep7WaitingKey: stateProps.sep7WaitingKey,
       signed: null,
       summary: {
         fee: '',
@@ -54,7 +58,6 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
         operations: [],
         source: '',
       },
-      waitingKey: stateProps.waitingKey,
     }
   }
   const {
@@ -73,6 +76,7 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
   } = stateProps.sep7ConfirmInfo
   const sendError = stateProps.sep7SendError
   const path = stateProps.sep7ConfirmPath
+  const {findPathError} = path
   const rawOp = stateProps.sep7ConfirmInfo.operation
   const fromQRCode = stateProps.sep7ConfirmFromQR
   const operation = rawOp === 'pay' ? ('pay' as const) : rawOp === 'tx' ? ('tx' as const) : ('' as const)
@@ -85,8 +89,10 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
     amount,
     assetCode,
     availableToSendNative,
+    builtPaymentAdvancedWaitingKey: stateProps.builtPaymentAdvancedWaitingKey,
     callbackURL,
     displayAmountFiat,
+    findPathError,
     fromQRCode,
     loading: stateProps.loading,
     memo,
@@ -102,8 +108,8 @@ export default Container.connect(mapStateToProps, mapDispatchToProps, (stateProp
     path,
     recipient,
     sendError,
+    sep7WaitingKey: stateProps.sep7WaitingKey,
     signed,
     summary,
-    waitingKey: stateProps.waitingKey,
   }
 })(SEP7Confirm)

--- a/shared/wallets/sep7-confirm/index.stories.tsx
+++ b/shared/wallets/sep7-confirm/index.stories.tsx
@@ -22,10 +22,12 @@ const commonProps = {
   assetCode: '',
   availableToSendFiat: '$12.34 USD',
   availableToSendNative: '20 XLM',
+  builtPaymentAdvancedWaitingKey: 'false',
   callbackURL: null,
   displayAmountFiat: '$23.45 USD',
   displayAmountNative: '40 XLM',
   error: '',
+  findPathError: '',
   fromQRCode: false,
   loading: false,
   memo: '',
@@ -39,9 +41,9 @@ const commonProps = {
   path: commonPath,
   readyToSend: true,
   sendError: '',
+  sep7WaitingKey: 'false',
   userAmount: '',
   waiting: false,
-  waitingKey: 'false',
 }
 
 const payProps = {
@@ -117,6 +119,13 @@ const load = () => {
     .add('Unsigned Tx', () => <SEP7Confirm {...commonProps} {...unsignedTxProps} />)
     .add('Signed Pay with send error', () => (
       <SEP7Confirm {...commonProps} {...payProps} sendError="Your balance is too low." />
+    ))
+    .add('Find path error ', () => (
+      <SEP7Confirm
+        {...commonProps}
+        {...payProps}
+        findPathError="No path was found to convert these 2 assets. Please pick other assets."
+      />
     ))
   Sb.storiesOf('Wallets/SEP7Error', module).add('Error', () => (
     <KeybaseLinkErrorBody


### PR DESCRIPTION
In `actions/wallets` we make an RPC call to `localFindPaymentPathLocalRpcPromise`.

If this errored we would set `sep7ConfirmPath.findPathError`. However this error field was not being used by `sep7-confirm/container.tsx` to display an error.

This PR plumbs this value through and renders an error if the path payment fails.

cc @keybase/react-hackers @keybase/picnicsquad @cjb 