### PR TITLE
remove absolute positioning style on team header actions

### DIFF
--- a/shared/teams/team/custom-title/index.tsx
+++ b/shared/teams/team/custom-title/index.tsx
@@ -39,8 +39,6 @@ const styles = styleSheetCreate(() => ({
   container: {
     ...globalStyles.flexBoxRow,
     alignItems: 'center',
-    position: 'absolute',
-    right: 0,
   },
   icon: {
     marginRight: globalMargins.tiny,


### PR DESCRIPTION
fixes tapping header icons on android. cc @keybase/y2ksquad 