### PR TITLE
files: fix windows upload

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -417,7 +417,7 @@ const dismissDownload = (action: FsGen.DismissDownloadPayload) =>
 const upload = async (_: Container.TypedState, action: FsGen.UploadPayload) => {
   try {
     await RPCTypes.SimpleFSSimpleFSStartUploadRpcPromise({
-      sourceLocalPath: action.payload.localPath,
+      sourceLocalPath: Types.getNormalizedLocalPath(action.payload.localPath),
       targetParentPath: Constants.pathToRPCPath(action.payload.parentPath).kbfs,
     })
     return false
@@ -664,7 +664,9 @@ const moveOrCopy = async (state: Container.TypedState, action: FsGen.MovePayload
             overwriteExistingFiles: false,
             src: {
               PathType: RPCTypes.PathType.local,
-              local: Types.localPathToString(state.fs.destinationPicker.source.source),
+              local: Types.getNormalizedLocalPath(
+                Types.localPathToString(state.fs.destinationPicker.source.source)
+              ),
             } as RPCTypes.Path,
           },
         ]
@@ -683,10 +685,10 @@ const moveOrCopy = async (state: Container.TypedState, action: FsGen.MovePayload
             overwriteExistingFiles: false,
             src: {
               PathType: RPCTypes.PathType.local,
-              // @ts-ignore
-              local: state.fs.destinationPicker.source.useOriginal
-                ? originalPath
-                : scaledPath || originalPath,
+              local: Types.getNormalizedLocalPath(
+                // @ts-ignore
+                state.fs.destinationPicker.source.useOriginal ? originalPath : scaledPath || originalPath
+              ),
             } as RPCTypes.Path,
           }))
 

--- a/shared/constants/types/fs.tsx
+++ b/shared/constants/types/fs.tsx
@@ -681,6 +681,10 @@ export const getLocalPathName = (localPath: LocalPath): string => {
   return ''
 }
 export const getLocalPathDir = (p: LocalPath): string => p.slice(0, p.lastIndexOf(localSep))
+
+// SimpleFS always uses forward slashes for local paths. So we need to convert
+// them on Windows before sending over.
+// TODO: move this conversion to Go side
 export const getNormalizedLocalPath = (p: LocalPath): LocalPath =>
   localSep === '\\' ? p.replace(/\\/g, '/') : p
 


### PR DESCRIPTION
SimpleFS always uses forward slashes for local path even on Windows. So convert them before sending over to Go. In the future we should probably move this conversion to the Go side but this should be good enough for now.