### PR TITLE
bring back subman changes

### DIFF
--- a/go/client/cmd_show_notifications.go
+++ b/go/client/cmd_show_notifications.go
@@ -245,10 +245,10 @@ func (d *notificationDisplay) RuntimeStatsUpdate(
 }
 
 func (d *notificationDisplay) FSSubscriptionNotify(_ context.Context, arg keybase1.FSSubscriptionNotifyArg) error {
-	return d.printf("FS subscription notify: %s %s\n", arg.SubscriptionID, arg.Topic.String())
+	return d.printf("FS subscription notify: %v %s\n", arg.SubscriptionIDs, arg.Topic.String())
 }
 func (d *notificationDisplay) FSSubscriptionNotifyPath(_ context.Context, arg keybase1.FSSubscriptionNotifyPathArg) error {
-	return d.printf("FS subscription notify path: %s %q %s\n", arg.SubscriptionID, arg.Path, arg.Topic.String())
+	return d.printf("FS subscription notify path: %v %q %v\n", arg.SubscriptionIDs, arg.Path, arg.Topics)
 }
 func (d *notificationDisplay) IdentifyUpdate(_ context.Context, arg keybase1.IdentifyUpdateArg) error {
 	return d.printf("identify update: ok:%v broken:%v\n", arg.OkUsernames, arg.BrokenUsernames)

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -269,7 +269,7 @@ func (s SimpleFSMock) SimpleFSSyncConfigAndStatus(
 
 // SimpleFSGetOnlineStatus implements the SimpleFSInterface.
 func (s SimpleFSMock) SimpleFSGetOnlineStatus(
-	_ context.Context) (keybase1.KbfsOnlineStatus, error) {
+	_ context.Context, _ string) (keybase1.KbfsOnlineStatus, error) {
 	return keybase1.KbfsOnlineStatus_ONLINE, nil
 }
 

--- a/go/kbfs/libkbfs/block_ops_test.go
+++ b/go/kbfs/libkbfs/block_ops_test.go
@@ -135,7 +135,9 @@ func (config testBlockOpsConfig) GetSettingsDB() *SettingsDB {
 	return nil
 }
 
-func (config testBlockOpsConfig) SubscriptionManager() SubscriptionManager {
+func (config testBlockOpsConfig) SubscriptionManager(
+	_ SubscriptionManagerClientID, _ bool,
+	_ SubscriptionNotifier) SubscriptionManager {
 	return config.subscriptionManager
 }
 

--- a/go/kbfs/libkbfs/block_retrieval_queue_test.go
+++ b/go/kbfs/libkbfs/block_retrieval_queue_test.go
@@ -89,7 +89,9 @@ func (c testBlockRetrievalConfig) GetSettingsDB() *SettingsDB {
 	return nil
 }
 
-func (c testBlockRetrievalConfig) SubscriptionManager() SubscriptionManager {
+func (c testBlockRetrievalConfig) SubscriptionManager(
+	_ SubscriptionManagerClientID, _ bool,
+	_ SubscriptionNotifier) SubscriptionManager {
 	return c.subscriptionManager
 }
 

--- a/go/kbfs/libkbfs/config_local.go
+++ b/go/kbfs/libkbfs/config_local.go
@@ -1838,15 +1838,11 @@ func (c *ConfigLocal) SetDiskCacheMode(m DiskCacheMode) {
 func (c *ConfigLocal) SubscriptionManager(
 	clientID SubscriptionManagerClientID, purgeable bool,
 	notifier SubscriptionNotifier) SubscriptionManager {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	return c.subscriptionManagerManager.get(clientID, purgeable, notifier)
 }
 
 // SubscriptionManagerPublisher implements the Config interface.
 func (c *ConfigLocal) SubscriptionManagerPublisher() SubscriptionManagerPublisher {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	return c.subscriptionManagerManager
 }
 

--- a/go/kbfs/libkbfs/config_mock_test.go
+++ b/go/kbfs/libkbfs/config_mock_test.go
@@ -143,8 +143,8 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.mode = modeTest{NewInitModeFromType(InitDefault)}
 	config.conflictResolutionDB = openCRDB(config)
 
+	config.subscriptionManagerManager = newSubscriptionManagerManager(config)
 	config.mockSubscriptionManagerPublisher = NewMockSubscriptionManagerPublisher(gomock.NewController(ctr.t))
-	config.subscriptionManagerPublisher = config.mockSubscriptionManagerPublisher
 	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(
 		keybase1.SubscriptionTopic_FAVORITES).AnyTimes()
 	config.mockSubscriptionManagerPublisher.EXPECT().PublishChange(

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -145,10 +145,30 @@ type settingsDBGetter interface {
 	GetSettingsDB() *SettingsDB
 }
 
+// SubscriptionManagerClientID identifies a subscriptionManager client.
+type SubscriptionManagerClientID string
+
 type subscriptionManagerGetter interface {
 	// SubscriptionManager returns a subscription manager that can be used to
 	// subscribe to events.
-	SubscriptionManager() SubscriptionManager
+	//
+	// clientID identifies a subscriptionManager client. Each user of the
+	// subscription manager should specify a unique clientID. When a
+	// notification happens, the client ID is provided.
+	//
+	// This is helpful for caller to filter out notifications that other clients
+	// subscribe.
+	//
+	// If purgeable is true, the client is marked as purgeable. We keep a
+	// maximum of 3 purgeable clients (FIFO). This is useful as a way to purge
+	// old, likely dead, clients, which happens a lot with electron refreshes.
+	//
+	// notifier specifies how a notification should be delivered when things
+	// change. If different notifiers are used across multiple calls to get the
+	// subscription manager for the same clientID, only the first one is
+	// effective.
+	SubscriptionManager(clientID SubscriptionManagerClientID, purgeable bool,
+		notifier SubscriptionNotifier) SubscriptionManager
 }
 
 type subscriptionManagerPublisherGetter interface {
@@ -2105,14 +2125,31 @@ type SubscriptionID string
 // on subscribed topics.
 type SubscriptionNotifier interface {
 	// OnPathChange notifies about a change that's related to a specific path.
-	OnPathChange(subscriptionID SubscriptionID,
-		path string, topic keybase1.PathSubscriptionTopic)
-	// OnNonPathChange notifies about a change that's not related to a specific path.
-	OnNonPathChange(subscriptionID SubscriptionID,
+	// Multiple subscriptionIDs may be sent because a client can subscribe on
+	// the same path multiple times. In the future topics will become a single
+	// topic but we don't differeciate between the two topics for now so they
+	// are just sent together if both topics are subscribed.
+	OnPathChange(
+		clientID SubscriptionManagerClientID, subscriptionIDs []SubscriptionID,
+		path string, topics []keybase1.PathSubscriptionTopic)
+	// OnNonPathChange notifies about a change that's not related to a specific
+	// path.
+	OnNonPathChange(
+		clientID SubscriptionManagerClientID, subscriptionIDs []SubscriptionID,
 		topic keybase1.SubscriptionTopic)
 }
 
-// Subscriber defines a type that can be used to subscribe to different topic.
+// OnlineStatusTracker tracks the online status for the GUI.
+type OnlineStatusTracker interface {
+	GetOnlineStatus() keybase1.KbfsOnlineStatus
+	UserIn(ctx context.Context, clientKey string)
+	UserOut(ctx context.Context, clientKey string)
+}
+
+// SubscriptionManager manages subscriptions associated with one clientID.
+// Multiple subscribers can be used with the same SubscriptionManager.
+// If multiple subscriptions exist on the same topic (and for the same path, if
+// applicable), notifications are deduplicated.
 //
 // The two Subscribe methods are for path and non-path subscriptions
 // respectively. Notes on some common arguments:
@@ -2123,7 +2160,7 @@ type SubscriptionNotifier interface {
 //    debounce the events so it doesn't send more frequently than the interval.
 //    If deduplicateInterval is not set, i.e. nil, no deduplication is done and
 //    all events will be delivered.
-type Subscriber interface {
+type SubscriptionManager interface {
 	// SubscribePath subscribes to changes about path, when topic happens.
 	SubscribePath(
 		ctx context.Context, subscriptionID SubscriptionID,
@@ -2136,22 +2173,6 @@ type Subscriber interface {
 	// Unsubscribe unsubscribes a previsous subscription. The subscriptionID
 	// should be the same as when caller subscribed. Otherwise, it's a no-op.
 	Unsubscribe(context.Context, SubscriptionID)
-}
-
-// OnlineStatusTracker tracks the online status for the GUI.
-type OnlineStatusTracker interface {
-	GetOnlineStatus() keybase1.KbfsOnlineStatus
-	UserIn(ctx context.Context, clientKey string)
-	UserOut(ctx context.Context, clientKey string)
-}
-
-// SubscriptionManager manages subscriptions. Use the Subscriber interface to
-// subscribe and unsubscribe. Multiple subscribers can be used with the same
-// SubscriptionManager.
-type SubscriptionManager interface {
-	// Subscriber returns a new subscriber. All subscriptions made on this
-	// subscriber causes notifications sent through the give notifier here.
-	Subscriber(SubscriptionNotifier) Subscriber
 	// OnlineStatusTracker returns the OnlineStatusTracker for getting the
 	// current online status for GUI.
 	OnlineStatusTracker() OnlineStatusTracker

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -436,12 +436,15 @@ func (k *KeybaseDaemonLocal) PutGitMetadata(
 }
 
 // OnPathChange implements the SubscriptionNotifier interface.
-func (k *KeybaseDaemonLocal) OnPathChange(subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
+func (k *KeybaseDaemonLocal) OnPathChange(
+	clientID SubscriptionManagerClientID,
+	subscriptionIDs []SubscriptionID, path string, topics []keybase1.PathSubscriptionTopic) {
 }
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseDaemonLocal) OnNonPathChange(
-	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
+	clientID SubscriptionManagerClientID,
+	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
 }
 
 // Shutdown implements KeybaseDaemon for KeybaseDaemonLocal.

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -1227,13 +1227,19 @@ func (k *KeybaseServiceBase) NotifyFavoritesChanged(ctx context.Context) error {
 
 // OnPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseServiceBase) OnPathChange(
-	subscriptionID SubscriptionID, path string,
-	topic keybase1.PathSubscriptionTopic) {
+	clientID SubscriptionManagerClientID,
+	subscriptionIDs []SubscriptionID, path string,
+	topics []keybase1.PathSubscriptionTopic) {
+	subscriptionIDStrings := make([]string, 0, len(subscriptionIDs))
+	for _, sid := range subscriptionIDs {
+		subscriptionIDStrings = append(subscriptionIDStrings, string(sid))
+	}
 	err := k.kbfsClient.FSSubscriptionNotifyPathEvent(
 		context.Background(), keybase1.FSSubscriptionNotifyPathEventArg{
-			SubscriptionID: string(subscriptionID),
-			Path:           path,
-			Topic:          topic,
+			ClientID:        string(clientID),
+			SubscriptionIDs: subscriptionIDStrings,
+			Path:            path,
+			Topics:          topics,
 		})
 	if err != nil {
 		k.log.CDebugf(
@@ -1243,11 +1249,17 @@ func (k *KeybaseServiceBase) OnPathChange(
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k *KeybaseServiceBase) OnNonPathChange(
-	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
+	clientID SubscriptionManagerClientID,
+	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
+	subscriptionIDStrings := make([]string, 0, len(subscriptionIDs))
+	for _, sid := range subscriptionIDs {
+		subscriptionIDStrings = append(subscriptionIDStrings, string(sid))
+	}
 	err := k.kbfsClient.FSSubscriptionNotifyEvent(context.Background(),
 		keybase1.FSSubscriptionNotifyEventArg{
-			SubscriptionID: string(subscriptionID),
-			Topic:          topic,
+			ClientID:        string(clientID),
+			SubscriptionIDs: subscriptionIDStrings,
+			Topic:           topic,
 		})
 	if err != nil {
 		k.log.CDebugf(

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -376,17 +376,19 @@ func (k KeybaseServiceMeasured) PutGitMetadata(
 }
 
 // OnPathChange implements the SubscriptionNotifier interface.
-func (k KeybaseServiceMeasured) OnPathChange(subscriptionID SubscriptionID, path string, topic keybase1.PathSubscriptionTopic) {
+func (k KeybaseServiceMeasured) OnPathChange(clientID SubscriptionManagerClientID,
+	subscriptionIDs []SubscriptionID, path string, topics []keybase1.PathSubscriptionTopic) {
 	k.onPathChangeTimer.Time(func() {
-		k.delegate.OnPathChange(subscriptionID, path, topic)
+		k.delegate.OnPathChange(clientID, subscriptionIDs, path, topics)
 	})
 }
 
 // OnNonPathChange implements the SubscriptionNotifier interface.
 func (k KeybaseServiceMeasured) OnNonPathChange(
-	subscriptionID SubscriptionID, topic keybase1.SubscriptionTopic) {
+	clientID SubscriptionManagerClientID,
+	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
 	k.onChangeTimer.Time(func() {
-		k.delegate.OnNonPathChange(subscriptionID, topic)
+		k.delegate.OnNonPathChange(clientID, subscriptionIDs, topic)
 	})
 }
 

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -2504,27 +2504,27 @@ func (mr *MockKeybaseServiceMockRecorder) NotifySyncStatus(arg0, arg1 interface{
 }
 
 // OnNonPathChange mocks base method.
-func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionID, arg1 keybase1.SubscriptionTopic) {
+func (m *MockKeybaseService) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 keybase1.SubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1)
+	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1, arg2)
 }
 
 // OnNonPathChange indicates an expected call of OnNonPathChange.
-func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) OnNonPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnNonPathChange), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnNonPathChange), arg0, arg1, arg2)
 }
 
 // OnPathChange mocks base method.
-func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionID, arg1 string, arg2 keybase1.PathSubscriptionTopic) {
+func (m *MockKeybaseService) OnPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 string, arg3 []keybase1.PathSubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2)
+	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2, arg3)
 }
 
 // OnPathChange indicates an expected call of OnPathChange.
-func (mr *MockKeybaseServiceMockRecorder) OnPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKeybaseServiceMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnPathChange), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockKeybaseService)(nil).OnPathChange), arg0, arg1, arg2, arg3)
 }
 
 // PutGitMetadata mocks base method.
@@ -4335,27 +4335,27 @@ func (m *MockSubscriptionNotifier) EXPECT() *MockSubscriptionNotifierMockRecorde
 }
 
 // OnNonPathChange mocks base method.
-func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionID, arg1 keybase1.SubscriptionTopic) {
+func (m *MockSubscriptionNotifier) OnNonPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 keybase1.SubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1)
+	m.ctrl.Call(m, "OnNonPathChange", arg0, arg1, arg2)
 }
 
 // OnNonPathChange indicates an expected call of OnNonPathChange.
-func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSubscriptionNotifierMockRecorder) OnNonPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnNonPathChange), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNonPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnNonPathChange), arg0, arg1, arg2)
 }
 
 // OnPathChange mocks base method.
-func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionID, arg1 string, arg2 keybase1.PathSubscriptionTopic) {
+func (m *MockSubscriptionNotifier) OnPathChange(arg0 SubscriptionManagerClientID, arg1 []SubscriptionID, arg2 string, arg3 []keybase1.PathSubscriptionTopic) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2)
+	m.ctrl.Call(m, "OnPathChange", arg0, arg1, arg2, arg3)
 }
 
 // OnPathChange indicates an expected call of OnPathChange.
-func (mr *MockSubscriptionNotifierMockRecorder) OnPathChange(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockSubscriptionNotifierMockRecorder) OnPathChange(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnPathChange), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPathChange", reflect.TypeOf((*MockSubscriptionNotifier)(nil).OnPathChange), arg0, arg1, arg2, arg3)
 }
 
 // MockSubscriptionManagerPublisher is a mock of SubscriptionManagerPublisher interface.

--- a/go/kbfs/libkbfs/online_status_tracker.go
+++ b/go/kbfs/libkbfs/online_status_tracker.go
@@ -376,6 +376,9 @@ func (ost *onlineStatusTracker) run(ctx context.Context) {
 	}
 }
 
+// TODO: we now have clientID in the subscriptionManager so it's not necessary
+// anymore for onlineStatusTracker to track it.
+
 func (ost *onlineStatusTracker) userInOut(clientID string, clientIsIn bool) {
 	ost.lock.Lock()
 	wasIn := len(ost.userIsLooking) != 0

--- a/go/kbfs/libkbfs/subscription_manager_test.go
+++ b/go/kbfs/libkbfs/subscription_manager_test.go
@@ -203,3 +203,43 @@ func TestSubscriptionManagerFavoritesChange(t *testing.T) {
 	t.Logf("Waiting for last notification (done1) before finishing the test.")
 	waiter1()
 }
+
+func TestSubscriptionManagerSubscribePathNoFolderBranch(t *testing.T) {
+	config, sm, notifier, finish := initSubscriptionManagerTest(t)
+	defer finish()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	ctx, err := libcontext.NewContextWithCancellationDelayer(
+		libcontext.NewContextReplayable(
+			ctx, func(c context.Context) context.Context {
+				return ctx
+			}))
+	require.NoError(t, err)
+
+	waiter0, done0 := waitForCall(t, 4*time.Second)
+
+	t.Logf("Subscribe to CHILDREN at TLF root using sid1, before we have a folderBranch. Then create a file. We should get a notification.")
+	sid1 := SubscriptionID("sid1")
+
+	err = sm.SubscribePath(ctx, sid1, "/keybase/private/jdoe",
+		keybase1.PathSubscriptionTopic_CHILDREN, nil)
+	require.NoError(t, err)
+	notifier.EXPECT().OnPathChange(testSubscriptionManagerClientID,
+		[]SubscriptionID{sid1}, "/keybase/private/jdoe",
+		[]keybase1.PathSubscriptionTopic{keybase1.PathSubscriptionTopic_CHILDREN}).AnyTimes().Do(done0)
+
+	tlfHandle, err := GetHandleFromFolderNameAndType(
+		ctx, config.KBPKI(), config.MDOps(), config, "jdoe", tlf.Private)
+	require.NoError(t, err)
+	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
+		ctx, tlfHandle, data.MasterBranch)
+	require.NoError(t, err)
+	_, _, err = config.KBFSOps().CreateFile(
+		ctx, rootNode, rootNode.ChildName("file"), false, NoExcl)
+	require.NoError(t, err)
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	require.NoError(t, err)
+
+	waiter0()
+}

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -159,9 +159,7 @@ type SimpleFS struct {
 
 	localHTTPServer *libhttpserver.Server
 
-	subscriber libkbfs.Subscriber
-
-	onlineStatusTracker libkbfs.OnlineStatusTracker
+	subscriptionNotifier libkbfs.SubscriptionNotifier
 
 	downloadManager *downloadManager
 	uploadManager   *uploadManager
@@ -197,24 +195,26 @@ var _ libkbfs.SubscriptionNotifier = subscriptionNotifier{}
 
 // OnNonPathChange implements the libkbfs.SubscriptionNotifier interface.
 func (s subscriptionNotifier) OnPathChange(
-	subscriptionID libkbfs.SubscriptionID,
-	path string, topic keybase1.PathSubscriptionTopic) {
+	clientID libkbfs.SubscriptionManagerClientID,
+	subscriptionIDs []libkbfs.SubscriptionID,
+	path string, topics []keybase1.PathSubscriptionTopic) {
 	ks := s.config.KeybaseService()
 	if ks == nil {
 		return
 	}
-	ks.OnPathChange(subscriptionID, path, topic)
+	ks.OnPathChange(clientID, subscriptionIDs, path, topics)
 }
 
 // OnPathChange implements the libkbfs.SubscriptionNotifier interface.
 func (s subscriptionNotifier) OnNonPathChange(
-	subscriptionID libkbfs.SubscriptionID,
+	clientID libkbfs.SubscriptionManagerClientID,
+	subscriptionIDs []libkbfs.SubscriptionID,
 	topic keybase1.SubscriptionTopic) {
 	ks := s.config.KeybaseService()
 	if ks == nil {
 		return
 	}
-	ks.OnNonPathChange(subscriptionID, topic)
+	ks.OnNonPathChange(clientID, subscriptionIDs, topic)
 }
 
 func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *SimpleFS {
@@ -241,17 +241,16 @@ func newSimpleFS(appStateUpdater env.AppStateUpdater, config libkbfs.Config) *Si
 	k := &SimpleFS{
 		config: config,
 
-		handles:             map[keybase1.OpID]*handle{},
-		inProgress:          map[keybase1.OpID]*inprogress{},
-		log:                 log,
-		vlog:                config.MakeVLogger(log),
-		newFS:               defaultNewFS,
-		idd:                 libkbfs.NewImpatientDebugDumperForForcedDumps(config),
-		indexer:             indexer,
-		localHTTPServer:     localHTTPServer,
-		subscriber:          config.SubscriptionManager().Subscriber(subscriptionNotifier{config}),
-		onlineStatusTracker: config.SubscriptionManager().OnlineStatusTracker(),
-		httpClient:          &http.Client{},
+		handles:              map[keybase1.OpID]*handle{},
+		inProgress:           map[keybase1.OpID]*inprogress{},
+		log:                  log,
+		vlog:                 config.MakeVLogger(log),
+		newFS:                defaultNewFS,
+		idd:                  libkbfs.NewImpatientDebugDumperForForcedDumps(config),
+		indexer:              indexer,
+		localHTTPServer:      localHTTPServer,
+		subscriptionNotifier: subscriptionNotifier{config},
+		httpClient:           &http.Client{},
 	}
 	k.downloadManager = newDownloadManager(k)
 	k.uploadManager = newUploadManager(k)
@@ -2966,19 +2965,20 @@ func (k *SimpleFS) SimpleFSForceStuckConflict(
 }
 
 // SimpleFSGetOnlineStatus implements the SimpleFSInterface.
-func (k *SimpleFS) SimpleFSGetOnlineStatus(ctx context.Context) (keybase1.KbfsOnlineStatus, error) {
-	return k.onlineStatusTracker.GetOnlineStatus(), nil
+func (k *SimpleFS) SimpleFSGetOnlineStatus(
+	ctx context.Context, clientID string) (keybase1.KbfsOnlineStatus, error) {
+	return k.subscriptionManager(clientID).OnlineStatusTracker().GetOnlineStatus(), nil
 }
 
 // SimpleFSUserIn implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSUserIn(ctx context.Context, clientID string) error {
-	k.onlineStatusTracker.UserIn(ctx, clientID)
+	k.subscriptionManager(clientID).OnlineStatusTracker().UserIn(ctx, clientID)
 	return nil
 }
 
 // SimpleFSUserOut implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSUserOut(ctx context.Context, clientID string) error {
-	k.onlineStatusTracker.UserOut(ctx, clientID)
+	k.subscriptionManager(clientID).OnlineStatusTracker().UserOut(ctx, clientID)
 	return nil
 }
 
@@ -3172,6 +3172,13 @@ func (k *SimpleFS) SimpleFSGetStats(ctx context.Context) (
 	return res, nil
 }
 
+func (k *SimpleFS) subscriptionManager(
+	clientID string) libkbfs.SubscriptionManager {
+	return k.config.SubscriptionManager(
+		libkbfs.SubscriptionManagerClientID(clientID), true,
+		k.subscriptionNotifier)
+}
+
 // SimpleFSSubscribePath implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSSubscribePath(
 	ctx context.Context, arg keybase1.SimpleFSSubscribePathArg) (err error) {
@@ -3184,7 +3191,9 @@ func (k *SimpleFS) SimpleFSSubscribePath(
 		return err
 	}
 	interval := time.Second * time.Duration(arg.DeduplicateIntervalSecond)
-	return k.subscriber.SubscribePath(ctx, libkbfs.SubscriptionID(arg.SubscriptionID), arg.KbfsPath, arg.Topic, &interval)
+	return k.subscriptionManager(arg.ClientID).SubscribePath(
+		ctx, libkbfs.SubscriptionID(arg.SubscriptionID),
+		arg.KbfsPath, arg.Topic, &interval)
 }
 
 // SimpleFSSubscribeNonPath implements the SimpleFSInterface.
@@ -3195,7 +3204,8 @@ func (k *SimpleFS) SimpleFSSubscribeNonPath(
 		return err
 	}
 	interval := time.Second * time.Duration(arg.DeduplicateIntervalSecond)
-	return k.subscriber.SubscribeNonPath(ctx, libkbfs.SubscriptionID(arg.SubscriptionID), arg.Topic, &interval)
+	return k.subscriptionManager(arg.ClientID).SubscribeNonPath(
+		ctx, libkbfs.SubscriptionID(arg.SubscriptionID), arg.Topic, &interval)
 }
 
 // SimpleFSUnsubscribe implements the SimpleFSInterface.
@@ -3205,7 +3215,8 @@ func (k *SimpleFS) SimpleFSUnsubscribe(
 	if err != nil {
 		return err
 	}
-	k.subscriber.Unsubscribe(ctx, libkbfs.SubscriptionID(arg.SubscriptionID))
+	k.subscriptionManager(arg.ClientID).Unsubscribe(
+		ctx, libkbfs.SubscriptionID(arg.SubscriptionID))
 	return nil
 }
 

--- a/go/protocol/keybase1/kbfs.go
+++ b/go/protocol/keybase1/kbfs.go
@@ -53,14 +53,16 @@ type FSFavoritesChangedEventArg struct {
 }
 
 type FSSubscriptionNotifyPathEventArg struct {
-	SubscriptionID string                `codec:"subscriptionID" json:"subscriptionID"`
-	Path           string                `codec:"path" json:"path"`
-	Topic          PathSubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string                  `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string                `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Path            string                  `codec:"path" json:"path"`
+	Topics          []PathSubscriptionTopic `codec:"topics" json:"topics"`
 }
 
 type FSSubscriptionNotifyEventArg struct {
-	SubscriptionID string            `codec:"subscriptionID" json:"subscriptionID"`
-	Topic          SubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string            `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string          `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Topic           SubscriptionTopic `codec:"topic" json:"topic"`
 }
 
 type CreateTLFArg struct {

--- a/go/protocol/keybase1/notify_fs.go
+++ b/go/protocol/keybase1/notify_fs.go
@@ -43,14 +43,16 @@ type FSOnlineStatusChangedArg struct {
 }
 
 type FSSubscriptionNotifyPathArg struct {
-	SubscriptionID string                `codec:"subscriptionID" json:"subscriptionID"`
-	Path           string                `codec:"path" json:"path"`
-	Topic          PathSubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string                  `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string                `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Path            string                  `codec:"path" json:"path"`
+	Topics          []PathSubscriptionTopic `codec:"topics" json:"topics"`
 }
 
 type FSSubscriptionNotifyArg struct {
-	SubscriptionID string            `codec:"subscriptionID" json:"subscriptionID"`
-	Topic          SubscriptionTopic `codec:"topic" json:"topic"`
+	ClientID        string            `codec:"clientID" json:"clientID"`
+	SubscriptionIDs []string          `codec:"subscriptionIDs" json:"subscriptionIDs"`
+	Topic           SubscriptionTopic `codec:"topic" json:"topic"`
 }
 
 type NotifyFSInterface interface {

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1852,6 +1852,7 @@ type SimpleFSGetFolderArg struct {
 }
 
 type SimpleFSGetOnlineStatusArg struct {
+	ClientID string `codec:"clientID" json:"clientID"`
 }
 
 type SimpleFSCheckReachabilityArg struct {
@@ -1889,6 +1890,7 @@ type SimpleFSGetStatsArg struct {
 
 type SimpleFSSubscribePathArg struct {
 	IdentifyBehavior          *TLFIdentifyBehavior  `codec:"identifyBehavior,omitempty" json:"identifyBehavior,omitempty"`
+	ClientID                  string                `codec:"clientID" json:"clientID"`
 	SubscriptionID            string                `codec:"subscriptionID" json:"subscriptionID"`
 	KbfsPath                  string                `codec:"kbfsPath" json:"kbfsPath"`
 	Topic                     PathSubscriptionTopic `codec:"topic" json:"topic"`
@@ -1897,6 +1899,7 @@ type SimpleFSSubscribePathArg struct {
 
 type SimpleFSSubscribeNonPathArg struct {
 	IdentifyBehavior          *TLFIdentifyBehavior `codec:"identifyBehavior,omitempty" json:"identifyBehavior,omitempty"`
+	ClientID                  string               `codec:"clientID" json:"clientID"`
 	SubscriptionID            string               `codec:"subscriptionID" json:"subscriptionID"`
 	Topic                     SubscriptionTopic    `codec:"topic" json:"topic"`
 	DeduplicateIntervalSecond int                  `codec:"deduplicateIntervalSecond" json:"deduplicateIntervalSecond"`
@@ -1904,6 +1907,7 @@ type SimpleFSSubscribeNonPathArg struct {
 
 type SimpleFSUnsubscribeArg struct {
 	IdentifyBehavior *TLFIdentifyBehavior `codec:"identifyBehavior,omitempty" json:"identifyBehavior,omitempty"`
+	ClientID         string               `codec:"clientID" json:"clientID"`
 	SubscriptionID   string               `codec:"subscriptionID" json:"subscriptionID"`
 }
 
@@ -2084,7 +2088,7 @@ type SimpleFSInterface interface {
 	SimpleFSSetFolderSyncConfig(context.Context, SimpleFSSetFolderSyncConfigArg) error
 	SimpleFSSyncConfigAndStatus(context.Context, *TLFIdentifyBehavior) (SyncConfigAndStatusRes, error)
 	SimpleFSGetFolder(context.Context, KBFSPath) (FolderWithFavFlags, error)
-	SimpleFSGetOnlineStatus(context.Context) (KbfsOnlineStatus, error)
+	SimpleFSGetOnlineStatus(context.Context, string) (KbfsOnlineStatus, error)
 	SimpleFSCheckReachability(context.Context) error
 	SimpleFSSetDebugLevel(context.Context, string) error
 	SimpleFSSettings(context.Context) (FSSettings, error)
@@ -2667,7 +2671,12 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return &ret
 				},
 				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					ret, err = i.SimpleFSGetOnlineStatus(ctx)
+					typedArgs, ok := args.(*[1]SimpleFSGetOnlineStatusArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSGetOnlineStatusArg)(nil), args)
+						return
+					}
+					ret, err = i.SimpleFSGetOnlineStatus(ctx, typedArgs[0].ClientID)
 					return
 				},
 			},
@@ -3356,8 +3365,9 @@ func (c SimpleFSClient) SimpleFSGetFolder(ctx context.Context, path KBFSPath) (r
 	return
 }
 
-func (c SimpleFSClient) SimpleFSGetOnlineStatus(ctx context.Context) (res KbfsOnlineStatus, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOnlineStatus", []interface{}{SimpleFSGetOnlineStatusArg{}}, &res, 0*time.Millisecond)
+func (c SimpleFSClient) SimpleFSGetOnlineStatus(ctx context.Context, clientID string) (res KbfsOnlineStatus, err error) {
+	__arg := SimpleFSGetOnlineStatusArg{ClientID: clientID}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetOnlineStatus", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }
 

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -541,14 +541,14 @@ func (s *SimpleFSHandler) SimpleFSForceStuckConflict(
 
 // SimpleFSGetOnlineStatus implements the SimpleFSInterface.
 func (s *SimpleFSHandler) SimpleFSGetOnlineStatus(
-	ctx context.Context) (keybase1.KbfsOnlineStatus, error) {
+	ctx context.Context, clientID string) (keybase1.KbfsOnlineStatus, error) {
 	cli, err := s.client(ctx)
 	if err != nil {
 		return keybase1.KbfsOnlineStatus_OFFLINE, err
 	}
 	ctx, cancel := s.wrapContextWithTimeout(ctx)
 	defer cancel()
-	return cli.SimpleFSGetOnlineStatus(ctx)
+	return cli.SimpleFSGetOnlineStatus(ctx, clientID)
 }
 
 // SimpleFSCheckReachability implements the SimpleFSInterface.

--- a/protocol/avdl/keybase1/kbfs.avdl
+++ b/protocol/avdl/keybase1/kbfs.avdl
@@ -69,10 +69,10 @@ protocol kbfs {
   void FSFavoritesChangedEvent();
 
   @lint("ignore")
-  void FSSubscriptionNotifyPathEvent(string subscriptionID, string path,  PathSubscriptionTopic topic);
+  void FSSubscriptionNotifyPathEvent(string clientID, array<string> subscriptionIDs, string path, array<PathSubscriptionTopic> topics);
 
   @lint("ignore")
-  void FSSubscriptionNotifyEvent(string subscriptionID, SubscriptionTopic topic);
+  void FSSubscriptionNotifyEvent(string clientID, array<string> subscriptionIDs, SubscriptionTopic topic);
 
   /**
     createTLF is called by KBFS to associate the tlfID with the given teamID,

--- a/protocol/avdl/keybase1/notify_fs.avdl
+++ b/protocol/avdl/keybase1/notify_fs.avdl
@@ -30,8 +30,8 @@ protocol NotifyFS {
   void FSOnlineStatusChanged(boolean online) oneway;
 
   @lint("ignore")
-  void FSSubscriptionNotifyPath(string subscriptionID, string path, PathSubscriptionTopic topic) oneway;
+  void FSSubscriptionNotifyPath(string clientID, array<string> subscriptionIDs, string path, array<PathSubscriptionTopic> topics) oneway;
 
   @lint("ignore")
-  void FSSubscriptionNotify(string subscriptionID, SubscriptionTopic topic) oneway;
+  void FSSubscriptionNotify(string clientID, array<string> subscriptionIDs, SubscriptionTopic topic) oneway;
 }

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -521,7 +521,7 @@ protocol SimpleFS {
     TRYING_1,
     ONLINE_2
   }
-  KbfsOnlineStatus simpleFSGetOnlineStatus();
+  KbfsOnlineStatus simpleFSGetOnlineStatus(string clientID);
 
   // This is called when GUI learns about a OS level network status change, and
   // causes mdserver_remote to check reachability with a Dial. Then it either
@@ -580,12 +580,26 @@ protocol SimpleFS {
     STAT_1
   }
 
-  // Caller needs to make sure subscriptionID is unique. Notifications are
-  // delivered through notify_fs.
-  void simpleFSSubscribePath(union{ null, TLFIdentifyBehavior } identifyBehavior, string subscriptionID, string kbfsPath, PathSubscriptionTopic topic, int deduplicateIntervalSecond);
-  void simpleFSSubscribeNonPath(union{ null, TLFIdentifyBehavior } identifyBehavior, string subscriptionID, SubscriptionTopic topic, int deduplicateIntervalSecond);
+  // Caller needs to make sure subscriptionID is unique.
+  //
+  // Notifications are delivered through notify_fs. It's OK to subscribe on the
+  // same thing multiple times as long as subscriptionIDs are unique.
+  //
+  // Caller should pass in a clientID that's consistent within a single run.
+  // For example, all GUI calls should use the same clientID that can be
+  // randomly generated when the app starts.
+  //
+  // ClientIDs are included in the notification so caller can verify if
+  // the notification is for them or not.
+  //
+  // We only keep subscriptions for up to 3 clientIDs, to avoid sending
+  // unnecessary notifications for dead clients.
+  void simpleFSSubscribePath(union{ null, TLFIdentifyBehavior }
+  identifyBehavior, string clientID, string subscriptionID, string kbfsPath,
+  PathSubscriptionTopic topic, int deduplicateIntervalSecond);
+  void simpleFSSubscribeNonPath(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID, SubscriptionTopic topic, int deduplicateIntervalSecond);
 
-  void simpleFSUnsubscribe(union{ null, TLFIdentifyBehavior } identifyBehavior, string subscriptionID);
+  void simpleFSUnsubscribe(union{ null, TLFIdentifyBehavior } identifyBehavior, string clientID, string subscriptionID);
 
   record DownloadInfo {
     string downloadID;

--- a/protocol/json/keybase1/kbfs.json
+++ b/protocol/json/keybase1/kbfs.json
@@ -114,16 +114,26 @@
     "FSSubscriptionNotifyPathEvent": {
       "request": [
         {
-          "name": "subscriptionID",
+          "name": "clientID",
           "type": "string"
+        },
+        {
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "path",
           "type": "string"
         },
         {
-          "name": "topic",
-          "type": "PathSubscriptionTopic"
+          "name": "topics",
+          "type": {
+            "type": "array",
+            "items": "PathSubscriptionTopic"
+          }
         }
       ],
       "response": null,
@@ -132,8 +142,15 @@
     "FSSubscriptionNotifyEvent": {
       "request": [
         {
-          "name": "subscriptionID",
+          "name": "clientID",
           "type": "string"
+        },
+        {
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "topic",

--- a/protocol/json/keybase1/notify_fs.json
+++ b/protocol/json/keybase1/notify_fs.json
@@ -103,16 +103,26 @@
     "FSSubscriptionNotifyPath": {
       "request": [
         {
-          "name": "subscriptionID",
+          "name": "clientID",
           "type": "string"
+        },
+        {
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "path",
           "type": "string"
         },
         {
-          "name": "topic",
-          "type": "PathSubscriptionTopic"
+          "name": "topics",
+          "type": {
+            "type": "array",
+            "items": "PathSubscriptionTopic"
+          }
         }
       ],
       "response": null,
@@ -122,8 +132,15 @@
     "FSSubscriptionNotify": {
       "request": [
         {
-          "name": "subscriptionID",
+          "name": "clientID",
           "type": "string"
+        },
+        {
+          "name": "subscriptionIDs",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
         },
         {
           "name": "topic",

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1544,7 +1544,12 @@
       "response": "FolderWithFavFlags"
     },
     "simpleFSGetOnlineStatus": {
-      "request": [],
+      "request": [
+        {
+          "name": "clientID",
+          "type": "string"
+        }
+      ],
       "response": "KbfsOnlineStatus"
     },
     "simpleFSCheckReachability": {
@@ -1627,6 +1632,10 @@
           ]
         },
         {
+          "name": "clientID",
+          "type": "string"
+        },
+        {
           "name": "subscriptionID",
           "type": "string"
         },
@@ -1655,6 +1664,10 @@
           ]
         },
         {
+          "name": "clientID",
+          "type": "string"
+        },
+        {
           "name": "subscriptionID",
           "type": "string"
         },
@@ -1677,6 +1690,10 @@
             null,
             "TLFIdentifyBehavior"
           ]
+        },
+        {
+          "name": "clientID",
+          "type": "string"
         },
         {
           "name": "subscriptionID",

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -100,11 +100,11 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.NotifyFS.FSSubscriptionNotify': {
-    inParam: {readonly subscriptionID: String; readonly topic: SubscriptionTopic}
+    inParam: {readonly clientID: String; readonly subscriptionIDs?: Array<String> | null; readonly topic: SubscriptionTopic}
     outParam: void
   }
   'keybase.1.NotifyFS.FSSubscriptionNotifyPath': {
-    inParam: {readonly subscriptionID: String; readonly path: String; readonly topic: PathSubscriptionTopic}
+    inParam: {readonly clientID: String; readonly subscriptionIDs?: Array<String> | null; readonly path: String; readonly topics?: Array<PathSubscriptionTopic> | null}
     outParam: void
   }
   'keybase.1.NotifyFS.FSSyncActivity': {
@@ -328,7 +328,7 @@ export type MessageTypes = {
     outParam: GUIFileContext
   }
   'keybase.1.SimpleFS.simpleFSGetOnlineStatus': {
-    inParam: void
+    inParam: {readonly clientID: String}
     outParam: KbfsOnlineStatus
   }
   'keybase.1.SimpleFS.simpleFSGetUploadStatus': {
@@ -404,11 +404,11 @@ export type MessageTypes = {
     outParam: Dirent
   }
   'keybase.1.SimpleFS.simpleFSSubscribeNonPath': {
-    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly subscriptionID: String; readonly topic: SubscriptionTopic; readonly deduplicateIntervalSecond: Int}
+    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly clientID: String; readonly subscriptionID: String; readonly topic: SubscriptionTopic; readonly deduplicateIntervalSecond: Int}
     outParam: void
   }
   'keybase.1.SimpleFS.simpleFSSubscribePath': {
-    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly subscriptionID: String; readonly kbfsPath: String; readonly topic: PathSubscriptionTopic; readonly deduplicateIntervalSecond: Int}
+    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly clientID: String; readonly subscriptionID: String; readonly kbfsPath: String; readonly topic: PathSubscriptionTopic; readonly deduplicateIntervalSecond: Int}
     outParam: void
   }
   'keybase.1.SimpleFS.simpleFSSyncConfigAndStatus': {
@@ -420,7 +420,7 @@ export type MessageTypes = {
     outParam: FSSyncStatus
   }
   'keybase.1.SimpleFS.simpleFSUnsubscribe': {
-    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly subscriptionID: String}
+    inParam: {readonly identifyBehavior?: TLFIdentifyBehavior | null; readonly clientID: String; readonly subscriptionID: String}
     outParam: void
   }
   'keybase.1.SimpleFS.simpleFSUserEditHistory': {


### PR DESCRIPTION
Only the last commit is new. The first commits have already been reviewed.

The problem is `SubscriptionManager` calls `get` while holding lock, and inside the `get` call it calls other config methods that also need the lock. We never set `SubscriptionManager` once a config is created, so locking here isn't necessary.