### PR TITLE
disk_block_cache: move compaction to a loop, only do it when idle

### DIFF
--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2074,6 +2074,9 @@ type InitMode interface {
 	// DelayInitialConnect indicates whether the initial connection to KBFS
 	// servers should be delayed.
 	DelayInitialConnect() bool
+	// DiskCacheCompactionEnabled indicates whether the local disk
+	// block cache should trigger compaction automatically.
+	DiskCacheCompactionEnabled() bool
 
 	ldbutils.DbWriteBufferSizeGetter
 }

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -207,6 +207,10 @@ func (md modeDefault) DbWriteBufferSize() int {
 	return 10 * opt.MiB // 10 MB
 }
 
+func (md modeDefault) DiskCacheCompactionEnabled() bool {
+	return true
+}
+
 // Minimal mode:
 
 type modeMinimal struct {
@@ -389,6 +393,10 @@ func (mm modeMinimal) DbWriteBufferSize() int {
 	return 1 * opt.KiB // 1 KB
 }
 
+func (mm modeMinimal) DiskCacheCompactionEnabled() bool {
+	return false
+}
+
 // Single op mode:
 
 type modeSingleOp struct {
@@ -481,6 +489,10 @@ func (mso modeSingleOp) BackgroundWorkPeriod() time.Duration {
 
 func (mso modeSingleOp) IsSingleOp() bool {
 	return true
+}
+
+func (mso modeSingleOp) DiskCacheCompactionEnabled() bool {
+	return false
 }
 
 // Single-op mode with QR:
@@ -621,6 +633,10 @@ func (mc modeConstrained) DelayInitialConnect() bool {
 
 func (mc modeConstrained) DbWriteBufferSize() int {
 	return 100 * opt.KiB // 100 KB
+}
+
+func (mc modeConstrained) DiskCacheCompactionEnabled() bool {
+	return false
 }
 
 // Memory limited mode


### PR DESCRIPTION
Some users on slow systems were experiencing blocking, due to new behavior where the disk cache compacts the leveldbs immediately after a big delete (in order to save disk space).  Instead, move that compaction to a background thread that only triggers when the DB has been idle for 5 minutes.  A user could still get unlucky here of course, but it's much less likely to be disruptive.

And only do this on desktop, to avoid issues with compacting while the mobile app is backgrounded.

Issue: HOTPOT-2508