### PR TITLE
hook up wot review screen

### DIFF
--- a/go/client/cmd_wot_list.go
+++ b/go/client/cmd_wot_list.go
@@ -116,9 +116,7 @@ func (c *cmdWotList) Run() error {
 				line("    `keybase wot revoke %s` to revoke your proposed vouch (coming soon)", vouch.VoucheeUsername) // TODO
 			}
 		}
-		if vouch.Confidence != nil {
-			line("Additional Details: %+v", *vouch.Confidence)
-		}
+		line("Additional Details: %+v", vouch.Confidence)
 		line("-------------------------------")
 	}
 	return nil

--- a/go/engine/wot_test.go
+++ b/go/engine/wot_test.go
@@ -193,7 +193,7 @@ func TestWebOfTrustPending(t *testing.T) {
 	require.EqualValues(t, bobVouch, vouches[0])
 	charlieVouch := vouches[1]
 	require.Equal(t, keybase1.WotStatusType_PROPOSED, charlieVouch.Status)
-	require.Equal(t, confidence, *charlieVouch.Confidence)
+	require.Equal(t, confidence, charlieVouch.Confidence)
 	t.Log("alice sees two pending vouches")
 
 	// alice gets just charlie's vouch using FetchWotVouches
@@ -266,7 +266,7 @@ func TestWebOfTrustAccept(t *testing.T) {
 	require.Equal(t, keybase1.WotStatusType_ACCEPTED, vouch.Status)
 	require.Equal(t, bob.User.GetUID(), vouch.Voucher.Uid)
 	require.Equal(t, vouchText, vouch.VouchText)
-	require.EqualValues(t, confidence, *vouch.Confidence)
+	require.EqualValues(t, confidence, vouch.Confidence)
 
 	vouches, err = libkb.FetchWotVouches(mctxB, libkb.FetchWotVouchesArg{Vouchee: aliceName})
 	require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestWebOfTrustAccept(t *testing.T) {
 	require.Equal(t, keybase1.WotStatusType_ACCEPTED, vouch.Status)
 	require.Equal(t, bob.User.GetUID(), vouch.Voucher.Uid)
 	require.Equal(t, vouchText, vouch.VouchText)
-	require.EqualValues(t, confidence, *vouch.Confidence)
+	require.EqualValues(t, confidence, vouch.Confidence)
 }
 
 func TestWebOfTrustReject(t *testing.T) {

--- a/go/externals/proof_service_generic_social.go
+++ b/go/externals/proof_service_generic_social.go
@@ -339,9 +339,9 @@ func (t *GenericSocialProofServiceType) ProveParameters(mctx libkb.MetaContext) 
 		subtext = t.DisplayName()
 	}
 	return keybase1.ProveParameters{
-		LogoFull:    MakeIcons(mctx, t.GetLogoKey(), "logo_full", 64),
-		LogoBlack:   MakeIcons(mctx, t.GetLogoKey(), "logo_black", 16),
-		LogoWhite:   MakeIcons(mctx, t.GetLogoKey(), "logo_white", 16),
+		LogoFull:    libkb.MakeProofIcons(mctx, t.GetLogoKey(), "logo_full", 64),
+		LogoBlack:   libkb.MakeProofIcons(mctx, t.GetLogoKey(), "logo_black", 16),
+		LogoWhite:   libkb.MakeProofIcons(mctx, t.GetLogoKey(), "logo_white", 16),
 		Title:       t.config.Domain,
 		Subtext:     subtext,
 		Suffix:      fmt.Sprintf("@%v", t.config.Domain),

--- a/go/identify3/adapter.go
+++ b/go/identify3/adapter.go
@@ -240,18 +240,14 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 		humanURLOrSigchainURL = i.makeSigchainViewURL(mctx, proof.SigID)
 	}
 
-	iconKey := proof.Key
 	row.ProofURL = humanURLOrSigchainURL
 	switch proof.ProofType {
 	case keybase1.ProofType_TWITTER:
 		row.SiteURL = fmt.Sprintf("https://twitter.com/%v", proof.Value)
-		iconKey = "twitter"
 	case keybase1.ProofType_GITHUB:
 		row.SiteURL = fmt.Sprintf("https://github.com/%v", proof.Value)
-		iconKey = "github"
 	case keybase1.ProofType_REDDIT:
 		row.SiteURL = fmt.Sprintf("https://reddit.com/user/%v", proof.Value)
-		iconKey = "reddit"
 	case keybase1.ProofType_HACKERNEWS:
 		// hackernews profile urls must have the username in its original casing.
 		username := proof.Value
@@ -259,10 +255,8 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 			username = proof.DisplayMarkup
 		}
 		row.SiteURL = fmt.Sprintf("https://news.ycombinator.com/user?id=%v", username)
-		iconKey = "hackernews"
 	case keybase1.ProofType_FACEBOOK:
 		row.SiteURL = fmt.Sprintf("https://facebook.com/%v", proof.Value)
-		iconKey = "facebook"
 	case keybase1.ProofType_GENERIC_SOCIAL:
 		row.SiteURL = humanURLOrSigchainURL
 		serviceType := mctx.G().GetProofServices().GetServiceType(mctx.Ctx(), proof.Key)
@@ -273,9 +267,6 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 					row.SiteURL = profileURL
 				}
 			}
-			iconKey = serviceType.GetLogoKey()
-		} else {
-			iconKey = proof.Key
 		}
 		row.ProofURL = i.makeSigchainViewURL(mctx, proof.SigID)
 	case keybase1.ProofType_GENERIC_WEB_SITE:
@@ -284,18 +275,17 @@ func (i *UIAdapter) rowPartial(mctx libkb.MetaContext, proof keybase1.RemoteProo
 			protocol = "http"
 		}
 		row.SiteURL = fmt.Sprintf("%v://%v", protocol, proof.Value)
-		iconKey = "web"
 	case keybase1.ProofType_DNS:
 		row.SiteURL = fmt.Sprintf("http://%v", proof.Value)
 		row.ProofURL = i.makeSigchainViewURL(mctx, proof.SigID)
-		iconKey = "web"
 	default:
 		row.SiteURL = humanURLOrSigchainURL
 	}
-	row.SiteIcon = externals.MakeIcons(mctx, iconKey, externals.IconTypeSmall, 16)
-	row.SiteIconDarkmode = externals.MakeIcons(mctx, iconKey, externals.IconTypeSmallDarkmode, 16)
-	row.SiteIconFull = externals.MakeIcons(mctx, iconKey, externals.IconTypeFull, 64)
-	row.SiteIconFullDarkmode = externals.MakeIcons(mctx, iconKey, externals.IconTypeFullDarkmode, 64)
+	iconKey := libkb.ProofIconKey(mctx, proof.ProofType, proof.Key)
+	row.SiteIcon = libkb.MakeProofIcons(mctx, iconKey, libkb.ProofIconTypeSmall, 16)
+	row.SiteIconDarkmode = libkb.MakeProofIcons(mctx, iconKey, libkb.ProofIconTypeSmallDarkmode, 16)
+	row.SiteIconFull = libkb.MakeProofIcons(mctx, iconKey, libkb.ProofIconTypeFull, 64)
+	row.SiteIconFullDarkmode = libkb.MakeProofIcons(mctx, iconKey, libkb.ProofIconTypeFullDarkmode, 64)
 	switch proof.ProofType {
 	case keybase1.ProofType_NONE, keybase1.ProofType_PGP:
 		// These types are not eligible for web-of-trust selection.
@@ -370,10 +360,10 @@ func (i *UIAdapter) displayKey(mctx libkb.MetaContext, key keybase1.IdentifyKey)
 		SiteURL:  i.makeKeybaseProfileURL(mctx),
 		// key.SigID is blank if the PGP key was there pre-sigchain
 		ProofURL:             i.makeSigchainViewURL(mctx, key.SigID),
-		SiteIcon:             externals.MakeIcons(mctx, "pgp", externals.IconTypeSmall, 16),
-		SiteIconDarkmode:     externals.MakeIcons(mctx, "pgp", externals.IconTypeSmallDarkmode, 16),
-		SiteIconFull:         externals.MakeIcons(mctx, "pgp", externals.IconTypeFull, 64),
-		SiteIconFullDarkmode: externals.MakeIcons(mctx, "pgp", externals.IconTypeFullDarkmode, 64),
+		SiteIcon:             libkb.MakeProofIcons(mctx, "pgp", libkb.ProofIconTypeSmall, 16),
+		SiteIconDarkmode:     libkb.MakeProofIcons(mctx, "pgp", libkb.ProofIconTypeSmallDarkmode, 16),
+		SiteIconFull:         libkb.MakeProofIcons(mctx, "pgp", libkb.ProofIconTypeFull, 64),
+		SiteIconFullDarkmode: libkb.MakeProofIcons(mctx, "pgp", libkb.ProofIconTypeFullDarkmode, 64),
 		Kid:                  &key.KID,
 		// PICNIC-1092 consider adding `WotProof` to support pgp in web-of-trust.
 	}
@@ -515,10 +505,10 @@ func (i *UIAdapter) plumbCryptocurrency(mctx libkb.MetaContext, crypto keybase1.
 		SigID:                crypto.SigID,
 		Ctime:                0,
 		SiteURL:              i.makeSigchainViewURL(mctx, crypto.SigID),
-		SiteIcon:             externals.MakeIcons(mctx, key, externals.IconTypeSmall, 16),
-		SiteIconDarkmode:     externals.MakeIcons(mctx, key, externals.IconTypeSmallDarkmode, 16),
-		SiteIconFull:         externals.MakeIcons(mctx, key, externals.IconTypeFull, 64),
-		SiteIconFullDarkmode: externals.MakeIcons(mctx, key, externals.IconTypeFullDarkmode, 64),
+		SiteIcon:             libkb.MakeProofIcons(mctx, key, libkb.ProofIconTypeSmall, 16),
+		SiteIconDarkmode:     libkb.MakeProofIcons(mctx, key, libkb.ProofIconTypeSmallDarkmode, 16),
+		SiteIconFull:         libkb.MakeProofIcons(mctx, key, libkb.ProofIconTypeFull, 64),
+		SiteIconFullDarkmode: libkb.MakeProofIcons(mctx, key, libkb.ProofIconTypeFullDarkmode, 64),
 		ProofURL:             i.makeSigchainViewURL(mctx, crypto.SigID),
 	})
 }
@@ -537,10 +527,10 @@ func (i *UIAdapter) plumbStellarAccount(mctx libkb.MetaContext, str keybase1.Ste
 		SigID:                str.SigID,
 		Ctime:                0,
 		SiteURL:              i.makeSigchainViewURL(mctx, str.SigID),
-		SiteIcon:             externals.MakeIcons(mctx, "stellar", externals.IconTypeSmall, 16),
-		SiteIconDarkmode:     externals.MakeIcons(mctx, "stellar", externals.IconTypeSmallDarkmode, 16),
-		SiteIconFull:         externals.MakeIcons(mctx, "stellar", externals.IconTypeFull, 64),
-		SiteIconFullDarkmode: externals.MakeIcons(mctx, "stellar", externals.IconTypeFullDarkmode, 64),
+		SiteIcon:             libkb.MakeProofIcons(mctx, "stellar", libkb.ProofIconTypeSmall, 16),
+		SiteIconDarkmode:     libkb.MakeProofIcons(mctx, "stellar", libkb.ProofIconTypeSmallDarkmode, 16),
+		SiteIconFull:         libkb.MakeProofIcons(mctx, "stellar", libkb.ProofIconTypeFull, 64),
+		SiteIconFullDarkmode: libkb.MakeProofIcons(mctx, "stellar", libkb.ProofIconTypeFullDarkmode, 64),
 		ProofURL:             i.makeSigchainViewURL(mctx, str.SigID),
 	})
 }

--- a/go/libkb/proof_icon.go
+++ b/go/libkb/proof_icon.go
@@ -1,10 +1,9 @@
-package externals
+package libkb
 
 import (
 	"fmt"
 	"strings"
 
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -21,20 +20,20 @@ func normalizeIconKey(key string) string {
 	}
 }
 
-const IconTypeSmall = "logo_black"
-const IconTypeSmallDarkmode = "logo_white"
-const IconTypeFull = "logo_full"
-const IconTypeFullDarkmode = "logo_full_darkmode"
+const ProofIconTypeSmall = "logo_black"
+const ProofIconTypeSmallDarkmode = "logo_white"
+const ProofIconTypeFull = "logo_full"
+const ProofIconTypeFullDarkmode = "logo_full_darkmode"
 
-func MakeIcons(mctx libkb.MetaContext, serviceKey, iconType string, size int) (res []keybase1.SizedImage) {
+func MakeProofIcons(mctx MetaContext, serviceKey, iconType string, size int) (res []keybase1.SizedImage) {
 	for _, factor := range []int{1, 2} {
 		factorix := ""
 		if factor > 1 {
 			factorix = fmt.Sprintf("@%vx", factor)
 		}
 
-		site := libkb.SiteURILookup[mctx.G().Env.GetRunMode()]
-		if mctx.G().Env.GetRunMode() == libkb.DevelRunMode {
+		site := SiteURILookup[mctx.G().Env.GetRunMode()]
+		if mctx.G().Env.GetRunMode() == DevelRunMode {
 			site = strings.Replace(site, "localhost", "127.0.0.1", 1)
 		}
 

--- a/go/protocol/keybase1/wot.go
+++ b/go/protocol/keybase1/wot.go
@@ -36,6 +36,42 @@ func (o WotProof) DeepCopy() WotProof {
 	}
 }
 
+type WotProofUI struct {
+	Type             string       `codec:"type" json:"type"`
+	Value            string       `codec:"value" json:"value"`
+	SiteIcon         []SizedImage `codec:"siteIcon" json:"siteIcon"`
+	SiteIconDarkmode []SizedImage `codec:"siteIconDarkmode" json:"siteIconDarkmode"`
+}
+
+func (o WotProofUI) DeepCopy() WotProofUI {
+	return WotProofUI{
+		Type:  o.Type,
+		Value: o.Value,
+		SiteIcon: (func(x []SizedImage) []SizedImage {
+			if x == nil {
+				return nil
+			}
+			ret := make([]SizedImage, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.SiteIcon),
+		SiteIconDarkmode: (func(x []SizedImage) []SizedImage {
+			if x == nil {
+				return nil
+			}
+			ret := make([]SizedImage, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.SiteIconDarkmode),
+	}
+}
+
 type Confidence struct {
 	UsernameVerifiedVia UsernameVerificationType `codec:"usernameVerifiedVia" json:"username_verified_via,omitempty"`
 	Proofs              []WotProof               `codec:"proofs" json:"proofs,omitempty"`
@@ -63,20 +99,20 @@ func (o Confidence) DeepCopy() Confidence {
 type WotReactionType int
 
 const (
-	WotReactionType_ACCEPT WotReactionType = 0
-	WotReactionType_REJECT WotReactionType = 1
+	WotReactionType_REJECT WotReactionType = 0
+	WotReactionType_ACCEPT WotReactionType = 1
 )
 
 func (o WotReactionType) DeepCopy() WotReactionType { return o }
 
 var WotReactionTypeMap = map[string]WotReactionType{
-	"ACCEPT": 0,
-	"REJECT": 1,
+	"REJECT": 0,
+	"ACCEPT": 1,
 }
 
 var WotReactionTypeRevMap = map[WotReactionType]string{
-	0: "ACCEPT",
-	1: "REJECT",
+	0: "REJECT",
+	1: "ACCEPT",
 }
 
 func (e WotReactionType) String() string {
@@ -95,7 +131,8 @@ type WotVouch struct {
 	VoucherUsername string        `codec:"voucherUsername" json:"voucherUsername"`
 	VouchText       string        `codec:"vouchText" json:"vouchText"`
 	VouchedAt       Time          `codec:"vouchedAt" json:"vouchedAt"`
-	Confidence      *Confidence   `codec:"confidence,omitempty" json:"confidence,omitempty"`
+	Confidence      Confidence    `codec:"confidence" json:"confidence"`
+	Proofs          []WotProofUI  `codec:"proofs" json:"proofs"`
 }
 
 func (o WotVouch) DeepCopy() WotVouch {
@@ -108,13 +145,18 @@ func (o WotVouch) DeepCopy() WotVouch {
 		VoucherUsername: o.VoucherUsername,
 		VouchText:       o.VouchText,
 		VouchedAt:       o.VouchedAt.DeepCopy(),
-		Confidence: (func(x *Confidence) *Confidence {
+		Confidence:      o.Confidence.DeepCopy(),
+		Proofs: (func(x []WotProofUI) []WotProofUI {
 			if x == nil {
 				return nil
 			}
-			tmp := (*x).DeepCopy()
-			return &tmp
-		})(o.Confidence),
+			ret := make([]WotProofUI, len(x))
+			for i, v := range x {
+				vCopy := v.DeepCopy()
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Proofs),
 	}
 }
 

--- a/go/service/user.go
+++ b/go/service/user.go
@@ -17,7 +17,6 @@ import (
 	"github.com/keybase/client/go/chat/globals"
 	"github.com/keybase/client/go/chat/utils"
 	"github.com/keybase/client/go/engine"
-	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/offline"
 	"github.com/keybase/client/go/phonenumbers"
@@ -516,10 +515,10 @@ func (h *UserHandler) proofSuggestionsHelper(mctx libkb.MetaContext, tracer prof
 	tracer.Stage("icons")
 	for i := range suggestions {
 		suggestion := &suggestions[i]
-		suggestion.ProfileIcon = externals.MakeIcons(mctx, suggestion.LogoKey, externals.IconTypeSmall, 16)
-		suggestion.ProfileIconDarkmode = externals.MakeIcons(mctx, suggestion.LogoKey, externals.IconTypeSmallDarkmode, 16)
-		suggestion.PickerIcon = externals.MakeIcons(mctx, suggestion.LogoKey, externals.IconTypeFull, 32)
-		suggestion.PickerIconDarkmode = externals.MakeIcons(mctx, suggestion.LogoKey, externals.IconTypeFullDarkmode, 32)
+		suggestion.ProfileIcon = libkb.MakeProofIcons(mctx, suggestion.LogoKey, libkb.ProofIconTypeSmall, 16)
+		suggestion.ProfileIconDarkmode = libkb.MakeProofIcons(mctx, suggestion.LogoKey, libkb.ProofIconTypeSmallDarkmode, 16)
+		suggestion.PickerIcon = libkb.MakeProofIcons(mctx, suggestion.LogoKey, libkb.ProofIconTypeFull, 32)
+		suggestion.PickerIconDarkmode = libkb.MakeProofIcons(mctx, suggestion.LogoKey, libkb.ProofIconTypeFullDarkmode, 32)
 	}
 
 	// Alphabetize so that ties later on in SliceStable are deterministic.

--- a/go/service/usersearch.go
+++ b/go/service/usersearch.go
@@ -642,10 +642,10 @@ func (h *UserSearchHandler) GetNonUserDetails(ctx context.Context, arg keybase1.
 			mctx.Warning("Can't get external profile data with: %s", err)
 		}
 
-		res.SiteIcon = externals.MakeIcons(mctx, service, externals.IconTypeSmall, 16)
-		res.SiteIconDarkmode = externals.MakeIcons(mctx, service, externals.IconTypeSmallDarkmode, 16)
-		res.SiteIconFull = externals.MakeIcons(mctx, service, externals.IconTypeFull, 64)
-		res.SiteIconFullDarkmode = externals.MakeIcons(mctx, service, externals.IconTypeFullDarkmode, 64)
+		res.SiteIcon = libkb.MakeProofIcons(mctx, service, libkb.ProofIconTypeSmall, 16)
+		res.SiteIconDarkmode = libkb.MakeProofIcons(mctx, service, libkb.ProofIconTypeSmallDarkmode, 16)
+		res.SiteIconFull = libkb.MakeProofIcons(mctx, service, libkb.ProofIconTypeFull, 64)
+		res.SiteIconFullDarkmode = libkb.MakeProofIcons(mctx, service, libkb.ProofIconTypeFullDarkmode, 64)
 	} else if service == "phone" || service == "email" {
 		contacts, err := mctx.G().SyncedContactList.RetrieveContacts(mctx)
 		if err == nil {

--- a/protocol/avdl/keybase1/wot.avdl
+++ b/protocol/avdl/keybase1/wot.avdl
@@ -23,6 +23,15 @@ protocol wot {
     @jsonkey("domain,omitempty") string domain; // For dns.
   }
 
+  // One of the vouchee's proofs.
+  // For displaying in the gui.
+  record WotProofUI {
+    string type;
+    string value;
+    array<SizedImage> siteIcon;
+    array<SizedImage> siteIconDarkmode;
+  }
+
   record Confidence {
     @jsonkey("username_verified_via,omitempty")
     UsernameVerificationType usernameVerifiedVia;
@@ -36,8 +45,8 @@ protocol wot {
   void wotVouchCLI(int sessionID, string assertion, string vouchText, Confidence confidence);
 
   enum WotReactionType {
-    ACCEPT_0,
-    REJECT_1
+    REJECT_0,
+    ACCEPT_1
   }
   void wotReact(int sessionID, string voucher, WotReactionType reaction);
 
@@ -50,7 +59,8 @@ protocol wot {
     string voucherUsername;
     string vouchText;
     Time vouchedAt;
-    union { null, Confidence } confidence;
+    Confidence confidence;
+    array<WotProofUI> proofs;
   }
 
   // dismiss notifications for a user vouch

--- a/protocol/json/keybase1/wot.json
+++ b/protocol/json/keybase1/wot.json
@@ -51,6 +51,34 @@
     },
     {
       "type": "record",
+      "name": "WotProofUI",
+      "fields": [
+        {
+          "type": "string",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "value"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "SizedImage"
+          },
+          "name": "siteIcon"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "SizedImage"
+          },
+          "name": "siteIconDarkmode"
+        }
+      ]
+    },
+    {
+      "type": "record",
       "name": "Confidence",
       "fields": [
         {
@@ -77,8 +105,8 @@
       "type": "enum",
       "name": "WotReactionType",
       "symbols": [
-        "ACCEPT_0",
-        "REJECT_1"
+        "REJECT_0",
+        "ACCEPT_1"
       ]
     },
     {
@@ -118,11 +146,15 @@
           "name": "vouchedAt"
         },
         {
-          "type": [
-            null,
-            "Confidence"
-          ],
+          "type": "Confidence",
           "name": "confidence"
+        },
+        {
+          "type": {
+            "type": "array",
+            "items": "WotProofUI"
+          },
+          "name": "proofs"
         }
       ]
     }

--- a/shared/actions/json/users.json
+++ b/shared/actions/json/users.json
@@ -35,7 +35,8 @@
     },
     "wotReact": {
       "voucher": "string",
-      "reaction": "RPCTypes.WotReactionType"
+      "reaction": "RPCTypes.WotReactionType",
+      "fromModal?": "boolean"
     },
     "reportUser": {
       "_description": "Calls RPC to report user",

--- a/shared/actions/tracker2.tsx
+++ b/shared/actions/tracker2.tsx
@@ -146,9 +146,11 @@ const loadWebOfTrustEntries = async (
       wotVouches?.map(entry => ({
         attestation: entry.vouchText,
         attestingUser: entry.voucherUsername,
+        otherText: entry.confidence.other,
         proofID: entry.vouchProof,
+        proofs: entry.proofs ?? undefined,
         status: entry.status,
-        verificationType: (entry.confidence?.usernameVerifiedVia || 'none') as WebOfTrustVerificationType,
+        verificationType: (entry.confidence.usernameVerifiedVia || 'none') as WebOfTrustVerificationType, // xxx this is an incorrect cast. Go does not gaurantee this match.
         vouchedAt: entry.vouchedAt,
       })) || []
     return Tracker2Gen.createUpdateWotEntries({

--- a/shared/actions/tracker2.tsx
+++ b/shared/actions/tracker2.tsx
@@ -7,6 +7,7 @@ import * as RouteTreeGen from './route-tree-gen'
 import * as Saga from '../util/saga'
 import * as Container from '../util/container'
 import * as Constants from '../constants/tracker2'
+import * as ProfileConstants from '../constants/profile'
 import {WebOfTrustVerificationType} from '../constants/types/more'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import logger from '../logger'
@@ -150,7 +151,11 @@ const loadWebOfTrustEntries = async (
         proofID: entry.vouchProof,
         proofs: entry.proofs ?? undefined,
         status: entry.status,
-        verificationType: (entry.confidence.usernameVerifiedVia || 'none') as WebOfTrustVerificationType, // xxx this is an incorrect cast. Go does not gaurantee this match.
+        verificationType: (ProfileConstants.choosableWotVerificationTypes.find(
+          x => x === entry.confidence.usernameVerifiedVia
+        )
+          ? entry.confidence.usernameVerifiedVia
+          : 'none') as WebOfTrustVerificationType,
         vouchedAt: entry.vouchedAt,
       })) || []
     return Tracker2Gen.createUpdateWotEntries({

--- a/shared/actions/users-gen.tsx
+++ b/shared/actions/users-gen.tsx
@@ -33,7 +33,11 @@ type _UpdateBlockStatePayload = {
 }
 type _UpdateBrokenStatePayload = {readonly newlyBroken: Array<string>; readonly newlyFixed: Array<string>}
 type _UpdateFullnamesPayload = {readonly usernameToFullname: {[username: string]: string}}
-type _WotReactPayload = {readonly voucher: string; readonly reaction: RPCTypes.WotReactionType}
+type _WotReactPayload = {
+  readonly voucher: string
+  readonly reaction: RPCTypes.WotReactionType
+  readonly fromModal?: boolean
+}
 
 // Action Creators
 /**

--- a/shared/actions/users.tsx
+++ b/shared/actions/users.tsx
@@ -8,6 +8,8 @@ import * as RPCTypes from '../constants/types/rpc-gen'
 import * as Constants from '../constants/users'
 import * as TrackerConstants from '../constants/tracker2'
 import * as Tracker2Gen from './tracker2-gen'
+import * as ProfileGen from './profile-gen'
+import * as RouteTreeGen from './route-tree-gen'
 import {TypedState} from '../util/container'
 import logger from '../logger'
 import {RPCError} from 'util/errors'
@@ -88,8 +90,28 @@ const submitRevokeVouch = async (_: TypedState, action: UsersGen.SubmitRevokeVou
   })
 }
 
-const wotReact = async (action: UsersGen.WotReactPayload) => {
-  await RPCTypes.wotWotReactRpcPromise(action.payload, Constants.wotReactWaitingKey)
+const wotReact = async (action: UsersGen.WotReactPayload, logger: Saga.SagaLogger) => {
+  const {reaction, voucher} = action.payload
+  if (!action.payload.fromModal) {
+    // This needs an error path. Happens when coming from a button directly on the profile screen.
+    await RPCTypes.wotWotReactRpcPromise({reaction, voucher}, Constants.wotReactWaitingKey)
+    return []
+  }
+  try {
+    await RPCTypes.wotWotReactRpcPromise(
+      {
+        reaction,
+        voucher,
+      },
+      Constants.wotReactWaitingKey
+    )
+  } catch (e) {
+    logger.warn('Error from wotReact:', e)
+    return ProfileGen.createWotVouchSetError({
+      error: e.desc || `There was an error reviewing the claim.`,
+    })
+  }
+  return [ProfileGen.createWotVouchSetError({error: ''}), RouteTreeGen.createClearModals()]
 }
 
 function* usersSaga() {

--- a/shared/actions/users.tsx
+++ b/shared/actions/users.tsx
@@ -91,8 +91,8 @@ const submitRevokeVouch = async (_: TypedState, action: UsersGen.SubmitRevokeVou
 }
 
 const wotReact = async (action: UsersGen.WotReactPayload, logger: Saga.SagaLogger) => {
-  const {reaction, voucher} = action.payload
-  if (!action.payload.fromModal) {
+  const {fromModal, reaction, voucher} = action.payload
+  if (!fromModal) {
     // This needs an error path. Happens when coming from a button directly on the profile screen.
     await RPCTypes.wotWotReactRpcPromise({reaction, voucher}, Constants.wotReactWaitingKey)
     return []

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -2800,8 +2800,8 @@ export enum UserOrTeamResult {
 }
 
 export enum WotReactionType {
-  accept = 0,
-  reject = 1,
+  reject = 0,
+  accept = 1,
 }
 
 export enum WotStatusType {
@@ -3429,8 +3429,9 @@ export type VerifySessionRes = {readonly uid: UID; readonly sid: String; readonl
 export type WalletAccountInfo = {readonly accountID: String; readonly numUnread: Int}
 export type WebProof = {readonly hostname: String; readonly protocols?: Array<String> | null}
 export type WotProof = {readonly proofType: ProofType; readonly name: String; readonly username: String; readonly protocol: String; readonly hostname: String; readonly domain: String}
+export type WotProofUI = {readonly type: String; readonly value: String; readonly siteIcon?: Array<SizedImage> | null; readonly siteIconDarkmode?: Array<SizedImage> | null}
 export type WotUpdate = {readonly voucher: String; readonly vouchee: String; readonly status: WotStatusType}
-export type WotVouch = {readonly status: WotStatusType; readonly vouchProof: SigID; readonly vouchee: UserVersion; readonly voucheeUsername: String; readonly voucher: UserVersion; readonly voucherUsername: String; readonly vouchText: String; readonly vouchedAt: Time; readonly confidence?: Confidence | null}
+export type WotVouch = {readonly status: WotStatusType; readonly vouchProof: SigID; readonly vouchee: UserVersion; readonly voucheeUsername: String; readonly voucher: UserVersion; readonly voucherUsername: String; readonly vouchText: String; readonly vouchedAt: Time; readonly confidence: Confidence; readonly proofs?: Array<WotProofUI> | null}
 export type WriteArgs = {readonly opID: OpID; readonly path: Path; readonly offset: Long}
 
 export type IncomingCallMapType = {

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -88,9 +88,11 @@ export type NonUserDetails = {
 }
 
 export type WebOfTrustEntry = {
-  attestingUser: string
   attestation: string
+  attestingUser: string
+  otherText?: string
   proofID: RPCTypes.SigID
+  proofs?: Array<RPCTypes.WotProofUI>
   status: RPCTypes.WotStatusType
   verificationType: WebOfTrustVerificationType
   vouchedAt: number

--- a/shared/constants/types/tracker2.tsx
+++ b/shared/constants/types/tracker2.tsx
@@ -90,7 +90,7 @@ export type NonUserDetails = {
 export type WebOfTrustEntry = {
   attestation: string
   attestingUser: string
-  otherText?: string
+  otherText: string
   proofID: RPCTypes.SigID
   proofs?: Array<RPCTypes.WotProofUI>
   status: RPCTypes.WotStatusType

--- a/shared/profile/routes.tsx
+++ b/shared/profile/routes.tsx
@@ -12,7 +12,7 @@ import ProfileProveEnterUsername from './prove-enter-username/container'
 import ProfileProveWebsiteChoice from './prove-website-choice/container'
 import ProfileRevoke from './revoke/container'
 import ProfileShowcaseTeamOffer from './showcase-team-offer/container'
-import {Question1Wrapper, Question2Wrapper} from './wot-author'
+import {Question1Wrapper, Question2Wrapper, ReviewWrapper} from './wot-author'
 
 export const newRoutes = {
   profile: {getScreen: (): typeof Profile => require('./user/container').default},
@@ -51,6 +51,9 @@ export const newModalRoutes = {
   },
   profileWotAuthorQ2: {
     getScreen: (): typeof Question2Wrapper => require('./wot-author').Question2Wrapper,
+  },
+  profileWotReview: {
+    getScreen: (): typeof ReviewWrapper => require('./wot-author').ReviewWrapper,
   },
   ...PGPRoutes,
 }

--- a/shared/profile/user/weboftrust/index.tsx
+++ b/shared/profile/user/weboftrust/index.tsx
@@ -4,6 +4,7 @@ import {formatTimeRelativeToNow} from '../../../util/timestamp'
 import * as Kb from '../../../common-adapters'
 import * as Styles from '../../../styles'
 import * as UsersGen from '../../../actions/users-gen'
+import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import {WebOfTrustVerificationType} from '../../../constants/types/more'
 import {WotReactionType, WotStatusType} from '../../../constants/types/rpc-gen'
 import {wotReactWaitingKey, wotRevokeWaitingKey} from '../../../constants/users'
@@ -26,10 +27,14 @@ const WebOfTrust = (props: Props) => {
   const {attestation, attestingUser, proofID, vouchedAt, status} = webOfTrustAttestation
   const userIsYou = Container.useSelector(state => username === state.config.username)
   const voucherIsYou = Container.useSelector(state => attestingUser === state.config.username)
-  const canAccept = userIsYou && status === WotStatusType.proposed
-  const onAccept = () => {
-    if (!canAccept) return
-    dispatch(UsersGen.createWotReact({reaction: WotReactionType.accept, voucher: attestingUser}))
+  const canReview = userIsYou && status === WotStatusType.proposed
+  const onReview = () => {
+    if (!canReview) return
+    dispatch(
+      RouteTreeGen.createNavigateAppend({
+        path: [{props: {sigID: proofID}, selected: 'profileWotReview'}],
+      })
+    )
   }
   const canReject = userIsYou && (status === WotStatusType.proposed || status === WotStatusType.accepted)
   const onReject = () => {
@@ -84,18 +89,10 @@ const WebOfTrust = (props: Props) => {
           </Kb.Box2>
         </Kb.Box2>
       </Kb.Box2>
-      {(canAccept || canReject || canRevoke) && (
+      {(canReview || canReject || canRevoke) && (
         <Kb.Box2 direction="horizontal" fullWidth={true} centerChildren={false} style={styles.buttonBar}>
           <Kb.ButtonBar align="flex-start">
-            {canAccept && (
-              <Kb.WaitingButton
-                label="Accept"
-                onClick={onAccept}
-                small={true}
-                type="Success"
-                waitingKey={wotReactWaitingKey}
-              />
-            )}
+            {canReview && <Kb.Button label="Review" onClick={onReview} small={true} type="Default" />}
             {canReject && (
               <Kb.WaitingButton
                 label={rejectLabel}

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {WebOfTrustVerificationType} from '../../constants/types/more'
 import * as Constants from '../../constants/profile'
+import * as UsersConstants from '../../constants/users'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
@@ -8,6 +9,7 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Tracker2Types from '../../constants/types/tracker2'
 import {SiteIcon} from '../../profile/generic/shared'
 import * as ProfileGen from '../../actions/profile-gen'
+import * as UsersGen from '../../actions/users-gen'
 import * as Tracker2Constants from '../../constants/tracker2'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import sortBy from 'lodash/sortBy'
@@ -33,13 +35,14 @@ export type Question1Answer = {
 type ReviewAction = 'accept' | 'propose' | 'reject'
 
 export type ReviewProps = {
+  disabled?: boolean // disable all buttons
   error?: string
   firstDraft: boolean
   onAccept: () => void
   onProposeEdits: () => void
   onReject: () => void
   otherText: string
-  proofs: Array<Proof>
+  proofs: Array<ProofLite>
   statement: string
   verificationType: WebOfTrustVerificationType
   voucheeUsername: string
@@ -66,12 +69,15 @@ type WotModalProps = {
   submitWaiting?: boolean
 }
 
-export type Proof = {
+export type Proof = ProofLite & {
+  wotProof: RPCTypes.WotProof
+}
+
+type ProofLite = {
   type: string
   value: string
-  siteIcon?: Tracker2Types.SiteIconSet
-  siteIconDarkmode?: Tracker2Types.SiteIconSet
-  wotProof: RPCTypes.WotProof
+  siteIcon?: Tracker2Types.SiteIconSet | null
+  siteIconDarkmode?: Tracker2Types.SiteIconSet | null
 }
 
 type Checkboxed = {
@@ -99,7 +105,7 @@ export const Question1Wrapper = (
   let proofs: Proof[] = []
   if (trackerUsername === voucheeUsername) {
     if (assertions) {
-      // Pull proofs from the profile they were just looking at.
+      // Pull proofs from the profile the user was just looking at.
       // Only take passing proofs that have a `wotProof` field filled by the service.
       proofs = sortBy(
         Array.from(assertions, ([_, assertion]) => assertion),
@@ -183,6 +189,79 @@ export const Question2Wrapper = (
       onBack={onBack}
       onSubmit={onSubmit}
       voucheeUsername={voucheeUsername}
+      waiting={waiting}
+    />
+  )
+}
+
+export const ReviewWrapper = (
+  props: Container.RouteProps<{
+    sigID: string // sigID of the vouch.
+  }>
+) => {
+  const sigID = Container.getRouteProps(props, 'sigID', '')
+  const dispatch = Container.useDispatch()
+  const voucheeUsername = Container.useSelector(state => state.config.username)
+  const details = Container.useSelector(state => Tracker2Constants.getDetails(state, voucheeUsername))
+  const wotEntry = (details.webOfTrustEntries || []).find(entry => entry.proofID === sigID)
+  const error = Container.useSelector(state => state.profile.wotAuthorError)
+  const [lastAction, setLastAction] = React.useState<ReviewAction | undefined>(undefined)
+  const isWaiting = Container.useAnyWaiting(UsersConstants.wotReactWaitingKey)
+  let waiting = isWaiting ? lastAction : undefined
+  let fatalError = ''
+  if (!sigID) {
+    fatalError = 'Routing missing ID.'
+  }
+  if (!wotEntry) {
+    fatalError = 'Statement not found.'
+  }
+  if (fatalError || !wotEntry) {
+    return (
+      <Review
+        disabled={true}
+        error={fatalError}
+        firstDraft={false}
+        onAccept={() => {}}
+        onProposeEdits={() => {}}
+        onReject={() => {}}
+        otherText=""
+        proofs={[]}
+        statement=""
+        verificationType="in_person"
+        voucheeUsername={voucheeUsername}
+        voucherUsername="_"
+      />
+    )
+  }
+  const onReact = (accept: boolean) => () => {
+    setLastAction(accept ? 'accept' : 'reject')
+    // TODO PICNIC-1150 pin reactions to the sigID
+    dispatch(
+      UsersGen.createWotReact({
+        fromModal: true,
+        reaction: accept ? RPCTypes.WotReactionType.accept : RPCTypes.WotReactionType.reject,
+        voucher: wotEntry.attestingUser,
+      })
+    )
+  }
+  const onProposeEdits = () => {
+    // TODO PICNIC-1145 hook this up
+    setLastAction('propose')
+    dispatch(ProfileGen.createWotVouchSetError({error: 'proposing edits not implemented'}))
+  }
+  return (
+    <Review
+      error={error}
+      firstDraft={true} // TODO PICNIC-1171 plug this bit in
+      onAccept={onReact(true)}
+      onProposeEdits={onProposeEdits}
+      onReject={onReact(false)}
+      otherText={wotEntry.otherText ?? ''}
+      proofs={wotEntry.proofs || []}
+      statement={wotEntry.attestation}
+      verificationType={wotEntry.verificationType}
+      voucheeUsername={voucheeUsername}
+      voucherUsername={wotEntry.attestingUser}
       waiting={waiting}
     />
   )
@@ -325,13 +404,14 @@ export const Review = (props: ReviewProps) => {
   const [checkedStatement, setCheckedStatement] = React.useState(false)
   const canAccept = checkedVerificationType && checkedStatement
   const onClose = () => {
+    dispatch(ProfileGen.createWotVouchSetError({error: ''}))
     dispatch(RouteTreeGen.createClearModals())
   }
   const buttonState = (button: ReviewAction) => {
     // When waiting, spinner the relevant button and disable the others.
     if (props.waiting === button) {
       return {waiting: true}
-    } else if (props.waiting) {
+    } else if (props.waiting || props.disabled) {
       return {disabled: true}
     }
     if (button === 'accept' && !canAccept) {
@@ -640,7 +720,7 @@ const proofList = (selected: boolean, proofs: Array<Proof & Checkboxed>) =>
     </Kb.Box2>
   ))
 
-const ProofSingle = (props: Proof) => {
+const ProofSingle = (props: ProofLite) => {
   let siteIcon: React.ReactNode = null
   const iconSet = Styles.isDarkMode() ? props.siteIconDarkmode : props.siteIcon
   if (iconSet) {

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -38,11 +38,11 @@ export type ReviewProps = {
   disabled?: boolean // disable all buttons
   error?: string
   firstDraft: boolean
-  onAccept: () => void
-  onProposeEdits: () => void
-  onReject: () => void
+  onAccept?: () => void
+  onProposeEdits?: () => void
+  onReject?: () => void
   otherText: string
-  proofs: Array<ProofLite>
+  proofs?: Array<ProofLite>
   statement: string
   verificationType: WebOfTrustVerificationType
   voucheeUsername: string
@@ -203,7 +203,7 @@ export const ReviewWrapper = (
   const dispatch = Container.useDispatch()
   const voucheeUsername = Container.useSelector(state => state.config.username)
   const details = Container.useSelector(state => Tracker2Constants.getDetails(state, voucheeUsername))
-  const wotEntry = (details.webOfTrustEntries || []).find(entry => entry.proofID === sigID)
+  const wotEntry = details.webOfTrustEntries?.find(entry => entry.proofID === sigID)
   const error = Container.useSelector(state => state.profile.wotAuthorError)
   const [lastAction, setLastAction] = React.useState<ReviewAction | undefined>(undefined)
   const isWaiting = Container.useAnyWaiting(UsersConstants.wotReactWaitingKey)
@@ -221,11 +221,7 @@ export const ReviewWrapper = (
         disabled={true}
         error={fatalError}
         firstDraft={false}
-        onAccept={() => {}}
-        onProposeEdits={() => {}}
-        onReject={() => {}}
         otherText=""
-        proofs={[]}
         statement=""
         verificationType="in_person"
         voucheeUsername={voucheeUsername}
@@ -516,6 +512,7 @@ export const Review = (props: ReviewProps) => {
               </Kb.Text>
             </Kb.Box2>
             {props.verificationType === 'proofs' &&
+              props.proofs &&
               props.proofs.map(proof => (
                 <Kb.Box2
                   key={`${proof.type}:${proof.value}`}


### PR DESCRIPTION
- Hook up review screen.
- Pass `otherText` and `proofs` to gui for vouches. Make `confidence` less optional.
- Move some shared icon stuff to libkb to avoid import cycles.