### PR TITLE
PICNIC-1117 - Fix borders on expanded git rows

### DIFF
--- a/shared/git/row/index.tsx
+++ b/shared/git/row/index.tsx
@@ -33,175 +33,165 @@ const channelNameToString = (channelName?: string) => (channelName ? `#${channel
 // TODO use ListItem2
 const Row = (props: Props) => (
   <Kb.Box style={styles.container}>
-    <Kb.Box
-      style={{
-        ...(props.expanded
-          ? {
-              backgroundColor: Styles.globalColors.blueLighter3,
-              height: 6,
-            }
-          : {}),
-      }}
-    />
-    <Kb.Box
-      style={{
-        ...styles.rowStyle,
-        ...(props.expanded
-          ? {
-              backgroundColor: Styles.globalColors.white,
-              paddingBottom: Styles.globalMargins.tiny,
-              paddingTop: Styles.globalMargins.xtiny,
-            }
-          : {}),
-      }}
-    >
-      <Kb.ClickableBox
-        onClick={props.onToggleExpand}
-        style={props.expanded ? styles.rowClickExpanded : styles.rowClick}
-        hoverColor={Styles.isMobile ? undefined : Styles.globalColors.transparent}
-        underlayColor={Styles.globalColors.transparent}
+    <Kb.Box style={styles.containerMobile}>
+      <Kb.Box
+        style={{
+          ...styles.rowStyle,
+          ...(props.expanded
+            ? {
+                backgroundColor: Styles.globalColors.white,
+              }
+            : {}),
+        }}
       >
-        <Kb.Box style={styles.rowTop}>
-          <Kb.Icon
-            type={props.expanded ? 'iconfont-caret-down' : 'iconfont-caret-right'}
-            style={styles.iconCaret}
-            sizeType="Tiny"
-          />
-          <Kb.Avatar
-            size={Styles.isMobile ? 48 : 32}
-            isTeam={!!props.teamname}
-            teamname={props.teamname}
-            username={props.teamname ? undefined : props.you}
-            style={{marginRight: Styles.globalMargins.tiny}}
-          />
-          <Kb.Text lineClamp={1} type="BodySemibold" style={{color: Styles.globalColors.black}}>
-            {props.teamname ? `${props.teamname}/${props.name}` : props.name}
-          </Kb.Text>
-          {props.isNew && (
-            <Kb.Meta title="new" style={styles.meta} backgroundColor={Styles.globalColors.orange} />
-          )}
-        </Kb.Box>
-      </Kb.ClickableBox>
-      {props.expanded && (
-        <Kb.Box style={styles.rowBottom}>
-          <Kb.Box
-            style={{
-              ...Styles.globalStyles.flexBoxRow,
-              alignItems: 'center',
-              maxWidth: '100%',
-              position: 'relative',
-            }}
-          >
-            <Kb.Text type="Body">Clone:</Kb.Text>
-            <Kb.Box2 direction="horizontal" style={styles.copyTextContainer}>
-              <Kb.CopyText text={props.url} containerStyle={{width: '100%'}} />
-            </Kb.Box2>
-          </Kb.Box>
-          <Kb.Box
-            style={{
-              ...Styles.globalStyles.flexBoxRow,
-              alignItems: 'center',
-              alignSelf: 'flex-start',
-              flexWrap: 'wrap',
-              marginTop: Styles.globalMargins.tiny,
-            }}
-          >
-            <Kb.Text type="BodySmall">
-              {`Last push ${props.lastEditTime}${!!props.teamname && !!props.lastEditUser ? ' by ' : ''}`}
+        <Kb.ClickableBox
+          onClick={props.onToggleExpand}
+          style={props.expanded ? styles.rowClickExpanded : styles.rowClick}
+          hoverColor={Styles.isMobile ? undefined : Styles.globalColors.transparent}
+          underlayColor={Styles.globalColors.transparent}
+        >
+          <Kb.Box style={styles.rowTop}>
+            <Kb.Icon
+              type={props.expanded ? 'iconfont-caret-down' : 'iconfont-caret-right'}
+              style={styles.iconCaret}
+              sizeType="Tiny"
+            />
+            <Kb.Avatar
+              size={Styles.isMobile ? 48 : 32}
+              isTeam={!!props.teamname}
+              teamname={props.teamname}
+              username={props.teamname ? undefined : props.you}
+              style={{marginRight: Styles.globalMargins.tiny}}
+            />
+            <Kb.Text lineClamp={1} type="BodySemibold" style={{color: Styles.globalColors.black}}>
+              {props.teamname ? `${props.teamname}/${props.name}` : props.name}
             </Kb.Text>
-            {!!props.teamname && !!props.lastEditUser && (
-              <Kb.Avatar
-                username={props.lastEditUser}
-                size={16}
-                style={{marginLeft: Styles.isMobile ? 0 : 4}}
-              />
+            {props.isNew && (
+              <Kb.Meta title="new" style={styles.meta} backgroundColor={Styles.globalColors.orange} />
             )}
-            {!!props.teamname && !!props.lastEditUser && (
-              <Kb.Box style={{marginLeft: 2}}>
-                <Kb.ConnectedUsernames
-                  type="BodySmallBold"
-                  underline={true}
-                  colorFollowing={true}
-                  usernames={props.lastEditUser}
-                  onUsernameClicked={() => props.openUserTracker(props.lastEditUser)}
+          </Kb.Box>
+        </Kb.ClickableBox>
+        {props.expanded && (
+          <Kb.Box style={styles.rowBottom}>
+            <Kb.Box
+              style={{
+                ...Styles.globalStyles.flexBoxRow,
+                alignItems: 'center',
+                maxWidth: '100%',
+                position: 'relative',
+              }}
+            >
+              <Kb.Text type="Body">Clone:</Kb.Text>
+              <Kb.Box2 direction="horizontal" style={styles.copyTextContainer}>
+                <Kb.CopyText text={props.url} containerStyle={{width: '100%'}} />
+              </Kb.Box2>
+            </Kb.Box>
+            <Kb.Box
+              style={{
+                ...Styles.globalStyles.flexBoxRow,
+                alignItems: 'center',
+                alignSelf: 'flex-start',
+                flexWrap: 'wrap',
+                marginTop: Styles.globalMargins.tiny,
+              }}
+            >
+              <Kb.Text type="BodySmall">
+                {`Last push ${props.lastEditTime}${!!props.teamname && !!props.lastEditUser ? ' by ' : ''}`}
+              </Kb.Text>
+              {!!props.teamname && !!props.lastEditUser && (
+                <Kb.Avatar
+                  username={props.lastEditUser}
+                  size={16}
+                  style={{marginLeft: Styles.isMobile ? 0 : 4}}
                 />
+              )}
+              {!!props.teamname && !!props.lastEditUser && (
+                <Kb.Box style={{marginLeft: 2}}>
+                  <Kb.ConnectedUsernames
+                    type="BodySmallBold"
+                    underline={true}
+                    colorFollowing={true}
+                    usernames={props.lastEditUser}
+                    onUsernameClicked={() => props.openUserTracker(props.lastEditUser)}
+                  />
+                </Kb.Box>
+              )}
+              {Styles.isMobile && <Kb.Text type="BodySmall">. </Kb.Text>}
+              <Kb.Text type="BodySmall">
+                <Kb.Text type="BodySmall">
+                  {Styles.isMobile
+                    ? 'Signed and encrypted using device'
+                    : ', signed and encrypted using device'}
+                </Kb.Text>
+                <Kb.Text type="BodySmall" style={styles.device} onClick={props.onClickDevice}>
+                  {' '}
+                  {props.devicename}
+                </Kb.Text>
+                <Kb.Text type="BodySmall">.</Kb.Text>
+              </Kb.Text>
+            </Kb.Box>
+            {!!props.teamname && (
+              <Kb.Box style={{...Styles.globalStyles.flexBoxRow, alignItems: 'center'}}>
+                {props.canEdit && (
+                  <Kb.Checkbox
+                    checked={!props.chatDisabled}
+                    onCheck={props.onToggleChatEnabled}
+                    label=""
+                    labelComponent={
+                      <Kb.Text type="BodySmall">
+                        Announce pushes in{' '}
+                        <Kb.Text
+                          type={props.chatDisabled ? 'BodySmall' : 'BodySmallPrimaryLink'}
+                          onClick={props.onChannelClick}
+                        >
+                          {channelNameToString(props.channelName)}
+                        </Kb.Text>
+                      </Kb.Text>
+                    }
+                  />
+                )}
+                {!props.canEdit && (
+                  <Kb.Text type="BodySmall">
+                    {props.chatDisabled
+                      ? 'Pushes are not announced'
+                      : `Pushes are announced in ${props.teamname}${channelNameToString(props.channelName)}`}
+                  </Kb.Text>
+                )}
               </Kb.Box>
             )}
-            {Styles.isMobile && <Kb.Text type="BodySmall">. </Kb.Text>}
-            <Kb.Text type="BodySmall">
-              <Kb.Text type="BodySmall">
-                {Styles.isMobile
-                  ? 'Signed and encrypted using device'
-                  : ', signed and encrypted using device'}
-              </Kb.Text>
-              <Kb.Text type="BodySmall" style={styles.device} onClick={props.onClickDevice}>
-                {' '}
-                {props.devicename}
-              </Kb.Text>
-              <Kb.Text type="BodySmall">.</Kb.Text>
-            </Kb.Text>
-          </Kb.Box>
-          {!!props.teamname && (
-            <Kb.Box style={{...Styles.globalStyles.flexBoxRow, alignItems: 'center'}}>
-              {props.canEdit && (
-                <Kb.Checkbox
-                  checked={!props.chatDisabled}
-                  onCheck={props.onToggleChatEnabled}
-                  label=""
-                  labelComponent={
-                    <Kb.Text type="BodySmall">
-                      Announce pushes in{' '}
-                      <Kb.Text
-                        type={props.chatDisabled ? 'BodySmall' : 'BodySmallPrimaryLink'}
-                        onClick={props.onChannelClick}
-                      >
-                        {channelNameToString(props.channelName)}
-                      </Kb.Text>
-                    </Kb.Text>
-                  }
-                />
-              )}
-              {!props.canEdit && (
-                <Kb.Text type="BodySmall">
-                  {props.chatDisabled
-                    ? 'Pushes are not announced'
-                    : `Pushes are announced in ${props.teamname}${channelNameToString(props.channelName)}`}
-                </Kb.Text>
-              )}
-            </Kb.Box>
-          )}
-          <Kb.Box2
-            direction="horizontal"
-            fullWidth={true}
-            style={{marginTop: Styles.globalMargins.tiny}}
-            gap="tiny"
-          >
-            <Kb.Button
-              type="Dim"
-              mode="Secondary"
-              small={true}
-              label="View files"
-              onClick={props.onBrowseGitRepo}
+            <Kb.Box2
+              direction="horizontal"
+              fullWidth={true}
+              style={{marginTop: Styles.globalMargins.tiny}}
+              gap="tiny"
             >
-              <Kb.Icon
-                type="iconfont-file"
-                sizeType="Small"
-                color={Styles.globalColors.black_50}
-                style={{marginRight: Styles.globalMargins.xtiny}}
-              />
-            </Kb.Button>
-            {props.canDelete && (
               <Kb.Button
-                type="Danger"
+                type="Dim"
                 mode="Secondary"
                 small={true}
-                label="Delete repo"
-                onClick={props.onShowDelete}
-              />
-            )}
-          </Kb.Box2>
-        </Kb.Box>
-      )}
+                label="View files"
+                onClick={props.onBrowseGitRepo}
+              >
+                <Kb.Icon
+                  type="iconfont-file"
+                  sizeType="Small"
+                  color={Styles.globalColors.black_50}
+                  style={{marginRight: Styles.globalMargins.xtiny}}
+                />
+              </Kb.Button>
+              {props.canDelete && (
+                <Kb.Button
+                  type="Danger"
+                  mode="Secondary"
+                  small={true}
+                  label="Delete repo"
+                  onClick={props.onShowDelete}
+                />
+              )}
+            </Kb.Box2>
+          </Kb.Box>
+        )}
+      </Kb.Box>
     </Kb.Box>
     <Kb.Box
       style={{
@@ -219,12 +209,16 @@ const Row = (props: Props) => (
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      container: Styles.platformStyles({
+      container: {
+        width: '100%',
+      },
+      containerMobile: Styles.platformStyles({
         common: {
           width: '100%',
         },
         isMobile: {
-          ...Styles.padding(0, Styles.globalMargins.small),
+          paddingLeft: Styles.globalMargins.small,
+          paddingRight: Styles.globalMargins.small,
         },
       }),
       copyTextContainer: {


### PR DESCRIPTION
* Extends borders all the way on tablet and mobile devices
* Removes frivolous padding that caused rows to jump around
* Removes both top and bottom row dividers (unecessary)

cc @keybase/react-hackers @keybase/picnicsquad 

#### Before (Dekstop)

![image](https://user-images.githubusercontent.com/5200812/79474736-c568de80-7fd4-11ea-8acc-6742aaa42506.png)

#### After (Desktop)

![image](https://user-images.githubusercontent.com/5200812/79474807-dfa2bc80-7fd4-11ea-819f-a08ea6b09893.png)

---

#### Before (Tablet & Mobile)

![image](https://user-images.githubusercontent.com/5200812/79474983-1c6eb380-7fd5-11ea-981d-29d5072d45cd.png)
![image](https://user-images.githubusercontent.com/5200812/79475078-37412800-7fd5-11ea-8326-b79c8803de15.png)

#### After (Tablet & Mobile)

![image](https://user-images.githubusercontent.com/5200812/79475124-488a3480-7fd5-11ea-97a1-d2fd689e5398.png)
![image](https://user-images.githubusercontent.com/5200812/79475140-4de77f00-7fd5-11ea-90a6-72f29de317f7.png)
