### PR TITLE
Still add log-point if not changing role

### DIFF
--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -469,11 +469,6 @@ func (t TeamSigChainState) GetSubteamName(id keybase1.TeamID) (*keybase1.TeamNam
 // Must be called with seqno's and events in correct order.
 // Idempotent if called correctly.
 func (t *TeamSigChainState) inform(u keybase1.UserVersion, role keybase1.TeamRole, sigMeta keybase1.SignatureMetadata) {
-	currentRole := t.getUserRole(u)
-	if currentRole == role {
-		// no change in role, no new checkpoint needed
-		return
-	}
 	t.inner.UserLog[u] = append(t.inner.UserLog[u], keybase1.UserLogPoint{
 		Role:    role,
 		SigMeta: sigMeta,

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -2286,6 +2286,7 @@ func (t *teamSigchainPlayer) useInvites(stateToUpdate *TeamSigChainState, roleUp
 		return nil
 	}
 
+	seenUVs := make(map[keybase1.UserVersion]bool)
 	hasStubbedLinks := stateToUpdate.HasAnyStubbedLinks()
 	for _, pair := range used {
 		inviteID, err := pair.InviteID.TeamInviteID()
@@ -2341,6 +2342,11 @@ func (t *teamSigchainPlayer) useInvites(stateToUpdate *TeamSigChainState, roleUp
 			return fmt.Errorf("used_invite for UV %s that was not added as role %s", pair.UV,
 				inviteMD.Invite.Role.HumanString())
 		}
+
+		if seen := seenUVs[uv]; seen {
+			return fmt.Errorf("duplicate used_invite for UV %s", pair.UV)
+		}
+		seenUVs[uv] = true
 
 		// Because we use information from the UserLog here, useInvites should be called after
 		// updateMembership.

--- a/go/teams/chain.go
+++ b/go/teams/chain.go
@@ -467,7 +467,6 @@ func (t TeamSigChainState) GetSubteamName(id keybase1.TeamID) (*keybase1.TeamNam
 // Inform the UserLog and Bots of a user's role.
 // Mutates the UserLog and Bots.
 // Must be called with seqno's and events in correct order.
-// Idempotent if called correctly.
 func (t *TeamSigChainState) inform(u keybase1.UserVersion, role keybase1.TeamRole, sigMeta keybase1.SignatureMetadata) {
 	t.inner.UserLog[u] = append(t.inner.UserLog[u], keybase1.UserLogPoint{
 		Role:    role,

--- a/go/teams/implicit_test.go
+++ b/go/teams/implicit_test.go
@@ -398,17 +398,13 @@ func TestImplicitInvalidLinks(t *testing.T) {
 	teamObj, _, _, err := LookupOrCreateImplicitTeam(context.Background(), tcs[0].G, impteamName, false /*isPublic*/)
 	require.NoError(t, err)
 
-	RequirePrecheckError := func(err error) {
-		requirePrecheckError(t, err)
-	}
-
 	{
 		// Adding entirely new member should be illegal
 		req := keybase1.TeamChangeReq{
 			Owners: []keybase1.UserVersion{pam.GetUserVersion()},
 		}
 		err := teamObj.ChangeMembership(context.Background(), req)
-		RequirePrecheckError(err)
+		requirePrecheckError(t, err)
 	}
 
 	{
@@ -419,13 +415,13 @@ func TestImplicitInvalidLinks(t *testing.T) {
 			ID:   NewInviteID(),
 		}
 		err := teamObj.postInvite(context.Background(), invite, keybase1.TeamRole_OWNER)
-		RequirePrecheckError(err)
+		requirePrecheckError(t, err)
 	}
 
 	{
 		// Adding new social invite never works
 		_, err := teamObj.inviteSBSMember(context.Background(), ann.Username+"@rooter", keybase1.TeamRole_OWNER)
-		RequirePrecheckError(err)
+		requirePrecheckError(t, err)
 	}
 
 	{
@@ -434,7 +430,7 @@ func TestImplicitInvalidLinks(t *testing.T) {
 			None: []keybase1.UserVersion{bob.GetUserVersion()},
 		}
 		err := teamObj.ChangeMembership(context.Background(), req)
-		RequirePrecheckError(err)
+		requirePrecheckError(t, err)
 	}
 
 	{
@@ -442,7 +438,7 @@ func TestImplicitInvalidLinks(t *testing.T) {
 		invite, _, found := teamObj.FindActiveKeybaseInvite(cat.GetUID())
 		require.True(t, found)
 		err := removeInviteID(context.Background(), teamObj, invite.Id)
-		RequirePrecheckError(err)
+		requirePrecheckError(t, err)
 	}
 }
 

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -2075,17 +2075,24 @@ func TestTeamPlayerNoRoleChange(t *testing.T) {
 		teamSectionCM, me, nil /* merkleRoot */)
 	require.NoError(t, err)
 
-	require.Len(t, state.inner.UserLog[testUV], 1)
-	require.EqualValues(t, 2, state.inner.UserLog[testUV][0].SigMeta.SigChainLocation.Seqno)
+	userLog := state.inner.UserLog[testUV]
+	require.Len(t, userLog, 1)
+	require.Equal(t, keybase1.TeamRole_WRITER, userLog[0].Role)
+	require.EqualValues(t, 2, userLog[0].SigMeta.SigChainLocation.Seqno)
 
 	// Append the same link again: "change" Writer testUV to Writer.
 	state, err = appendSigToState(t, team, state, libkb.LinkTypeChangeMembership,
 		teamSectionCM, me, nil /* merkleRoot */)
 	require.NoError(t, err)
 
-	// That didn't change UserLog - no change in role, didn't add a checkpoint.
-	require.Len(t, state.inner.UserLog[testUV], 1)
-	require.EqualValues(t, 2, state.inner.UserLog[testUV][0].SigMeta.SigChainLocation.Seqno)
+	// That adds a new UserLog point with proper SigChainLocation, and the same
+	// role (writer).
+	userLog = state.inner.UserLog[testUV]
+	require.Len(t, userLog, 2)
+	for i, lp := range userLog {
+		require.Equal(t, keybase1.TeamRole_WRITER, lp.Role)
+		require.EqualValues(t, 2+i, lp.SigMeta.SigChainLocation.Seqno)
+	}
 }
 
 var rmMaker = func(assertion string) keybase1.TeamMemberToRemove {

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -2325,8 +2325,8 @@ func TestTeamPlayerIdempotentChangesAssertRole(t *testing.T) {
 	// Add Alice as a writer and Bob as an admin, in separate links.
 
 	memberLists := []*SCTeamMembers{
-		&SCTeamMembers{Writers: &[]SCTeamMember{SCTeamMember(uvAlice)}},
-		&SCTeamMembers{Admins: &[]SCTeamMember{SCTeamMember(uvBob)}},
+		{Writers: &[]SCTeamMember{SCTeamMember(uvAlice)}},
+		{Admins: &[]SCTeamMember{SCTeamMember(uvBob)}},
 	}
 
 	var err error


### PR DESCRIPTION
... fixes weird interaction with used_invites where it would store a log pointer to bad log point

i don't think `UserLog` should lie about latest sig-meta if there is a change_membership entry that doesn't change role

This PR also fixes an issue where there could be multiple used_invites row for same UserVersion.