### PR TITLE
folder_branch_ops: unregister from MD updates on shutdown

### DIFF
--- a/go/kbfs/libkbfs/conflict_resolver_test.go
+++ b/go/kbfs/libkbfs/conflict_resolver_test.go
@@ -43,6 +43,9 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 		gomock.Any(), gomock.Any(), gomock.Any()).
 		AnyTimes().Return(kbname.NormalizedUsername("mockUser"), nil)
 
+	config.mockMdserv.EXPECT().CancelRegistration(
+		gomock.Any(), gomock.Any()).AnyTimes().Return()
+
 	mockDaemon := NewMockKeybaseService(mockCtrl)
 	mockDaemon.EXPECT().LoadUserPlusKeys(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -577,6 +577,8 @@ func (fbo *folderBranchOps) Shutdown(ctx context.Context) error {
 	// Wait for all the goroutines to finish, so that we don't have any races
 	// with logging during test reporting.
 	fbo.doneWg.Wait()
+
+	fbo.config.MDServer().CancelRegistration(ctx, fbo.id())
 	return nil
 }
 

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -98,6 +98,8 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	c := make(chan error, 1)
 	config.mockMdserv.EXPECT().RegisterForUpdate(gomock.Any(),
 		gomock.Any(), gomock.Any()).AnyTimes().Return(c, nil)
+	config.mockMdserv.EXPECT().CancelRegistration(
+		gomock.Any(), gomock.Any()).AnyTimes().Return()
 	config.mockMdserv.EXPECT().OffsetFromServerTime().
 		Return(time.Duration(0), true).AnyTimes()
 	// No chat monitoring.


### PR DESCRIPTION
If someone calls `FinishResolvingConflict` on a TLF, it will shutdown the existing `folderBranchOps` for that TLF.  Normally that's fine if it's really a conflict TLF, since it shouldn't be re-used again.  But if they call it on a normal TLF, they'll receive an error and life will go on.  But the FBO will still get shut down.  Then the next time the TLF is accessed, a new FBO will be made and try to re-register for mdserver updates, which will cause the panic.

So, just unregister during shutdown so this doesn't happen.

Issue: HOTPOT-2495