### PR TITLE
fix iPad incoming share routing and send attachment from files

### DIFF
--- a/shared/chat/conversation/attachment-get-titles/container.tsx
+++ b/shared/chat/conversation/attachment-get-titles/container.tsx
@@ -5,7 +5,6 @@ import * as FsTypes from '../../../constants/types/fs'
 import GetTitles, {Info} from '.'
 import * as Container from '../../../util/container'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import * as Tabs from '../../../constants/tabs'
 
 type OwnProps = Container.RouteProps<{
   conversationIDKey: Types.ConversationIDKey
@@ -55,13 +54,6 @@ export default Container.connect(
         dispatch(RouteTreeGen.createClearModals())
 
         if (selectConversationWithReason) {
-          dispatch(
-            RouteTreeGen.createResetStack({
-              actions: [],
-              index: 0,
-              tab: Tabs.chatTab,
-            })
-          )
           dispatch(Chat2Gen.createNavigateToThread({conversationIDKey, reason: selectConversationWithReason}))
         }
       },

--- a/shared/fs/send-to-chat/attachment/index.tsx
+++ b/shared/fs/send-to-chat/attachment/index.tsx
@@ -28,7 +28,7 @@ const MobileSendAttachmentToChat = (props: Props) => {
   const incomingShareItems = Container.getRouteProps(props, 'incomingShareItems', undefined)
   const useOriginal = Container.getRouteProps(props, 'useOriginal', false)
   const url = Container.getRouteProps(props, 'url', undefined)
-  const path = Container.getRouteProps(props, 'path', undefined) ?? Constants.defaultPath
+  const path = Container.getRouteProps(props, 'path', undefined)
   const isFromShareExtension = !!Container.getRouteProps(props, 'incomingShareItems', undefined)
   const dispatch = Container.useDispatch()
 
@@ -37,8 +37,8 @@ const MobileSendAttachmentToChat = (props: Props) => {
     // as an attachment.
     ?.filter(item => !isChatText(item))
     ?.map(({originalPath, scaledPath}) => (useOriginal ? originalPath : scaledPath || originalPath))
-  const pathsFromUrl = url ? [url] : []
-  const pathsFromPath = path ? [path] : []
+  const pathsFromUrl = url ? [url] : undefined
+  const pathsFromPath = path ? [path] : undefined
   const sendPaths = pathsFromIncomingShare || pathsFromUrl || pathsFromPath || []
   const text =
     incomingShareItems
@@ -68,7 +68,6 @@ const MobileSendAttachmentToChat = (props: Props) => {
         })
       )
     } else {
-      dispatch(RouteTreeGen.createClearModals())
       dispatch(
         Chat2Gen.createNavigateToThread({
           conversationIDKey,


### PR DESCRIPTION
* [ ] rare routing bug on iPad. Repro:
1) go to Files tab and share an attachment to chat convo A. This ends up in chat tab. Choose some other convo B. 
2) share something (e.g. webpage) from outside into keybase, and select convo A. Now we end up in the Files tab. 

Without 1), it works fine and lands in the chat tab