### PR TITLE
Fix seitan handling when there are multiple acceptances for one uid

### DIFF
--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -142,6 +142,15 @@ func createAndSignupFakeUser(prefix string, g *libkb.GlobalContext, skipPaper bo
 	return fu, nil
 }
 
+func TCreateFakeUser(tc libkb.TestContext) *FakeUser {
+	Logout(tc)
+	// Not randomPW because these user's can't logout without setting a PW,
+	// and we do a lot of "switching" (logout-login) between users in tests.
+	user, err := createAndSignupFakeUser(tc.Tp.DevelPrefix, tc.G, true /* skipPaper */, keybase1.DeviceType_DESKTOP, false /* randomPW */)
+	require.NoError(tc.T, err)
+	return user
+}
+
 func GetContactSettings(tc libkb.TestContext, u *FakeUser) (ret keybase1.ContactSettings) {
 	m := libkb.NewMetaContextForTest(tc)
 	ret, err := libkb.GetContactSettings(m)

--- a/go/libkb/env.go
+++ b/go/libkb/env.go
@@ -215,6 +215,7 @@ type TestParameters struct {
 	// If we're in dev mode, the name for this test, with a random
 	// suffix.
 	DevelName                string
+	DevelPrefix              string // when in test - name for the test without suffix.
 	RuntimeDir               string
 	DisableUpgradePerUserKey bool
 	EnvironmentFeatureFlags  FeatureFlags

--- a/go/libkb/test_common.go
+++ b/go/libkb/test_common.go
@@ -217,6 +217,7 @@ func (tc TestContext) ClearAllStoredSecrets() error {
 	return nil
 }
 
+func (tc TestContext) Context() context.Context { return WithLogTag(context.Background(), "TST") }
 func (tc TestContext) MetaContext() MetaContext { return NewMetaContextForTest(tc) }
 
 var setupTestMu sync.Mutex
@@ -241,16 +242,17 @@ func setupTestContext(tb TestingTB, name string, tcPrev *TestContext) (tc TestCo
 	if _, err = rand.Read(buf); err != nil {
 		return
 	}
+
 	// Uniquify name, since multiple tests may use the same name.
-	name = fmt.Sprintf("%s_%s", name, hex.EncodeToString(buf))
+	develName := fmt.Sprintf("%s_%s", name, hex.EncodeToString(buf))
 
 	g.Init()
-	g.Log.Debug("SetupTest %s", name)
+	g.Log.Debug("SetupTest %s", develName)
 
 	// Set up our testing parameters.  We might add others later on
 	if tcPrev != nil {
 		tc.Tp = tcPrev.Tp
-	} else if tc.Tp.Home, err = ioutil.TempDir(os.TempDir(), name); err != nil {
+	} else if tc.Tp.Home, err = ioutil.TempDir(os.TempDir(), develName); err != nil {
 		return
 	}
 
@@ -262,7 +264,8 @@ func setupTestContext(tb TestingTB, name string, tcPrev *TestContext) (tc TestCo
 
 	tc.Tp.Debug = false
 	tc.Tp.Devel = true
-	tc.Tp.DevelName = name
+	tc.Tp.DevelName = develName
+	tc.Tp.DevelPrefix = name
 
 	g.Env.Test = tc.Tp
 

--- a/go/teams/invite_test.go
+++ b/go/teams/invite_test.go
@@ -94,14 +94,10 @@ func setupPuklessInviteTest(t *testing.T) (tc libkb.TestContext, owner, other *k
 
 	tc.Tp.DisableUpgradePerUserKey = true
 	tc.Tp.SkipSendingSystemChatMessages = true
-	other, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
-	err = tc.Logout()
-	require.NoError(t, err)
+	other = kbtest.TCreateFakeUser(tc)
 
 	tc.Tp.DisableUpgradePerUserKey = false
-	owner, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
+	owner = kbtest.TCreateFakeUser(tc)
 
 	teamname = createTeam(tc)
 
@@ -122,9 +118,7 @@ func TestKeybaseInviteAfterReset(t *testing.T) {
 	require.True(t, res.Invited)
 
 	// Reset account, should now have EldestSeqno=0
-	err = tc.Logout()
-	require.NoError(t, err)
-	require.NoError(t, other.Login(tc.G))
+	kbtest.LogoutAndLoginAs(tc, other)
 	kbtest.ResetAccount(tc, other)
 
 	// Try to remove member


### PR DESCRIPTION
E.g. you can accept multiple invite links in one team and we should get you in using one of them and reject everything else