### PR TITLE
PICNIC-1037 - Fix bages on tab icons being cut off on iPad

### DIFF
--- a/shared/common-adapters/badge.tsx
+++ b/shared/common-adapters/badge.tsx
@@ -19,7 +19,7 @@ export default class Badge extends React.Component<Badge2Props> {
   static defaultProps = {
     fontSize: Styles.isMobile ? 12 : 10,
     height: Styles.isMobile ? 20 : 16,
-    leftRightPadding: Styles.isMobile ? 5 : 4,
+    leftRightPadding: Styles.isTablet ? 4 : Styles.isMobile ? 5 : 4,
   }
 
   render() {

--- a/shared/common-adapters/badge.tsx
+++ b/shared/common-adapters/badge.tsx
@@ -19,7 +19,7 @@ export default class Badge extends React.Component<Badge2Props> {
   static defaultProps = {
     fontSize: Styles.isMobile ? 12 : 10,
     height: Styles.isMobile ? 20 : 16,
-    leftRightPadding: Styles.isTablet ? 4 : Styles.isMobile ? 5 : 4,
+    leftRightPadding: Styles.isPhone? 5 : 4,
   }
 
   render() {

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -270,13 +270,16 @@ const tabStyles = Styles.styleSheetCreate(
           right: 8,
           top: 3,
         },
+      }),
+      container: Styles.platformStyles({
+        common: {
+          justifyContent: 'center',
+        },
         isTablet: {
-          marginRight: Styles.globalMargins.tiny,
+          // This is to circumvent a React Navigation AnimatedComponent with minWidth: 64 that wraps TabBarIcon
+          minWidth: Styles.globalMargins.xlarge,
         },
       }),
-      container: {
-        justifyContent: 'center',
-      },
       label: {marginLeft: Styles.globalMargins.medium},
       labelDarkMode: {color: Styles.globalColors.black_50},
       labelDarkModeFocused: {color: Styles.globalColors.black},


### PR DESCRIPTION
This changes the styling on iPad to allow the badge number to grow correctly. It now behaves the same as on mobile devices.

cc @keybase/react-hackers @keybase/picnicsquad @cjb 

#### After

![image](https://user-images.githubusercontent.com/5200812/79994067-7f53c500-8483-11ea-816e-4aa50d0ec115.png)
![image](https://user-images.githubusercontent.com/5200812/79994107-8b3f8700-8483-11ea-850f-4e3108a36afb.png)
![image](https://user-images.githubusercontent.com/5200812/79994153-972b4900-8483-11ea-83f7-b091c969ca78.png)
![image](https://user-images.githubusercontent.com/5200812/79994193-a1e5de00-8483-11ea-80ac-b839bfe822c8.png)
