### PR TITLE
fs subscription manager deduplication

### DIFF
--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -245,10 +245,10 @@ func (d *notificationDisplay) RuntimeStatsUpdate(
 }
 
 func (d *notificationDisplay) FSSubscriptionNotify(_ context.Context, arg keybase1.FSSubscriptionNotifyArg) error {
-	return d.printf("FS subscription notify: %s %s\n", arg.SubscriptionID, arg.Topic.String())
+	return d.printf("FS subscription notify: %v %s\n", arg.SubscriptionIDs, arg.Topic.String())
 }
 func (d *notificationDisplay) FSSubscriptionNotifyPath(_ context.Context, arg keybase1.FSSubscriptionNotifyPathArg) error {
-	return d.printf("FS subscription notify path: %s %q %s\n", arg.SubscriptionID, arg.Path, arg.Topic.String())
+	return d.printf("FS subscription notify path: %v %q %v\n", arg.SubscriptionIDs, arg.Path, arg.Topics)
 }
 func (d *notificationDisplay) IdentifyUpdate(_ context.Context, arg keybase1.IdentifyUpdateArg) error {
 	return d.printf("identify update: ok:%v broken:%v\n", arg.OkUsernames, arg.BrokenUsernames)

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -269,7 +269,7 @@ func (s SimpleFSMock) SimpleFSSyncConfigAndStatus(
 
 // SimpleFSGetOnlineStatus implements the SimpleFSInterface.
 func (s SimpleFSMock) SimpleFSGetOnlineStatus(
-	_ context.Context) (keybase1.KbfsOnlineStatus, error) {
+	_ context.Context, _ string) (keybase1.KbfsOnlineStatus, error) {
 	return keybase1.KbfsOnlineStatus_ONLINE, nil
 }
 

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -136,7 +136,8 @@ func (config testBlockOpsConfig) GetSettingsDB() *SettingsDB {
 }
 
 func (config testBlockOpsConfig) SubscriptionManager(
-	_ SubscriptionManagerClientID, _ bool) SubscriptionManager {
+	_ SubscriptionManagerClientID, _ bool,
+	_ SubscriptionNotifier) SubscriptionManager {
 	return config.subscriptionManager
 }
 

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -135,7 +135,8 @@ func (config testBlockOpsConfig) GetSettingsDB() *SettingsDB {
 	return nil
 }
 
-func (config testBlockOpsConfig) SubscriptionManager() SubscriptionManager {
+func (config testBlockOpsConfig) SubscriptionManager(
+	_ SubscriptionManagerClientID, _ bool) SubscriptionManager {
 	return config.subscriptionManager
 }
 

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -89,7 +89,8 @@ func (c testBlockRetrievalConfig) GetSettingsDB() *SettingsDB {
 	return nil
 }
 
-func (c testBlockRetrievalConfig) SubscriptionManager() SubscriptionManager {
+func (c testBlockRetrievalConfig) SubscriptionManager(
+	_ SubscriptionManagerClientID, _ bool) SubscriptionManager {
 	return c.subscriptionManager
 }
 

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -90,7 +90,8 @@ func (c testBlockRetrievalConfig) GetSettingsDB() *SettingsDB {
 }
 
 func (c testBlockRetrievalConfig) SubscriptionManager(
-	_ SubscriptionManagerClientID, _ bool) SubscriptionManager {
+	_ SubscriptionManagerClientID, _ bool,
+	_ SubscriptionNotifier) SubscriptionManager {
 	return c.subscriptionManager
 }
 

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1835,10 +1835,12 @@ func (c *ConfigLocal) SetDiskCacheMode(m DiskCacheMode) {
 }
 
 // SubscriptionManager implements the Config interface.
-func (c *ConfigLocal) SubscriptionManager(clientID SubscriptionManagerClientID, purgeable bool) SubscriptionManager {
+func (c *ConfigLocal) SubscriptionManager(
+	clientID SubscriptionManagerClientID, purgeable bool,
+	notifier SubscriptionNotifier) SubscriptionManager {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.subscriptionManagerManager.get(clientID, purgeable)
+	return c.subscriptionManagerManager.get(clientID, purgeable, notifier)
 }
 
 // SubscriptionManagerPublisher implements the Config interface.

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -167,8 +167,7 @@ type ConfigLocal struct {
 	quotaUsage      map[keybase1.UserOrTeamID]*EventuallyConsistentQuotaUsage
 	rekeyFSMLimiter *OngoingWorkLimiter
 
-	subscriptionManager          SubscriptionManager
-	subscriptionManagerPublisher SubscriptionManagerPublisher
+	subscriptionManagerManager *subscriptionManagerManager
 }
 
 // DiskCacheMode represents the mode of initialization for the disk cache.
@@ -306,8 +305,7 @@ func NewConfigLocal(mode InitMode,
 	config.conflictResolutionDB = openCRDB(config)
 	config.settingsDB = openSettingsDB(config)
 
-	config.subscriptionManager, config.subscriptionManagerPublisher =
-		newSubscriptionManager(config)
+	config.subscriptionManagerManager = newSubscriptionManagerManager(config)
 
 	return config
 }
@@ -1154,7 +1152,7 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 		kbfsServ.Shutdown()
 	}
 
-	c.subscriptionManager.Shutdown(ctx)
+	c.subscriptionManagerManager.Shutdown(ctx)
 
 	if len(errorList) == 1 {
 		return errorList[0]
@@ -1837,17 +1835,17 @@ func (c *ConfigLocal) SetDiskCacheMode(m DiskCacheMode) {
 }
 
 // SubscriptionManager implements the Config interface.
-func (c *ConfigLocal) SubscriptionManager() SubscriptionManager {
+func (c *ConfigLocal) SubscriptionManager(clientID SubscriptionManagerClientID, purgeable bool) SubscriptionManager {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.subscriptionManager
+	return c.subscriptionManagerManager.get(clientID, purgeable)
 }
 
 // SubscriptionManagerPublisher implements the Config interface.
 func (c *ConfigLocal) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.subscriptionManagerPublisher
+	return c.subscriptionManagerManager
 }
 
 // KbEnv implements the Config interface.

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -143,8 +143,8 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.mode = modeTest{NewInitModeFromType(InitDefault)}
 	config.conflictResolutionDB = openCRDB(config)
 
+	config.subscriptionManagerManager = newSubscriptionManagerManager(config)
 	config.mockSubscriptionManagerPublisher = NewMockSubscriptionManagerPublisher(gomock.NewController(ctr.t))
-	config.subscriptionManagerPublisher = config.mockSubscriptionManagerPublisher
 	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(
 		keybase1.SubscriptionTopic_FAVORITES).AnyTimes()
 	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -148,7 +148,18 @@ type settingsDBGetter interface {
 type subscriptionManagerGetter interface {
 	// SubscriptionManager returns a subscription manager that can be used to
 	// subscribe to events.
-	SubscriptionManager() SubscriptionManager
+	//
+	// clientID identifies a subscriptionManager client. Each user of the
+	// subscription manager should specify a unique clientID. When a
+	// notification happens, the client ID is provided.
+	//
+	// This is helpful for caller to filter out notifications that other clients
+	// subscribe.
+	//
+	// If purgeable is true, the client is marked as purgeable. We keep maximum
+	// 3 purgeable clients (FIFO). This is useful as a way to purge old, likely
+	// dead, clients, which happens a lot with electron refreshes.
+	SubscriptionManager(clientID SubscriptionManagerClientID, purgeable bool) SubscriptionManager
 }
 
 type subscriptionManagerPublisherGetter interface {
@@ -2102,10 +2113,13 @@ type SubscriptionID string
 // on subscribed topics.
 type SubscriptionNotifier interface {
 	// OnPathChange notifies about a change that's related to a specific path.
-	OnPathChange(subscriptionID SubscriptionID,
+	OnPathChange(
+		clientID SubscriptionManagerClientID, subscriptionID SubscriptionID,
 		path string, topic keybase1.PathSubscriptionTopic)
-	// OnNonPathChange notifies about a change that's not related to a specific path.
-	OnNonPathChange(subscriptionID SubscriptionID,
+	// OnNonPathChange notifies about a change that's not related to a specific
+	// path.
+	OnNonPathChange(
+		clientID SubscriptionManagerClientID, subscriptionID SubscriptionID,
 		topic keybase1.SubscriptionTopic)
 }
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -145,6 +145,9 @@ type settingsDBGetter interface {
 	GetSettingsDB() *SettingsDB
 }
 
+// SubscriptionManagerClientID identifies a subscriptionManager client.
+type SubscriptionManagerClientID string
+
 type subscriptionManagerGetter interface {
 	// SubscriptionManager returns a subscription manager that can be used to
 	// subscribe to events.
@@ -156,11 +159,11 @@ type subscriptionManagerGetter interface {
 	// This is helpful for caller to filter out notifications that other clients
 	// subscribe.
 	//
-	// If purgeable is true, the client is marked as purgeable. We keep maximum
-	// 3 purgeable clients (FIFO). This is useful as a way to purge old, likely
-	// dead, clients, which happens a lot with electron refreshes.
+	// If purgeable is true, the client is marked as purgeable. We keep a
+	// maximum of 3 purgeable clients (FIFO). This is useful as a way to purge
+	// old, likely dead, clients, which happens a lot with electron refreshes.
 	//
-	// notifier specifies how notification should be delivered when things
+	// notifier specifies how a notification should be delivered when things
 	// change. If different notifiers are used across multiple calls to get the
 	// subscription manager for the same clientID, only the first one is
 	// effective.
@@ -2119,6 +2122,10 @@ type SubscriptionID string
 // on subscribed topics.
 type SubscriptionNotifier interface {
 	// OnPathChange notifies about a change that's related to a specific path.
+	// Multiple subscriptionIDs may be sent because a client can subscribe on
+	// the same path multiple times. In the future topics will become a single
+	// topic but we don't differeciate between the two topics for now so they
+	// are just sent together if both topics are subscribed.
 	OnPathChange(
 		clientID SubscriptionManagerClientID, subscriptionIDs []SubscriptionID,
 		path string, topics []keybase1.PathSubscriptionTopic)

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -436,11 +436,14 @@ func (k *KeybaseDaemonLocal) PutGitMetadata(
 }
 
 // OnPathChange implements the SubscriptionNotifier interface.
-func (k *KeybaseDaemonLocal) OnPathChange(subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
+func (k *KeybaseDaemonLocal) OnPathChange(
+	clientID SubscriptionManagerClientID,
+	subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
 }
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseDaemonLocal) OnNonPathChange(
+	clientID SubscriptionManagerClientID,
 	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
 }
 

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -438,13 +438,13 @@ func (k *KeybaseDaemonLocal) PutGitMetadata(
 // OnPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseDaemonLocal) OnPathChange(
 	clientID SubscriptionManagerClientID,
-	subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
+	subscriptionIDs []SubscriptionID, path string, topics []keybase1.PathSubscriptionTopic) {
 }
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseDaemonLocal) OnNonPathChange(
 	clientID SubscriptionManagerClientID,
-	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
+	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
 }
 
 // Shutdown implements KeybaseDaemon for KeybaseDaemonLocal.

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1227,10 +1227,12 @@ func (k *KeybaseServiceBase) NotifyFavoritesChanged(ctx context.Context) error {
 
 // OnPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseServiceBase) OnPathChange(
+	clientID SubscriptionManagerClientID,
 	subscriptionID SubscriptionID, path string,
 	topic keybase1.PathSubscriptionTopic) {
 	err := k.kbfsClient.FSSubscriptionNotifyPathEvent(
 		context.Background(), keybase1.FSSubscriptionNotifyPathEventArg{
+			ClientID:       string(clientID),
 			SubscriptionID: string(subscriptionID),
 			Path:           path,
 			Topic:          topic,
@@ -1243,9 +1245,11 @@ func (k *KeybaseServiceBase) OnPathChange(
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseServiceBase) OnNonPathChange(
+	clientID SubscriptionManagerClientID,
 	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
 	err := k.kbfsClient.FSSubscriptionNotifyEvent(context.Background(),
 		keybase1.FSSubscriptionNotifyEventArg{
+			ClientID:       string(clientID),
 			SubscriptionID: string(subscriptionID),
 			Topic:          topic,
 		})

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1228,14 +1228,18 @@ func (k *KeybaseServiceBase) NotifyFavoritesChanged(ctx context.Context) error {
 // OnPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseServiceBase) OnPathChange(
 	clientID SubscriptionManagerClientID,
-	subscriptionID SubscriptionID, path string,
-	topic keybase1.PathSubscriptionTopic) {
+	subscriptionIDs []SubscriptionID, path string,
+	topics []keybase1.PathSubscriptionTopic) {
+	subscriptionIDStrings := make([]string, 0, len(subscriptionIDs))
+	for _, sid := range subscriptionIDs {
+		subscriptionIDStrings = append(subscriptionIDStrings, string(sid))
+	}
 	err := k.kbfsClient.FSSubscriptionNotifyPathEvent(
 		context.Background(), keybase1.FSSubscriptionNotifyPathEventArg{
-			ClientID:       string(clientID),
-			SubscriptionID: string(subscriptionID),
-			Path:           path,
-			Topic:          topic,
+			ClientID:        string(clientID),
+			SubscriptionIDs: subscriptionIDStrings,
+			Path:            path,
+			Topics:          topics,
 		})
 	if err != nil {
 		k.log.CDebugf(
@@ -1246,12 +1250,16 @@ func (k *KeybaseServiceBase) OnPathChange(
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseServiceBase) OnNonPathChange(
 	clientID SubscriptionManagerClientID,
-	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
+	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
+	subscriptionIDStrings := make([]string, 0, len(subscriptionIDs))
+	for _, sid := range subscriptionIDs {
+		subscriptionIDStrings = append(subscriptionIDStrings, string(sid))
+	}
 	err := k.kbfsClient.FSSubscriptionNotifyEvent(context.Background(),
 		keybase1.FSSubscriptionNotifyEventArg{
-			ClientID:       string(clientID),
-			SubscriptionID: string(subscriptionID),
-			Topic:          topic,
+			ClientID:        string(clientID),
+			SubscriptionIDs: subscriptionIDStrings,
+			Topic:           topic,
 		})
 	if err != nil {
 		k.log.CDebugf(

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -376,17 +376,19 @@ func (k KeybaseServiceMeasured) PutGitMetadata(
 }
 
 // OnPathChange implements the SubscriptionNotifier interface.
-func (k KeybaseServiceMeasured) OnPathChange(subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
+func (k KeybaseServiceMeasured) OnPathChange(clientID SubscriptionManagerClientID,
+	subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
 	k.onPathChangeTimer.Time(func() {
-		k.delegate.OnPathChange(subscriptionID, path, topic)
+		k.delegate.OnPathChange(clientID, subscriptionID, path, topic)
 	})
 }
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k KeybaseServiceMeasured) OnNonPathChange(
+	clientID SubscriptionManagerClientID,
 	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
 	k.onChangeTimer.Time(func() {
-		k.delegate.OnNonPathChange(subscriptionID, topic)
+		k.delegate.OnNonPathChange(clientID, subscriptionID, topic)
 	})
 }
 

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -377,18 +377,18 @@ func (k KeybaseServiceMeasured) PutGitMetadata(
 
 // OnPathChange implements the SubscriptionNotifier interface.
 func (k KeybaseServiceMeasured) OnPathChange(clientID SubscriptionManagerClientID,
-	subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
+	subscriptionIDs []SubscriptionID, path string, topics []keybase1.PathSubscriptionTopic) {
 	k.onPathChangeTimer.Time(func() {
-		k.delegate.OnPathChange(clientID, subscriptionID, path, topic)
+		k.delegate.OnPathChange(clientID, subscriptionIDs, path, topics)
 	})
 }
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k KeybaseServiceMeasured) OnNonPathChange(
 	clientID SubscriptionManagerClientID,
-	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
+	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
 	k.onChangeTimer.Time(func() {
-		k.delegate.OnNonPathChange(clientID, subscriptionID, topic)
+		k.delegate.OnNonPathChange(clientID, subscriptionIDs, topic)
 	})
 }
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -2504,7 +2504,7 @@ func (mr *MockKeybaseServiceMockRecorder) NotifySyncStatus(arg0, arg1 interface{
 }
 
 // OnNonPathChange mocks base method.
-func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 keybase1.SubscriptionTopic) {
+func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 keybase1.SubscriptionTopic) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1, arg2)
 }
@@ -2516,7 +2516,7 @@ func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1, arg2 inter
 }
 
 // OnPathChange mocks base method.
-func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 string, arg3 keybase1.PathSubscriptionTopic) {
+func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 string, arg3 []keybase1.PathSubscriptionTopic) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2, arg3)
 }
@@ -4335,7 +4335,7 @@ func (m *MockSubscriptionNotifier) EXPECT() *MockSubscriptionNotifierMockRecorde
 }
 
 // OnNonPathChange mocks base method.
-func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 keybase1.SubscriptionTopic) {
+func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 keybase1.SubscriptionTopic) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1, arg2)
 }
@@ -4347,7 +4347,7 @@ func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1, arg2
 }
 
 // OnPathChange mocks base method.
-func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 string, arg3 keybase1.PathSubscriptionTopic) {
+func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 string, arg3 []keybase1.PathSubscriptionTopic) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2, arg3)
 }

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -2504,27 +2504,27 @@ func (mr *MockKeybaseServiceMockRecorder) NotifySyncStatus(arg0, arg1 interface{
 }
 
 // OnNonPathChange mocks base method.
-func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionID, arg1 keybase1.SubscriptionTopic) {
+func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 keybase1.SubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1)
+	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1, arg2)
 }
 
 // OnNonPathChange indicates an expected call of OnNonPathChange.
-func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnNonPathChange), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnNonPathChange), arg0, arg1, arg2)
 }
 
 // OnPathChange mocks base method.
-func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionID, arg1 string, arg2 keybase1.PathSubscriptionTopic) {
+func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 string, arg3 keybase1.PathSubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2)
+	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2, arg3)
 }
 
 // OnPathChange indicates an expected call of OnPathChange.
-func (mr *MockKeybaseServiceMockRecorder) OnPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnPathChange), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnPathChange), arg0, arg1, arg2, arg3)
 }
 
 // PutGitMetadata mocks base method.
@@ -4335,27 +4335,27 @@ func (m *MockSubscriptionNotifier) EXPECT() *MockSubscriptionNotifierMockRecorde
 }
 
 // OnNonPathChange mocks base method.
-func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionID, arg1 keybase1.SubscriptionTopic) {
+func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 keybase1.SubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1)
+	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1, arg2)
 }
 
 // OnNonPathChange indicates an expected call of OnNonPathChange.
-func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnNonPathChange), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnNonPathChange), arg0, arg1, arg2)
 }
 
 // OnPathChange mocks base method.
-func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionID, arg1 string, arg2 keybase1.PathSubscriptionTopic) {
+func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionManagerClientID, arg1 SubscriptionID, arg2 string, arg3 keybase1.PathSubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2)
+	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2, arg3)
 }
 
 // OnPathChange indicates an expected call of OnPathChange.
-func (mr *MockSubscriptionNotifierMockRecorder) OnPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockSubscriptionNotifierMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnPathChange), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnPathChange), arg0, arg1, arg2, arg3)
 }
 
 // MockSubscriptionManagerPublisher is a mock of SubscriptionManagerPublisher interface.

--- a/go/kbfs/libkbfs/online_status_tracker.go
+++ b/go/kbfs/libkbfs/online_status_tracker.go
@@ -376,6 +376,9 @@ func (ost *onlineStatusTracker) run(ctx context.Context) {
 	}
 }
 
+// TODO: we now have clientID in the subscriptionManager so it's not necessary
+// anymore for onlineStatusTracker to track it.
+
 func (ost *onlineStatusTracker) userInOut(clientID string, clientIsIn bool) {
 	ost.lock.Lock()
 	wasIn := len(ost.userIsLooking) != 0

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1462,10 +1462,7 @@ func (p *blockPrefetcher) run(
 		} else {
 			defer subMan.Unsubscribe(context.TODO(), prefetcherSubKey)
 		}
-		go func() {
-			<-p.shutdownCh
-			subMan.Shutdown(context.Background())
-		}()
+		defer subMan.Shutdown(context.TODO())
 	} else {
 		close(subCh)
 		subCh = nil

--- a/go/kbfs/libkbfs/subscription_manager.go
+++ b/go/kbfs/libkbfs/subscription_manager.go
@@ -230,7 +230,7 @@ func (sm *subscriptionManager) makePathSubscriptionDebouncedNotify(
 			return
 		}
 		sids := make([]SubscriptionID, 0, len(ps.subscriptionIDs))
-		topicsMap := make(map[keybase1.PathSubscriptionTopic]struct{}, 0)
+		topicsMap := make(map[keybase1.PathSubscriptionTopic]struct{})
 		for sid, topic := range ps.subscriptionIDs {
 			sids = append(sids, sid)
 			topicsMap[topic] = struct{}{}

--- a/go/kbfs/libkbfs/subscription_manager.go
+++ b/go/kbfs/libkbfs/subscription_manager.go
@@ -171,10 +171,10 @@ func newSubscriptionManager(clientID SubscriptionManagerClientID, config Config,
 
 func (sm *subscriptionManager) Shutdown(ctx context.Context) {
 	sm.onlineStatusTracker.shutdown()
-	pathSids := make([]SubscriptionID, 0, len(sm.pathSubscriptionIDToRef))
-	nonPathSids := make([]SubscriptionID, 0, len(sm.nonPathSubscriptionIDToTopic))
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
+	pathSids := make([]SubscriptionID, 0, len(sm.pathSubscriptionIDToRef))
+	nonPathSids := make([]SubscriptionID, 0, len(sm.nonPathSubscriptionIDToTopic))
 	for sid := range sm.pathSubscriptionIDToRef {
 		pathSids = append(pathSids, sid)
 	}

--- a/go/kbfs/libkbfs/subscription_manager_test.go
+++ b/go/kbfs/libkbfs/subscription_manager_test.go
@@ -64,7 +64,7 @@ func (e sliceMatcherNoOrder) Matches(x interface{}) bool {
 	if vExpected.Len() != vGot.Len() {
 		return false
 	}
-outer: // O(n^2) (to void more complicated reflect) but it's usually small
+outer: // O(n^2) (to avoid more complicated reflect) but it's usually small.
 	for i := 0; i < vExpected.Len(); i++ {
 		for j := 0; j < vGot.Len(); j++ {
 			if reflect.DeepEqual(vExpected.Index(i).Interface(), vGot.Index(j).Interface()) {

--- a/go/kbfs/libkbfs/subscription_manager_test.go
+++ b/go/kbfs/libkbfs/subscription_manager_test.go
@@ -104,6 +104,8 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, tlfHandle, data.MasterBranch)
 	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 
 	sid1, sid2 := SubscriptionID("sid1"), SubscriptionID("sid2")
 
@@ -115,6 +117,8 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 		[]SubscriptionID{sid1}, "/keybase/private/jdoe",
 		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_CHILDREN})
 	fileNode, _, err := config.KBFSOps().CreateFile(ctx, rootNode, rootNode.ChildName("file"), false, NoExcl)
+	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
 
 	t.Logf("Try to subscribe using sid1 again, and it should fail")
@@ -136,6 +140,8 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 	_, _, err = config.KBFSOps().CreateDir(
 		ctx, rootNode, rootNode.ChildName("dir1"))
 	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 
 	// These waits are needed to avoid races.
 	t.Logf("Waiting for last notifications (done0 and done1) before unsubscribing.")
@@ -150,6 +156,8 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 	_, _, err = config.KBFSOps().CreateDir(
 		ctx, rootNode, rootNode.ChildName("dir2"))
 	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 
 	t.Logf("Waiting for last notification (done2) before unsubscribing.")
 	waiter2()
@@ -163,12 +171,11 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_STAT}).Do(done3)
 	err = config.KBFSOps().Write(ctx, fileNode, []byte("hello"), 0)
 	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
 
 	t.Logf("Waiting for last notification (done3) before finishing the test.")
 	waiter3()
-
-	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
-	require.NoError(t, err)
 }
 
 func TestSubscriptionManagerFavoritesChange(t *testing.T) {

--- a/go/kbfs/libkbfs/subscription_manager_test.go
+++ b/go/kbfs/libkbfs/subscription_manager_test.go
@@ -5,6 +5,8 @@
 package libkbfs
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -35,22 +37,51 @@ func waitForCall(t *testing.T, timeout time.Duration) (
 const testSubscriptionManagerClientID SubscriptionManagerClientID = "test"
 
 func initSubscriptionManagerTest(t *testing.T) (config Config,
-	subscriber Subscriber, notifier *MockSubscriptionNotifier,
+	sm SubscriptionManager, notifier *MockSubscriptionNotifier,
 	finish func()) {
 	ctl := gomock.NewController(t)
 	config = MakeTestConfigOrBust(t, "jdoe")
 	notifier = NewMockSubscriptionNotifier(ctl)
-	subscriber = config.SubscriptionManager(
-		testSubscriptionManagerClientID, false).Subscriber(notifier)
-	return config, subscriber, notifier, func() {
+	sm = config.SubscriptionManager(
+		testSubscriptionManagerClientID, false, notifier)
+	return config, sm, notifier, func() {
 		err := config.Shutdown(context.Background())
 		require.NoError(t, err)
 		ctl.Finish()
 	}
 }
 
+type sliceMatcherNoOrder struct {
+	x interface{}
+}
+
+func (e sliceMatcherNoOrder) Matches(x interface{}) bool {
+	vExpected := reflect.ValueOf(e.x)
+	vGot := reflect.ValueOf(x)
+	if vExpected.Kind() != reflect.Slice || vGot.Kind() != reflect.Slice {
+		return false
+	}
+	if vExpected.Len() != vGot.Len() {
+		return false
+	}
+outer: // O(n^2) (to void more complicated reflect) but it's usually small
+	for i := 0; i < vExpected.Len(); i++ {
+		for j := 0; j < vGot.Len(); j++ {
+			if reflect.DeepEqual(vExpected.Index(i).Interface(), vGot.Index(j).Interface()) {
+				continue outer
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func (e sliceMatcherNoOrder) String() string {
+	return fmt.Sprintf("is %v (but order doesn't matter)", e.x)
+}
+
 func TestSubscriptionManagerSubscribePath(t *testing.T) {
-	config, subscriber, notifier, finish := initSubscriptionManagerTest(t)
+	config, sm, notifier, finish := initSubscriptionManagerTest(t)
 	defer finish()
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -77,30 +108,31 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 	sid1, sid2 := SubscriptionID("sid1"), SubscriptionID("sid2")
 
 	t.Logf("Subscribe to CHILDREN at TLF root using sid1, and create a file. We should get a notification.")
-	err = subscriber.SubscribePath(ctx, sid1, "/keybase/private/jdoe",
+	err = sm.SubscribePath(ctx, sid1, "/keybase/private/jdoe",
 		keybase1.PathSubscriptionTopic_CHILDREN, nil)
 	require.NoError(t, err)
 	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
-		sid1, "/keybase/private/jdoe",
-		keybase1.PathSubscriptionTopic_CHILDREN)
+		[]SubscriptionID{sid1}, "/keybase/private/jdoe",
+		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_CHILDREN})
 	fileNode, _, err := config.KBFSOps().CreateFile(ctx, rootNode, rootNode.ChildName("file"), false, NoExcl)
 	require.NoError(t, err)
 
 	t.Logf("Try to subscribe using sid1 again, and it should fail")
-	err = subscriber.SubscribePath(ctx, sid1, "/keybase/private/jdoe",
+	err = sm.SubscribePath(ctx, sid1, "/keybase/private/jdoe",
 		keybase1.PathSubscriptionTopic_STAT, nil)
 	require.Error(t, err)
 
 	t.Logf("Subscribe to STAT at TLF root using sid2, and create a dir. We should get a notification for STAT, and a notificiation for CHILDREN.")
-	err = subscriber.SubscribePath(ctx, sid2, "/keybase/private/jdoe",
+	err = sm.SubscribePath(ctx, sid2, "/keybase/private/jdoe",
 		keybase1.PathSubscriptionTopic_STAT, nil)
 	require.NoError(t, err)
 	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
-		sid1, "/keybase/private/jdoe",
-		keybase1.PathSubscriptionTopic_CHILDREN).Do(done0)
-	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
-		sid2, "/keybase/private/jdoe",
-		keybase1.PathSubscriptionTopic_STAT).Do(done1)
+		sliceMatcherNoOrder{[]SubscriptionID{sid1, sid2}},
+		"/keybase/private/jdoe",
+		sliceMatcherNoOrder{[]keybase1.PathSubscriptionTopic{
+			keybase1.PathSubscriptionTopic_STAT,
+			keybase1.PathSubscriptionTopic_CHILDREN,
+		}}).Do(func(args ...interface{}) { done0(args...); done1(args...) })
 	_, _, err = config.KBFSOps().CreateDir(
 		ctx, rootNode, rootNode.ChildName("dir1"))
 	require.NoError(t, err)
@@ -111,10 +143,10 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 	waiter1()
 
 	t.Logf("Unsubscribe sid1, and make another dir. We should only get a notification for STAT.")
-	subscriber.Unsubscribe(ctx, sid1)
+	sm.Unsubscribe(ctx, sid1)
 	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
-		sid2, "/keybase/private/jdoe",
-		keybase1.PathSubscriptionTopic_STAT).Do(done2)
+		[]SubscriptionID{sid2}, "/keybase/private/jdoe",
+		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_STAT}).Do(done2)
 	_, _, err = config.KBFSOps().CreateDir(
 		ctx, rootNode, rootNode.ChildName("dir2"))
 	require.NoError(t, err)
@@ -123,12 +155,12 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 	waiter2()
 
 	t.Logf("Unsubscribe sid2 as well. Then subscribe to STAT on the file using sid1 (which we unsubscribed earlier), and write to it. We should get STAT notification.")
-	subscriber.Unsubscribe(ctx, sid2)
-	err = subscriber.SubscribePath(ctx, sid1, "/keybase/private/jdoe/dir1/../file", keybase1.PathSubscriptionTopic_STAT, nil)
+	sm.Unsubscribe(ctx, sid2)
+	err = sm.SubscribePath(ctx, sid1, "/keybase/private/jdoe/dir1/../file", keybase1.PathSubscriptionTopic_STAT, nil)
 	require.NoError(t, err)
 	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
-		sid1, "/keybase/private/jdoe/dir1/../file",
-		keybase1.PathSubscriptionTopic_STAT).Do(done3)
+		[]SubscriptionID{sid1}, "/keybase/private/jdoe/dir1/../file",
+		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_STAT}).Do(done3)
 	err = config.KBFSOps().Write(ctx, fileNode, []byte("hello"), 0)
 	require.NoError(t, err)
 
@@ -140,18 +172,18 @@ func TestSubscriptionManagerSubscribePath(t *testing.T) {
 }
 
 func TestSubscriptionManagerFavoritesChange(t *testing.T) {
-	config, subscriber, notifier, finish := initSubscriptionManagerTest(t)
+	config, sm, notifier, finish := initSubscriptionManagerTest(t)
 	defer finish()
 	ctx := context.Background()
 
 	waiter1, done1 := waitForCall(t, 4*time.Second)
 
 	sid1 := SubscriptionID("sid1")
-	err := subscriber.SubscribeNonPath(ctx, sid1, keybase1.SubscriptionTopic_FAVORITES, nil)
+	err := sm.SubscribeNonPath(ctx, sid1, keybase1.SubscriptionTopic_FAVORITES, nil)
 	require.NoError(t, err)
 	notifier.EXPECT().OnNonPathChange(
 		testSubscriptionManagerClientID,
-		sid1, keybase1.SubscriptionTopic_FAVORITES).Do(done1)
+		[]SubscriptionID{sid1}, keybase1.SubscriptionTopic_FAVORITES).Do(done1)
 	err = config.KBFSOps().AddFavorite(ctx,
 		favorites.Folder{
 			Name: "test",

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -159,9 +159,7 @@ type SimpleFS struct {
 
 	localHTTPServer *libhttpserver.Server
 
-	subscriber libkbfs.Subscriber
-
-	onlineStatusTracker libkbfs.OnlineStatusTracker
+	subscriptionNotifier libkbfs.SubscriptionNotifier
 
 	downloadManager *downloadManager
 	uploadManager   *uploadManager
@@ -197,24 +195,26 @@ var _ libkbfs.SubscriptionNotifier = subscriptionNotifier{}
 
 // OnNonPathChange implements the libkbfs.SubscriptionNotifier interface.
 func (s subscriptionNotifier) OnPathChange(
+	clientID libkbfs.SubscriptionManagerClientID,
 	subscriptionID libkbfs.SubscriptionID,
 	path string, topic keybase1.PathSubscriptionTopic) {
 	ks := s.config.KeybaseService()
 	if ks == nil {
 		return
 	}
-	ks.OnPathChange(subscriptionID, path, topic)
+	ks.OnPathChange(clientID, subscriptionID, path, topic)
 }
 
 // OnPathChange implements the libkbfs.SubscriptionNotifier interface.
 func (s subscriptionNotifier) OnNonPathChange(
+	clientID libkbfs.SubscriptionManagerClientID,
 	subscriptionID libkbfs.SubscriptionID,
 	topic keybase1.SubscriptionTopic) {
 	ks := s.config.KeybaseService()
 	if ks == nil {
 		return
 	}
-	ks.OnNonPathChange(subscriptionID, topic)
+	ks.OnNonPathChange(clientID, subscriptionID, topic)
 }
 
 func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *SimpleFS {
@@ -241,17 +241,16 @@ func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *Si
 	k := &SimpleFS{
 		config: config,
 
-		handles:             map[keybase1.OpID]*handle{},
-		inProgress:          map[keybase1.OpID]*inprogress{},
-		log:                 log,
-		vlog:                config.MakeVLogger(log),
-		newFS:               defaultNewFS,
-		idd:                 libkbfs.NewImpatientDebugDumperForForcedDumps(config),
-		indexer:             indexer,
-		localHTTPServer:     localHTTPServer,
-		subscriber:          config.SubscriptionManager().Subscriber(subscriptionNotifier{config}),
-		onlineStatusTracker: config.SubscriptionManager().OnlineStatusTracker(),
-		httpClient:          &http.Client{},
+		handles:              map[keybase1.OpID]*handle{},
+		inProgress:           map[keybase1.OpID]*inprogress{},
+		log:                  log,
+		vlog:                 config.MakeVLogger(log),
+		newFS:                defaultNewFS,
+		idd:                  libkbfs.NewImpatientDebugDumperForForcedDumps(config),
+		indexer:              indexer,
+		localHTTPServer:      localHTTPServer,
+		subscriptionNotifier: subscriptionNotifier{config},
+		httpClient:           &http.Client{},
 	}
 	k.downloadManager = newDownloadManager(k)
 	k.uploadManager = newUploadManager(k)
@@ -2966,19 +2965,20 @@ func (k *SimpleFS) SimpleFSForceStuckConflict(
 }
 
 // SimpleFSGetOnlineStatus implements the SimpleFSInterface.
-func (k *SimpleFS) SimpleFSGetOnlineStatus(ctx context.Context) (keybase1.KbfsOnlineStatus, error) {
-	return k.onlineStatusTracker.GetOnlineStatus(), nil
+func (k *SimpleFS) SimpleFSGetOnlineStatus(
+	ctx context.Context, clientID string) (keybase1.KbfsOnlineStatus, error) {
+	return k.subscriptionManager(clientID).OnlineStatusTracker().GetOnlineStatus(), nil
 }
 
 // SimpleFSUserIn implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSUserIn(ctx context.Context, clientID string) error {
-	k.onlineStatusTracker.UserIn(ctx, clientID)
+	k.subscriptionManager(clientID).OnlineStatusTracker().UserIn(ctx, clientID)
 	return nil
 }
 
 // SimpleFSUserOut implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSUserOut(ctx context.Context, clientID string) error {
-	k.onlineStatusTracker.UserOut(ctx, clientID)
+	k.subscriptionManager(clientID).OnlineStatusTracker().UserOut(ctx, clientID)
 	return nil
 }
 
@@ -3172,6 +3172,16 @@ func (k *SimpleFS) SimpleFSGetStats(ctx context.Context) (
 	return res, nil
 }
 
+func (k *SimpleFS) subscriptionManager(
+	clientID string) libkbfs.SubscriptionManager {
+	return k.config.SubscriptionManager(
+		libkbfs.SubscriptionManagerClientID(clientID), true)
+}
+
+func (k *SimpleFS) subscriber(clientID string) libkbfs.Subscriber {
+	return k.subscriptionManager(clientID).Subscriber(k.subscriptionNotifier)
+}
+
 // SimpleFSSubscribePath implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSSubscribePath(
 	ctx context.Context, arg keybase1.SimpleFSSubscribePathArg) (err error) {
@@ -3184,7 +3194,9 @@ func (k *SimpleFS) SimpleFSSubscribePath(
 		return err
 	}
 	interval := time.Second * time.Duration(arg.DeduplicateIntervalSecond)
-	return k.subscriber.SubscribePath(ctx, libkbfs.SubscriptionID(arg.SubscriptionID), arg.KbfsPath, arg.Topic, &interval)
+	return k.subscriber(arg.ClientID).SubscribePath(
+		ctx, libkbfs.SubscriptionID(arg.SubscriptionID),
+		arg.KbfsPath, arg.Topic, &interval)
 }
 
 // SimpleFSSubscribeNonPath implements the SimpleFSInterface.
@@ -3195,7 +3207,8 @@ func (k *SimpleFS) SimpleFSSubscribeNonPath(
 		return err
 	}
 	interval := time.Second * time.Duration(arg.DeduplicateIntervalSecond)
-	return k.subscriber.SubscribeNonPath(ctx, libkbfs.SubscriptionID(arg.SubscriptionID), arg.Topic, &interval)
+	return k.subscriber(arg.ClientID).SubscribeNonPath(
+		ctx, libkbfs.SubscriptionID(arg.SubscriptionID), arg.Topic, &interval)
 }
 
 // SimpleFSUnsubscribe implements the SimpleFSInterface.
@@ -3205,7 +3218,7 @@ func (k *SimpleFS) SimpleFSUnsubscribe(
 	if err != nil {
 		return err
 	}
-	k.subscriber.Unsubscribe(ctx, libkbfs.SubscriptionID(arg.SubscriptionID))
+	k.subscriber(arg.ClientID).Unsubscribe(ctx, libkbfs.SubscriptionID(arg.SubscriptionID))
 	return nil
 }
 

--- a/go/protocol/keybase1/kbfs.go
+++ b/go/protocol/keybase1/kbfs.go
@@ -53,12 +53,14 @@ type FSFavoritesChangedEventArg struct {
 }
 
 type FSSubscriptionNotifyPathEventArg struct {
+	ClientID       string                `codec:"clientID" json:"clientID"`
 	SubscriptionID string                `codec:"subscriptionID" json:"subscriptionID"`
 	Path           string                `codec:"path" json:"path"`
 	Topic          PathSubscriptionTopic `codec:"topic" json:"topic"`
 }
 
 type FSSubscriptionNotifyEventArg struct {
+	ClientID       string            `codec:"clientID" json:"clientID"`
 	SubscriptionID string            `codec:"subscriptionID" json:"subscriptionID"`
 	Topic          SubscriptionTopic `codec:"topic" json:"topic"`
 }

--- a/go/protocol/keybase1/kbfs.go
+++ b/go/protocol/keybase1/kbfs.go
@@ -53,16 +53,16 @@ type FSFavoritesChangedEventArg struct {
 }
 
 type FSSubscriptionNotifyPathEventArg struct {
-	ClientID       string                `codec:"clientID" json:"clientID"`
-	SubscriptionID string                `codec:"subscriptionID" json:"subscriptionID"`
-	Path           string                `codec:"path" json:"path"`
-	Topic          PathSubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string                  `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string                `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Path            string                  `codec:"path" json:"path"`
+	Topics          []PathSubscriptionTopic `codec:"topics" json:"topics"`
 }
 
 type FSSubscriptionNotifyEventArg struct {
-	ClientID       string            `codec:"clientID" json:"clientID"`
-	SubscriptionID string            `codec:"subscriptionID" json:"subscriptionID"`
-	Topic          SubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string            `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string          `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Topic           SubscriptionTopic `codec:"topic" json:"topic"`
 }
 
 type CreateTLFArg struct {

--- a/go/protocol/keybase1/notify_fs.go
+++ b/go/protocol/keybase1/notify_fs.go
@@ -43,12 +43,14 @@ type FSOnlineStatusChangedArg struct {
 }
 
 type FSSubscriptionNotifyPathArg struct {
+	ClientID       string                `codec:"clientID" json:"clientID"`
 	SubscriptionID string                `codec:"subscriptionID" json:"subscriptionID"`
 	Path           string                `codec:"path" json:"path"`
 	Topic          PathSubscriptionTopic `codec:"topic" json:"topic"`
 }
 
 type FSSubscriptionNotifyArg struct {
+	ClientID       string            `codec:"clientID" json:"clientID"`
 	SubscriptionID string            `codec:"subscriptionID" json:"subscriptionID"`
 	Topic          SubscriptionTopic `codec:"topic" json:"topic"`
 }

--- a/go/protocol/keybase1/notify_fs.go
+++ b/go/protocol/keybase1/notify_fs.go
@@ -43,16 +43,16 @@ type FSOnlineStatusChangedArg struct {
 }
 
 type FSSubscriptionNotifyPathArg struct {
-	ClientID       string                `codec:"clientID" json:"clientID"`
-	SubscriptionID string                `codec:"subscriptionID" json:"subscriptionID"`
-	Path           string                `codec:"path" json:"path"`
-	Topic          PathSubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string                  `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string                `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Path            string                  `codec:"path" json:"path"`
+	Topics          []PathSubscriptionTopic `codec:"topics" json:"topics"`
 }
 
 type FSSubscriptionNotifyArg struct {
-	ClientID       string            `codec:"clientID" json:"clientID"`
-	SubscriptionID string            `codec:"subscriptionID" json:"subscriptionID"`
-	Topic          SubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string            `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string          `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Topic           SubscriptionTopic `codec:"topic" json:"topic"`
 }
 
 type NotifyFSInterface interface {

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1852,6 +1852,7 @@ type SimpleFSGetFolderArg struct {
 }
 
 type SimpleFSGetOnlineStatusArg struct {
+	ClientID string `codec:"clientID" json:"clientID"`
 }
 
 type SimpleFSCheckReachabilityArg struct {
@@ -1889,6 +1890,7 @@ type SimpleFSGetStatsArg struct {
 
 type SimpleFSSubscribePathArg struct {
 	IdentifyBehavior          *TLFIdentifyBehavior  `codec:"identifyBehavior,omitempty" json:"identifyBehavior,omitempty"`
+	ClientID                  string                `codec:"clientID" json:"clientID"`
 	SubscriptionID            string                `codec:"subscriptionID" json:"subscriptionID"`
 	KbfsPath                  string                `codec:"kbfsPath" json:"kbfsPath"`
 	Topic                     PathSubscriptionTopic `codec:"topic" json:"topic"`
@@ -1897,6 +1899,7 @@ type SimpleFSSubscribePathArg struct {
 
 type SimpleFSSubscribeNonPathArg struct {
 	IdentifyBehavior          *TLFIdentifyBehavior `codec:"identifyBehavior,omitempty" json:"identifyBehavior,omitempty"`
+	ClientID                  string               `codec:"clientID" json:"clientID"`
 	SubscriptionID            string               `codec:"subscriptionID" json:"subscriptionID"`
 	Topic                     SubscriptionTopic    `codec:"topic" json:"topic"`
 	DeduplicateIntervalSecond int                  `codec:"deduplicateIntervalSecond" json:"deduplicateIntervalSecond"`
@@ -1904,6 +1907,7 @@ type SimpleFSSubscribeNonPathArg struct {
 
 type SimpleFSUnsubscribeArg struct {
 	IdentifyBehavior *TLFIdentifyBehavior `codec:"identifyBehavior,omitempty" json:"identifyBehavior,omitempty"`
+	ClientID         string               `codec:"clientID" json:"clientID"`
 	SubscriptionID   string               `codec:"subscriptionID" json:"subscriptionID"`
 }
 
@@ -2084,7 +2088,7 @@ type SimpleFSInterface interface {
 	SimpleFSSetFolderSyncConfig(context.Context, SimpleFSSetFolderSyncConfigArg) error
 	SimpleFSSyncConfigAndStatus(context.Context, *TLFIdentifyBehavior) (SyncConfigAndStatusRes, error)
 	SimpleFSGetFolder(context.Context, KBFSPath) (FolderWithFavFlags, error)
-	SimpleFSGetOnlineStatus(context.Context) (KbfsOnlineStatus, error)
+	SimpleFSGetOnlineStatus(context.Context, string) (KbfsOnlineStatus, error)
 	SimpleFSCheckReachability(context.Context) error
 	SimpleFSSetDebugLevel(context.Context, string) error
 	SimpleFSSettings(context.Context) (FSSettings, error)
@@ -2667,7 +2671,12 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					ret, err = i.SimpleFSGetOnlineStatus(ctx)
+					typedArgs, ok := args.(*[1]SimpleFSGetOnlineStatusArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSGetOnlineStatusArg)(nil), args)
+						return
+					}
+					ret, err = i.SimpleFSGetOnlineStatus(ctx, typedArgs[0].ClientID)
 					return
 				},
 			},
@@ -3356,8 +3365,9 @@ func (c SimpleFSClient) SimpleFSGetFolder(ctx context.Context, path KBFSPath) (r
 	return
 }
 
-func (c SimpleFSClient) SimpleFSGetOnlineStatus(ctx context.Context) (res KbfsOnlineStatus, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOnlineStatus", []interface{}{SimpleFSGetOnlineStatusArg{}}, &res, 0*time.Millisecond)
+func (c SimpleFSClient) SimpleFSGetOnlineStatus(ctx context.Context, clientID string) (res KbfsOnlineStatus, err error) {
+	__arg := SimpleFSGetOnlineStatusArg{ClientID: clientID}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOnlineStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -541,14 +541,14 @@ func (s *SimpleFSHandler) SimpleFSForceStuckConflict(
 
 // SimpleFSGetOnlineStatus implements the SimpleFSInterface.
 func (s *SimpleFSHandler) SimpleFSGetOnlineStatus(
-	ctx context.Context) (keybase1.KbfsOnlineStatus, error) {
+	ctx context.Context, clientID string) (keybase1.KbfsOnlineStatus, error) {
 	cli, err := s.client(ctx)
 	if err != nil {
 		return keybase1.KbfsOnlineStatus_OFFLINE, err
 	}
 	ctx, cancel := s.wrapContextWithTimeout(ctx)
 	defer cancel()
-	return cli.SimpleFSGetOnlineStatus(ctx)
+	return cli.SimpleFSGetOnlineStatus(ctx, clientID)
 }
 
 // SimpleFSCheckReachability implements the SimpleFSInterface.

--- a/protocol/avdl/keybase1/kbfs.avdl
+++ b/protocol/avdl/keybase1/kbfs.avdl
@@ -69,10 +69,10 @@ protocol kbfs {
   void FSFavoritesChangedEvent();
 
   @lint("ignore")
-  void FSSubscriptionNotifyPathEvent(string subscriptionID, string path,  PathSubscriptionTopic topic);
+  void FSSubscriptionNotifyPathEvent(string clientID, string subscriptionID, string path,  PathSubscriptionTopic topic);
 
   @lint("ignore")
-  void FSSubscriptionNotifyEvent(string subscriptionID, SubscriptionTopic topic);
+  void FSSubscriptionNotifyEvent(string clientID, string subscriptionID, SubscriptionTopic topic);
 
   /**
     createTLF is called by KBFS to associate the tlfID with the given teamID,

--- a/protocol/avdl/keybase1/kbfs.avdl
+++ b/protocol/avdl/keybase1/kbfs.avdl
@@ -69,10 +69,10 @@ protocol kbfs {
   void FSFavoritesChangedEvent();
 
   @lint("ignore")
-  void FSSubscriptionNotifyPathEvent(string clientID, string subscriptionID, string path,  PathSubscriptionTopic topic);
+  void FSSubscriptionNotifyPathEvent(string clientID, array<string> subscriptionIDs, string path, array<PathSubscriptionTopic> topics);
 
   @lint("ignore")
-  void FSSubscriptionNotifyEvent(string clientID, string subscriptionID, SubscriptionTopic topic);
+  void FSSubscriptionNotifyEvent(string clientID, array<string> subscriptionIDs, SubscriptionTopic topic);
 
   /**
     createTLF is called by KBFS to associate the tlfID with the given teamID,

--- a/protocol/avdl/keybase1/notify_fs.avdl
+++ b/protocol/avdl/keybase1/notify_fs.avdl
@@ -30,8 +30,8 @@ protocol NotifyFS {
   void FSOnlineStatusChanged(boolean online) oneway;
 
   @lint("ignore")
-  void FSSubscriptionNotifyPath(string subscriptionID, string path, PathSubscriptionTopic topic) oneway;
+  void FSSubscriptionNotifyPath(string clientID, string subscriptionID, string path, PathSubscriptionTopic topic) oneway;
 
   @lint("ignore")
-  void FSSubscriptionNotify(string subscriptionID, SubscriptionTopic topic) oneway;
+  void FSSubscriptionNotify(string clientID, string subscriptionID, SubscriptionTopic topic) oneway;
 }

--- a/protocol/avdl/keybase1/notify_fs.avdl
+++ b/protocol/avdl/keybase1/notify_fs.avdl
@@ -30,8 +30,8 @@ protocol NotifyFS {
   void FSOnlineStatusChanged(boolean online) oneway;
 
   @lint("ignore")
-  void FSSubscriptionNotifyPath(string clientID, string subscriptionID, string path, PathSubscriptionTopic topic) oneway;
+  void FSSubscriptionNotifyPath(string clientID, array<string> subscriptionIDs, string path, array<PathSubscriptionTopic> topics) oneway;
 
   @lint("ignore")
-  void FSSubscriptionNotify(string clientID, string subscriptionID, SubscriptionTopic topic) oneway;
+  void FSSubscriptionNotify(string clientID, array<string> subscriptionIDs, SubscriptionTopic topic) oneway;
 }

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -580,9 +580,23 @@ protocol SimpleFS {
     STAT_1
   }
 
-  // Caller needs to make sure subscriptionID is unique. Notifications are
-  // delivered through notify_fs.
-  void simpleFSSubscribePath(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID, string kbfsPath, PathSubscriptionTopic topic, int deduplicateIntervalSecond);
+  // Caller needs to make sure subscriptionID is unique.
+  //
+  // Notifications are delivered through notify_fs. It's OK to subscribe on the
+  // same thing multiple times as long as subscriptionIDs are unique.
+  //
+  // Caller should pass in a clientID that's consistent within a single run.
+  // For example, all GUI calls should use the same clientID that can be
+  // randomly generated when the app starts.
+  //
+  // ClientIDs are included in the notification so caller can verify if
+  // the notification is for them or not.
+  //
+  // We only keep subscriptions for up to 3 clientIDs, to avoid sending
+  // unnecessary notifications for dead clients.
+  void simpleFSSubscribePath(union{ null, TLFIdentifyBehavior }
+  identifyBehavior, string clientID, string subscriptionID, string kbfsPath,
+  PathSubscriptionTopic topic, int deduplicateIntervalSecond);
   void simpleFSSubscribeNonPath(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID, SubscriptionTopic topic, int deduplicateIntervalSecond);
 
   void simpleFSUnsubscribe(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID);

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -521,7 +521,7 @@ protocol SimpleFS {
     TRYING_1,
     ONLINE_2
   }
-  KbfsOnlineStatus simpleFSGetOnlineStatus();
+  KbfsOnlineStatus simpleFSGetOnlineStatus(string clientID);
 
   // This is called when GUI learns about a OS level network status change, and
   // causes mdserver_remote to check reachability with a Dial. Then it either
@@ -582,10 +582,10 @@ protocol SimpleFS {
 
   // Caller needs to make sure subscriptionID is unique. Notifications are
   // delivered through notify_fs.
-  void simpleFSSubscribePath(union{ null, TLFIdentifyBehavior } identifyBehavior, string subscriptionID, string kbfsPath, PathSubscriptionTopic topic, int deduplicateIntervalSecond);
-  void simpleFSSubscribeNonPath(union{ null, TLFIdentifyBehavior } identifyBehavior, string subscriptionID, SubscriptionTopic topic, int deduplicateIntervalSecond);
+  void simpleFSSubscribePath(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID, string kbfsPath, PathSubscriptionTopic topic, int deduplicateIntervalSecond);
+  void simpleFSSubscribeNonPath(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID, SubscriptionTopic topic, int deduplicateIntervalSecond);
 
-  void simpleFSUnsubscribe(union{ null, TLFIdentifyBehavior } identifyBehavior, string subscriptionID);
+  void simpleFSUnsubscribe(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID);
 
   record DownloadInfo {
     string downloadID;

--- a/protocol/json/keybase1/kbfs.json
+++ b/protocol/json/keybase1/kbfs.json
@@ -118,16 +118,22 @@
           "type": "string"
         },
         {
-          "name": "subscriptionID",
-          "type": "string"
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "path",
           "type": "string"
         },
         {
-          "name": "topic",
-          "type": "PathSubscriptionTopic"
+          "name": "topics",
+          "type": {
+            "type": "array",
+            "items": "PathSubscriptionTopic"
+          }
         }
       ],
       "response": null,
@@ -140,8 +146,11 @@
           "type": "string"
         },
         {
-          "name": "subscriptionID",
-          "type": "string"
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "topic",

--- a/protocol/json/keybase1/kbfs.json
+++ b/protocol/json/keybase1/kbfs.json
@@ -114,6 +114,10 @@
     "FSSubscriptionNotifyPathEvent": {
       "request": [
         {
+          "name": "clientID",
+          "type": "string"
+        },
+        {
           "name": "subscriptionID",
           "type": "string"
         },
@@ -131,6 +135,10 @@
     },
     "FSSubscriptionNotifyEvent": {
       "request": [
+        {
+          "name": "clientID",
+          "type": "string"
+        },
         {
           "name": "subscriptionID",
           "type": "string"

--- a/protocol/json/keybase1/notify_fs.json
+++ b/protocol/json/keybase1/notify_fs.json
@@ -107,16 +107,22 @@
           "type": "string"
         },
         {
-          "name": "subscriptionID",
-          "type": "string"
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "path",
           "type": "string"
         },
         {
-          "name": "topic",
-          "type": "PathSubscriptionTopic"
+          "name": "topics",
+          "type": {
+            "type": "array",
+            "items": "PathSubscriptionTopic"
+          }
         }
       ],
       "response": null,
@@ -130,8 +136,11 @@
           "type": "string"
         },
         {
-          "name": "subscriptionID",
-          "type": "string"
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "topic",

--- a/protocol/json/keybase1/notify_fs.json
+++ b/protocol/json/keybase1/notify_fs.json
@@ -103,6 +103,10 @@
     "FSSubscriptionNotifyPath": {
       "request": [
         {
+          "name": "clientID",
+          "type": "string"
+        },
+        {
           "name": "subscriptionID",
           "type": "string"
         },
@@ -121,6 +125,10 @@
     },
     "FSSubscriptionNotify": {
       "request": [
+        {
+          "name": "clientID",
+          "type": "string"
+        },
         {
           "name": "subscriptionID",
           "type": "string"

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1544,7 +1544,12 @@
       "response": "FolderWithFavFlags"
     },
     "simpleFSGetOnlineStatus": {
-      "request": [],
+      "request": [
+        {
+          "name": "clientID",
+          "type": "string"
+        }
+      ],
       "response": "KbfsOnlineStatus"
     },
     "simpleFSCheckReachability": {
@@ -1627,6 +1632,10 @@
           ]
         },
         {
+          "name": "clientID",
+          "type": "string"
+        },
+        {
           "name": "subscriptionID",
           "type": "string"
         },
@@ -1655,6 +1664,10 @@
           ]
         },
         {
+          "name": "clientID",
+          "type": "string"
+        },
+        {
           "name": "subscriptionID",
           "type": "string"
         },
@@ -1677,6 +1690,10 @@
             null,
             "TLFIdentifyBehavior"
           ]
+        },
+        {
+          "name": "clientID",
+          "type": "string"
         },
         {
           "name": "subscriptionID",

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -908,26 +908,37 @@ const unsubscribe = async (action: FsGen.UnsubscribePayload) => {
 }
 
 const onPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPathPayload) => {
-  const {clientID: clientIDFromNotification, path, topic} = action.payload.params
+  const {clientID: clientIDFromNotification, path, topics} = action.payload.params
   KB.debugConsoleLog({
     songgao: 'onPathChange',
     clientIDFromNotification,
-    subscriptionID: action.payload.params.subscriptionID,
+    subscriptionIDs: action.payload.params.subscriptionIDs,
     skip: clientIDFromNotification !== clientID,
+    topics,
+    path,
   })
   if (clientIDFromNotification !== clientID) {
     return
   }
-  switch (topic) {
-    case RPCTypes.PathSubscriptionTopic.children:
-      return FsGen.createFolderListLoad({path: Types.stringToPath(path), recursive: false})
-    case RPCTypes.PathSubscriptionTopic.stat:
-      return FsGen.createLoadPathMetadata({path: Types.stringToPath(path)})
-  }
+  return topics?.map(topic => {
+    switch (topic) {
+      case RPCTypes.PathSubscriptionTopic.children:
+        return FsGen.createFolderListLoad({path: Types.stringToPath(path), recursive: false})
+      case RPCTypes.PathSubscriptionTopic.stat:
+        return FsGen.createLoadPathMetadata({path: Types.stringToPath(path)})
+    }
+  })
 }
 
 const onNonPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPayload) => {
   const {clientID: clientIDFromNotification, topic} = action.payload.params
+  KB.debugConsoleLog({
+    songgao: 'onNonPathChange',
+    clientIDFromNotification,
+    subscriptionIDs: action.payload.params.subscriptionIDs,
+    skip: clientIDFromNotification !== clientID,
+    topic,
+  })
   if (clientIDFromNotification !== clientID) {
     return
   }

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -18,6 +18,8 @@ import {errorToActionOrThrow} from './shared'
 import {NotifyPopup} from '../../native/notifications'
 import {RPCError} from '../../util/errors'
 
+const clientID = Constants.makeUUID()
+
 const rpcFolderTypeToTlfType = (rpcFolderType: RPCTypes.FolderType) => {
   switch (rpcFolderType) {
     case RPCTypes.FolderType.private:
@@ -764,7 +766,7 @@ const finishManualCR = async (action: FsGen.FinishManualConflictResolutionPayloa
 // and we deserve a black bar.
 const checkIfWeReConnectedToMDServerUpToNTimes = async (n: number) => {
   try {
-    const onlineStatus = await RPCTypes.SimpleFSSimpleFSGetOnlineStatusRpcPromise()
+    const onlineStatus = await RPCTypes.SimpleFSSimpleFSGetOnlineStatusRpcPromise({clientID})
     return FsGen.createKbfsDaemonOnlineStatusChanged({onlineStatus})
   } catch (error) {
     if (n > 0) {
@@ -863,6 +865,7 @@ const subscriptionDeduplicateIntervalSecond = 1
 const subscribePath = async (action: FsGen.SubscribePathPayload) => {
   try {
     await RPCTypes.SimpleFSSimpleFSSubscribePathRpcPromise({
+      clientID,
       deduplicateIntervalSecond: subscriptionDeduplicateIntervalSecond,
       identifyBehavior: RPCTypes.TLFIdentifyBehavior.fsGui,
       kbfsPath: Types.pathToString(action.payload.path),
@@ -882,6 +885,7 @@ const subscribePath = async (action: FsGen.SubscribePathPayload) => {
 const subscribeNonPath = async (action: FsGen.SubscribeNonPathPayload) => {
   try {
     await RPCTypes.SimpleFSSimpleFSSubscribeNonPathRpcPromise({
+      clientID,
       deduplicateIntervalSecond: subscriptionDeduplicateIntervalSecond,
       identifyBehavior: RPCTypes.TLFIdentifyBehavior.fsGui,
       subscriptionID: action.payload.subscriptionID,
@@ -896,6 +900,7 @@ const subscribeNonPath = async (action: FsGen.SubscribeNonPathPayload) => {
 const unsubscribe = async (action: FsGen.UnsubscribePayload) => {
   try {
     await RPCTypes.SimpleFSSimpleFSUnsubscribeRpcPromise({
+      clientID,
       identifyBehavior: RPCTypes.TLFIdentifyBehavior.fsGui,
       subscriptionID: action.payload.subscriptionID,
     })
@@ -903,7 +908,16 @@ const unsubscribe = async (action: FsGen.UnsubscribePayload) => {
 }
 
 const onPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPathPayload) => {
-  const {path, topic} = action.payload.params
+  const {clientID: clientIDFromNotification, path, topic} = action.payload.params
+  KB.debugConsoleLog({
+    songgao: 'onPathChange',
+    clientIDFromNotification,
+    subscriptionID: action.payload.params.subscriptionID,
+    skip: clientIDFromNotification !== clientID,
+  })
+  if (clientIDFromNotification !== clientID) {
+    return
+  }
   switch (topic) {
     case RPCTypes.PathSubscriptionTopic.children:
       return FsGen.createFolderListLoad({path: Types.stringToPath(path), recursive: false})
@@ -913,7 +927,10 @@ const onPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPath
 }
 
 const onNonPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPayload) => {
-  const {topic} = action.payload.params
+  const {clientID: clientIDFromNotification, topic} = action.payload.params
+  if (clientIDFromNotification !== clientID) {
+    return
+  }
   switch (topic) {
     case RPCTypes.SubscriptionTopic.favorites:
       return FsGen.createFavoritesLoad()
@@ -1024,10 +1041,8 @@ const loadFilesTabBadge = async () => {
   return false
 }
 
-const userInOutClientKey = Constants.makeUUID()
-const userIn = () => RPCTypes.SimpleFSSimpleFSUserInRpcPromise({clientID: userInOutClientKey}).catch(() => {})
-const userOut = () =>
-  RPCTypes.SimpleFSSimpleFSUserOutRpcPromise({clientID: userInOutClientKey}).catch(() => {})
+const userIn = () => RPCTypes.SimpleFSSimpleFSUserInRpcPromise({clientID}).catch(() => {})
+const userOut = () => RPCTypes.SimpleFSSimpleFSUserOutRpcPromise({clientID}).catch(() => {})
 
 let fsBadgeSubscriptionID: string = ''
 

--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -909,16 +909,8 @@ const unsubscribe = async (action: FsGen.UnsubscribePayload) => {
 
 const onPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPathPayload) => {
   const {clientID: clientIDFromNotification, path, topics} = action.payload.params
-  KB.debugConsoleLog({
-    songgao: 'onPathChange',
-    clientIDFromNotification,
-    subscriptionIDs: action.payload.params.subscriptionIDs,
-    skip: clientIDFromNotification !== clientID,
-    topics,
-    path,
-  })
   if (clientIDFromNotification !== clientID) {
-    return
+    return null
   }
   return topics?.map(topic => {
     switch (topic) {
@@ -932,15 +924,8 @@ const onPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPath
 
 const onNonPathChange = (action: EngineGen.Keybase1NotifyFSFSSubscriptionNotifyPayload) => {
   const {clientID: clientIDFromNotification, topic} = action.payload.params
-  KB.debugConsoleLog({
-    songgao: 'onNonPathChange',
-    clientIDFromNotification,
-    subscriptionIDs: action.payload.params.subscriptionIDs,
-    skip: clientIDFromNotification !== clientID,
-    topic,
-  })
   if (clientIDFromNotification !== clientID) {
-    return
+    return null
   }
   switch (topic) {
     case RPCTypes.SubscriptionTopic.favorites:

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -100,11 +100,11 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.NotifyFS.FSSubscriptionNotify': {
-    inParam: {readonly clientID: String; readonly subscriptionID: String; readonly topic: SubscriptionTopic}
+    inParam: {readonly clientID: String; readonly subscriptionIDs?: Array<String> | null; readonly topic: SubscriptionTopic}
     outParam: void
   }
   'keybase.1.NotifyFS.FSSubscriptionNotifyPath': {
-    inParam: {readonly clientID: String; readonly subscriptionID: String; readonly path: String; readonly topic: PathSubscriptionTopic}
+    inParam: {readonly clientID: String; readonly subscriptionIDs?: Array<String> | null; readonly path: String; readonly topics?: Array<PathSubscriptionTopic> | null}
     outParam: void
   }
   'keybase.1.NotifyFS.FSSyncActivity': {

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -100,11 +100,11 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.NotifyFS.FSSubscriptionNotify': {
-    inParam: {readonly subscriptionID: String; readonly topic: SubscriptionTopic}
+    inParam: {readonly clientID: String; readonly subscriptionID: String; readonly topic: SubscriptionTopic}
     outParam: void
   }
   'keybase.1.NotifyFS.FSSubscriptionNotifyPath': {
-    inParam: {readonly subscriptionID: String; readonly path: String; readonly topic: PathSubscriptionTopic}
+    inParam: {readonly clientID: String; readonly subscriptionID: String; readonly path: String; readonly topic: PathSubscriptionTopic}
     outParam: void
   }
   'keybase.1.NotifyFS.FSSyncActivity': {
@@ -328,7 +328,7 @@ export type MessageTypes = {
     outParam: GUIFileContext
   }
   'keybase.1.SimpleFS.simpleFSGetOnlineStatus': {
-    inParam: void
+    inParam: {readonly clientID: String}
     outParam: KbfsOnlineStatus
   }
   'keybase.1.SimpleFS.simpleFSGetUploadStatus': {
@@ -404,11 +404,11 @@ export type MessageTypes = {
     outParam: Dirent
   }
   'keybase.1.SimpleFS.simpleFSSubscribeNonPath': {
-    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly subscriptionID: String; readonly topic: SubscriptionTopic; readonly deduplicateIntervalSecond: Int}
+    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly clientID: String; readonly subscriptionID: String; readonly topic: SubscriptionTopic; readonly deduplicateIntervalSecond: Int}
     outParam: void
   }
   'keybase.1.SimpleFS.simpleFSSubscribePath': {
-    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly subscriptionID: String; readonly kbfsPath: String; readonly topic: PathSubscriptionTopic; readonly deduplicateIntervalSecond: Int}
+    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly clientID: String; readonly subscriptionID: String; readonly kbfsPath: String; readonly topic: PathSubscriptionTopic; readonly deduplicateIntervalSecond: Int}
     outParam: void
   }
   'keybase.1.SimpleFS.simpleFSSyncConfigAndStatus': {
@@ -420,7 +420,7 @@ export type MessageTypes = {
     outParam: FSSyncStatus
   }
   'keybase.1.SimpleFS.simpleFSUnsubscribe': {
-    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly subscriptionID: String}
+    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly clientID: String; readonly subscriptionID: String}
     outParam: void
   }
   'keybase.1.SimpleFS.simpleFSUserEditHistory': {


### PR DESCRIPTION
Files in GUI duplicate notifications have two reasons:

1. In GUI we don't track subscription counts, but instead just subscribe wherever we need. So multiple places in GUI can subscribe to the same topic and we end up receiving multiple notifications for the same event.

2. If multiple GUI instances are running, or if GUI refreshes (thus reloading TS), we can end up with dead subscriptions inside the KBFS process since unsubscribe never happened for them. This one is mostly an issue for devs but still nice to fix.

This PR addresses both issues:

1. Introduce a `clientID: SubscriptionManagerClientID` in subscription manager. Instead of getting a `Subscriber`, we now have `SubscriptionManagerManager` inside `ConfigLocal`, and caller can use that to get a `SubscriptionManager` associated with a `SubscriptionManagerClientID`. The `SubscriptionManager` now has subscribe/unsubscribe methods. When getting a `SubscriptionManager`, one can specify whether it's purgeable (e.g. GUI) or not (e.g. the prefetcher). We only keep at most 3 purgeable `SubscriptionManager`s around. The `clientID` is included in the notifications so GUI can filter out those for other GUI instances, and not do anything.

2. Within a `SubscriptionManager`, i.e. same `clientID`, when an event happens and it has associated subscriptions, only one notification is sent. When the notification is sent, we include all `subscriptionID`s that match the event. Note that for path notifications, we send both "stat" and "children" events together in the same notification for now, since we don't differentiate them yet anyway.