### PR TITLE
Fix narrow scrollbar (#23102)

### DIFF
--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -235,7 +235,7 @@ body {
 }
 
 :root {
-  --scrollbar-size: 0.375rem;
+  --scrollbar-size: 0.750rem;
   --scrollbar-minlength: 0.5rem;
   --scrollbar-ff-width: thin;
   --scrollbar-track-color: transparent;


### PR DESCRIPTION
This commit doubles the width of the scrollbar. It is still slender, but rather easy to click.
Tested on Linux without issues.