### PR TITLE
libfs: move .kbfs_profiles support into node wrappers 

### DIFF
--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -318,7 +318,7 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 
 		// This section is equivalent to
 		// handleCommonSpecialFile in libfuse.
-	case libkbfs.ErrorFile == ps[psl-1]:
+	case libfs.ErrorFileName == ps[psl-1]:
 		return oc.returnFileNoCleanup(NewErrorFile(f))
 	case libfs.MetricsFileName == ps[psl-1]:
 		return oc.returnFileNoCleanup(NewMetricsFile(f))

--- a/go/kbfs/libdokan/profilelist.go
+++ b/go/kbfs/libdokan/profilelist.go
@@ -42,6 +42,10 @@ func (pl ProfileList) open(ctx context.Context, oc *openContext, path []string) 
 
 // FindFiles does readdir for dokan.
 func (ProfileList) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
+	// TODO: eventually this should use `libfs.ListProfileNames`, but
+	// first we have to figure out how to use the dokan API to handle
+	// the timed profiles (i.e., only read them once on open, and not
+	// trigger the timed wait on every read).
 	profiles := pprof.Profiles()
 	var ns dokan.NamedStat
 	ns.FileAttributes = dokan.FileAttributeReadonly

--- a/go/kbfs/libfs/constants.go
+++ b/go/kbfs/libfs/constants.go
@@ -136,3 +136,7 @@ const DirBlockPrefix = ".kbfs_dirblock_"
 // ProfileListDirName is the name of the KBFS profile directory -- it
 // can be reached from any KBFS directory.
 const ProfileListDirName = ".kbfs_profiles"
+
+// ErrorFileName is the name of the virtual file in KBFS that should
+// contain the last reported error(s).
+var ErrorFileName = ".kbfs_error"

--- a/go/kbfs/libfs/constants.go
+++ b/go/kbfs/libfs/constants.go
@@ -132,3 +132,7 @@ const OpenFileCountFileName = ".kbfs_open_file_count"
 // Note that if this is used for a directory that is already live in
 // the current TLF, it will make that existing directory read-only.
 const DirBlockPrefix = ".kbfs_dirblock_"
+
+// ProfileListDirName is the name of the KBFS profile directory -- it
+// can be reached from any KBFS directory.
+const ProfileListDirName = ".kbfs_profiles"

--- a/go/kbfs/libfs/dummy_fs_read_only.go
+++ b/go/kbfs/libfs/dummy_fs_read_only.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"os"
+	"path"
+
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+// dummyFSReadOnly is a wrapper struct that extends a `libkbfs.NodeFSReadOnly`
+// implementation into a full `billy.Filesystem` (which fails all
+// write calls to it).
+type dummyFSReadOnly struct {
+	libkbfs.NodeFSReadOnly
+}
+
+var _ billy.Filesystem = dummyFSReadOnly{}
+
+func (dfsro dummyFSReadOnly) Create(_ string) (billy.File, error) {
+	return nil, errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Stat(_ string) (os.FileInfo, error) {
+	return nil, errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Rename(_, _ string) error {
+	return errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Remove(_ string) error {
+	return errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Join(p ...string) string {
+	return path.Join(p...)
+}
+
+func (dfsro dummyFSReadOnly) TempFile(_, _ string) (billy.File, error) {
+	return nil, errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) MkdirAll(_ string, _ os.FileMode) error {
+	return errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Symlink(_, _ string) error {
+	return errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Chroot(_ string) (billy.Filesystem, error) {
+	return nil, errors.New("read-only filesystem")
+}
+
+func (dfsro dummyFSReadOnly) Root() string {
+	return ""
+}

--- a/go/kbfs/libfs/profilelist.go
+++ b/go/kbfs/libfs/profilelist.go
@@ -6,16 +6,54 @@ package libfs
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"os"
 	"regexp"
 	"runtime/pprof"
+	"runtime/trace"
+	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
 )
 
-// ProfileListDirName is the name of the KBFS profile directory -- it
-// can be reached from any KBFS directory.
-const ProfileListDirName = ".kbfs_profiles"
+const (
+	// CPUProfilePrefix is the prefix to a CPU profile file (a
+	// duration should follow the prefix in the actual file name).
+	CPUProfilePrefix = "profile."
+
+	// TraceProfilePrefix is the prefix to a trace profile file (a
+	// duration should follow the prefix in the actual file name).
+	TraceProfilePrefix = "trace."
+)
+
+type timedProfile interface {
+	Start(w io.Writer) error
+	Stop()
+}
+
+type cpuProfile struct{}
+
+func (p cpuProfile) Start(w io.Writer) error {
+	return pprof.StartCPUProfile(w)
+}
+
+func (p cpuProfile) Stop() {
+	pprof.StopCPUProfile()
+}
+
+type traceProfile struct{}
+
+func (p traceProfile) Start(w io.Writer) error {
+	return trace.Start(w)
+}
+
+func (p traceProfile) Stop() {
+	trace.Stop()
+}
 
 // ProfileGet gets the relevant read function for the profile or nil if it doesn't exist.
 func ProfileGet(name string) func(context.Context) ([]byte, time.Time, error) {
@@ -55,4 +93,166 @@ func IsSupportedProfileName(name string) bool {
 	// would require faking out sub-directories, too. For now,
 	// just support alphanumeric filenames.
 	return profileNameRE.MatchString(name)
+}
+
+// ProfileFS provides an easy way to browse the go profiles.
+type ProfileFS struct {
+	config libkbfs.Config
+}
+
+// NewProfileFS returns a read-only filesystem for browsing profiles.
+func NewProfileFS(config libkbfs.Config) ProfileFS {
+	return ProfileFS{config}
+}
+
+var _ libkbfs.NodeFSReadOnly = ProfileFS{}
+
+// Lstat implements the libkbfs.NodeFSReadOnly interface.
+func (pfs ProfileFS) Lstat(filename string) (os.FileInfo, error) {
+	if strings.HasPrefix(filename, CPUProfilePrefix) ||
+		strings.HasPrefix(filename, TraceProfilePrefix) {
+		// Set profile sizes to 0 because it's too expensive to read them
+		// ahead of time.
+		return &wrappedReadFileInfo{filename, 0, time.Now(), false}, nil
+	}
+
+	if !IsSupportedProfileName(filename) {
+		return nil, errors.Errorf("Unsupported profile %s", filename)
+	}
+
+	f := ProfileGet(filename)
+	// Get the data, just for the size.
+	b, t, err := f(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return &wrappedReadFileInfo{filename, int64(len(b)), t, false}, nil
+}
+
+// ListProfileNames returns the name of all profiles to list.
+func ListProfileNames() (res []string) {
+	profiles := pprof.Profiles()
+	res = make([]string, 0, len(profiles)+2)
+	for _, p := range profiles {
+		name := p.Name()
+		if !IsSupportedProfileName(name) {
+			continue
+		}
+		res = append(res, name)
+	}
+	res = append(res, CPUProfilePrefix+"30s")
+	res = append(res, TraceProfilePrefix+"30s")
+	return res
+}
+
+// ReadDir implements the libkbfs.NodeFSReadOnly interface.
+func (pfs ProfileFS) ReadDir(path string) ([]os.FileInfo, error) {
+	if path != "" && path != "." {
+		return nil, errors.New("Can't read subdirectories in profile list")
+	}
+
+	profiles := ListProfileNames()
+	res := make([]os.FileInfo, 0, len(profiles))
+	for _, p := range profiles {
+		fi, err := pfs.Lstat(p)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, fi)
+	}
+	return res, nil
+}
+
+// Readlink implements the libkbfs.NodeFSReadOnly interface.
+func (pfs ProfileFS) Readlink(_ string) (string, error) {
+	return "", errors.New("Readlink not supported")
+}
+
+func (pfs ProfileFS) openTimedProfile(
+	ctx context.Context, durationStr string, prof timedProfile) (
+	[]byte, error) {
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Blocking here until the profile is done is
+	// weird. Blocking on read is better.
+	//
+	// TODO: Maybe keep around a special last_profile file to be
+	// able to start capturing a profile and then interrupt when
+	// done, which would also be useful in general, since you be
+	// able to save a profile even if you open it up with a tool.
+	var buf bytes.Buffer
+	err = prof.Start(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	defer prof.Stop()
+
+	select {
+	case <-time.After(duration):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	prof.Stop()
+
+	return buf.Bytes(), nil
+}
+
+// OpenWithContext opens a profile, with a custom context.
+func (pfs ProfileFS) OpenWithContext(
+	ctx context.Context, filename string) (billy.File, error) {
+	var durationStr string
+	var prof timedProfile
+	if strings.HasPrefix(filename, CPUProfilePrefix) {
+		durationStr = strings.TrimPrefix(filename, CPUProfilePrefix)
+		prof = cpuProfile{}
+	} else if strings.HasPrefix(filename, TraceProfilePrefix) {
+		durationStr = strings.TrimPrefix(filename, TraceProfilePrefix)
+		prof = traceProfile{}
+	}
+	if durationStr != "" {
+		// Read and cache the timed profiles contents on open, so we
+		// don't re-do it on every read.
+		b, err := pfs.openTimedProfile(ctx, durationStr, prof)
+		if err != nil {
+			return nil, err
+		}
+		now := pfs.config.Clock().Now()
+		return &wrappedReadFile{
+			filename,
+			func(_ context.Context) ([]byte, time.Time, error) {
+				return b, now, nil
+			},
+			pfs.config.MakeLogger(""),
+			0}, nil
+	}
+
+	if !IsSupportedProfileName(filename) {
+		return nil, errors.Errorf("Unsupported profile %s", filename)
+	}
+
+	f := ProfileGet(filename)
+	return &wrappedReadFile{filename, f, pfs.config.MakeLogger(""), 0}, nil
+}
+
+// Open implements the libkbfs.NodeFSReadOnly interface.
+func (pfs ProfileFS) Open(filename string) (billy.File, error) {
+	// TODO: we should figure out some way to route the actual
+	// request context here if at all possible, so we can end
+	// early if it's canceled.
+	return pfs.OpenWithContext(context.TODO(), filename)
+}
+
+// OpenFile implements the libkbfs.NodeFSReadOnly interface.
+func (pfs ProfileFS) OpenFile(
+	filename string, flag int, _ os.FileMode) (billy.File, error) {
+	if flag&os.O_CREATE != 0 {
+		return nil, errors.New("read-only filesystem")
+	}
+
+	return pfs.Open(filename)
 }

--- a/go/kbfs/libfs/profilelist.go
+++ b/go/kbfs/libfs/profilelist.go
@@ -179,10 +179,10 @@ func (pfs ProfileFS) openTimedProfile(
 	// TODO: Blocking here until the profile is done is
 	// weird. Blocking on read is better.
 	//
-	// TODO: Maybe keep around a special last_profile file to be
-	// able to start capturing a profile and then interrupt when
-	// done, which would also be useful in general, since you be
-	// able to save a profile even if you open it up with a tool.
+	// TODO: Maybe keep around a special last_profile file to be able
+	// to start capturing a profile and then interrupt when done,
+	// which would also be useful in general, since you'd be able to
+	// save a profile even if you open it up with a tool.
 	var buf bytes.Buffer
 	err = prof.Start(&buf)
 	if err != nil {

--- a/go/kbfs/libfs/root_fs.go
+++ b/go/kbfs/libfs/root_fs.go
@@ -52,6 +52,7 @@ var _ billy.Filesystem = (*RootFS)(nil)
 var rootWrappedNodeNames = map[string]bool{
 	StatusFileName:     true,
 	MetricsFileName:    true,
+	ErrorFileName:      true,
 	ProfileListDirName: true,
 }
 
@@ -69,6 +70,8 @@ func (rfs *RootFS) Open(filename string) (f billy.File, err error) {
 		return newStatusFileNode(rfs.config, rfs.log).GetFile(ctx), nil
 	case MetricsFileName:
 		return newMetricsFileNode(rfs.config, nil, rfs.log).GetFile(ctx), nil
+	case ErrorFileName:
+		return newErrorFileNode(rfs.config, nil, rfs.log).GetFile(ctx), nil
 	default:
 		panic(fmt.Sprintf("Name %s was in map, but not in switch", filename))
 	}
@@ -105,6 +108,9 @@ func (rfs *RootFS) Lstat(filename string) (fi os.FileInfo, err error) {
 	case MetricsFileName:
 		mfn := newMetricsFileNode(rfs.config, nil, rfs.log).GetFile(ctx)
 		return mfn.(*wrappedReadFile).GetInfo(), nil
+	case ErrorFileName:
+		efn := newErrorFileNode(rfs.config, nil, rfs.log).GetFile(ctx)
+		return efn.(*wrappedReadFile).GetInfo(), nil
 	case ProfileListDirName:
 		return &wrappedReadFileInfo{
 			filename, 0, rfs.config.Clock().Now(), true}, nil

--- a/go/kbfs/libfuse/profilelist.go
+++ b/go/kbfs/libfuse/profilelist.go
@@ -7,56 +7,29 @@
 package libfuse
 
 import (
-	"bytes"
-	"io"
+	"io/ioutil"
 	"os"
-	"runtime/pprof"
-	"runtime/trace"
 	"strings"
 	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/keybase/client/go/kbfs/libfs"
+	"github.com/keybase/client/go/kbfs/libkbfs"
 
 	"golang.org/x/net/context"
 )
 
-type timedProfile interface {
-	Start(w io.Writer) error
-	Stop()
-}
-
-type cpuProfile struct{}
-
-func (p cpuProfile) Start(w io.Writer) error {
-	return pprof.StartCPUProfile(w)
-}
-
-func (p cpuProfile) Stop() {
-	pprof.StopCPUProfile()
-}
-
-type traceProfile struct{}
-
-func (p traceProfile) Start(w io.Writer) error {
-	return trace.Start(w)
-}
-
-func (p traceProfile) Stop() {
-	trace.Stop()
-}
-
 // timedProfileFile represents a file whose contents are determined by
 // taking a profile for some duration.
 type timedProfileFile struct {
-	duration time.Duration
-	profile  timedProfile
+	pfs  libfs.ProfileFS
+	name string
 }
 
 var _ fs.Node = timedProfileFile{}
 
-func (f timedProfileFile) Attr(ctx context.Context, a *fuse.Attr) error {
+func (tpf timedProfileFile) Attr(ctx context.Context, a *fuse.Attr) error {
 	// Have a low non-zero value for Valid to avoid being swamped
 	// with requests.
 	a.Valid = 1 * time.Second
@@ -70,37 +43,26 @@ func (f timedProfileFile) Attr(ctx context.Context, a *fuse.Attr) error {
 
 var _ fs.NodeOpener = timedProfileFile{}
 
-func (f timedProfileFile) Open(ctx context.Context,
+func (tpf timedProfileFile) Open(ctx context.Context,
 	req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
-	// TODO: Blocking here until the profile is done is
-	// weird. Blocking on read is better.
-	//
-	// TODO: Maybe keep around a special last_profile file to be
-	// able to start capturing a profile and then interrupt when
-	// done, which would also be useful in general, since you be
-	// able to save a profile even if you open it up with a tool.
-	var buf bytes.Buffer
-	err := f.profile.Start(&buf)
+	f, err := tpf.pfs.OpenWithContext(ctx, tpf.name)
 	if err != nil {
 		return nil, err
 	}
 
-	defer f.profile.Stop()
-
-	select {
-	case <-time.After(f.duration):
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
 	}
 
-	f.profile.Stop()
-
 	resp.Flags |= fuse.OpenDirectIO
-	return fs.DataHandle(buf.Bytes()), nil
+	return fs.DataHandle(buf), nil
 }
 
 // ProfileList is a node that can list all of the available profiles.
-type ProfileList struct{}
+type ProfileList struct {
+	config libkbfs.Config
+}
 
 var _ fs.Node = ProfileList{}
 
@@ -112,27 +74,14 @@ func (ProfileList) Attr(_ context.Context, a *fuse.Attr) error {
 
 var _ fs.NodeRequestLookuper = ProfileList{}
 
-const cpuProfilePrefix = "profile."
-const traceProfilePrefix = "trace."
-
 // Lookup implements the fs.NodeRequestLookuper interface.
 func (pl ProfileList) Lookup(_ context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (node fs.Node, err error) {
-	// Handle timed profiles first.
-	if strings.HasPrefix(req.Name, cpuProfilePrefix) {
-		durationStr := strings.TrimPrefix(req.Name, cpuProfilePrefix)
-		duration, err := time.ParseDuration(durationStr)
-		if err != nil {
-			return nil, err
-		}
+	pfs := libfs.NewProfileFS(pl.config)
 
-		return timedProfileFile{duration, cpuProfile{}}, nil
-	} else if strings.HasPrefix(req.Name, traceProfilePrefix) {
-		durationStr := strings.TrimPrefix(req.Name, traceProfilePrefix)
-		duration, err := time.ParseDuration(durationStr)
-		if err != nil {
-			return nil, err
-		}
-		return timedProfileFile{duration, traceProfile{}}, nil
+	// Handle timed profiles first.
+	if strings.HasPrefix(req.Name, libfs.CPUProfilePrefix) ||
+		strings.HasPrefix(req.Name, libfs.TraceProfilePrefix) {
+		return timedProfileFile{pfs, req.Name}, nil
 	}
 
 	f := libfs.ProfileGet(req.Name)
@@ -149,26 +98,14 @@ var _ fs.HandleReadDirAller = ProfileList{}
 
 // ReadDirAll implements the ReadDirAll interface.
 func (pl ProfileList) ReadDirAll(_ context.Context) (res []fuse.Dirent, err error) {
-	profiles := pprof.Profiles()
+	profiles := libfs.ListProfileNames()
 	res = make([]fuse.Dirent, 0, len(profiles))
 	for _, p := range profiles {
-		name := p.Name()
-		if !libfs.IsSupportedProfileName(name) {
-			continue
-		}
 		res = append(res, fuse.Dirent{
 			Type: fuse.DT_File,
-			Name: name,
+			Name: p,
 		})
 	}
-	res = append(res, fuse.Dirent{
-		Type: fuse.DT_File,
-		Name: cpuProfilePrefix + "30s",
-	})
-	res = append(res, fuse.Dirent{
-		Type: fuse.DT_File,
-		Name: traceProfilePrefix + "1s",
-	})
 	return res, nil
 }
 

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -23,8 +23,6 @@ func handleCommonSpecialFile(
 		return NewErrorFile(fs, entryValid)
 	case libfs.MetricsFileName:
 		return NewMetricsFile(fs, entryValid)
-	case libfs.ProfileListDirName:
-		return ProfileList{}
 	case libfs.ResetCachesFileName:
 		return &ResetCachesFile{fs}
 	}
@@ -44,6 +42,11 @@ func handleNonTLFSpecialFile(
 	switch name {
 	case libfs.StatusFileName:
 		return NewNonTLFStatusFile(fs, entryValid)
+	case libfs.ProfileListDirName:
+		// Need to handle profiles explicitly here since we aren't
+		// using a wrapped file system with nodes for the
+		// root/folderlist directories.
+		return ProfileList{fs.config}
 	case libfs.HumanErrorFileName, libfs.HumanNoLoginFileName:
 		*entryValid = 0
 		return &SpecialReadFile{fs.remoteStatus.NewSpecialReadFunc}

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -17,8 +17,7 @@ import (
 // within a TLF and outside a TLF.
 func handleCommonSpecialFile(
 	name string, fs *FS, entryValid *time.Duration) fs.Node {
-	switch name {
-	case libfs.ResetCachesFileName:
+	if name == libfs.ResetCachesFileName {
 		return &ResetCachesFile{fs}
 	}
 
@@ -88,9 +87,6 @@ func handleTLFSpecialFile(
 	}
 
 	switch name {
-	case libfs.EditHistoryName:
-		return NewTlfEditHistoryFile(folder, entryValid)
-
 	case libfs.UnstageFileName:
 		return &UnstageFile{
 			folder: folder,

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -21,8 +21,6 @@ func handleCommonSpecialFile(
 	switch name {
 	case libkbfs.ErrorFile:
 		return NewErrorFile(fs, entryValid)
-	case libfs.MetricsFileName:
-		return NewMetricsFile(fs, entryValid)
 	case libfs.ResetCachesFileName:
 		return &ResetCachesFile{fs}
 	}
@@ -47,6 +45,8 @@ func handleNonTLFSpecialFile(
 		// using a wrapped file system with nodes for the
 		// root/folderlist directories.
 		return ProfileList{fs.config}
+	case libfs.MetricsFileName:
+		return NewMetricsFile(fs, entryValid)
 	case libfs.HumanErrorFileName, libfs.HumanNoLoginFileName:
 		*entryValid = 0
 		return &SpecialReadFile{fs.remoteStatus.NewSpecialReadFunc}

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -11,7 +11,6 @@ import (
 
 	"bazil.org/fuse/fs"
 	"github.com/keybase/client/go/kbfs/libfs"
-	"github.com/keybase/client/go/kbfs/libkbfs"
 )
 
 // handleCommonSpecialFile handles special files that are present both
@@ -19,8 +18,6 @@ import (
 func handleCommonSpecialFile(
 	name string, fs *FS, entryValid *time.Duration) fs.Node {
 	switch name {
-	case libkbfs.ErrorFile:
-		return NewErrorFile(fs, entryValid)
 	case libfs.ResetCachesFileName:
 		return &ResetCachesFile{fs}
 	}
@@ -47,6 +44,8 @@ func handleNonTLFSpecialFile(
 		return ProfileList{fs.config}
 	case libfs.MetricsFileName:
 		return NewMetricsFile(fs, entryValid)
+	case libfs.ErrorFileName:
+		return NewErrorFile(fs, entryValid)
 	case libfs.HumanErrorFileName, libfs.HumanNoLoginFileName:
 		*entryValid = 0
 		return &SpecialReadFile{fs.remoteStatus.NewSpecialReadFunc}

--- a/go/kbfs/libgit/autogit_node_wrappers.go
+++ b/go/kbfs/libgit/autogit_node_wrappers.go
@@ -176,7 +176,7 @@ func (rdn *repoDirNode) ShouldCreateMissedLookup(
 
 }
 
-func (rdn *repoDirNode) GetFS(ctx context.Context) billy.Filesystem {
+func (rdn *repoDirNode) GetFS(ctx context.Context) libkbfs.NodeFSReadOnly {
 	ctx = libkbfs.CtxWithRandomIDReplayable(
 		ctx, ctxAutogitIDKey, ctxAutogitOpID, rdn.am.log)
 	_, b, err := rdn.am.GetBrowserForRepo(
@@ -281,7 +281,7 @@ type autogitRootNode struct {
 
 var _ libkbfs.Node = (*autogitRootNode)(nil)
 
-func (arn autogitRootNode) GetFS(ctx context.Context) billy.Filesystem {
+func (arn autogitRootNode) GetFS(ctx context.Context) libkbfs.NodeFSReadOnly {
 	ctx = libkbfs.CtxWithRandomIDReplayable(
 		ctx, ctxAutogitIDKey, ctxAutogitOpID, arn.am.log)
 	return &wrappedRepoList{arn.fs.WithContext(ctx)}

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -19,10 +19,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-// ErrorFile is the name of the virtual file in KBFS that should
-// contain the last reported error(s).
-var ErrorFile = ".kbfs_error"
-
 // WrapError simply wraps an error in a fmt.Stringer interface, so
 // that it can be reported.
 type WrapError struct {
@@ -98,16 +94,6 @@ type RenameAcrossDirsError struct {
 // Error implements the error interface for RenameAcrossDirsError
 func (e RenameAcrossDirsError) Error() string {
 	return fmt.Sprintf("Cannot rename across directories")
-}
-
-// ErrorFileAccessError indicates that the user tried to perform an
-// operation on the ErrorFile that is not allowed.
-type ErrorFileAccessError struct {
-}
-
-// Error implements the error interface for ErrorFileAccessError
-func (e ErrorFileAccessError) Error() string {
-	return fmt.Sprintf("Operation not allowed on file %s", ErrorFile)
 }
 
 // WriteUnsupportedError indicates an error when trying to write a file

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -176,6 +176,15 @@ type NodeFSReadOnly interface {
 	Lstat(filename string) (os.FileInfo, error)
 	// Readlink returns the target path of link.
 	Readlink(link string) (string, error)
+	// Open opens the named file for reading. If successful, methods on the
+	// returned file can be used for reading; the associated file descriptor has
+	// mode O_RDONLY.
+	Open(filename string) (billy.File, error)
+	// OpenFile is the generalized open call; most users will use Open or Create
+	// instead. It opens the named file with specified flag (O_RDONLY etc.) and
+	// perm, (0666 etc.) if applicable. If successful, methods on the returned
+	// File can be used for I/O.
+	OpenFile(filename string, flags int, mode os.FileMode) (billy.File, error)
 }
 
 // Node represents a direct pointer to a file or directory in KBFS.

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -164,6 +164,20 @@ type NodeID interface {
 	ParentID() NodeID
 }
 
+// NodeFSReadOnly is the subset of billy.Filesystem that is actually
+// used by libkbfs.  The method comments are copied from go-billy.
+type NodeFSReadOnly interface {
+	// ReadDir reads the directory named by dirname and returns a list of
+	// directory entries sorted by filename.
+	ReadDir(path string) ([]os.FileInfo, error)
+	// Lstat returns a FileInfo describing the named file. If the file is a
+	// symbolic link, the returned FileInfo describes the symbolic link. Lstat
+	// makes no attempt to follow the link.
+	Lstat(filename string) (os.FileInfo, error)
+	// Readlink returns the target path of link.
+	Readlink(link string) (string, error)
+}
+
 // Node represents a direct pointer to a file or directory in KBFS.
 // It is somewhat like an inode in a regular file system.  Users of
 // KBFS can use Node as a handle when accessing files or directories
@@ -235,7 +249,7 @@ type Node interface {
 	// instead of the standard, block-based method of acessing data.
 	// The provided context will be used, if possible, for any
 	// subsequent calls on the file system.
-	GetFS(ctx context.Context) billy.Filesystem
+	GetFS(ctx context.Context) NodeFSReadOnly
 	// GetFile returns a file interface that, if non-nil, should be
 	// used to satisfy any file-related calls on this Node, instead of
 	// the standard, block-based method of accessing data.  The

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4094,7 +4094,7 @@ type testKBFSOpsMemFSNode struct {
 	fs billy.Filesystem
 }
 
-func (n testKBFSOpsMemFSNode) GetFS(_ context.Context) billy.Filesystem {
+func (n testKBFSOpsMemFSNode) GetFS(_ context.Context) NodeFSReadOnly {
 	return n.fs
 }
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -3612,10 +3612,10 @@ func (mr *MockNodeMockRecorder) GetBlockID() *gomock.Call {
 }
 
 // GetFS mocks base method.
-func (m *MockNode) GetFS(arg0 context.Context) go_billy_v4.Filesystem {
+func (m *MockNode) GetFS(arg0 context.Context) NodeFSReadOnly {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFS", arg0)
-	ret0, _ := ret[0].(go_billy_v4.Filesystem)
+	ret0, _ := ret[0].(NodeFSReadOnly)
 	return ret0
 }
 

--- a/go/kbfs/libkbfs/node.go
+++ b/go/kbfs/libkbfs/node.go
@@ -136,7 +136,7 @@ func (n *nodeStandard) Unwrap() Node {
 	return n
 }
 
-func (n *nodeStandard) GetFS(_ context.Context) billy.Filesystem {
+func (n *nodeStandard) GetFS(_ context.Context) NodeFSReadOnly {
 	return nil
 }
 

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -466,10 +466,16 @@ func (k *SimpleFS) getFSWithMaybeCreate(
 		if err != nil {
 			return nil, "", err
 		}
-		if len(ps) < 2 {
+		if len(ps) < 2 || len(ps) < 3 && strings.HasPrefix(ps[0], ".kbfs_") {
 			fs = libfs.NewRootFS(k.config)
 			if len(ps) == 1 {
 				finalElem = ps[0]
+			} else if len(ps) == 2 {
+				fs, err = fs.Chroot(ps[0])
+				if err != nil {
+					return nil, "", err
+				}
+				finalElem = ps[1]
 			}
 			return fs, finalElem, nil
 		}


### PR DESCRIPTION
So they can be accessed via SimpleFS, under both `/keybase/` and inside TLFs.  And the libfuse support was refactored to use all the libfs stuff.

This is a bit more complicated than other `.kbfs_` special nodes, because it's a directory.  That means we have to build a full file system interface for that, so that `folderBranchOps` and `rootFS` can use it, and we have to extend the SimpleFS support for the root FS to include special subdirectories.

libdokan still needs some work to support timed profiles; I'm leaving that work until later if we decide it's necessary.  (But now we can always get those timed profiles out of SimpleFS anyway.)

Issue: HOTPOT-2434