### PR TITLE
track the error on attempting to recover a corrupted leveldb instance

### DIFF
--- a/go/libkb/leveldb.go
+++ b/go/libkb/leveldb.go
@@ -166,11 +166,14 @@ func (l *LevelDb) doWhileOpenAndNukeIfCorrupted(action func() error) (err error)
 			l.db, err = leveldb.OpenFile(fn, l.Opts())
 			if _, ok := err.(*errors.ErrCorrupted); ok {
 				l.G().Log.Debug("| LevelDb was corrupted; attempting recovery (%v)", err)
-				l.db, err = leveldb.RecoverFile(fn, nil)
-				if err != nil {
-					l.G().Log.Debug("| Recovery failed: %v", err)
+				var recoveryError error
+				l.db, recoveryError = leveldb.RecoverFile(fn, nil)
+				if recoveryError != nil {
+					l.G().Log.Debug("| Recovery failed: %v", recoveryError)
 				} else {
 					l.G().Log.Debug("| Recovery succeeded!")
+					// wipe the outer error since it's fixed now
+					err = nil
 				}
 			}
 			l.G().Log.Debug("- LevelDb.open -> %s", ErrToOk(err))


### PR DESCRIPTION
a windows user got into a restart loop because their leveldb instance was corrupted, and the conditional nuking wasn't getting triggered. a failed attempt to recover was changing the error that should have triggered the nuke. 

## before
```
err = open()
if err == corrupted {
    err = recover()
}
if err == corrupted {
   db nuke
}
```

## after 
```
err = open()
if err == corrupted {
    err2 = recover()
    if recovered {
        err = nil
    }
}
if err == corrupted {
   db nuke
}
```

log id: 2c90231c869601231dfc2a1c