### PR TITLE
keybase_service_base: don't ignore deleted errors if missing name

### DIFF
--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -521,10 +521,15 @@ func (k *KeybaseServiceBase) Identify(
 	switch err.(type) {
 	case nil:
 	case libkb.NoSigChainError, libkb.UserDeletedError:
+		ei.OnError(ctx)
+		// But if the username is blame, just return it, since the
+		// returned username would be useless and confusing.
+		if res.Ul.Name == "" {
+			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		}
 		k.log.CDebugf(ctx,
 			"Ignoring error (%s) for user %s with no sigchain; "+
 				"error type=%T", err, res.Ul.Name, err)
-		ei.OnError(ctx)
 	default:
 		// If the caller is waiting for breaks, let them know we got an error.
 		ei.OnError(ctx)


### PR DESCRIPTION
Usually when the service returns a `UserDeletedError`, it still fills in some details about the user.  There seems to be at least one case where it doesn't though, and in that case want to return the proper error back up to the GUI so that it can handle it correctly and display the right banner.

Issue: HOTPOT-2557