### PR TITLE
Don't fill the entire width.

### DIFF
--- a/shared/chat/conversation/conversation.css
+++ b/shared/chat/conversation/conversation.css
@@ -18,8 +18,6 @@
   display: none;
   flex-direction: row;
   justify-content: flex-end;
-  max-width: 100%;
-  width: 100%;
   margin-left: 0;
 }
 .WrapperMessage-hoverBox:hover .WrapperMessage-buttons,
@@ -27,8 +25,6 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  max-width: 100%;
-  width: 100%;
   margin-left: 0;
 }
 .WrapperMessage-hoverColor:hover {


### PR DESCRIPTION
@keybase/react-hackers, this is ready for review. We now have a set space on messages where the sending animation (or exploding timer) lives. This was causing the ellipsis area to fill that entire space.

Before:
![64986917-58c0-4ddf-b8d4-85a810bde106](https://user-images.githubusercontent.com/30595/79367140-5d09f680-7f1b-11ea-8ac8-83b461d3e558.png)

After:
<img width="133" alt="Screen Shot 2020-04-15 at 13 16 29" src="https://user-images.githubusercontent.com/30595/79367160-62ffd780-7f1b-11ea-9577-92c22d405f5f.png">