### PR TITLE
microphone stuck fixes

### DIFF
--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -105,7 +105,13 @@ const AudioRecorder = (props: Props) => {
       />
       {!visible ? null : (
         <Gateway into="convOverlay">
-          <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} style={styles.container}>
+          <Kb.Box2
+            direction="vertical"
+            fullHeight={true}
+            fullWidth={true}
+            style={styles.container}
+            pointerEvents="box-none"
+          >
             <AudioButton
               ampScale={ampScale}
               closeDown={closingDown}
@@ -415,6 +421,7 @@ const AudioSlideToCancel = (props: CancelProps) => {
     </Kb.NativeAnimated.View>
   ) : (
     <Kb.NativeAnimated.View
+      pointerEvents="none"
       style={{
         bottom: 35,
         opacity: props.translate,

--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -228,6 +228,7 @@ const AudioButton = (props: ButtonProps) => {
   return (
     <>
       <Kb.NativeAnimated.View
+        pointerEvents="box-none"
         style={{
           backgroundColor: Styles.globalColors.white,
           borderRadius: outerSize / 2,
@@ -421,7 +422,7 @@ const AudioSlideToCancel = (props: CancelProps) => {
     </Kb.NativeAnimated.View>
   ) : (
     <Kb.NativeAnimated.View
-      pointerEvents="none"
+      pointerEvents="box-none"
       style={{
         bottom: 35,
         opacity: props.translate,
@@ -439,7 +440,9 @@ const AudioSlideToCancel = (props: CancelProps) => {
     >
       <Kb.Box2 direction="horizontal" gap="tiny" centerChildren={true}>
         <Kb.Icon sizeType="Tiny" type="iconfont-arrow-left" />
-        <Kb.Text type="BodySmall">Slide to cancel</Kb.Text>
+        <Kb.Text type="BodySmall" onClick={props.onCancel}>
+          Slide to cancel
+        </Kb.Text>
       </Kb.Box2>
     </Kb.NativeAnimated.View>
   )

--- a/shared/chat/audio/audio-starter.native.tsx
+++ b/shared/chat/audio/audio-starter.native.tsx
@@ -90,6 +90,7 @@ const AudioStarter = (props: AudioStarterProps) => {
         <Tooltip shouldBeVisible={showToolTip} />
       </Gateway>
       <Kb.TapGestureHandler
+        shouldCancelWhenOutside={false}
         onHandlerStateChange={({nativeEvent}) => {
           if (!props.recording && nativeEvent.state === Kb.GestureState.BEGAN) {
             tapLive.current = true
@@ -131,6 +132,7 @@ const AudioStarter = (props: AudioStarterProps) => {
         simultaneousHandlers={panRef}
       >
         <Kb.PanGestureHandler
+          shouldCancelWhenOutside={false}
           minDeltaX={0}
           minDeltaY={0}
           onGestureEvent={({nativeEvent}) => {

--- a/shared/common-adapters/box.d.ts
+++ b/shared/common-adapters/box.d.ts
@@ -34,7 +34,7 @@ export type Box2Props = {
   onMouseUp?: (syntheticEvent: React.SyntheticEvent) => void // desktop only
   onMouseOver?: (syntheticEvent: React.SyntheticEvent) => void // desktop only
   onCopyCapture?: (syntheticEvent: React.SyntheticEvent) => void // desktop only
-  pointerEvents?: 'none'
+  pointerEvents?: 'none' | 'box-none'
   style?: StylesCrossPlatform
   gap?: keyof typeof globalMargins
   gapStart?: boolean

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -7,7 +7,7 @@ import noop from 'lodash/noop'
 const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 
 // Toggle this to disable yellowboxes
-console.disableYellowBox = false
+console.disableYellowBox = true
 //
 // Ignore some yellowboxes on 3rd party libs we can't control
 YellowBox.ignoreWarnings([

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -7,7 +7,7 @@ import noop from 'lodash/noop'
 const nativeBridge = NativeModules.KeybaseEngine || {test: 'fallback'}
 
 // Toggle this to disable yellowboxes
-console.disableYellowBox = true
+console.disableYellowBox = false
 //
 // Ignore some yellowboxes on 3rd party libs we can't control
 YellowBox.ignoreWarnings([


### PR DESCRIPTION
This doesn't fix this 100%. I think how it works currently is a little flakey but doing it a different way would be a much larger project which i don't think we should do now. I believe its mostly issues around gesture handling that launches things on top of itself and there being timing issues w/ lost taps.

This pr makes it harder to repro for me, mostly by turning off taps of things that don't need taps and additionally making the 'slide to cancel' text actually clickable so you can actually escape the state where its stuck thinking you're holding the tap down
