### PR TITLE
proof list exact match

### DIFF
--- a/shared/profile/generic/proofs-list/index.tsx
+++ b/shared/profile/generic/proofs-list/index.tsx
@@ -68,7 +68,17 @@ class Providers extends React.Component<ProvidersProps> {
   render() {
     const filterRegexp = makeInsertMatcher(this.props.filter)
 
-    const items = this.props.providers.filter(p => filterProvider(p, filterRegexp))
+    let exact: Array<IdentityProvider> = []
+    let inexact: Array<IdentityProvider> = []
+    this.props.providers.forEach(p => {
+      if (p.name === this.props.filter) {
+        exact.push(p)
+      } else if (filterProvider(p, filterRegexp)) {
+        inexact.push(p)
+      }
+    })
+
+    const items = [...exact, ...inexact]
     return (
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true}>
         <Kb.Box2 direction="vertical" fullWidth={true} style={styles.flexOne}>


### PR DESCRIPTION
Raise exact match to the top:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/705646/79162328-11383f80-7dab-11ea-961e-cdbe402ea72a.png">

Previously it was hard to find mastodon.se and mastodon.ml in the list.