### PR TITLE
Deeplink to Chat message: failing case for team convos

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2028,6 +2028,7 @@ const previewConversationTeam = async (
     actions.push(
       Chat2Gen.createNavigateToThread({
         conversationIDKey: first.conversationIDKey,
+        highlightMessageID,
         reason: 'previewResolved',
       })
     )


### PR DESCRIPTION
@keybase/react-hackers 

@zapu found a case where deeplink to a chat message wasn't working, if the conversation is inside a big team channel.  Thanks @zapu!

- [ ] to cherry-pick