### PR TITLE
iPad: always have nav bar label text beside icons

### DIFF
--- a/shared/override-d.ts/react-navigation/index.d.ts
+++ b/shared/override-d.ts/react-navigation/index.d.ts
@@ -1029,6 +1029,7 @@ declare module 'react-navigation' {
       tabStyle?: StyleProp<ViewStyle>
       indicatorStyle?: StyleProp<ViewStyle>
       keyboardHidesTabBar?: boolean
+      labelPosition?: 'beside-icon' | 'below-icon'
     }
     swipeEnabled?: boolean
     animationEnabled?: boolean

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -235,6 +235,7 @@ const VanillaTabNavigator = createBottomTabNavigator(
       },
       // else keyboard avoiding is racy on ios and won't work correctly
       keyboardHidesTabBar: Styles.isAndroid,
+      labelPosition: 'beside-icon',
       showLabel: Styles.isTablet,
       get style() {
         return {backgroundColor: Styles.globalColors.blueDarkOrGreyDarkest}


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/design 

On iPad (and only iPad) we have react-navigation put a text label next to each nav bar icon.  On low-res iPads in portrait modes, react-navigation was deciding to switch to iPhone-style "label below icon" mode, which looks bad and isn't necessary.  There's a flag in the library to tell it to always use label-besides-icon.

The change only affects low-res older iPads with the app started in portrait mode.

Before:

![Screen Shot 2020-04-13 at 11 11 35 AM](https://user-images.githubusercontent.com/21217/79146869-e5e82d00-7d77-11ea-9baf-3172f45f87c4.png)

After:

![Screen Shot 2020-04-13 at 11 11 27 AM](https://user-images.githubusercontent.com/21217/79146887-eaace100-7d77-11ea-9b6a-2a2a646d2679.png)