### PR TITLE
kbpages: disable listing by default

### DIFF
--- a/go/kbfs/libpages/config/config_v1.go
+++ b/go/kbfs/libpages/config/config_v1.go
@@ -58,7 +58,7 @@ func DefaultV1() *V1 {
 		},
 		PerPathConfigs: map[string]PerPathConfigV1{
 			"/": {
-				AnonymousPermissions: "read,list",
+				AnonymousPermissions: "read",
 			},
 		},
 	}

--- a/go/kbfs/libpages/config/config_v1_test.go
+++ b/go/kbfs/libpages/config/config_v1_test.go
@@ -20,9 +20,9 @@ func TestConfigV1Default(t *testing.T) {
 		realm, err := config.GetPermissions("/", nil)
 	require.NoError(t, err)
 	require.True(t, read)
-	require.True(t, list)
+	require.False(t, list)
 	require.True(t, possibleRead)
-	require.True(t, possibleList)
+	require.False(t, possibleList)
 	require.Equal(t, "/", realm)
 }
 
@@ -349,7 +349,7 @@ func TestV1EncodeObjectKeyOrder(t *testing.T) {
 	require.NoError(t, err)
 	const expectedJSON = `{"version":"v1","users":null,` +
 		`"per_path_configs":{"/":{"whitelist_additional_permissions":null,` +
-		`"anonymous_permissions":"read,list"}}}`
+		`"anonymous_permissions":"read"}}}`
 	require.Equal(t, expectedJSON, strings.TrimSpace(buf.String()))
 }
 

--- a/go/kbfs/libpages/server_test.go
+++ b/go/kbfs/libpages/server_test.go
@@ -108,7 +108,7 @@ func TestServerDefault(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	server.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
-	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, http.StatusForbidden, w.Code)
 
 	w = httptest.NewRecorder()
 	server.ServeHTTP(w, httptest.NewRequest("GET", "/non-existent", nil))


### PR DESCRIPTION
This is a more sensible default. Not sure why I went with the other way in the first place. This will disable listing for those don't have a config, but they can make a config to get the listing back if that's what they want. For those who already have a config file, this shouldn't change anything.