### PR TITLE
libfs: move support for more special nodes into node wrappers

### DIFF
--- a/go/kbfs/libdokan/fs.go
+++ b/go/kbfs/libdokan/fs.go
@@ -318,7 +318,7 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 
 		// This section is equivalent to
 		// handleCommonSpecialFile in libfuse.
-	case libkbfs.ErrorFile == ps[psl-1]:
+	case libfs.ErrorFileName == ps[psl-1]:
 		return oc.returnFileNoCleanup(NewErrorFile(f))
 	case libfs.MetricsFileName == ps[psl-1]:
 		return oc.returnFileNoCleanup(NewMetricsFile(f))

--- a/go/kbfs/libfs/constants.go
+++ b/go/kbfs/libfs/constants.go
@@ -136,3 +136,7 @@ const DirBlockPrefix = ".kbfs_dirblock_"
 // ProfileListDirName is the name of the KBFS profile directory -- it
 // can be reached from any KBFS directory.
 const ProfileListDirName = ".kbfs_profiles"
+
+// ErrorFileName is the name of the virtual file in KBFS that should
+// contain the last reported error(s).
+var ErrorFileName = ".kbfs_error"

--- a/go/kbfs/libfs/root_fs.go
+++ b/go/kbfs/libfs/root_fs.go
@@ -52,6 +52,7 @@ var _ billy.Filesystem = (*RootFS)(nil)
 var rootWrappedNodeNames = map[string]bool{
 	StatusFileName:     true,
 	MetricsFileName:    true,
+	ErrorFileName:      true,
 	ProfileListDirName: true,
 }
 
@@ -69,6 +70,8 @@ func (rfs *RootFS) Open(filename string) (f billy.File, err error) {
 		return newStatusFileNode(rfs.config, rfs.log).GetFile(ctx), nil
 	case MetricsFileName:
 		return newMetricsFileNode(rfs.config, nil, rfs.log).GetFile(ctx), nil
+	case ErrorFileName:
+		return newErrorFileNode(rfs.config, nil, rfs.log).GetFile(ctx), nil
 	default:
 		panic(fmt.Sprintf("Name %s was in map, but not in switch", filename))
 	}
@@ -105,6 +108,9 @@ func (rfs *RootFS) Lstat(filename string) (fi os.FileInfo, err error) {
 	case MetricsFileName:
 		mfn := newMetricsFileNode(rfs.config, nil, rfs.log).GetFile(ctx)
 		return mfn.(*wrappedReadFile).GetInfo(), nil
+	case ErrorFileName:
+		efn := newErrorFileNode(rfs.config, nil, rfs.log).GetFile(ctx)
+		return efn.(*wrappedReadFile).GetInfo(), nil
 	case ProfileListDirName:
 		return &wrappedReadFileInfo{
 			filename, 0, rfs.config.Clock().Now(), true}, nil

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -17,8 +17,7 @@ import (
 // within a TLF and outside a TLF.
 func handleCommonSpecialFile(
 	name string, fs *FS, entryValid *time.Duration) fs.Node {
-	switch name {
-	case libfs.ResetCachesFileName:
+	if name == libfs.ResetCachesFileName {
 		return &ResetCachesFile{fs}
 	}
 
@@ -88,9 +87,6 @@ func handleTLFSpecialFile(
 	}
 
 	switch name {
-	case libfs.EditHistoryName:
-		return NewTlfEditHistoryFile(folder, entryValid)
-
 	case libfs.UnstageFileName:
 		return &UnstageFile{
 			folder: folder,

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -21,8 +21,6 @@ func handleCommonSpecialFile(
 	switch name {
 	case libkbfs.ErrorFile:
 		return NewErrorFile(fs, entryValid)
-	case libfs.MetricsFileName:
-		return NewMetricsFile(fs, entryValid)
 	case libfs.ResetCachesFileName:
 		return &ResetCachesFile{fs}
 	}
@@ -47,6 +45,8 @@ func handleNonTLFSpecialFile(
 		// using a wrapped file system with nodes for the
 		// root/folderlist directories.
 		return ProfileList{fs.config}
+	case libfs.MetricsFileName:
+		return NewMetricsFile(fs, entryValid)
 	case libfs.HumanErrorFileName, libfs.HumanNoLoginFileName:
 		*entryValid = 0
 		return &SpecialReadFile{fs.remoteStatus.NewSpecialReadFunc}

--- a/go/kbfs/libfuse/special_files.go
+++ b/go/kbfs/libfuse/special_files.go
@@ -11,7 +11,6 @@ import (
 
 	"bazil.org/fuse/fs"
 	"github.com/keybase/client/go/kbfs/libfs"
-	"github.com/keybase/client/go/kbfs/libkbfs"
 )
 
 // handleCommonSpecialFile handles special files that are present both
@@ -19,8 +18,6 @@ import (
 func handleCommonSpecialFile(
 	name string, fs *FS, entryValid *time.Duration) fs.Node {
 	switch name {
-	case libkbfs.ErrorFile:
-		return NewErrorFile(fs, entryValid)
 	case libfs.ResetCachesFileName:
 		return &ResetCachesFile{fs}
 	}
@@ -47,6 +44,8 @@ func handleNonTLFSpecialFile(
 		return ProfileList{fs.config}
 	case libfs.MetricsFileName:
 		return NewMetricsFile(fs, entryValid)
+	case libfs.ErrorFileName:
+		return NewErrorFile(fs, entryValid)
 	case libfs.HumanErrorFileName, libfs.HumanNoLoginFileName:
 		*entryValid = 0
 		return &SpecialReadFile{fs.remoteStatus.NewSpecialReadFunc}

--- a/go/kbfs/libkbfs/errors.go
+++ b/go/kbfs/libkbfs/errors.go
@@ -19,10 +19,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
-// ErrorFile is the name of the virtual file in KBFS that should
-// contain the last reported error(s).
-var ErrorFile = ".kbfs_error"
-
 // WrapError simply wraps an error in a fmt.Stringer interface, so
 // that it can be reported.
 type WrapError struct {
@@ -98,16 +94,6 @@ type RenameAcrossDirsError struct {
 // Error implements the error interface for RenameAcrossDirsError
 func (e RenameAcrossDirsError) Error() string {
 	return fmt.Sprintf("Cannot rename across directories")
-}
-
-// ErrorFileAccessError indicates that the user tried to perform an
-// operation on the ErrorFile that is not allowed.
-type ErrorFileAccessError struct {
-}
-
-// Error implements the error interface for ErrorFileAccessError
-func (e ErrorFileAccessError) Error() string {
-	return fmt.Sprintf("Operation not allowed on file %s", ErrorFile)
 }
 
 // WriteUnsupportedError indicates an error when trying to write a file


### PR DESCRIPTION
(Builds off of #23765, review that one first)

So they can be accessed via Simplefs.
* `.kbfs_metrics`
* `.kbfs_error`
* `.kbfs_edit_history`
* Refactors `.kbfs_update_history` to use new shared code.