### PR TITLE
Tooltip when hovering proof icons

### DIFF
--- a/shared/tracker2/assertion/index.tsx
+++ b/shared/tracker2/assertion/index.tsx
@@ -379,33 +379,33 @@ class Assertion extends React.PureComponent<Props, State> {
             )}
           </Kb.Text>
           <Kb.ClickableBox onClick={items ? this._toggleMenu : p.onShowProof} style={styles.statusContainer}>
-            <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny">
-              <Kb.WithTooltip tooltip={(p.state == 'valid' || p.state == 'revoked') && 'Check proof'}>
+            <Kb.WithTooltip tooltip={(p.state === 'valid' || p.state === 'revoked') && 'View proof'}>
+              <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny">
                 <Kb.Icon
                   type={stateToIcon(p.state)}
                   fontSize={20}
                   hoverColor={assertionColorToColor(p.color)}
                   color={p.isSuggestion ? Styles.globalColors.black_20 : assertionColorToColor(p.color)}
                 />
-              </Kb.WithTooltip>
-              {items ? (
-                <>
-                  <Kb.Icon className="hover-visible" type="iconfont-caret-down" sizeType="Tiny" />
-                  <Kb.FloatingMenu
-                    closeOnSelect={true}
-                    visible={this.state.showingMenu}
-                    onHidden={this._hideMenu}
-                    attachTo={this._getRef}
-                    position="bottom right"
-                    containerStyle={styles.floatingMenu}
-                    header={header}
-                    items={items}
-                  />
-                </>
-              ) : (
-                <Kb.Box2 direction="vertical" />
-              )}
-            </Kb.Box2>
+                {items ? (
+                  <>
+                    <Kb.Icon className="hover-visible" type="iconfont-caret-down" sizeType="Tiny" />
+                    <Kb.FloatingMenu
+                      closeOnSelect={true}
+                      visible={this.state.showingMenu}
+                      onHidden={this._hideMenu}
+                      attachTo={this._getRef}
+                      position="bottom right"
+                      containerStyle={styles.floatingMenu}
+                      header={header}
+                      items={items}
+                    />
+                  </>
+                ) : (
+                  <Kb.Box2 direction="vertical" />
+                )}
+              </Kb.Box2>
+            </Kb.WithTooltip>
           </Kb.ClickableBox>
         </Kb.Box2>
         {!!p.metas.length && (

--- a/shared/tracker2/assertion/index.tsx
+++ b/shared/tracker2/assertion/index.tsx
@@ -380,12 +380,14 @@ class Assertion extends React.PureComponent<Props, State> {
           </Kb.Text>
           <Kb.ClickableBox onClick={items ? this._toggleMenu : p.onShowProof} style={styles.statusContainer}>
             <Kb.Box2 direction="horizontal" alignItems="center" gap="tiny">
-              <Kb.Icon
-                type={stateToIcon(p.state)}
-                fontSize={20}
-                hoverColor={assertionColorToColor(p.color)}
-                color={p.isSuggestion ? Styles.globalColors.black_20 : assertionColorToColor(p.color)}
-              />
+              <Kb.WithTooltip tooltip={(p.state == 'valid' || p.state == 'revoked') && 'Check proof'}>
+                <Kb.Icon
+                  type={stateToIcon(p.state)}
+                  fontSize={20}
+                  hoverColor={assertionColorToColor(p.color)}
+                  color={p.isSuggestion ? Styles.globalColors.black_20 : assertionColorToColor(p.color)}
+                />
+              </Kb.WithTooltip>
               {items ? (
                 <>
                   <Kb.Icon className="hover-visible" type="iconfont-caret-down" sizeType="Tiny" />


### PR DESCRIPTION
@keybase/react-hackers cc @adamjspooner 
This adds a tooltip when hovering a proof icon that's either good or broken:

![image](https://user-images.githubusercontent.com/2807426/79094361-1abe9a80-7d0c-11ea-8a60-1f01d7dba1fc.png)
