### PR TITLE
show pushPrompt on switching to logged in routedef

### DIFF
--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -307,7 +307,7 @@ const switchRouteDef = (
         RouteTreeGen.createSwitchTab({tab: Tabs.peopleTab}),
         ...(action.payload.causedBySignup
           ? [RouteTreeGen.createNavigateAppend({path: ['signupEnterPhoneNumber']})]
-          : []),
+          : [PushGen.createShowPermissionsPrompt({justSignedUp: false, show: true})]),
       ]
     }
 
@@ -370,9 +370,6 @@ const showMonsterPushPrompt = () => [
   RouteTreeGen.createSwitchTab({tab: Tabs.peopleTab}),
   RouteTreeGen.createNavigateAppend({
     path: ['settingsPushPrompt'],
-  }),
-  PushGen.createShowPermissionsPrompt({
-    show: false, // disable the prompt after showing it once, this does not perma-skip
   }),
 ]
 


### PR DESCRIPTION
cc @cjb this is your diff. I tested provisioning, signup, restarting the app after having ignored the prompt, etc. reviewer please test too. cc @keybase/y2ksquad 