### PR TITLE
fix inbox join team button

### DIFF
--- a/shared/chat/inbox/row/build-team/index.tsx
+++ b/shared/chat/inbox/row/build-team/index.tsx
@@ -15,7 +15,6 @@ const BuildTeam = React.memo((_: {}) => {
     dispatch(TeamsGen.createLaunchNewTeamWizardOrModal())
   }
   const onJoinTeam = () => {
-    dispatch(RouteTreeGen.createSwitchTab({tab: teamsTab}))
     dispatch(nav.safeNavigateAppendPayload({path: ['teamJoinTeamDialog']}))
   }
 


### PR DESCRIPTION
The `safeNavigateAppend` would bail because the tab has switched. We should stay on the chat tab anyway (cc @cecileboucheron). cc @keybase/y2ksquad 