### PR TITLE
check install file before including in windows logs

### DIFF
--- a/go/install/install_test.go
+++ b/go/install/install_test.go
@@ -64,9 +64,11 @@ func TestLastModifiedMatchingFile(t *testing.T) {
 	contentMatch := "lemon"
 	matchingContent := fmt.Sprintf("la la la\nblah blah\nblah%s a match!\n", contentMatch)
 	unmatchingContent := "la la la\nblah blah\nblah no matches\n"
+	filePattern := filepath.Join(tmpdir, fmt.Sprintf("*%s*", nameMatch))
 
 	// no matches with no files
-	match := LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	match, err := LastModifiedMatchingFile(filePattern, contentMatch)
+	require.NoError(t, err)
 	require.Nil(t, match)
 
 	// no matches with two files that each only half match
@@ -75,14 +77,16 @@ func TestLastModifiedMatchingFile(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(tmpdir, "secondfile.txt"), []byte(matchingContent), 0644)
 	require.NoError(t, err)
 
-	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	match, err = LastModifiedMatchingFile(filePattern, contentMatch)
+	require.NoError(t, err)
 	require.Nil(t, match)
 
 	// with an actual match
 	fullPath := filepath.Join(tmpdir, fmt.Sprintf("third%sfile.txt", nameMatch))
 	err = ioutil.WriteFile(fullPath, []byte(matchingContent), 0644)
 	require.NoError(t, err)
-	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	match, err = LastModifiedMatchingFile(filePattern, contentMatch)
+	require.NoError(t, err)
 	require.NotNil(t, match)
 	require.Equal(t, fullPath, *match)
 
@@ -90,7 +94,8 @@ func TestLastModifiedMatchingFile(t *testing.T) {
 	fullPath = filepath.Join(tmpdir, fmt.Sprintf("fourth%sfile.txt", nameMatch))
 	err = ioutil.WriteFile(fullPath, []byte(matchingContent), 0644)
 	require.NoError(t, err)
-	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	match, err = LastModifiedMatchingFile(filePattern, contentMatch)
+	require.NoError(t, err)
 	require.NotNil(t, match)
 	require.Equal(t, fullPath, *match)
 
@@ -99,7 +104,8 @@ func TestLastModifiedMatchingFile(t *testing.T) {
 	require.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(tmpdir, "sixthfile.txt"), []byte(matchingContent), 0644)
 	require.NoError(t, err)
-	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	match, err = LastModifiedMatchingFile(filePattern, contentMatch)
+	require.NoError(t, err)
 	require.NotNil(t, match)
 	require.Equal(t, fullPath, *match)
 }

--- a/go/install/install_test.go
+++ b/go/install/install_test.go
@@ -6,12 +6,15 @@
 package install
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
+	"github.com/stretchr/testify/require"
 )
 
 var testLog = logger.New("test")
@@ -48,4 +51,55 @@ func TestCommandLine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
+}
+
+func TestLastModifiedMatchingFile(t *testing.T) {
+	var err error
+	tc := libkb.SetupTest(t, "TestLastModifiedMatchingFile", 1)
+	defer tc.Cleanup()
+	tmpdir, err := ioutil.TempDir("", "TestLastModifiedMatchingFile")
+	defer os.RemoveAll(tmpdir)
+	require.NoError(t, err)
+	nameMatch := "blerg"
+	contentMatch := "lemon"
+	matchingContent := fmt.Sprintf("la la la\nblah blah\nblah%s a match!\n", contentMatch)
+	unmatchingContent := "la la la\nblah blah\nblah no matches\n"
+
+	// no matches with no files
+	match := LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	require.Nil(t, match)
+
+	// no matches with two files that each only half match
+	err = ioutil.WriteFile(filepath.Join(tmpdir, fmt.Sprintf("first%sfile.txt", nameMatch)), []byte(unmatchingContent), 0644)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "secondfile.txt"), []byte(matchingContent), 0644)
+	require.NoError(t, err)
+
+	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	require.Nil(t, match)
+
+	// with an actual match
+	fullPath := filepath.Join(tmpdir, fmt.Sprintf("third%sfile.txt", nameMatch))
+	err = ioutil.WriteFile(fullPath, []byte(matchingContent), 0644)
+	require.NoError(t, err)
+	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	require.NotNil(t, match)
+	require.Equal(t, fullPath, *match)
+
+	// with another match
+	fullPath = filepath.Join(tmpdir, fmt.Sprintf("fourth%sfile.txt", nameMatch))
+	err = ioutil.WriteFile(fullPath, []byte(matchingContent), 0644)
+	require.NoError(t, err)
+	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	require.NotNil(t, match)
+	require.Equal(t, fullPath, *match)
+
+	// result doesn't change after additional files are added
+	err = ioutil.WriteFile(filepath.Join(tmpdir, fmt.Sprintf("fifth%sfile.txt", nameMatch)), []byte(unmatchingContent), 0644)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(tmpdir, "sixthfile.txt"), []byte(matchingContent), 0644)
+	require.NoError(t, err)
+	match = LastModifiedMatchingFile(tmpdir, nameMatch, contentMatch)
+	require.NotNil(t, match)
+	require.Equal(t, fullPath, *match)
 }

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -176,6 +176,8 @@ func WatchdogLogPath(logGlobPath string) (string, error) {
 	if len(watchdogLogFiles) > 5 {
 		watchdogLogFiles = watchdogLogFiles[:5]
 	}
+	// resort the files so the combined file will be chronological
+	sort.Sort((sort.StringSlice(watchdogLogFiles)))
 
 	logName, logFile, err := libkb.OpenTempFile("KeybaseWatchdogUpload", ".log", 0)
 	defer logFile.Close()

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -113,20 +113,21 @@ func newScannerUTF16or8(filename string) (utfScanner, error) {
 // and translate if necessary.
 func InstallLogPath() (string, error) {
 	// Get the 3 newest keybase logs - sorting by name works because timestamp
-	keybaseLogFiles, err := filepath.Glob(os.ExpandEnv(filepath.Join("${TEMP}", "Keybase*.log")))
+	keybaseLogFiles, keybaseFetchLogErr := filepath.Glob(os.ExpandEnv(filepath.Join("${TEMP}", "Keybase*.log")))
 	sort.Sort(sort.Reverse(sort.StringSlice(keybaseLogFiles)))
 	if len(keybaseLogFiles) > 6 {
 		keybaseLogFiles = keybaseLogFiles[:6]
 	}
 
-	// Get the latest msi log for a keybase install
-	installFile := LastModifiedMatchingFile("${TEMP}", "MSI", "Keybase")
-	if installFile != nil {
-		keybaseLogFiles = append(keybaseLogFiles, *installFile)
+	// Get the latest msi log (in the app data temp dir) for a keybase install
+	msiLogPattern := os.ExpandEnv(filepath.Join("${TEMP}", "MSI*.LOG"))
+	msiLogFile, msiFetchLogErr := LastModifiedMatchingFile(msiLogPattern, "Keybase")
+	if msiLogFile != nil {
+		keybaseLogFiles = append(keybaseLogFiles, *msiLogFile)
 	}
 
 	// Get the 2 newest dokan logs - sorting by name works because timestamp
-	dokanLogFiles, err := filepath.Glob(os.ExpandEnv(filepath.Join("${TEMP}", "Dokan*.log")))
+	dokanLogFiles, dokanFetchLogErr := filepath.Glob(os.ExpandEnv(filepath.Join("${TEMP}", "Dokan*.log")))
 	sort.Sort(sort.Reverse(sort.StringSlice(dokanLogFiles)))
 	if len(dokanLogFiles) > 2 {
 		dokanLogFiles = dokanLogFiles[:2]
@@ -137,6 +138,16 @@ func InstallLogPath() (string, error) {
 	defer logFile.Close()
 	if err != nil {
 		return "", err
+	}
+
+	if msiFetchLogErr != nil {
+		fmt.Fprintf(logFile, "  --- error fetching msi log %v---\n", msiFetchLogErr)
+	}
+	if keybaseFetchLogErr != nil {
+		fmt.Fprintf(logFile, "  --- error fetching keybase install log %v---\n", keybaseFetchLogErr)
+	}
+	if dokanFetchLogErr != nil {
+		fmt.Fprintf(logFile, "  --- error fetching dokan log %v---\n", dokanFetchLogErr)
 	}
 
 	getVersionAndDrivers(logFile)

--- a/go/install/install_windows.go
+++ b/go/install/install_windows.go
@@ -119,11 +119,10 @@ func InstallLogPath() (string, error) {
 		keybaseLogFiles = keybaseLogFiles[:6]
 	}
 
-	// Get the latest msi log - this is the clean install .msi log
-	msiLogFiles, err := filepath.Glob(os.ExpandEnv(filepath.Join("${TEMP}", "MSI*.LOG")))
-	sort.Sort(sort.Reverse(sort.StringSlice(msiLogFiles)))
-	if len(msiLogFiles) >= 1 {
-		keybaseLogFiles = append(keybaseLogFiles, msiLogFiles[0])
+	// Get the latest msi log for a keybase install
+	installFile := LastModifiedMatchingFile("${TEMP}", "MSI", "Keybase")
+	if installFile != nil {
+		keybaseLogFiles = append(keybaseLogFiles, *installFile)
 	}
 
 	// Get the 2 newest dokan logs - sorting by name works because timestamp


### PR DESCRIPTION
problem: when sending windows logs, we grab the most recent MSI-generated install logs from the appdata/local/temp folder (where MSI Wix install logs get place). turns out this location (and file name) is kind of a default random situation (`MSI____.log`). so if the user has installed another wix app since their last install, we might pick up the wrong file. 

this solution: go to the folder where we log install files, pull up the names of all of them, and look at them in order of most recently modified. choose the first file that has the word `Keybase` in it. so we could potentially be wasting some time here cycling through a big file for a different app. but in this specific situation, at least we're not pushing it over the wire. 

other things i looked at: trying to name the file something else. doesn't look possible. we _can_ move the file at the end of the installation. the reason i don't love this approach is that, if the install fails for some reason, we won't get to the step where we move it to a place we can find it. so we might not have the file when we most need it. 

so, i don't super love this approach. and i'm open to suggestions.