### PR TITLE
Make both reacji rows look the same.

### DIFF
--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -620,16 +620,13 @@ class _WrapperMessage extends React.Component<Props & Kb.OverlayParentProps, Sta
                   Constants.isMessageWithReactions(this.props.message) &&
                   !this.props.showingMenu && (
                     <EmojiRow
-                      className={Styles.classNames({
-                        'WrapperMessage-emojiRow': !this.props.isLastInThread,
-                      })}
+                      className="WrapperMessage-emojiButton"
                       conversationIDKey={this.props.conversationIDKey}
                       onShowingEmojiPicker={this.setShowingPicker}
                       ordinal={message.ordinal}
                       tooltipPosition={this.props.isLastInThread ? 'top center' : 'bottom center'}
                       style={Styles.collapseStyles([
                         styles.emojiRow,
-                        !Styles.isDarkMode && styles.emojiRowBorder,
                         this.props.isLastInThread && styles.emojiRowLast,
                       ])}
                     />
@@ -775,35 +772,19 @@ const styles = Styles.styleSheetCreate(
       },
       emojiRow: Styles.platformStyles({
         isElectron: {
-          borderBottomLeftRadius: Styles.borderRadius,
-          borderBottomRightRadius: Styles.borderRadius,
-          bottom: -Styles.globalMargins.mediumLarge + 1,
-          height: Styles.globalMargins.mediumLarge,
-          paddingBottom: Styles.globalMargins.tiny,
+          backgroundColor: Styles.globalColors.white,
+          border: `1px solid ${Styles.globalColors.black_10}`,
+          borderRadius: Styles.borderRadius,
+          bottom: -Styles.globalMargins.medium + 3,
           paddingRight: Styles.globalMargins.xtiny,
-          paddingTop: Styles.globalMargins.xtiny,
           position: 'absolute',
           right: 96,
           zIndex: 2,
         },
       }),
-      emojiRowBorder: Styles.platformStyles({
-        isElectron: {
-          borderBottom: `1px solid ${Styles.globalColors.black_10}`,
-          borderLeft: `1px solid ${Styles.globalColors.black_10}`,
-          borderRight: `1px solid ${Styles.globalColors.black_10}`,
-        },
-      }),
       emojiRowLast: Styles.platformStyles({
         isElectron: {
-          border: 'none',
-          borderBottomLeftRadius: 0,
-          borderBottomRightRadius: 0,
-          borderTopLeftRadius: Styles.borderRadius,
-          borderTopRightRadius: Styles.borderRadius,
-          paddingBottom: Styles.globalMargins.xtiny,
-          paddingTop: Styles.globalMargins.tiny,
-          top: -Styles.globalMargins.mediumLarge + 1, // compensation for the orange line
+          top: -Styles.globalMargins.medium + 5,
         },
       }),
       fail: {color: Styles.globalColors.redDark},


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. It makes both uses of the reacji bar the same.

Message with reactions:
<img width="288" alt="Screen Shot 2020-04-13 at 11 40 01" src="https://user-images.githubusercontent.com/30595/79134372-9a378280-7d7b-11ea-8342-8b646fbd79a2.png">

Message without reactions:
<img width="236" alt="Screen Shot 2020-04-13 at 11 40 11" src="https://user-images.githubusercontent.com/30595/79134378-9f94cd00-7d7b-11ea-8525-80e6ab07005b.png">