### PR TITLE
 Fix FindFilePathWithNumberSuffix when no basename 

### DIFF
--- a/go/libkb/util.go
+++ b/go/libkb/util.go
@@ -1118,9 +1118,10 @@ func FindFilePathWithNumberSuffix(parentDir string, basename string, useArbitrar
 	if useArbitraryName {
 		return filepath.Join(parentDir, strconv.FormatInt(time.Now().UnixNano(), 16)+ext), nil
 	}
-	destPathBase := filepath.Join(parentDir, basename[:len(basename)-len(ext)])
-	destPath := destPathBase + ext
-	for suffix := 1; ; suffix++ {
+	destPath := filepath.Join(parentDir, basename)
+	basename = basename[:len(basename)-len(ext)]
+	// keep a sane limit on the loop.
+	for suffix := 1; suffix < 100000; suffix++ {
 		_, err := os.Stat(destPath)
 		if os.IsNotExist(err) {
 			break
@@ -1128,7 +1129,7 @@ func FindFilePathWithNumberSuffix(parentDir string, basename string, useArbitrar
 		if err != nil {
 			return "", err
 		}
-		destPath = fmt.Sprintf("%s (%d)%s", destPathBase, suffix, ext)
+		destPath = filepath.Join(parentDir, fmt.Sprintf("%s (%d)%s", basename, suffix, ext))
 	}
 	// Could race but it should be rare enough so fine.
 	return destPath, nil
@@ -1142,7 +1143,7 @@ func JsonwStringArray(a []string) *jsonw.Wrapper {
 	return aj
 }
 
-var throttleBatchClock clockwork.Clock = clockwork.NewRealClock()
+var throttleBatchClock = clockwork.NewRealClock()
 
 type throttleBatchEmpty struct{}
 

--- a/go/libkb/util_test.go
+++ b/go/libkb/util_test.go
@@ -6,6 +6,8 @@ package libkb
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -298,4 +300,28 @@ func TestThrottleBatch(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	clock.Advance(300 * time.Millisecond)
 	noVal()
+}
+
+func TestFindFilePathWithNumberSuffix(t *testing.T) {
+	parentDir := os.TempDir()
+	path, err := FindFilePathWithNumberSuffix(parentDir, "", true)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(path, parentDir))
+
+	path, err = FindFilePathWithNumberSuffix(parentDir, "test.txt", true)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(path, parentDir))
+	require.True(t, strings.HasSuffix(path, ".txt"))
+
+	path, err = FindFilePathWithNumberSuffix(parentDir, "", false)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(parentDir, " (1)"), path)
+
+	path, err = FindFilePathWithNumberSuffix(parentDir, "test.txt", false)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(parentDir, "test.txt"), path)
+
+	path, err = FindFilePathWithNumberSuffix(parentDir, ".txt", false)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(parentDir, ".txt"), path)
 }


### PR DESCRIPTION
fixes a problem where if `basename := ".txt"` dest path would be set to `~/Downloads.txt` instead of `~/Downloads/.txt`. 