### PR TITLE
Fix push options in Settings->Notifications

### DIFF
--- a/shared/constants/types/settings.tsx
+++ b/shared/constants/types/settings.tsx
@@ -38,9 +38,23 @@ export type NotificationsSettingsState = {
   description: string
 }
 
+export type NotificationsGroupStateFromServer = {
+  notifications: {
+    [key: string]: {
+      settings: Array<{
+        description: string
+        description_h: string
+        name: string
+        subscribed: boolean
+      }>
+      unsub: boolean
+    }
+  }
+}
+
 export type NotificationsGroupState = {
   settings: Array<NotificationsSettingsState>
-  unsubscribedFromAll: boolean
+  unsub: boolean
 }
 
 export type NotificationSettingsStateGroups = Map<string, NotificationsGroupState>

--- a/shared/reducers/settings.tsx
+++ b/shared/reducers/settings.tsx
@@ -44,10 +44,10 @@ const notificationActions: Container.ActionHandler<Actions, Types.State> = {
 
     const groupMap = notifications.groups.get(group) ?? {
       settings: [],
-      unsubscribedFromAll: false,
+      unsub: false,
     }
 
-    const {settings, unsubscribedFromAll} = groupMap
+    const {settings, unsub} = groupMap
     if (!settings) {
       logger.warn('Trying to toggle unknown settings')
       return
@@ -57,7 +57,7 @@ const notificationActions: Container.ActionHandler<Actions, Types.State> = {
     notifications.groups.set(group, {
       settings: settings.map(s => updateSubscribe(s, group)),
       // No name means toggle the unsubscribe option
-      unsubscribedFromAll: !name && !unsubscribedFromAll,
+      unsub: !name && !unsub,
     })
   },
   [SettingsGen.notificationsSaved]: draftState => {

--- a/shared/settings/chat/index.stories.tsx
+++ b/shared/settings/chat/index.stories.tsx
@@ -45,6 +45,32 @@ const props = {
     openteam1: false,
   },
   contactSettingsTeamsEnabled: false,
+  groups: new Map([
+    [
+      'security',
+      {
+        settings: [
+          {
+            description: 'Show message content in phone chat notifications',
+            name: 'plaintextmobile',
+            subscribed: true,
+          },
+          {
+            description: 'Show message content in computer chat notifications',
+            name: 'plaintextdesktop',
+            subscribed: true,
+          },
+          {
+            description: "Show others when you're typing",
+            name: 'disabletyping',
+            subscribed: true,
+          },
+        ],
+        unsub: false,
+      },
+    ],
+  ]),
+  sound: false,
   teamMeta,
   unfurlMode: RPCChatTypes.UnfurlMode.whitelisted,
   unfurlWhitelist: [

--- a/shared/settings/notifications/index.stories.tsx
+++ b/shared/settings/notifications/index.stories.tsx
@@ -15,7 +15,7 @@ const props = {
             subscribed: true,
           },
         ],
-        unsubscribedFromAll: false,
+        unsub: false,
       },
     ],
     [
@@ -43,7 +43,7 @@ const props = {
             subscribed: true,
           },
         ],
-        unsubscribedFromAll: false,
+        unsub: false,
       },
     ],
   ]),
@@ -58,7 +58,7 @@ const props = {
 }
 
 const unsubProps = {...props}
-unsubProps.groups.get('email')!.unsubscribedFromAll = true
+unsubProps.groups.get('email')!.unsub = true
 
 const load = () => {
   Sb.storiesOf('Settings/Notifications', module)

--- a/shared/settings/notifications/render.tsx
+++ b/shared/settings/notifications/render.tsx
@@ -66,7 +66,7 @@ const EmailSection = (props: Props) => (
     title="Email notifications"
     unsub="mail"
     settings={props.groups.get('email')!.settings}
-    unsubscribedFromAll={props.groups.get('email')!.unsubscribedFromAll}
+    unsubscribedFromAll={props.groups.get('email')!.unsub}
   />
 )
 const PhoneSection = (props: Props) => (
@@ -79,7 +79,7 @@ const PhoneSection = (props: Props) => (
     title="Phone notifications"
     unsub="phone"
     settings={props.groups.get('app_push')!.settings}
-    unsubscribedFromAll={props.groups.get('app_push')!.unsubscribedFromAll}
+    unsubscribedFromAll={props.groups.get('app_push')!.unsub}
   />
 )
 const Notifications = (props: Props) =>


### PR DESCRIPTION
@keybase/react-hackers 

Back in November, Settings got an Immer refactor in #20953.  Before the refactor, the sections in the Settings->Notifications screen were server-driven -- the server sends down a list of sections of notifications and their options and they're rendered.

But this line of the PR: https://github.com/keybase/client/pull/20953/files#diff-ef032d2ad9f2d230105d31de06e2c974L326

.. changed the code from mapping over the server-driven sections to explicitly pulling out two sections only, "email" and "security".  That doesn't include "phone", so the push notifications options disappeared from the app.

The fix is to go back to mapping over the server payload.  Also, we can remove a map over `settingsToPayload()` by renaming `unsubscribedFromAll` to `unsub` in Redux and then using the server payload unmodified, this PR does that too.

Before and after screenshots:

<img width="1177" alt="Screen Shot 2020-04-24 at 3 22 36 PM" src="https://user-images.githubusercontent.com/21217/80262629-e5d31180-8642-11ea-8920-602b06d34025.png">

<img width="1177" alt="Screen Shot 2020-04-24 at 3 22 39 PM" src="https://user-images.githubusercontent.com/21217/80262635-ebc8f280-8642-11ea-8107-dce8a98a7374.png">
