### PR TITLE
poll on FolderBranch in SubMan for empty TLF

### DIFF
--- a/go/kbfs/libkbfs/subscription_manager.go
+++ b/go/kbfs/libkbfs/subscription_manager.go
@@ -351,8 +351,7 @@ func (sm *subscriptionManager) cancelAndDeleteFolderBranchPoller(
 }
 
 func (sm *subscriptionManager) pollOnFolderBranchForSubscribePathRequest(
-	ctx context.Context, loggingCtx context.Context,
-	req subscribePathRequest, parsedPath *parsedPath) {
+	ctx context.Context, req subscribePathRequest, parsedPath *parsedPath) {
 	ticker := time.NewTicker(folderBranchPollingInterval)
 	for {
 		select {
@@ -385,7 +384,7 @@ func (sm *subscriptionManager) pollOnFolderBranchForSubscribePathRequest(
 
 			err = sm.subscribePathWithFolderBranchLocked(req, parsedPath, fb)
 			if err != nil {
-				sm.log.CErrorf(loggingCtx,
+				sm.log.CErrorf(ctx,
 					"subscribePathWithFolderBranchLocked sid=%s err=%v", req.sid, err)
 			}
 
@@ -403,11 +402,10 @@ func (sm *subscriptionManager) pollOnFolderBranchForSubscribePathRequest(
 }
 
 func (sm *subscriptionManager) subscribePathWithoutFolderBranchLocked(
-	loggingCtx context.Context, req subscribePathRequest, parsedPath *parsedPath) {
+	req subscribePathRequest, parsedPath *parsedPath) {
 	ctx, cancel := context.WithCancel(context.Background())
 	sm.folderBranchPollerCancelers[req.sid] = cancel
-	go sm.pollOnFolderBranchForSubscribePathRequest(
-		ctx, loggingCtx, req, parsedPath)
+	go sm.pollOnFolderBranchForSubscribePathRequest(ctx, req, parsedPath)
 }
 
 // SubscribePath implements the SubscriptionManager interface.
@@ -434,7 +432,7 @@ func (sm *subscriptionManager) SubscribePath(ctx context.Context,
 	if fb != (data.FolderBranch{}) {
 		return sm.subscribePathWithFolderBranchLocked(req, parsedPath, fb)
 	}
-	sm.subscribePathWithoutFolderBranchLocked(ctx, req, parsedPath)
+	sm.subscribePathWithoutFolderBranchLocked(req, parsedPath)
 	return nil
 }
 

--- a/go/kbfs/libkbfs/subscription_manager.go
+++ b/go/kbfs/libkbfs/subscription_manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/client/go/kbfs/data"
 	"github.com/keybase/client/go/kbfs/tlfhandle"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -124,6 +125,7 @@ type nonPathSubscription struct {
 type subscriptionManager struct {
 	clientID SubscriptionManagerClientID
 	config   Config
+	log      logger.Logger
 	notifier SubscriptionNotifier
 
 	onlineStatusTracker *onlineStatusTracker
@@ -136,6 +138,7 @@ type subscriptionManager struct {
 	nonPathSubscriptionIDToTopic    map[SubscriptionID]keybase1.SubscriptionTopic
 	subscriptionIDs                 map[SubscriptionID]bool
 	subscriptionCountByFolderBranch map[data.FolderBranch]int
+	folderBranchPollerCancelers     map[SubscriptionID]context.CancelFunc
 }
 
 func (sm *subscriptionManager) notifyOnlineStatus() {
@@ -157,9 +160,11 @@ func newSubscriptionManager(clientID SubscriptionManagerClientID, config Config,
 		nonPathSubscriptionIDToTopic:    make(map[SubscriptionID]keybase1.SubscriptionTopic),
 		clientID:                        clientID,
 		config:                          config,
+		log:                             config.MakeLogger("SubMan"),
 		notifier:                        notifier,
 		subscriptionIDs:                 make(map[SubscriptionID]bool),
 		subscriptionCountByFolderBranch: make(map[data.FolderBranch]int),
+		folderBranchPollerCancelers:     make(map[SubscriptionID]context.CancelFunc),
 	}
 	sm.onlineStatusTracker = newOnlineStatusTracker(config, sm.notifyOnlineStatus)
 	return sm
@@ -277,41 +282,31 @@ func (sm *subscriptionManager) makeNonPathSubscriptionDebouncedNotify(
 	}, limit)
 }
 
-// SubscribePath implements the SubscriptionManager interface.
-func (sm *subscriptionManager) SubscribePath(ctx context.Context,
-	sid SubscriptionID, path string, topic keybase1.PathSubscriptionTopic,
-	deduplicateInterval *time.Duration) error {
-	parsedPath, err := parsePath(userPath(path))
-	if err != nil {
-		return err
-	}
-	fb, err := parsedPath.getFolderBranch(ctx, sm.config)
-	if err != nil {
-		return err
-	}
-	if fb == (data.FolderBranch{}) {
-		// ignore non-existent TLF.
-		// TODO: deal with this case HOTPOTP-501
-		return nil
-	}
-	nitp := getCleanInTlfPath(parsedPath)
+type subscribePathRequest struct {
+	sid                 SubscriptionID
+	path                string // original, uncleaned path from GUI
+	topic               keybase1.PathSubscriptionTopic
+	deduplicateInterval *time.Duration
+}
 
+func (sm *subscriptionManager) subscribePathWithFolderBranchLocked(
+	req subscribePathRequest,
+	parsedPath *parsedPath, fb data.FolderBranch) error {
+	nitp := getCleanInTlfPath(parsedPath)
 	ref := pathSubscriptionRef{
 		folderBranch: fb,
 		path:         nitp,
 	}
 
-	sm.lock.Lock()
-	defer sm.lock.Unlock()
-	subscriptionIDSetter, err := sm.checkSubscriptionIDLocked(sid)
+	subscriptionIDSetter, err := sm.checkSubscriptionIDLocked(req.sid)
 	if err != nil {
 		return err
 	}
 	sm.registerForChangesLocked(ref.folderBranch)
 
 	limit := rate.Inf
-	if deduplicateInterval != nil {
-		limit = rate.Every(*deduplicateInterval)
+	if req.deduplicateInterval != nil {
+		limit = rate.Every(*req.deduplicateInterval)
 	}
 	ps, ok := sm.pathSubscriptions[ref]
 	if !ok {
@@ -328,11 +323,118 @@ func (sm *subscriptionManager) SubscribePath(ctx context.Context,
 		ps.debouncedNotify.shutdown()
 		ps.debouncedNotify = sm.makePathSubscriptionDebouncedNotify(ref, limit)
 	}
-	ps.subscriptionIDs[sid] = topic
-	ps.pathsToNotify[path] = struct{}{}
+	ps.subscriptionIDs[req.sid] = req.topic
+	ps.pathsToNotify[req.path] = struct{}{}
 
-	sm.pathSubscriptionIDToRef[sid] = ref
+	sm.pathSubscriptionIDToRef[req.sid] = ref
 	subscriptionIDSetter()
+	return nil
+}
+
+const folderBranchPollingInterval = time.Second
+
+func (sm *subscriptionManager) cancelAndDeleteFolderBranchPollerLocked(
+	sid SubscriptionID) (deleted bool) {
+	if cancel, ok := sm.folderBranchPollerCancelers[sid]; ok {
+		cancel()
+		delete(sm.folderBranchPollerCancelers, sid)
+		return true
+	}
+	return false
+}
+
+func (sm *subscriptionManager) cancelAndDeleteFolderBranchPoller(
+	sid SubscriptionID) (deleted bool) {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+	return sm.cancelAndDeleteFolderBranchPollerLocked(sid)
+}
+
+func (sm *subscriptionManager) pollOnFolderBranchForSubscribePathRequest(
+	ctx context.Context, loggingCtx context.Context,
+	req subscribePathRequest, parsedPath *parsedPath) {
+	ticker := time.NewTicker(folderBranchPollingInterval)
+	for {
+		select {
+		case <-ticker.C:
+			fb, err := parsedPath.getFolderBranch(ctx, sm.config)
+			if err != nil {
+				_ = sm.cancelAndDeleteFolderBranchPoller(req.sid)
+				return
+			}
+
+			if fb == (data.FolderBranch{}) {
+				continue
+			}
+
+			// We have a folderBranch now! Go ahead and complete the
+			// sbuscription, and send a notification too.
+
+			sm.lock.Lock()
+			defer sm.lock.Unlock()
+			// Check if we're done while holding the lock to protect
+			// against racing against unsubscribe.
+			select {
+			case <-ctx.Done():
+				// No need to call cancelAndDeleteFolderBranchPollerLocked here
+				// since we always cancel and delete at the same tiem and if
+				// it's canceled it must have been deleted too.
+				return
+			default:
+			}
+
+			err = sm.subscribePathWithFolderBranchLocked(req, parsedPath, fb)
+			if err != nil {
+				sm.log.CErrorf(loggingCtx,
+					"subscribePathWithFolderBranchLocked sid=%s err=%v", req.sid, err)
+			}
+
+			sm.notifier.OnPathChange(
+				sm.clientID, []SubscriptionID{req.sid},
+				req.path, []keybase1.PathSubscriptionTopic{req.topic})
+
+			_ = sm.cancelAndDeleteFolderBranchPollerLocked(req.sid)
+			return
+		case <-ctx.Done():
+			_ = sm.cancelAndDeleteFolderBranchPoller(req.sid)
+			return
+		}
+	}
+}
+
+func (sm *subscriptionManager) subscribePathWithoutFolderBranchLocked(
+	loggingCtx context.Context, req subscribePathRequest, parsedPath *parsedPath) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sm.folderBranchPollerCancelers[req.sid] = cancel
+	go sm.pollOnFolderBranchForSubscribePathRequest(
+		ctx, loggingCtx, req, parsedPath)
+}
+
+// SubscribePath implements the SubscriptionManager interface.
+func (sm *subscriptionManager) SubscribePath(ctx context.Context,
+	sid SubscriptionID, path string, topic keybase1.PathSubscriptionTopic,
+	deduplicateInterval *time.Duration) error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	parsedPath, err := parsePath(userPath(path))
+	if err != nil {
+		return err
+	}
+	fb, err := parsedPath.getFolderBranch(ctx, sm.config)
+	if err != nil {
+		return err
+	}
+	req := subscribePathRequest{
+		sid:                 sid,
+		path:                path,
+		topic:               topic,
+		deduplicateInterval: deduplicateInterval,
+	}
+	if fb != (data.FolderBranch{}) {
+		return sm.subscribePathWithFolderBranchLocked(req, parsedPath, fb)
+	}
+	sm.subscribePathWithoutFolderBranchLocked(ctx, req, parsedPath)
 	return nil
 }
 
@@ -340,6 +442,10 @@ func (sm *subscriptionManager) SubscribePath(ctx context.Context,
 func (sm *subscriptionManager) SubscribeNonPath(
 	ctx context.Context, sid SubscriptionID, topic keybase1.SubscriptionTopic,
 	deduplicateInterval *time.Duration) error {
+	// Lock at the beginnning to protect against racing with unsubscribe. We
+	// could still endup lingering subscription if unsubscribe happens to fast
+	// and RPC somehow gives use the unsubscribe call before the subscribe
+	// call, but that's probably rare enough to ignore here.
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 	subscriptionIDSetter, err := sm.checkSubscriptionIDLocked(sid)
@@ -374,6 +480,12 @@ func (sm *subscriptionManager) SubscribeNonPath(
 
 func (sm *subscriptionManager) unsubscribePathLocked(
 	ctx context.Context, subscriptionID SubscriptionID) {
+	// First check if this is a subscription we don't yet have a folderBranch
+	// for.
+	if sm.cancelAndDeleteFolderBranchPollerLocked(subscriptionID) {
+		return
+	}
+
 	ref, ok := sm.pathSubscriptionIDToRef[subscriptionID]
 	if !ok {
 		return

--- a/go/kbfs/libkbfs/subscription_manager_test.go
+++ b/go/kbfs/libkbfs/subscription_manager_test.go
@@ -203,3 +203,43 @@ func TestSubscriptionManagerFavoritesChange(t *testing.T) {
 	t.Logf("Waiting for last notification (done1) before finishing the test.")
 	waiter1()
 }
+
+func TestSubscriptionManagerSubscribePathNoFolderBranch(t *testing.T) {
+	config, sm, notifier, finish := initSubscriptionManagerTest(t)
+	defer finish()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	ctx, err := libcontext.NewContextWithCancellationDelayer(
+		libcontext.NewContextReplayable(
+			ctx, func(c context.Context) context.Context {
+				return ctx
+			}))
+	require.NoError(t, err)
+
+	waiter0, done0 := waitForCall(t, 4*time.Second)
+
+	t.Logf("Subscribe to CHILDREN at TLF root using sid1, before we have a folderBranch. Then create a file. We should get a notification.")
+	sid1 := SubscriptionID("sid1")
+
+	err = sm.SubscribePath(ctx, sid1, "/keybase/private/jdoe",
+		keybase1.PathSubscriptionTopic_CHILDREN, nil)
+	require.NoError(t, err)
+	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
+		[]SubscriptionID{sid1}, "/keybase/private/jdoe",
+		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_CHILDREN}).AnyTimes().Do(done0)
+
+	tlfHandle, err := GetHandleFromFolderNameAndType(
+		ctx, config.KBPKI(), config.MDOps(), config, "jdoe", tlf.Private)
+	require.NoError(t, err)
+	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
+		ctx, tlfHandle, data.MasterBranch)
+	require.NoError(t, err)
+	_, _, err = config.KBFSOps().CreateFile(
+		ctx, rootNode, rootNode.ChildName("file"), false, NoExcl)
+	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
+
+	waiter0()
+}


### PR DESCRIPTION
When user goes into an empty TLF in GUI and upload something, it doesn't show any changes because the subscription manager can't register for changes with an empty FolderBranch. This PR fixes that by polling on trying to get FolderBranch for the TLF at a 1s interval while subscription is active, and make the subscription actually happen and send a notification as soon as it gets a FolderBranch.