### PR TITLE
Fix monster illustration width

### DIFF
--- a/shared/settings/notifications/push-prompt.native.tsx
+++ b/shared/settings/notifications/push-prompt.native.tsx
@@ -68,7 +68,14 @@ const styles = Styles.styleSheetCreate(
   () =>
     ({
       background: {backgroundColor: Styles.globalColors.blue},
-      button: {maxHeight: 40},
+      button: Styles.platformStyles({
+        common: {
+          maxHeight: 40,
+        },
+        isTablet: {
+          marginBottom: Styles.globalMargins.medium,
+        },
+      }),
       container: {
         ...Styles.globalStyles.fillAbsolute,
         backgroundColor: Styles.globalColors.blue,

--- a/shared/settings/notifications/push-prompt.native.tsx
+++ b/shared/settings/notifications/push-prompt.native.tsx
@@ -56,8 +56,8 @@ const PushPrompt = () => {
           Notifications are very important.
         </Kb.Text>
         <Kb.Text center={true} type="Body" negative={true}>
-          Your phone might need to be contacted, for example if you install Keybase on another device. This is
-          a crucial security setting.
+          Your device might need to be contacted, for example if you install Keybase on another device. This
+          is a crucial security setting.
         </Kb.Text>
       </Kb.Box2>
     </Kb.Modal>
@@ -83,13 +83,8 @@ const styles = Styles.styleSheetCreate(
         color: Styles.globalColors.white,
       },
       image: Styles.platformStyles({
-        common: {
-          flex: 1,
-          width: '150%',
-        },
         isTablet: {
           alignSelf: 'center',
-          maxWidth: 460,
         },
       }),
     } as const)


### PR DESCRIPTION
@keybase/react-hackers CC @keybase/design 

 - [ ] cherry pick

Before:

<img width="584" alt="Screen Shot 2020-04-14 at 1 44 17 PM" src="https://user-images.githubusercontent.com/21217/79273143-60d44500-7e57-11ea-8631-fe15e9c64ac2.png">

<img width="1311" alt="Screen Shot 2020-04-14 at 1 08 54 PM" src="https://user-images.githubusercontent.com/21217/79273164-692c8000-7e57-11ea-947c-35d8bff0eb2c.png">

After:

<img width="584" alt="Screen Shot 2020-04-14 at 1 43 54 PM" src="https://user-images.githubusercontent.com/21217/79273187-70538e00-7e57-11ea-832e-44d05912c3bc.png">

<img width="1311" alt="Screen Shot 2020-04-14 at 1 40 55 PM" src="https://user-images.githubusercontent.com/21217/79273199-76496f00-7e57-11ea-9f08-429ad3937190.png">

<img width="945" alt="Screen Shot 2020-04-14 at 1 40 44 PM" src="https://user-images.githubusercontent.com/21217/79273214-7c3f5000-7e57-11ea-9048-eb061169f8f4.png">