### PR TITLE
folder_branch_ops: disable edit history prefetching by default

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -1395,6 +1395,7 @@ func (fbo *folderBranchOps) kickOffPartialSyncIfNeeded(
 		// using the recently-edited files list, storing the blocks in
 		// the working set cache.
 		if !fbo.config.Mode().TLFEditHistoryEnabled() ||
+			!fbo.config.Mode().EditHistoryPrefetchingEnabled() ||
 			fbo.config.Mode().DefaultBlockRequestAction() == BlockRequestSolo {
 			return
 		}
@@ -9710,6 +9711,10 @@ func (fbo *folderBranchOps) recomputeEditHistory(
 func (fbo *folderBranchOps) kickOffEditActivityPartialSync(
 	ctx context.Context, lState *kbfssync.LockState,
 	rmd ImmutableRootMetadata) (err error) {
+	if !fbo.config.Mode().EditHistoryPrefetchingEnabled() {
+		return
+	}
+
 	defer func() {
 		if err != nil {
 			fbo.log.CDebugf(

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -2077,6 +2077,9 @@ type InitMode interface {
 	// DiskCacheCompactionEnabled indicates whether the local disk
 	// block cache should trigger compaction automatically.
 	DiskCacheCompactionEnabled() bool
+	// EditHistoryPrefetchingEnabled indicates whether we should
+	// auto-prefetch the most recently-edited files.
+	EditHistoryPrefetchingEnabled() bool
 
 	ldbutils.DbWriteBufferSizeGetter
 }

--- a/go/kbfs/libkbfs/kbfs_ops_test.go
+++ b/go/kbfs/libkbfs/kbfs_ops_test.go
@@ -4931,12 +4931,21 @@ func TestKBFSOpsPartialSync(t *testing.T) {
 	checkStatus(fNode, NoPrefetch)
 }
 
+type modeTestWithPrefetch struct {
+	modeTest
+}
+
+func (mtwp modeTestWithPrefetch) EditHistoryPrefetchingEnabled() bool {
+	return true
+}
+
 func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(ctx, t, config, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.
-	config.SetMode(modeTest{NewInitModeFromType(InitDefault)})
+	config.SetMode(
+		modeTestWithPrefetch{modeTest{NewInitModeFromType(InitDefault)}})
 	config.SetVLogLevel(libkb.VLog2String)
 
 	name := "u1"
@@ -4956,7 +4965,8 @@ func TestKBFSOpsRecentHistorySync(t *testing.T) {
 	// config2 is the writer.
 	config2 := ConfigAsUser(config, u1)
 	defer CheckConfigAndShutdown(ctx, t, config2)
-	config2.SetMode(modeTest{NewInitModeFromType(InitDefault)})
+	config2.SetMode(
+		modeTestWithPrefetch{modeTest{NewInitModeFromType(InitDefault)}})
 	kbfsOps2 := config2.KBFSOps()
 
 	config.SetBlockServer(bserverPutToDiskCache{config.BlockServer(), dbc})

--- a/go/kbfs/libkbfs/modes.go
+++ b/go/kbfs/libkbfs/modes.go
@@ -211,6 +211,10 @@ func (md modeDefault) DiskCacheCompactionEnabled() bool {
 	return true
 }
 
+func (md modeDefault) EditHistoryPrefetchingEnabled() bool {
+	return false
+}
+
 // Minimal mode:
 
 type modeMinimal struct {
@@ -394,6 +398,10 @@ func (mm modeMinimal) DbWriteBufferSize() int {
 }
 
 func (mm modeMinimal) DiskCacheCompactionEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) EditHistoryPrefetchingEnabled() bool {
 	return false
 }
 


### PR DESCRIPTION
Now that we have explicit per-device syncing, we no longer need to pre-emptively prefetch recent files.