### PR TITLE
Mobile: fix return on hardware keyboards after backgrounding on iOS

### DIFF
--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -99,11 +99,13 @@ class _PlatformInput extends React.PureComponent<PlatformInputPropsInternal, Sta
     }
   }
 
-  // Enter should send a message like on desktop, when a hardware keyboard's attached.
+  // Enter should send a message like on desktop, when a hardware keyboard's
+  // attached.  On Android we get "hardware" keypresses from soft keyboards,
+  // so check whether a soft keyboard's up.
   private handleHardwareEnterPress = (hwKeyEvent: {pressedKey: string}) => {
     switch (hwKeyEvent.pressedKey) {
       case 'enter':
-        !isOpen() ? this.onSubmit() : this.insertText('\n')
+        Styles.isIOS || !isOpen() ? this.onSubmit() : this.insertText('\n')
         break
       case 'shift-enter':
         this.insertText('\n')


### PR DESCRIPTION
@keybase/react-hackers r? @jzila 

@patrickxb found that return-to-send on a hardware keyboard in chat on iPad wasn't working anymore after backgrounding and reforegrounding the app.  It's because our `isOpen` bool is incorrectly thinking there's a soft keyboard open after the reforeground.

We don't actually need to be testing isOpen at all on iOS -- it was a workaround for an Android behavior where soft keyboards emulate hardware keypresses -- so this PR switches to only considering the state of `isOpen` on Android.