### PR TITLE
fix: unset lineHeight on markdown text element to fix emoji cutoff

### DIFF
--- a/shared/common-adapters/markdown/react.tsx
+++ b/shared/common-adapters/markdown/react.tsx
@@ -129,6 +129,7 @@ const markdownStyles = Styles.styleSheetCreate(
       }),
       textBlockStyle: Styles.platformStyles({
         isElectron: {color: 'inherit', display: 'block', fontWeight: 'inherit', ...wrapStyle},
+        isAndroid: {lineHeight: undefined},
       } as const),
       wrapStyle,
     } as const)

--- a/shared/common-adapters/markdown/react.tsx
+++ b/shared/common-adapters/markdown/react.tsx
@@ -128,8 +128,8 @@ const markdownStyles = Styles.styleSheetCreate(
         },
       }),
       textBlockStyle: Styles.platformStyles({
-        isElectron: {color: 'inherit', display: 'block', fontWeight: 'inherit', ...wrapStyle},
         isAndroid: {lineHeight: undefined},
+        isElectron: {color: 'inherit', display: 'block', fontWeight: 'inherit', ...wrapStyle},
       } as const),
       wrapStyle,
     } as const)


### PR DESCRIPTION
Android has this issue with components inside `Text` elements where if the parent element has a line height set, any children with heights larger than that will overflow or get cut off instead of growing the text container. This PR unsets the line height on a text element in the markdown adapter to allow big custom emojis to not overflow. 