### PR TITLE
PICNIC-1105 - Set border of info panel to black_10 on iPad

### DIFF
--- a/shared/chat/conversation/info-panel/index.tsx
+++ b/shared/chat/conversation/info-panel/index.tsx
@@ -181,7 +181,10 @@ const styles = Styles.styleSheetCreate(
           width: infoPanelWidthTablet,
         },
       }),
-      containerBorder: {backgroundColor: '#E5E5E5', width: tabletContainerBorderSize},
+      containerBorder: {
+        backgroundColor: Styles.globalColors.black_10,
+        width: tabletContainerBorderSize,
+      },
       containerOuterTablet: {width: infoPanelWidthTablet + tabletContainerBorderSize},
       tab: {
         paddingLeft: Styles.globalMargins.xsmall,


### PR DESCRIPTION
cc @keybase/react-hackers @keybase/picnicsquad 

### Before

![image](https://user-images.githubusercontent.com/5200812/79368195-03a2c700-7f1d-11ea-8179-fd9d721d925d.png)


### After

![image](https://user-images.githubusercontent.com/5200812/79368371-45cc0880-7f1d-11ea-97cf-511135c702db.png)
