### PR TITLE
Extended avatar cache stalelifetime to 24h

### DIFF
--- a/go/avatars/fullcaching.go
+++ b/go/avatars/fullcaching.go
@@ -138,10 +138,10 @@ func NewFullCachingSource(g *libkb.GlobalContext, staleThreshold time.Duration, 
 		actor(s.simpleSource.LoadTeams), batcher, reset, 100*time.Millisecond, false,
 	)
 	usersStaleBatch, _ := libkb.ThrottleBatch(
-		actor(s.simpleSource.LoadUsers), batcher, reset, 2000*time.Millisecond, false,
+		actor(s.simpleSource.LoadUsers), batcher, reset, 5000*time.Millisecond, false,
 	)
 	teamsStaleBatch, _ := libkb.ThrottleBatch(
-		actor(s.simpleSource.LoadTeams), batcher, reset, 2000*time.Millisecond, false,
+		actor(s.simpleSource.LoadTeams), batcher, reset, 5000*time.Millisecond, false,
 	)
 	s.usersMissBatch = usersMissBatch
 	s.teamsMissBatch = teamsMissBatch

--- a/go/avatars/interfaces.go
+++ b/go/avatars/interfaces.go
@@ -9,6 +9,12 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
+const (
+	// When changing staleThreshold here, serverside avatar
+	// `client_avatar_stale_threshold` should be adjusted to match.
+	staleThreshold = 24 * time.Hour
+)
+
 func CreateSourceFromEnvAndInstall(g *libkb.GlobalContext) {
 	var s libkb.AvatarLoaderSource
 	typ := g.Env.GetAvatarSource()
@@ -16,15 +22,13 @@ func CreateSourceFromEnvAndInstall(g *libkb.GlobalContext) {
 	case "simple":
 		s = NewSimpleSource()
 	case "url":
-		s = NewURLCachingSource(time.Hour /* staleThreshold */, 20000)
+		s = NewURLCachingSource(staleThreshold, 20000)
 	case "full":
 		maxSize := 10000
 		if g.IsMobileAppType() {
 			maxSize = 2000
 		}
-		// When changing staleThreshold here, serverside avatar change
-		// notification dismiss time should be adjusted as well.
-		s = NewFullCachingSource(g, time.Hour /* staleThreshold */, maxSize)
+		s = NewFullCachingSource(g, staleThreshold, maxSize)
 	}
 	g.AddDbNukeHook(s, fmt.Sprintf("AvatarLoader[%s]", typ))
 	g.SetAvatarLoader(s)

--- a/go/service/avatars.go
+++ b/go/service/avatars.go
@@ -32,13 +32,13 @@ func NewAvatarHandler(xp rpc.Transporter, g *libkb.GlobalContext, source libkb.A
 var _ keybase1.AvatarsInterface = (*AvatarHandler)(nil)
 
 func (h *AvatarHandler) LoadUserAvatars(ctx context.Context, arg keybase1.LoadUserAvatarsArg) (keybase1.LoadAvatarsRes, error) {
-	m := libkb.NewMetaContext(ctx, h.G())
-	return h.source.LoadUsers(m, arg.Names, arg.Formats)
+	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("UAVTR")
+	return h.source.LoadUsers(mctx, arg.Names, arg.Formats)
 }
 
 func (h *AvatarHandler) LoadTeamAvatars(ctx context.Context, arg keybase1.LoadTeamAvatarsArg) (keybase1.LoadAvatarsRes, error) {
-	m := libkb.NewMetaContext(ctx, h.G())
-	return h.source.LoadTeams(m, arg.Names, arg.Formats)
+	mctx := libkb.NewMetaContext(ctx, h.G()).WithLogTag("TAVTR")
+	return h.source.LoadTeams(mctx, arg.Names, arg.Formats)
 }
 
 const avatarGregorHandlerName = "avatarHandler"


### PR DESCRIPTION
Also delays the stale batcher to 5s instead of 2s