### PR TITLE
disk_block_cache: don't panic if sync cache isn't set

### DIFF
--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -326,7 +326,9 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 	// caches. So we use a read lock.
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
-	if cache.syncCache != nil &&
+	if cache.syncCache == nil && cacheType == DiskBlockSyncCache {
+		return 0, 0, errors.New("Sync cache not enabled")
+	} else if cache.syncCache != nil &&
 		(cacheType == DiskBlockAnyCache || cacheType == DiskBlockSyncCache) {
 		numRemoved, sizeRemoved, err = cache.syncCache.Delete(ctx, blockIDs)
 		if err != nil {
@@ -335,8 +337,6 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 		if cacheType == DiskBlockSyncCache {
 			return numRemoved, sizeRemoved, err
 		}
-	} else if cacheType == DiskBlockSyncCache {
-		return 0, 0, errors.New("Sync cache not enabled")
 	}
 
 	wsNumRemoved, wsSizeRemoved, err := cache.workingSetCache.Delete(

--- a/go/kbfs/libkbfs/disk_block_cache_wrapped.go
+++ b/go/kbfs/libkbfs/disk_block_cache_wrapped.go
@@ -249,6 +249,10 @@ func (cache *diskBlockCacheWrapped) GetPrefetchStatus(
 
 	// Try the sync cache first unless working set cache is required.
 	if cacheType != DiskBlockWorkingSetCache {
+		if cache.syncCache == nil {
+			return NoPrefetch, errors.New("Sync cache not enabled")
+		}
+
 		md, err := cache.syncCache.GetMetadata(ctx, blockID)
 		switch errors.Cause(err) {
 		case nil:
@@ -322,7 +326,8 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 	// caches. So we use a read lock.
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
-	if cacheType == DiskBlockAnyCache || cacheType == DiskBlockSyncCache {
+	if cache.syncCache != nil &&
+		(cacheType == DiskBlockAnyCache || cacheType == DiskBlockSyncCache) {
 		numRemoved, sizeRemoved, err = cache.syncCache.Delete(ctx, blockIDs)
 		if err != nil {
 			return 0, 0, err
@@ -330,6 +335,8 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 		if cacheType == DiskBlockSyncCache {
 			return numRemoved, sizeRemoved, err
 		}
+	} else if cacheType == DiskBlockSyncCache {
+		return 0, 0, errors.New("Sync cache not enabled")
 	}
 
 	wsNumRemoved, wsSizeRemoved, err := cache.workingSetCache.Delete(
@@ -504,7 +511,7 @@ func (cache *diskBlockCacheWrapped) GetTlfSize(
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
 
-	if cacheType != DiskBlockWorkingSetCache {
+	if cacheType != DiskBlockWorkingSetCache && cache.syncCache != nil {
 		// Either sync cache only, or both.
 		syncSize, err := cache.syncCache.GetTlfSize(ctx, tlfID)
 		if err != nil {
@@ -533,7 +540,7 @@ func (cache *diskBlockCacheWrapped) GetTlfIDs(
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
 
-	if cacheType != DiskBlockWorkingSetCache {
+	if cacheType != DiskBlockWorkingSetCache && cache.syncCache != nil {
 		// Either sync cache only, or both.
 		tlfIDs, err = cache.syncCache.GetTlfIDs(ctx)
 		if err != nil {
@@ -576,7 +583,7 @@ func (cache *diskBlockCacheWrapped) WaitUntilStarted(
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
 
-	if cacheType != DiskBlockWorkingSetCache {
+	if cacheType != DiskBlockWorkingSetCache && cache.syncCache != nil {
 		err = cache.syncCache.WaitUntilStarted()
 		if err != nil {
 			return err


### PR DESCRIPTION
It's possible the sync cache wouldn't be set if we aren't allowed to access the leveldb files (happens sometimes with iOS, for unknown reasons).

Issue: HOTPOT-2612