### PR TITLE
fix add button alignment on ipad

### DIFF
--- a/shared/people/invite-friends/modal.tsx
+++ b/shared/people/invite-friends/modal.tsx
@@ -153,7 +153,12 @@ const InviteFriendsModal = () => {
                   onClear={phoneNumbers.length === 1 ? undefined : () => removePhoneNumber(i)}
                 />
               ))}
-              <Kb.Button mode="Secondary" icon="iconfont-new" onClick={addPhoneNumber} />
+              <Kb.Button
+                mode="Secondary"
+                icon="iconfont-new"
+                onClick={addPhoneNumber}
+                style={styles.alignSelfStart}
+              />
             </Kb.Box2>
           </Kb.Box2>
           {Styles.isMobile && (
@@ -182,6 +187,7 @@ export const ShareLinkPopup = ({onClose}: {onClose: () => void}) => (
 )
 
 const styles = Styles.styleSheetCreate(() => ({
+  alignSelfStart: {alignSelf: 'flex-start'},
   banner: {
     position: 'absolute',
     top: 47,


### PR DESCRIPTION
Add phone number button was centered horizontally on ipad, fixed that. cc @keybase/y2ksquad 
![image](https://user-images.githubusercontent.com/11968340/79156838-94ed2e80-7da1-11ea-8d23-cd1d2e8b121b.png)
