### PR TITLE
Fix teamChangedByID notification with wrong seqno

### DIFF
--- a/go/chat/server_test.go
+++ b/go/chat/server_test.go
@@ -2219,7 +2219,9 @@ func (n *serverChatListener) ChatWelcomeMessageLoaded(teamID keybase1.TeamID,
 	_ chat1.WelcomeMessageDisplay) {
 	n.welcomeMessage <- teamID
 }
-func (n *serverChatListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno) {
+func (n *serverChatListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool,
+	changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno, source keybase1.TeamChangedSource) {
+
 	n.teamChangedByID <- keybase1.TeamChangedByIDArg{
 		TeamID:            teamID,
 		LatestSeqno:       latestSeqno,

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -369,7 +369,7 @@ type TeamNotifyListener struct {
 
 var _ libkb.NotifyListener = (*TeamNotifyListener)(nil)
 
-func (n *TeamNotifyListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno) {
+func (n *TeamNotifyListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno, source keybase1.TeamChangedSource) {
 	n.changeByIDCh <- keybase1.TeamChangedByIDArg{
 		TeamID:            teamID,
 		LatestSeqno:       latestSeqno,
@@ -378,7 +378,7 @@ func (n *TeamNotifyListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno
 		LatestHiddenSeqno: latestHiddenSeqno,
 	}
 }
-func (n *TeamNotifyListener) TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno) {
+func (n *TeamNotifyListener) TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet, latestHiddenSeqno keybase1.Seqno, source keybase1.TeamChangedSource) {
 	n.changeByNameCh <- keybase1.TeamChangedByNameArg{
 		TeamName:          teamName,
 		LatestSeqno:       latestSeqno,

--- a/go/protocol/keybase1/notify_team.go
+++ b/go/protocol/keybase1/notify_team.go
@@ -26,6 +26,35 @@ func (o TeamChangeSet) DeepCopy() TeamChangeSet {
 	}
 }
 
+type TeamChangedSource int
+
+const (
+	TeamChangedSource_SERVER       TeamChangedSource = 0
+	TeamChangedSource_LOCAL        TeamChangedSource = 1
+	TeamChangedSource_LOCAL_RENAME TeamChangedSource = 2
+)
+
+func (o TeamChangedSource) DeepCopy() TeamChangedSource { return o }
+
+var TeamChangedSourceMap = map[string]TeamChangedSource{
+	"SERVER":       0,
+	"LOCAL":        1,
+	"LOCAL_RENAME": 2,
+}
+
+var TeamChangedSourceRevMap = map[TeamChangedSource]string{
+	0: "SERVER",
+	1: "LOCAL",
+	2: "LOCAL_RENAME",
+}
+
+func (e TeamChangedSource) String() string {
+	if v, ok := TeamChangedSourceRevMap[e]; ok {
+		return v
+	}
+	return fmt.Sprintf("%v", int(e))
+}
+
 type AvatarUpdateType int
 
 const (
@@ -56,21 +85,23 @@ func (e AvatarUpdateType) String() string {
 }
 
 type TeamChangedByIDArg struct {
-	TeamID              TeamID        `codec:"teamID" json:"teamID"`
-	LatestSeqno         Seqno         `codec:"latestSeqno" json:"latestSeqno"`
-	ImplicitTeam        bool          `codec:"implicitTeam" json:"implicitTeam"`
-	Changes             TeamChangeSet `codec:"changes" json:"changes"`
-	LatestHiddenSeqno   Seqno         `codec:"latestHiddenSeqno" json:"latestHiddenSeqno"`
-	LatestOffchainSeqno Seqno         `codec:"latestOffchainSeqno" json:"latestOffchainSeqno"`
+	TeamID              TeamID            `codec:"teamID" json:"teamID"`
+	LatestSeqno         Seqno             `codec:"latestSeqno" json:"latestSeqno"`
+	ImplicitTeam        bool              `codec:"implicitTeam" json:"implicitTeam"`
+	Changes             TeamChangeSet     `codec:"changes" json:"changes"`
+	LatestHiddenSeqno   Seqno             `codec:"latestHiddenSeqno" json:"latestHiddenSeqno"`
+	LatestOffchainSeqno Seqno             `codec:"latestOffchainSeqno" json:"latestOffchainSeqno"`
+	Source              TeamChangedSource `codec:"source" json:"source"`
 }
 
 type TeamChangedByNameArg struct {
-	TeamName            string        `codec:"teamName" json:"teamName"`
-	LatestSeqno         Seqno         `codec:"latestSeqno" json:"latestSeqno"`
-	ImplicitTeam        bool          `codec:"implicitTeam" json:"implicitTeam"`
-	Changes             TeamChangeSet `codec:"changes" json:"changes"`
-	LatestHiddenSeqno   Seqno         `codec:"latestHiddenSeqno" json:"latestHiddenSeqno"`
-	LatestOffchainSeqno Seqno         `codec:"latestOffchainSeqno" json:"latestOffchainSeqno"`
+	TeamName            string            `codec:"teamName" json:"teamName"`
+	LatestSeqno         Seqno             `codec:"latestSeqno" json:"latestSeqno"`
+	ImplicitTeam        bool              `codec:"implicitTeam" json:"implicitTeam"`
+	Changes             TeamChangeSet     `codec:"changes" json:"changes"`
+	LatestHiddenSeqno   Seqno             `codec:"latestHiddenSeqno" json:"latestHiddenSeqno"`
+	LatestOffchainSeqno Seqno             `codec:"latestOffchainSeqno" json:"latestOffchainSeqno"`
+	Source              TeamChangedSource `codec:"source" json:"source"`
 }
 
 type TeamDeletedArg struct {

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -657,7 +657,7 @@ func TestEphemeralRotateSkipTeamEKRoll(t *testing.T) {
 	ann.addTeamMember(teamName.String(), bob.username, keybase1.TeamRole_WRITER)
 
 	bob.revokePaperKey()
-	ann.waitForRotateByID(teamID, keybase1.Seqno(3))
+	ann.waitForAnyRotateByID(teamID, keybase1.Seqno(2) /* toSeqno */, keybase1.Seqno(1) /* toHiddenSeqno */)
 	annMctx.G().SetEKLib(ekLib)
 
 	// Ensure that we access the old teamEK even though it was signed by a

--- a/go/systests/ephemeral_test.go
+++ b/go/systests/ephemeral_test.go
@@ -611,7 +611,7 @@ func runRotate(t *testing.T, createTeamEK bool) {
 	ann.addTeamMember(teamName.String(), bob.username, keybase1.TeamRole_WRITER)
 
 	bob.revokePaperKey()
-	ann.waitForRotateByID(teamID, keybase1.Seqno(3))
+	ann.waitForAnyRotateByID(teamID, keybase1.Seqno(2) /* toSeqno */, keybase1.Seqno(1) /* toHiddenSeqno */)
 
 	storage := annMctx.G().GetTeamEKBoxStorage()
 	teamEK, err := storage.Get(annMctx, teamID, expectedGeneration, nil)

--- a/go/systests/team_create_test.go
+++ b/go/systests/team_create_test.go
@@ -42,12 +42,13 @@ func testSubteamCreate(t *testing.T, joinSubteam bool) {
 		require.EqualValues(t, 1, teamObj.CurrentSeqno(), "expecting just one link in team")
 	} else {
 		require.Equal(t, keybase1.TeamRole_NONE, role, "role should be NONE")
-		// Expecting 3 links: subteam_head, leave, rotate_key
-		ann.waitForRotateByID(teamObj.ID, keybase1.Seqno(3))
+		// Expecting 2 links in main chain: subteam_head, leave
+		// And a link in hidden chain after leave: rotate_key
+		ann.waitForAnyRotateByID(teamObj.ID, keybase1.Seqno(2) /* toSeqno */, keybase1.Seqno(1) /* toHiddenSeqno */)
 	}
 }
 
 func TestSubteamCreate(t *testing.T) {
-	testSubteamCreate(t, false)
-	testSubteamCreate(t, true)
+	t.Run("just create", func(t *testing.T) { testSubteamCreate(t, false) })
+	t.Run("create and join", func(t *testing.T) { testSubteamCreate(t, true) })
 }

--- a/go/systests/team_tx_test.go
+++ b/go/systests/team_tx_test.go
@@ -249,7 +249,8 @@ func TestTeamTxSweepMembers(t *testing.T) {
 	t.Logf("Bob (%s) resets and reprovisions, he is now: %v", bob.username, bob.userVersion())
 
 	// Wait for CLKR and RotateKey link.
-	ann.waitForRotateByID(ann.loadTeam(team, false /* admin */).ID, keybase1.Seqno(3))
+	teamID := ann.loadTeam(team, false /* admin */).ID
+	ann.waitForAnyRotateByID(teamID, keybase1.Seqno(2) /* toSeqno */, keybase1.Seqno(1) /* toHiddenSeqno */)
 
 	teamObj := ann.loadTeam(team, true /* admin */)
 	tx := teams.CreateAddMemberTx(teamObj)

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -146,7 +146,7 @@ func TestTeamRotateOnRevoke(t *testing.T) {
 	tt.users[0].waitForTeamChangedGregor(teamID, keybase1.Seqno(2))
 
 	tt.users[1].revokePaperKey()
-	tt.users[0].waitForRotateByID(teamID, keybase1.Seqno(3))
+	tt.users[0].waitForAnyRotateByID(teamID, keybase1.Seqno(2) /* toSeqno */, keybase1.Seqno(1) /* toHiddenSeqno */)
 
 	// check that key was rotated for team
 	after, err := GetTeamForTestByStringName(context.TODO(), tt.users[0].tc.G, teamName.String())

--- a/go/systests/teams_test.go
+++ b/go/systests/teams_test.go
@@ -627,25 +627,28 @@ func (u *userPlusDevice) waitForAnyRotateByID(teamID keybase1.TeamID, toSeqno ke
 	// jump start the clkr queue processing loop
 	u.kickTeamRekeyd()
 
-	// process 10 team rotations or 10s worth of time
-	for i := 0; i < 10; i++ {
+	// process 20 team rotate notifications or 10s worth of time
+	timeout := time.After(10 * time.Second * libkb.CITimeMultiplier(u.tc.G))
+	for i := 0; i < 20; i++ {
 		select {
 		case arg := <-u.notifications.changeCh:
-			u.tc.T.Logf("rotate received: %+v", arg)
+			u.tc.T.Logf("rotate received: %s", spew.Sdump(arg))
 			if arg.TeamID.Eq(teamID) && arg.Changes.KeyRotated && arg.LatestSeqno == toSeqno && (toHiddenSeqno == keybase1.Seqno(0) || toHiddenSeqno == arg.LatestHiddenSeqno) {
 				u.tc.T.Logf("rotate matched!")
 				return
 			}
 			u.tc.T.Logf("ignoring rotate message")
-		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
+		case <-timeout:
+			require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
+			return
 		}
 	}
-	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
 }
 
 func (u *userPlusDevice) waitForTeamChangedAndRotated(teamID keybase1.TeamID, toSeqno keybase1.Seqno) {
-	// process 10 team rotations or 10s worth of time
-	for i := 0; i < 10; i++ {
+	// process 20 team rotate notifications or 10s worth of time
+	timeout := time.After(10 * time.Second * libkb.CITimeMultiplier(u.tc.G))
+	for i := 0; i < 20; i++ {
 		select {
 		case arg := <-u.notifications.changeCh:
 			u.tc.T.Logf("membership change received: %+v", arg)
@@ -654,10 +657,11 @@ func (u *userPlusDevice) waitForTeamChangedAndRotated(teamID keybase1.TeamID, to
 				return
 			}
 			u.tc.T.Logf("ignoring change message (expected team = %v, seqno = %d)", teamID, toSeqno)
-		case <-time.After(1 * time.Second * libkb.CITimeMultiplier(u.tc.G)):
+		case <-timeout:
+			require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
+			return
 		}
 	}
-	require.Fail(u.tc.T, fmt.Sprintf("timed out waiting for team rotate %s", teamID))
 }
 
 func (u *userPlusDevice) waitForTeamChangeRenamed(teamID keybase1.TeamID) {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -273,7 +273,8 @@ func handleChangeSingle(ctx context.Context, g *libkb.GlobalContext, row keybase
 	}
 	// Send teamID and teamName in two separate notifications. It is
 	// server-trust that they are the same team.
-	g.NotifyRouter.HandleTeamChangedByBothKeys(ctx, row.Id, row.Name, row.LatestSeqno, row.ImplicitTeam, change, row.LatestHiddenSeqno, row.LatestOffchainSeqno)
+	g.NotifyRouter.HandleTeamChangedByBothKeys(ctx, row.Id, row.Name, row.LatestSeqno, row.ImplicitTeam, change,
+		row.LatestHiddenSeqno, row.LatestOffchainSeqno, keybase1.TeamChangedSource_SERVER)
 
 	// Note we only get updates about new subteams we create because the flow
 	// is that we join the team as an admin when we create them and then

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1032,11 +1032,11 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		// Send a notification if we used to have the name cached and it has changed at all.
 		changeSet := keybase1.TeamChangeSet{Renamed: true}
 		go l.G().NotifyRouter.HandleTeamChangedByID(context.Background(), chain.GetID(), chain.GetLatestSeqno(),
-			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
+			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL_RENAME)
 		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(), cachedName.String(), chain.GetLatestSeqno(),
-			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
+			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL_RENAME)
 		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(), newName.String(), chain.GetLatestSeqno(),
-			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
+			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL_RENAME)
 	}
 
 	// Check request constraints

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -1031,12 +1031,12 @@ func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (
 		chain := TeamSigChainState{inner: ret.Chain, hidden: hiddenPackage.ChainData()}
 		// Send a notification if we used to have the name cached and it has changed at all.
 		changeSet := keybase1.TeamChangeSet{Renamed: true}
-		go l.G().NotifyRouter.HandleTeamChangedByID(context.Background(),
-			chain.GetID(), chain.GetLatestSeqno(), chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0))
-		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(),
-			cachedName.String(), chain.GetLatestSeqno(), chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0))
-		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(),
-			newName.String(), chain.GetLatestSeqno(), chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0))
+		go l.G().NotifyRouter.HandleTeamChangedByID(context.Background(), chain.GetID(), chain.GetLatestSeqno(),
+			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
+		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(), cachedName.String(), chain.GetLatestSeqno(),
+			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
+		go l.G().NotifyRouter.HandleTeamChangedByName(context.Background(), newName.String(), chain.GetLatestSeqno(),
+			chain.IsImplicit(), changeSet, chain.GetLatestHiddenSeqno(), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
 	}
 
 	// Check request constraints

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -2677,7 +2677,7 @@ func (t *Team) notify(ctx context.Context, changes keybase1.TeamChangeSet, lates
 	if latestSeqno > 0 {
 		err = HintLatestSeqno(m, t.ID, latestSeqno)
 	}
-	t.G().NotifyRouter.HandleTeamChangedByBothKeys(ctx, t.ID, t.Name().String(), t.NextSeqno(), t.IsImplicit(), changes, keybase1.Seqno(0), keybase1.Seqno(0))
+	t.G().NotifyRouter.HandleTeamChangedByBothKeys(ctx, t.ID, t.Name().String(), latestSeqno, t.IsImplicit(), changes, keybase1.Seqno(0), keybase1.Seqno(0))
 	return err
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -2662,7 +2662,7 @@ func (t *Team) AssociateWithTLFID(ctx context.Context, tlfID keybase1.TLFID) (er
 }
 
 func (t *Team) notifyNoChainChange(ctx context.Context, changes keybase1.TeamChangeSet) error {
-	return t.notify(ctx, changes, keybase1.Seqno(0))
+	return t.notify(ctx, changes, t.CurrentSeqno())
 }
 
 // Send notifyrouter messages.
@@ -2677,7 +2677,8 @@ func (t *Team) notify(ctx context.Context, changes keybase1.TeamChangeSet, lates
 	if latestSeqno > 0 {
 		err = HintLatestSeqno(m, t.ID, latestSeqno)
 	}
-	t.G().NotifyRouter.HandleTeamChangedByBothKeys(ctx, t.ID, t.Name().String(), latestSeqno, t.IsImplicit(), changes, keybase1.Seqno(0), keybase1.Seqno(0))
+	t.G().NotifyRouter.HandleTeamChangedByBothKeys(ctx, t.ID, t.Name().String(), latestSeqno, t.IsImplicit(),
+		changes, keybase1.Seqno(0), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
 	return err
 }
 

--- a/go/teams/teams.go
+++ b/go/teams/teams.go
@@ -738,7 +738,9 @@ func (t *Team) rotatePostHidden(ctx context.Context, section SCTeamSection, mr *
 		mctx.Warning("Failed to ratchet forward team chain: %s", tmp.Error())
 	}
 
-	// We rotated the key but didn't change the visibile chain
+	// We rotated the key but didn't change the visibile chain.
+	// TODO: We should be able to send a local notification here with
+	// new hidden chain seqno.
 	return t.notifyNoChainChange(ctx, keybase1.TeamChangeSet{KeyRotated: true})
 }
 
@@ -2678,7 +2680,7 @@ func (t *Team) notify(ctx context.Context, changes keybase1.TeamChangeSet, lates
 		err = HintLatestSeqno(m, t.ID, latestSeqno)
 	}
 	t.G().NotifyRouter.HandleTeamChangedByBothKeys(ctx, t.ID, t.Name().String(), latestSeqno, t.IsImplicit(),
-		changes, keybase1.Seqno(0), keybase1.Seqno(0), keybase1.TeamChangedSource_LOCAL)
+		changes, keybase1.Seqno(0) /* hiddenSeqno */, keybase1.Seqno(0) /* offchainSeqno */, keybase1.TeamChangedSource_LOCAL)
 	return err
 }
 

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -1246,9 +1246,10 @@ func (tx *AddMemberTx) Post(mctx libkb.MetaContext) (err error) {
 		return err
 	}
 
+	// nextSeqno-1 should be the sequence number of last link that we sent.
 	err = team.notify(mctx.Ctx(), keybase1.TeamChangeSet{MembershipChanged: true}, nextSeqno-1)
 	if err != nil {
-		return err
+		mctx.Warning("Failed to send team change notification: %s", err)
 	}
 
 	team.storeTeamEKPayload(mctx.Ctx(), teamEKPayload)

--- a/protocol/avdl/keybase1/notify_team.avdl
+++ b/protocol/avdl/keybase1/notify_team.avdl
@@ -17,6 +17,14 @@ protocol NotifyTeam {
     boolean misc;
   }
 
+  // These notifications either come from API server through gregor,
+  // or are spawned locally when a team change is being made.
+  enum TeamChangedSource {
+    SERVER_0,
+    LOCAL_1,
+    LOCAL_RENAME_2 // local notification sent when subteam rename is detected
+  }
+
   // All fields are unverified
   void teamChangedByID(
     TeamID teamID,
@@ -24,7 +32,8 @@ protocol NotifyTeam {
     boolean implicitTeam,
     TeamChangeSet changes,
     Seqno latestHiddenSeqno,
-    Seqno latestOffchainSeqno
+    Seqno latestOffchainSeqno,
+    TeamChangedSource source
   ) oneway;
 
   // All fields are unverified
@@ -34,7 +43,8 @@ protocol NotifyTeam {
     boolean implicitTeam,
     TeamChangeSet changes,
     Seqno latestHiddenSeqno,
-    Seqno latestOffchainSeqno
+    Seqno latestOffchainSeqno,
+    TeamChangedSource source
   ) oneway;
 
   void teamDeleted(TeamID teamID) oneway;

--- a/protocol/json/keybase1/notify_team.json
+++ b/protocol/json/keybase1/notify_team.json
@@ -31,6 +31,15 @@
     },
     {
       "type": "enum",
+      "name": "TeamChangedSource",
+      "symbols": [
+        "SERVER_0",
+        "LOCAL_1",
+        "LOCAL_RENAME_2"
+      ]
+    },
+    {
+      "type": "enum",
       "name": "AvatarUpdateType",
       "symbols": [
         "NONE_0",
@@ -65,6 +74,10 @@
         {
           "name": "latestOffchainSeqno",
           "type": "Seqno"
+        },
+        {
+          "name": "source",
+          "type": "TeamChangedSource"
         }
       ],
       "response": null,
@@ -95,6 +108,10 @@
         {
           "name": "latestOffchainSeqno",
           "type": "Seqno"
+        },
+        {
+          "name": "source",
+          "type": "TeamChangedSource"
         }
       ],
       "response": null,

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1046,6 +1046,8 @@ function* setPublicity(state: TypedState, action: TeamsGen.SetPublicityPayload) 
 
 const teamChangedByID = (state: TypedState, action: EngineGen.Keybase1NotifyTeamTeamChangedByIDPayload) => {
   const {teamID, latestHiddenSeqno, latestOffchainSeqno, latestSeqno} = action.payload.params
+  // Any of the Seqnos can be 0, which means that it was unknown at the source
+  // at the time when this notification was generated.
   const version = state.teams.teamVersion.get(teamID)
   let versionChanged = true
   if (version) {
@@ -1055,11 +1057,6 @@ const teamChangedByID = (state: TypedState, action: EngineGen.Keybase1NotifyTeam
       latestSeqno > version.latestSeqno
   }
   const shouldLoad = versionChanged && !!state.teams.teamDetailsSubscriptionCount.get(teamID)
-  console.log('zzz', 'teamChangedByID', action.payload.params)
-  console.log('zzz', 'known', version)
-  console.log('zzz', 'subs:', state.teams.teamDetailsSubscriptionCount)
-  console.log('zzz', 'changed:', versionChanged, 'should load', shouldLoad)
-  console.log('zzz -------')
   return [
     TeamsGen.createSetTeamVersion({teamID, version: {latestHiddenSeqno, latestOffchainSeqno, latestSeqno}}),
     shouldLoad && TeamsGen.createLoadTeam({teamID}),

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1055,6 +1055,11 @@ const teamChangedByID = (state: TypedState, action: EngineGen.Keybase1NotifyTeam
       latestSeqno > version.latestSeqno
   }
   const shouldLoad = versionChanged && !!state.teams.teamDetailsSubscriptionCount.get(teamID)
+  console.log('zzz', 'teamChangedByID', action.payload.params)
+  console.log('zzz', 'known', version)
+  console.log('zzz', 'subs:', state.teams.teamDetailsSubscriptionCount)
+  console.log('zzz', 'changed:', versionChanged, 'should load', shouldLoad)
+  console.log('zzz -------')
   return [
     TeamsGen.createSetTeamVersion({teamID, version: {latestHiddenSeqno, latestOffchainSeqno, latestSeqno}}),
     shouldLoad && TeamsGen.createLoadTeam({teamID}),

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -196,11 +196,11 @@ export type MessageTypes = {
     outParam: void
   }
   'keybase.1.NotifyTeam.teamChangedByID': {
-    inParam: {readonly teamID: TeamID; readonly latestSeqno: Seqno; readonly implicitTeam: Boolean; readonly changes: TeamChangeSet; readonly latestHiddenSeqno: Seqno; readonly latestOffchainSeqno: Seqno}
+    inParam: {readonly teamID: TeamID; readonly latestSeqno: Seqno; readonly implicitTeam: Boolean; readonly changes: TeamChangeSet; readonly latestHiddenSeqno: Seqno; readonly latestOffchainSeqno: Seqno; readonly source: TeamChangedSource}
     outParam: void
   }
   'keybase.1.NotifyTeam.teamChangedByName': {
-    inParam: {readonly teamName: String; readonly latestSeqno: Seqno; readonly implicitTeam: Boolean; readonly changes: TeamChangeSet; readonly latestHiddenSeqno: Seqno; readonly latestOffchainSeqno: Seqno}
+    inParam: {readonly teamName: String; readonly latestSeqno: Seqno; readonly implicitTeam: Boolean; readonly changes: TeamChangeSet; readonly latestHiddenSeqno: Seqno; readonly latestOffchainSeqno: Seqno; readonly source: TeamChangedSource}
     outParam: void
   }
   'keybase.1.NotifyTeam.teamDeleted': {
@@ -2669,6 +2669,12 @@ export enum TeamApplication {
   seitanInviteToken = 5,
   stellarRelay = 6,
   kvstore = 7,
+}
+
+export enum TeamChangedSource {
+  server = 0,
+  local = 1,
+  localRename = 2,
 }
 
 export enum TeamEphemeralKeyType {


### PR DESCRIPTION
~Do not trigger `createSetTeamVersion` when not actually loading the team because we are not subscribed. Current known team state in the store should be consistent with `teams.teamsVersion` map.~