### PR TITLE
prefetcher: proxy wait channel requests while paused

### DIFF
--- a/go/kbfs/libkbfs/prefetcher_test.go
+++ b/go/kbfs/libkbfs/prefetcher_test.go
@@ -2371,6 +2371,14 @@ func TestPrefetcherCellularPause(t *testing.T) {
 	last = <-callCh
 	require.Equal(t, keybase1.MobileNetworkState_CELLULAR, last)
 
+	t.Log("Make sure we get a wait channel right away")
+	ptr := makeRandomBlockPointer(t)
+	ctx, cancel := context.WithTimeout(
+		context.Background(), individualTestTimeout)
+	defer cancel()
+	_, err := q.Prefetcher().WaitChannelForBlockPrefetch(ctx, ptr)
+	require.NoError(t, err)
+
 	t.Log("Unpause it to make it notify again")
 	stateCh <- keybase1.MobileNetworkState_NONE
 	notifySyncCh(t, prefetchSyncCh)


### PR DESCRIPTION
If the prefetcher is paused because it's on a cellular network, or the app has been backgrounded, we shouldn't block the "wait channel" requests indefinitely.  These are processed on the same queue as regular prefetch requests, and so can't be processed until we're unpaused.  But the caller is just asking for a channel they can wait on; they don't actually expect this call itself to block.

So if the prefetcher is paused, return a proxy channel that the caller can use, and launch a goroutine that will close this channel when the request is eventually processed.

I considered _always_ returning a proxy channel, but it seemed nice to still wait on `ctx.Done()` and the shutdown channel in the case where we expect the request to be processed quickly.

Issue: HOTPOT-2569