### PR TITLE
kbpages: add KVStore backed cert store

### DIFF
--- a/go/kbfs/kbpagesd/main.go
+++ b/go/kbfs/kbpagesd/main.go
@@ -211,12 +211,17 @@ func main() {
 			logger, fStathatPrefix, fStathatEZKey, enabler)
 	}
 
+	certStore := libpages.NoCertStore
+	if fDiskCertCache {
+		certStore = libpages.DiskCertStore
+	}
+
 	serverConfig := &libpages.ServerConfig{
-		DomainBlacklist:  removeEmpty(strings.Split(fBlacklist, ",")),
-		UseStaging:       !fProd,
-		Logger:           logger,
-		UseDiskCertCache: fDiskCertCache,
-		StatsReporter:    statsReporter,
+		DomainBlacklist: removeEmpty(strings.Split(fBlacklist, ",")),
+		UseStaging:      !fProd,
+		Logger:          logger,
+		CertStore:       certStore,
+		StatsReporter:   statsReporter,
 	}
 
 	_ = libpages.ListenAndServe(ctx, serverConfig, kbConfig)

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -741,6 +741,9 @@ type KeybaseService interface {
 	// and sets it if not established.
 	EstablishMountDir(ctx context.Context) (string, error)
 
+	// GetKVStoreClient returns a client for accessing the KVStore service.
+	GetKVStoreClient() keybase1.KvstoreInterface
+
 	// Shutdown frees any resources associated with this
 	// instance. No other methods may be called after this is
 	// called.

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -447,6 +447,7 @@ func (k *KeybaseDaemonLocal) OnNonPathChange(
 	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
 }
 
+// GetKVStoreClient implements the KeybaseService interface.
 func (k *KeybaseDaemonLocal) GetKVStoreClient() keybase1.KvstoreInterface {
 	return nil
 }

--- a/go/kbfs/libkbfs/keybase_daemon_local.go
+++ b/go/kbfs/libkbfs/keybase_daemon_local.go
@@ -447,6 +447,10 @@ func (k *KeybaseDaemonLocal) OnNonPathChange(
 	subscriptionIDs []SubscriptionID, topic keybase1.SubscriptionTopic) {
 }
 
+func (k *KeybaseDaemonLocal) GetKVStoreClient() keybase1.KvstoreInterface {
+	return nil
+}
+
 // Shutdown implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Shutdown() {
 	k.favoriteStore.Shutdown()

--- a/go/kbfs/libkbfs/keybase_daemon_rpc.go
+++ b/go/kbfs/libkbfs/keybase_daemon_rpc.go
@@ -136,7 +136,9 @@ func (k *KeybaseDaemonRPC) fillClients(client rpc.GenericClient) {
 		keybase1.FavoriteClient{Cli: client},
 		keybase1.KbfsClient{Cli: client},
 		keybase1.KbfsMountClient{Cli: client},
-		keybase1.GitClient{Cli: client})
+		keybase1.GitClient{Cli: client},
+		keybase1.KvstoreClient{Cli: client},
+	)
 }
 
 type daemonLogUI struct {

--- a/go/kbfs/libkbfs/keybase_service_base.go
+++ b/go/kbfs/libkbfs/keybase_service_base.go
@@ -42,6 +42,7 @@ type KeybaseServiceBase struct {
 	kbfsClient      keybase1.KbfsInterface
 	kbfsMountClient keybase1.KbfsMountInterface
 	gitClient       keybase1.GitInterface
+	kvstoreClient   keybase1.KvstoreInterface
 	log             logger.Logger
 
 	config     Config
@@ -107,7 +108,7 @@ func (k *KeybaseServiceBase) FillClients(
 	favoriteClient keybase1.FavoriteInterface,
 	kbfsClient keybase1.KbfsInterface,
 	kbfsMountClient keybase1.KbfsMountInterface,
-	gitClient keybase1.GitInterface) {
+	gitClient keybase1.GitInterface, kvstoreClient keybase1.KvstoreClient) {
 	k.identifyClient = identifyClient
 	k.userClient = userClient
 	k.teamsClient = teamsClient
@@ -117,6 +118,7 @@ func (k *KeybaseServiceBase) FillClients(
 	k.kbfsClient = kbfsClient
 	k.kbfsMountClient = kbfsMountClient
 	k.gitClient = gitClient
+	k.kvstoreClient = kvstoreClient
 }
 
 type addVerifyingKeyFunc func(kbfscrypto.VerifyingKey)
@@ -1606,4 +1608,10 @@ func (k *KeybaseServiceBase) PutGitMetadata(
 		RepoID:   repoID,
 		Metadata: metadata,
 	})
+}
+
+// GetKVStoreClient implements the KeybaseService interface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) GetKVStoreClient() keybase1.KvstoreInterface {
+	return k.kvstoreClient
 }

--- a/go/kbfs/libkbfs/keybase_service_measured.go
+++ b/go/kbfs/libkbfs/keybase_service_measured.go
@@ -392,6 +392,11 @@ func (k KeybaseServiceMeasured) OnNonPathChange(
 	})
 }
 
+// GetKVStoreClient implements the KeybaseService interface.
+func (k KeybaseServiceMeasured) GetKVStoreClient() keybase1.KvstoreInterface {
+	return k.delegate.GetKVStoreClient()
+}
+
 // Shutdown implements the KeybaseService interface for
 // KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Shutdown() {

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -2343,6 +2343,20 @@ func (mr *MockKeybaseServiceMockRecorder) GetCurrentMerkleRoot(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentMerkleRoot", reflect.TypeOf((*MockKeybaseService)(nil).GetCurrentMerkleRoot), arg0)
 }
 
+// GetKVStoreClient mocks base method.
+func (m *MockKeybaseService) GetKVStoreClient() keybase1.KvstoreInterface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKVStoreClient")
+	ret0, _ := ret[0].(keybase1.KvstoreInterface)
+	return ret0
+}
+
+// GetKVStoreClient indicates an expected call of GetKVStoreClient.
+func (mr *MockKeybaseServiceMockRecorder) GetKVStoreClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKVStoreClient", reflect.TypeOf((*MockKeybaseService)(nil).GetKVStoreClient))
+}
+
 // GetTeamSettings mocks base method.
 func (m *MockKeybaseService) GetTeamSettings(arg0 context.Context, arg1 keybase1.TeamID, arg2 keybase1.OfflineAvailability) (keybase1.KBFSTeamSettings, error) {
 	m.ctrl.T.Helper()

--- a/go/kbfs/libpages/cert_store_backed_by_kvstore.go
+++ b/go/kbfs/libpages/cert_store_backed_by_kvstore.go
@@ -1,0 +1,85 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libpages
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/keybase/client/go/kbfs/libkbfs"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+// certStoreBackedByKVStore is a wrapper around the KVStore in Keybase. No
+// caching is done here since acme/autocert has a in-memory cache already.
+type certStoreBackedByKVStore struct {
+	kbfsConfig libkbfs.Config
+}
+
+var _ autocert.Cache = (*certStoreBackedByKVStore)(nil)
+
+func newCertStoreBackedByKVStore(kbfsConfig libkbfs.Config) autocert.Cache {
+	return &certStoreBackedByKVStore{
+		kbfsConfig: kbfsConfig,
+	}
+}
+
+func encodeData(data []byte) string {
+	return base64.URLEncoding.EncodeToString(data)
+}
+
+func decodeData(str string) ([]byte, error) {
+	return base64.URLEncoding.DecodeString(str)
+}
+
+const certKVStoreNamespace = "cert-store-v1"
+
+// Get implements the autocert.Cache interface.
+func (s *certStoreBackedByKVStore) Get(ctx context.Context, key string) ([]byte, error) {
+	res, err := s.kbfsConfig.KeybaseService().GetKVStoreClient().GetKVEntry(ctx,
+		keybase1.GetKVEntryArg{
+			Namespace: certKVStoreNamespace,
+			EntryKey:  key,
+		})
+	if err != nil {
+		return nil, errors.WithMessage(err, "kvstore get error")
+	}
+	if res.EntryValue == nil {
+		return nil, errors.New("kvstore get error: empty result")
+	}
+	data, err := decodeData(*res.EntryValue)
+	if err != nil {
+		return nil, errors.WithMessage(err, "decodeData error")
+	}
+	return data, nil
+}
+
+// Put implements the autocert.Cache interface.
+func (s *certStoreBackedByKVStore) Put(ctx context.Context, key string, data []byte) error {
+	_, err := s.kbfsConfig.KeybaseService().GetKVStoreClient().PutKVEntry(ctx,
+		keybase1.PutKVEntryArg{
+			Namespace:  certKVStoreNamespace,
+			EntryKey:   key,
+			EntryValue: encodeData(data),
+		})
+	if err != nil {
+		return errors.WithMessage(err, "kvstore put error")
+	}
+	return nil
+}
+
+// Delete implements the autocert.Cache interface.
+func (s *certStoreBackedByKVStore) Delete(ctx context.Context, key string) error {
+	_, err := s.kbfsConfig.KeybaseService().GetKVStoreClient().DelKVEntry(ctx, keybase1.DelKVEntryArg{
+		Namespace: certKVStoreNamespace,
+		EntryKey:  key,
+	})
+	if err != nil {
+		return errors.WithMessage(err, "kvstore del error")
+	}
+	return nil
+}

--- a/go/kbfs/libpages/cert_store_backed_by_kvstore.go
+++ b/go/kbfs/libpages/cert_store_backed_by_kvstore.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Keybase Inc. All rights reserved.
+// Copyright 2020 Keybase Inc. All rights reserved.
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 

--- a/go/kbfs/libpages/server.go
+++ b/go/kbfs/libpages/server.go
@@ -33,6 +33,7 @@ import (
 // for acme/autocert.
 type CertStoreType string
 
+// Possible cert store types.
 const (
 	NoCertStore      CertStoreType = ""
 	DiskCertStore    CertStoreType = "disk"


### PR DESCRIPTION
This store (`autocert.Cache`) is used both as an actual cert storage, and for storing temporary tokens for cert provisioning. So this would allow us to move toward being able to run multiple instances.

This doesn't use it yet. I'll have a separate PR to move away from CLI arg config.