### PR TITLE
use sync nav state value instead of async state to solve races

### DIFF
--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -184,7 +184,10 @@ const LoggedInStackNavigator = createNavigator(
       Main: {screen: TabNavigator},
       ...Shim.shim(modalRoutes),
     },
-    {}
+    {
+      initialRouteKey: 'Main',
+      initialRouteName: 'Main',
+    }
   ),
   {}
 )
@@ -338,7 +341,7 @@ const createElectronApp = Component => {
     getNavState = () => this.navState || this.state.nav
 
     dispatchOldAction = (old: any) => {
-      const actions = Shared.oldActionToNewActions(old, this.navigation) || []
+      const actions = Shared.oldActionToNewActions(old, this.getNavState()) || []
       actions.forEach(a => this.dispatch(a))
     }
   }

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -185,7 +185,9 @@ const LoggedInStackNavigator = createNavigator(
       ...Shim.shim(modalRoutes),
     },
     {
+      // @ts-ignore
       initialRouteKey: 'Main',
+      // @ts-ignore
       initialRouteName: 'Main',
     }
   ),

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -306,6 +306,8 @@ const LoggedInStackNavigator = createStackNavigator(
     bgOnlyDuringTransition: Styles.isAndroid ? getBg : undefined,
     cardStyle: Styles.isAndroid ? {backgroundColor: 'rgba(0,0,0,0)'} : undefined,
     headerMode: 'none',
+    initialRouteKey: 'Main',
+    initialRouteName: 'Main',
     mode: 'modal',
   }
 )
@@ -349,14 +351,13 @@ const AppContainer = createAppContainer(RootStackNavigator)
 class RNApp extends React.PureComponent<Props> {
   private nav: any = null
 
-  // TODO remove this eventually, just so we can handle the old style actions
   dispatchOldAction = (old: any) => {
     const nav = this.nav
     if (!nav) {
       throw new Error('Missing nav?')
     }
 
-    const actions = Shared.oldActionToNewActions(old, nav._navigation) || []
+    const actions = Shared.oldActionToNewActions(old, this.getNavState()) || []
     try {
       actions.forEach(a => nav.dispatch(a))
     } catch (e) {
@@ -374,6 +375,11 @@ class RNApp extends React.PureComponent<Props> {
 
   getNavState = () => {
     const n = this.nav
+    // try the local internal state first, this should be synchronously correct
+    if (n._navState) {
+      return n._navState
+    }
+    // else fallback to the react state version
     return (n && n.state && n.state.nav) || null
   }
 


### PR DESCRIPTION
Changed how we plumb the navigation state around.
Internally navigation keeps a local version of the nav state in a var and uses setState to do rendering. When we dispatch it updates the state (like redux) but it doesn't really expose that value outside of itself. This is problematic as we investigate the state to make various decisions. 
Instead we use the internal var which should be correct regardless of react's async setState call

Additionally changed how clearModals works to just nav to the root of the Main logged in stack which we can use instead