### PR TITLE
Fix bottom nav icons on phone

### DIFF
--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -235,7 +235,7 @@ const VanillaTabNavigator = createBottomTabNavigator(
       },
       // else keyboard avoiding is racy on ios and won't work correctly
       keyboardHidesTabBar: Styles.isAndroid,
-      labelPosition: 'beside-icon',
+      labelPosition: Styles.isTablet ? 'beside-icon' : undefined,
       showLabel: Styles.isTablet,
       get style() {
         return {backgroundColor: Styles.globalColors.blueDarkOrGreyDarkest}


### PR DESCRIPTION
@keybase/react-hackers CC @buoyad 

react-navigation uses `labelPosition` even when `showLabel` is false.