### PR TITLE
Jump to last read message

### DIFF
--- a/shared/chat/conversation/list-area/container.tsx
+++ b/shared/chat/conversation/list-area/container.tsx
@@ -28,10 +28,25 @@ const throttledLoadOlder = throttle(
   1000
 )
 
+const throttledJumpToUnread = throttle(
+    (dispatch: Container.TypedDispatch, conversationIDKey: Types.ConversationIDKey, lastUnreadId?: Types.MessageID) => {
+        const id = lastUnreadId ? lastUnreadId : 0
+        dispatch(
+            Chat2Gen.createReplyJump({
+                conversationIDKey: conversationIDKey,
+                messageID: id,
+            }))
+    },
+    1000
+)
+
+
 export default Container.connect(
   (state, {conversationIDKey}: OwnProps) => {
     const messageOrdinals = Constants.getMessageOrdinals(state, conversationIDKey)
     const lastOrdinal = [...messageOrdinals].pop()
+    const lastMessageID = state.chat2.metaMap.get(conversationIDKey)?.maxVisibleMsgID
+    const lastUnreadMessageID = state.chat2.metaMap.get(conversationIDKey)?.readMsgID
     const maybeCenterMessage = Constants.getMessageCenterOrdinal(state, conversationIDKey)
     const centeredOrdinal = maybeCenterMessage?.ordinal
     const containsLatestMessage = state.chat2.containsLatestMessageMap.get(conversationIDKey) || false
@@ -46,12 +61,15 @@ export default Container.connect(
       containsLatestMessage,
       conversationIDKey,
       editingOrdinal: state.chat2.editingMap.get(conversationIDKey),
+      lastMessageID,
       lastMessageIsOurs,
+      lastUnreadMessageID,
       messageOrdinals,
     }
   },
   (dispatch, {conversationIDKey}: OwnProps) => ({
     copyToClipboard: (text: string) => dispatch(ConfigGen.createCopyToClipboard({text})),
+    loadLastUnreadMessage: (lastUnreadId?: Types.MessageID) => throttledJumpToUnread(dispatch, conversationIDKey, lastUnreadId),
     loadNewerMessages: () => throttledLoadNewer(dispatch, conversationIDKey),
     loadOlderMessages: () => throttledLoadOlder(dispatch, conversationIDKey),
     markInitiallyLoadedThreadAsRead: () =>
@@ -64,7 +82,10 @@ export default Container.connect(
     conversationIDKey: stateProps.conversationIDKey,
     copyToClipboard: dispatchProps.copyToClipboard,
     editingOrdinal: stateProps.editingOrdinal,
+    lastMessageID: stateProps.lastMessageID,
     lastMessageIsOurs: stateProps.lastMessageIsOurs,
+    lastUnreadMessageID: stateProps.lastUnreadMessageID,
+    loadLastUnreadMessage: () => dispatchProps.loadLastUnreadMessage(stateProps?.lastUnreadMessageID),
     loadNewerMessages: dispatchProps.loadNewerMessages,
     loadOlderMessages: dispatchProps.loadOlderMessages,
     markInitiallyLoadedThreadAsRead: dispatchProps.markInitiallyLoadedThreadAsRead,

--- a/shared/chat/conversation/list-area/index.d.ts
+++ b/shared/chat/conversation/list-area/index.d.ts
@@ -9,7 +9,10 @@ export type Props = {
   conversationIDKey: Types.ConversationIDKey
   copyToClipboard: (arg0: string) => void
   editingOrdinal?: Types.Ordinal
+  lastMessageID: number
   lastMessageIsOurs: boolean
+  lastUnreadMessageID: number
+  loadLastUnreadMessage: (ordinal?: Types.Ordinal | null) => void
   loadNewerMessages: (ordinal?: Types.Ordinal | null) => void
   loadOlderMessages: (ordinal?: Types.Ordinal | null) => void
   markInitiallyLoadedThreadAsRead: () => void

--- a/shared/chat/conversation/list-area/index.desktop.tsx
+++ b/shared/chat/conversation/list-area/index.desktop.tsx
@@ -21,6 +21,7 @@ import throttle from 'lodash/throttle'
 import chunk from 'lodash/chunk'
 import {globalMargins} from '../../../styles/shared'
 import {memoize} from '../../../util/memoize'
+import JumpToLastRead from "./jump-to-last-read";
 
 // hot reload isn't supported with debouncing currently so just ignore hot here
 if (module.hot) {
@@ -79,6 +80,14 @@ class Thread extends React.PureComponent<Props, State> {
   set lockedToBottom(l: boolean) {
     // accessor just to help debug
     this._lockedToBottom = l
+  }
+
+  private _showLastReadBox: boolean = true
+  get showLastReadBox() {
+    return this._showLastReadBox
+  }
+  set showLastReadBox(l: boolean) {
+    this._showLastReadBox = l
   }
 
   private logAll = debug
@@ -140,6 +149,14 @@ class Thread extends React.PureComponent<Props, State> {
     setTimeout(() => {
       requestAnimationFrame(actuallyScroll)
     }, 1)
+  }
+
+  private scrollToUnread = () => {
+    this.showLastReadBox = false
+
+    this.props.loadLastUnreadMessage()
+
+    return;
   }
 
   private scrollDown = () => {
@@ -213,6 +230,7 @@ class Thread extends React.PureComponent<Props, State> {
     if (this.props.conversationIDKey !== prevProps.conversationIDKey) {
       this.cleanupDebounced()
       this.lockedToBottom = true
+      this.showLastReadBox = true
       this.scrollToBottom('componentDidUpdate-change-convo')
       return
     }
@@ -516,6 +534,12 @@ class Thread extends React.PureComponent<Props, State> {
       <div>Debug info: {this.isLockedToBottom() ? 'Locked to bottom' : 'Not locked to bottom'}</div>
     ) : null
 
+    const lastUnread = (this.props.lastUnreadMessageID !== this.props.lastMessageID && this.showLastReadBox === true) ?
+        (<JumpToLastRead onClick={this.scrollToUnread} style={styles.jumpToLastRead}/>) : null
+
+    if (!lastUnread)
+      this.showLastReadBox = false
+
     return (
       <ErrorBoundary>
         {debugInfo}
@@ -526,6 +550,7 @@ class Thread extends React.PureComponent<Props, State> {
               {items}
             </div>
           </div>
+          {lastUnread}
           {!this.props.containsLatestMessage && this.props.messageOrdinals.length > 0 && (
             <JumpToRecent onClick={this.jumpToRecent} style={styles.jumpToRecent} />
           )}
@@ -746,6 +771,10 @@ const styles = Styles.styleSheetCreate(
           position: 'relative',
         },
       }),
+      jumpToLastRead: {
+        bottom: 0,
+        position: 'absolute',
+      },
       jumpToRecent: {
         bottom: 0,
         position: 'absolute',

--- a/shared/chat/conversation/list-area/jump-to-last-read.tsx
+++ b/shared/chat/conversation/list-area/jump-to-last-read.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import * as Kb from '../../../common-adapters'
+import * as Styles from '../../../styles'
+
+type Props = {
+  onClick: () => void
+  style?: Styles.StylesCrossPlatform
+}
+
+const JumpToLastRead = (props: Props) => {
+  return (
+    <Kb.Box2 direction="vertical" style={Styles.collapseStyles([styles.outerContainer, props.style])}>
+      <Kb.Button label="Jump to last read message" onClick={props.onClick} small={true}>
+        <Kb.Icon
+          color={Styles.globalColors.whiteOrWhite}
+          type="iconfont-arrow-full-up"
+          boxStyle={styles.arrowBox}
+          sizeType="Small"
+          style={styles.arrowText}
+        />
+      </Kb.Button>
+    </Kb.Box2>
+  )
+}
+
+const styles = Styles.styleSheetCreate(
+  () =>
+    ({
+      arrowBox: Styles.platformStyles({
+        isElectron: {
+          display: 'inline',
+        },
+      }),
+      arrowText: {
+        paddingRight: Styles.globalMargins.tiny,
+      },
+      outerContainer: Styles.platformStyles({
+        common: {
+          alignItems: 'center',
+          paddingBottom: Styles.globalMargins.small,
+          paddingTop: Styles.globalMargins.small,
+          width: '100%',
+        },
+        isElectron: {
+          backgroundImage: `linear-gradient(transparent, ${Styles.globalColors.white} 75%)`,
+        },
+      }),
+    } as const)
+)
+
+export default JumpToLastRead


### PR DESCRIPTION
I created this pull request to add a "jump to last read message" button, as requested in issues #12476 and #15988. It's implemented only on desktop by now.
The button appears only when there are new messages in a chat.
It works even if the last read message is quite old (so not loaded in the last chunk of messages)
I attach a short video and I'm available for further informations or review https://youtu.be/f5Lyi00EER8