### PR TITLE
Team management add members: handle people already in the team

### DIFF
--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -468,6 +468,14 @@ func GenerateTestPhoneNumber() string {
 	return fmt.Sprintf("1555%s", string(ret))
 }
 
+func GenerateRandomEmailAddress(t libkb.TestingTB) keybase1.EmailAddress {
+	buf := make([]byte, 5)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+	email := fmt.Sprintf("%s@example.org", hex.EncodeToString(buf))
+	return keybase1.EmailAddress(email)
+}
+
 type getCodeResponse struct {
 	libkb.AppStatusEmbed
 	VerificationCode string `json:"verification_code"`

--- a/go/kbtest/kbtest.go
+++ b/go/kbtest/kbtest.go
@@ -468,10 +468,12 @@ func GenerateTestPhoneNumber() string {
 	return fmt.Sprintf("1555%s", string(ret))
 }
 
-func GenerateRandomEmailAddress(t libkb.TestingTB) keybase1.EmailAddress {
+func GenerateRandomEmailAddress() keybase1.EmailAddress {
 	buf := make([]byte, 5)
 	_, err := rand.Read(buf)
-	require.NoError(t, err)
+	if err != nil {
+		panic(err)
+	}
 	email := fmt.Sprintf("%s@example.org", hex.EncodeToString(buf))
 	return keybase1.EmailAddress(email)
 }

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2645,6 +2645,8 @@ func (a TeamInviteType) Eq(b TeamInviteType) bool {
 		return true
 	case TeamInviteCategory_EMAIL:
 		return true
+	case TeamInviteCategory_PHONE:
+		return true
 	case TeamInviteCategory_SBS:
 		return a.Sbs() == b.Sbs()
 	case TeamInviteCategory_UNKNOWN:

--- a/go/protocol/keybase1/extras.go
+++ b/go/protocol/keybase1/extras.go
@@ -2643,9 +2643,7 @@ func (a TeamInviteType) Eq(b TeamInviteType) bool {
 	switch ac {
 	case TeamInviteCategory_KEYBASE:
 		return true
-	case TeamInviteCategory_EMAIL:
-		return true
-	case TeamInviteCategory_PHONE:
+	case TeamInviteCategory_EMAIL, TeamInviteCategory_PHONE:
 		return true
 	case TeamInviteCategory_SBS:
 		return a.Sbs() == b.Sbs()

--- a/go/protocol/keybase1/teams.go
+++ b/go/protocol/keybase1/teams.go
@@ -4931,6 +4931,12 @@ type LoadTeamTreeMembershipsAsyncArg struct {
 	Username  string `codec:"username" json:"username"`
 }
 
+type FindAssertionsInTeamNoResolveArg struct {
+	SessionID  int      `codec:"sessionID" json:"sessionID"`
+	TeamID     TeamID   `codec:"teamID" json:"teamID"`
+	Assertions []string `codec:"assertions" json:"assertions"`
+}
+
 type TeamsInterface interface {
 	GetUntrustedTeamInfo(context.Context, TeamName) (UntrustedTeamInfo, error)
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
@@ -5016,6 +5022,7 @@ type TeamsInterface interface {
 	GetAnnotatedTeam(context.Context, TeamID) (AnnotatedTeam, error)
 	GetAnnotatedTeamByName(context.Context, string) (AnnotatedTeam, error)
 	LoadTeamTreeMembershipsAsync(context.Context, LoadTeamTreeMembershipsAsyncArg) (TeamTreeInitial, error)
+	FindAssertionsInTeamNoResolve(context.Context, FindAssertionsInTeamNoResolveArg) ([]string, error)
 }
 
 func TeamsProtocol(i TeamsInterface) rpc.Protocol {
@@ -6007,6 +6014,21 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 					return
 				},
 			},
+			"findAssertionsInTeamNoResolve": {
+				MakeArg: func() interface{} {
+					var ret [1]FindAssertionsInTeamNoResolveArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]FindAssertionsInTeamNoResolveArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]FindAssertionsInTeamNoResolveArg)(nil), args)
+						return
+					}
+					ret, err = i.FindAssertionsInTeamNoResolve(ctx, typedArgs[0])
+					return
+				},
+			},
 		},
 	}
 }
@@ -6375,5 +6397,10 @@ func (c TeamsClient) GetAnnotatedTeamByName(ctx context.Context, teamName string
 
 func (c TeamsClient) LoadTeamTreeMembershipsAsync(ctx context.Context, __arg LoadTeamTreeMembershipsAsyncArg) (res TeamTreeInitial, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.loadTeamTreeMembershipsAsync", []interface{}{__arg}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c TeamsClient) FindAssertionsInTeamNoResolve(ctx context.Context, __arg FindAssertionsInTeamNoResolveArg) (res []string, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.findAssertionsInTeamNoResolve", []interface{}{__arg}, &res, 0*time.Millisecond)
 	return
 }

--- a/go/service/teams.go
+++ b/go/service/teams.go
@@ -954,3 +954,11 @@ func (h *TeamsHandler) GetInviteLinkDetails(ctx context.Context, inviteID keybas
 	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
 	return teams.GetInviteLinkDetails(mctx, inviteID)
 }
+
+func (h *TeamsHandler) FindAssertionsInTeamNoResolve(ctx context.Context, arg keybase1.FindAssertionsInTeamNoResolveArg) (ret []string, err error) {
+	ctx = libkb.WithLogTag(ctx, "TM")
+	traceMsg := fmt.Sprintf("FindAssertionsInTeam(%s, %d)", arg.TeamID, len(arg.Assertions))
+	defer h.G().CTrace(ctx, traceMsg, &err)()
+	mctx := libkb.NewMetaContext(ctx, h.G().ExternalG())
+	return teams.FindAssertionsInTeamNoResolve(mctx, arg.TeamID, arg.Assertions)
+}

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -794,7 +794,7 @@ func TestMemberAddEmailBulk(t *testing.T) {
 	tc, _, name := memberSetup(t)
 	defer tc.Cleanup()
 
-	existingUserEmail := kbtest.GenerateRandomEmailAddress(t)
+	existingUserEmail := kbtest.GenerateRandomEmailAddress()
 	blob := string(existingUserEmail) + ", h@j.k,u1@keybase.io, u2@keybase.io\nu3@keybase.io,u4@keybase.io, u5@keybase.io,u6@keybase.io, u7@keybase.io\n\n\nFull Name <fullname@keybase.io>, Someone Else <someone@keybase.io>,u8@keybase.io\n\nXXXXXXXXXXXX"
 
 	// create a user with a searchable email to test addEmailsBulk resolves existing users correctly.
@@ -2335,7 +2335,7 @@ func TestFindAssertionsInTeamForInvites(t *testing.T) {
 		require.Equal(t, phone+"@phone", ret[0])
 	}
 
-	email := kbtest.GenerateRandomEmailAddress(t)
+	email := kbtest.GenerateRandomEmailAddress()
 	err = InviteEmailPhoneMember(context.TODO(), tc.G, teamID, email.String(), "email", keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
 
@@ -2349,7 +2349,7 @@ func TestFindAssertionsInTeamForInvites(t *testing.T) {
 		require.Equal(t, assertions[0], ret[0])
 	}
 
-	email2 := kbtest.GenerateRandomEmailAddress(t)
+	email2 := kbtest.GenerateRandomEmailAddress()
 	err = InviteEmailPhoneMember(context.TODO(), tc.G, teamID, email2.String(), "email", keybase1.TeamRole_WRITER)
 	require.NoError(t, err)
 
@@ -2357,7 +2357,7 @@ func TestFindAssertionsInTeamForInvites(t *testing.T) {
 		var assertions []string
 		assertions = append(assertions, fmt.Sprintf("[%s]@email", email2))
 		for i := 0; i < 5; i++ {
-			assertions = append(assertions, fmt.Sprintf("[%s]@email", kbtest.GenerateRandomEmailAddress(t)))
+			assertions = append(assertions, fmt.Sprintf("[%s]@email", kbtest.GenerateRandomEmailAddress()))
 		}
 		assertions = append(assertions, fmt.Sprintf("[%s]@email", email))
 		ret, err := FindAssertionsInTeamNoResolve(tc.MetaContext(), teamID, assertions)

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -2443,6 +2443,19 @@ func TestFindAssertionsInTeamForUsers(t *testing.T) {
 		require.Equal(t, otherA.Username, ret[0])
 		require.Equal(t, otherB.Username, ret[1])
 	}
+
+	{
+		// Deduplicate, do not check same assertion more than once.
+		assertions := []string{
+			owner.Username,
+			owner.Username,
+			owner.Username,
+		}
+		ret, err := FindAssertionsInTeamNoResolve(tc.MetaContext(), teamID, assertions)
+		require.NoError(t, err)
+		require.Len(t, ret, 1)
+		require.Equal(t, owner.Username, ret[0])
+	}
 }
 
 func TestTeamPlayerIdempotentChangesAssertRole(t *testing.T) {

--- a/go/teams/member_test.go
+++ b/go/teams/member_test.go
@@ -43,42 +43,21 @@ func memberSetup(t *testing.T) (libkb.TestContext, *kbtest.FakeUser, string) {
 }
 
 func memberSetupMultiple(t *testing.T) (tc libkb.TestContext, owner, otherA, otherB *kbtest.FakeUser, name string) {
-	tc = SetupTest(t, "team", 1)
-
-	otherA, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
-	err = tc.Logout()
-	require.NoError(t, err)
-
-	otherB, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
-	err = tc.Logout()
-	require.NoError(t, err)
-
-	owner, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
-
-	name = createTeam(tc)
-	t.Logf("Created team %q", name)
-
-	return tc, owner, otherA, otherB, name
+	tc, owner, otherA, otherB, teamName, _ := memberSetupMultipleWithTeamID(t)
+	return tc, owner, otherA, otherB, teamName.String()
 }
 
 func memberSetupMultipleWithTeamID(t *testing.T) (tc libkb.TestContext, owner, otherA, otherB *kbtest.FakeUser, name keybase1.TeamName, teamID keybase1.TeamID) {
 	tc = SetupTest(t, "team", 1)
 
-	otherA, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
-	err = tc.Logout()
-	require.NoError(t, err)
-
-	otherB, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
-	err = tc.Logout()
-	require.NoError(t, err)
-
-	owner, err = kbtest.CreateAndSignupFakeUser("team", tc.G)
-	require.NoError(t, err)
+	for i, ptr := range []**kbtest.FakeUser{&otherA, &otherB, &owner} {
+		if i > 0 {
+			kbtest.Logout(tc)
+		}
+		user, err := kbtest.CreateAndSignupFakeUser("team", tc.G)
+		require.NoError(t, err)
+		*ptr = user
+	}
 
 	name, teamID = createTeam2(tc)
 	t.Logf("Created team %q", name)

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -2226,6 +2226,10 @@ func FindAssertionsInTeamNoResolve(mctx libkb.MetaContext, teamID keybase1.TeamI
 			loadUserArg := libkb.NewLoadUserArgWithMetaContext(mctx).WithName(url.GetValue()).WithPublicKeyOptional()
 			user, err := libkb.LoadUser(loadUserArg)
 			if err != nil {
+				if _, ok := err.(libkb.NotFoundError); ok {
+					// User not found - that's fine.
+					continue
+				}
 				return nil, fmt.Errorf("error when loading user for assertion %q: %w", assertionStr, err)
 			}
 			if user.GetStatus() != keybase1.StatusCode_SCOk {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -6,13 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keybase/client/go/externals"
-
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/avatars"
 	email_utils "github.com/keybase/client/go/emails"
 	"github.com/keybase/client/go/engine"
+	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -2205,14 +2205,14 @@ func FindAssertionsInTeamNoResolve(mctx libkb.MetaContext, teamID keybase1.TeamI
 	}
 
 	// Don't check one assertion more than once, if we got duplicates.
-	checkedAssertions := make(map[string]bool)
+	checkedAssertions := make(map[string]struct{})
 
 	actx := externals.MakeAssertionContext(mctx)
 	for _, assertionStr := range assertions {
 		if _, found := checkedAssertions[assertionStr]; found {
 			continue
 		}
-		checkedAssertions[assertionStr] = true
+		checkedAssertions[assertionStr] = struct{}{}
 
 		assertion, err := libkb.AssertionParseAndOnly(actx, assertionStr)
 		if err != nil {

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -2221,6 +2221,9 @@ func FindAssertionsInTeamNoResolve(mctx libkb.MetaContext, teamID keybase1.TeamI
 
 		urls := assertion.CollectUrls(nil)
 		if len(urls) > 1 {
+			// Skip compound assertions for now. Rationale is that team invites
+			// cannot have compound assertions, and it's unclear what to look
+			// for in a team when compound assertion is found here.
 			continue
 		}
 
@@ -2240,7 +2243,7 @@ func FindAssertionsInTeamNoResolve(mctx libkb.MetaContext, teamID keybase1.TeamI
 				return nil, fmt.Errorf("error when loading user for assertion %q: %w", assertionStr, err)
 			}
 			if user.GetStatus() != keybase1.StatusCode_SCOk {
-				// User is deleted or something. Just skip for now.
+				// User is deleted or similar. Skip for now.
 				continue
 			}
 			uv := user.ToUserVersion()

--- a/go/teams/transactions.go
+++ b/go/teams/transactions.go
@@ -508,12 +508,12 @@ func (tx *AddMemberTx) AddMemberByUsername(ctx context.Context, username string,
 // assert that it only has one part (and isn't a+b compound). If there is only
 // one factor in the assertion, then that's returned as single. Otherwise,
 // single is nil.
-func preprocessAssertion(m libkb.MetaContext, s string) (isServerTrustInvite bool, single libkb.AssertionURL, full libkb.AssertionExpression, err error) {
-	a, err := externals.AssertionParseAndOnly(m, s)
+func preprocessAssertion(mctx libkb.MetaContext, assertionStr string) (isServerTrustInvite bool, single libkb.AssertionURL, full libkb.AssertionExpression, err error) {
+	assertion, err := externals.AssertionParseAndOnly(mctx, assertionStr)
 	if err != nil {
 		return false, nil, nil, err
 	}
-	urls := a.CollectUrls(nil)
+	urls := assertion.CollectUrls(nil)
 	if len(urls) == 1 {
 		single = urls[0]
 	}
@@ -525,7 +525,7 @@ func preprocessAssertion(m libkb.MetaContext, s string) (isServerTrustInvite boo
 	if isServerTrustInvite && len(urls) > 1 {
 		return false, nil, nil, NewMixedServerTrustAssertionError()
 	}
-	return isServerTrustInvite, single, a, nil
+	return isServerTrustInvite, single, assertion, nil
 }
 
 // resolveServerTrustAssertion resolves server-trust assertion. The possible

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1840,4 +1840,18 @@ protocol teams {
   // a `guid`: an opaque integer that happens to be the sessionID the initial RPC was called
   // with. Each notification for the same load will contain the same `guid`.
   TeamTreeInitial loadTeamTreeMembershipsAsync(int sessionID, TeamID teamID, string username);
+
+  // Given a list of assertions, check which ones are already in the team either
+  // as members on invites, and return a list of them. User has to be an admin of
+  // the team.
+  //
+  // It doesn't try to resolve assertions. If there's an assertion for
+  // 'alice@rooter' that resolves to 'alice' (Keybase user), and 'alice' is
+  // already in the team, 'alice@rooter' won't end up in the returned list.
+  //
+  // Compound assertion are ignored, as invites for compound assertions are not
+  // allowed. Technically, a user targetted by compound assertion could be in the
+  // team, assertion would have to be resolved to figure this out, which this
+  // function does not do
+  array<string> findAssertionsInTeamNoResolve(int sessionID, TeamID teamID, array<string> assertions);
 }

--- a/protocol/avdl/keybase1/teams.avdl
+++ b/protocol/avdl/keybase1/teams.avdl
@@ -1850,7 +1850,7 @@ protocol teams {
   // already in the team, 'alice@rooter' won't end up in the returned list.
   //
   // Compound assertion are ignored, as invites for compound assertions are not
-  // allowed. Technically, a user targetted by compound assertion could be in the
+  // allowed. Technically, a user targeted by compound assertion could be in the
   // team, assertion would have to be resolved to figure this out, which this
   // function does not do
   array<string> findAssertionsInTeamNoResolve(int sessionID, TeamID teamID, array<string> assertions);

--- a/protocol/bin/enabled-calls.json
+++ b/protocol/bin/enabled-calls.json
@@ -297,6 +297,7 @@
   "keybase.1.signup.getInvitationCode": {"promise": true},
   "keybase.1.signup.inviteRequest": {"promise": true},
   "keybase.1.signup.signup": {"engineSaga": true},
+  "keybase.1.teams.findAssertionsInTeamNoResolve": {"promise": true},
   "keybase.1.teams.getAnnotatedTeam": {"promise": true},
   "keybase.1.teams.getInviteLinkDetails": {"promise": true},
   "keybase.1.teams.getTarsDisabled": {"promise": true},

--- a/protocol/json/keybase1/teams.json
+++ b/protocol/json/keybase1/teams.json
@@ -5006,6 +5006,29 @@
         }
       ],
       "response": "TeamTreeInitial"
+    },
+    "findAssertionsInTeamNoResolve": {
+      "request": [
+        {
+          "name": "sessionID",
+          "type": "int"
+        },
+        {
+          "name": "teamID",
+          "type": "TeamID"
+        },
+        {
+          "name": "assertions",
+          "type": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "response": {
+        "type": "array",
+        "items": "string"
+      }
     }
   },
   "namespace": "keybase.1"

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -379,8 +379,13 @@
       "creatingChannels": "boolean"
     },
     "addMembersWizardPushMembers": {
-      "_description": "Add pending members to the add members wizard and show the confirm screen.",
+      "_description": "Add list of members to the add members wizard and show the confirm screen.",
       "members": "Array<Types.AddingMember>"
+    },
+    "addMembersWizardSetMembers": {
+      "_description": "Set member list for add members wizard confirmation screen, and members that are already in team and has been skipped.",
+      "members": "Array<Types.AddingMember>",
+      "membersAlreadyInTeam": "Array<string>"
     },
     "addMembersWizardRemoveMember": {
       "_description": "Remove a pending member from the add members wizard.",

--- a/shared/actions/json/teams.json
+++ b/shared/actions/json/teams.json
@@ -379,13 +379,13 @@
       "creatingChannels": "boolean"
     },
     "addMembersWizardPushMembers": {
-      "_description": "Add list of members to the add members wizard and show the confirm screen.",
+      "_description": "Should be called when user is trying to add new assertions to the wizard",
       "members": "Array<Types.AddingMember>"
     },
-    "addMembersWizardSetMembers": {
-      "_description": "Set member list for add members wizard confirmation screen, and members that are already in team and has been skipped.",
+    "addMembersWizardAddMembers": {
+      "_description": "Takes a member list and appends it to wizard state, using assertionsInTeam as a filter. When filtering, it also maintains membersAlreadyInTeam list.",
       "members": "Array<Types.AddingMember>",
-      "membersAlreadyInTeam": "Array<string>"
+      "assertionsInTeam": "Array<string>"
     },
     "addMembersWizardRemoveMember": {
       "_description": "Remove a pending member from the add members wizard.",

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -11,6 +11,7 @@ export const typePrefix = 'teams:'
 export const addMembersWizardPushMembers = 'teams:addMembersWizardPushMembers'
 export const addMembersWizardRemoveMember = 'teams:addMembersWizardRemoveMember'
 export const addMembersWizardSetDefaultChannels = 'teams:addMembersWizardSetDefaultChannels'
+export const addMembersWizardSetMembers = 'teams:addMembersWizardSetMembers'
 export const addParticipant = 'teams:addParticipant'
 export const addTeamWithChosenChannels = 'teams:addTeamWithChosenChannels'
 export const addToTeam = 'teams:addToTeam'
@@ -130,6 +131,10 @@ type _AddMembersWizardRemoveMemberPayload = {readonly assertion: string}
 type _AddMembersWizardSetDefaultChannelsPayload = {
   readonly toAdd?: Array<Types.ChannelNameID>
   readonly toRemove?: Types.ChannelNameID
+}
+type _AddMembersWizardSetMembersPayload = {
+  readonly members: Array<Types.AddingMember>
+  readonly membersAlreadyInTeam: Array<string>
 }
 type _AddParticipantPayload = {
   readonly teamID: Types.TeamID
@@ -399,7 +404,7 @@ type _UploadTeamAvatarPayload = {
 
 // Action Creators
 /**
- * Add pending members to the add members wizard and show the confirm screen.
+ * Add list of members to the add members wizard and show the confirm screen.
  */
 export const createAddMembersWizardPushMembers = (
   payload: _AddMembersWizardPushMembersPayload
@@ -548,6 +553,12 @@ export const createSetActivityLevels = (payload: _SetActivityLevelsPayload): Set
   payload,
   type: setActivityLevels,
 })
+/**
+ * Set member list for add members wizard confirmation screen, and members that are already in team and has been skipped.
+ */
+export const createAddMembersWizardSetMembers = (
+  payload: _AddMembersWizardSetMembersPayload
+): AddMembersWizardSetMembersPayload => ({payload, type: addMembersWizardSetMembers})
 /**
  * Set the role for a pending member in the add member wizard.
  */
@@ -911,6 +922,10 @@ export type AddMembersWizardRemoveMemberPayload = {
 export type AddMembersWizardSetDefaultChannelsPayload = {
   readonly payload: _AddMembersWizardSetDefaultChannelsPayload
   readonly type: typeof addMembersWizardSetDefaultChannels
+}
+export type AddMembersWizardSetMembersPayload = {
+  readonly payload: _AddMembersWizardSetMembersPayload
+  readonly type: typeof addMembersWizardSetMembers
 }
 export type AddParticipantPayload = {
   readonly payload: _AddParticipantPayload
@@ -1307,6 +1322,7 @@ export type Actions =
   | AddMembersWizardPushMembersPayload
   | AddMembersWizardRemoveMemberPayload
   | AddMembersWizardSetDefaultChannelsPayload
+  | AddMembersWizardSetMembersPayload
   | AddParticipantPayload
   | AddTeamWithChosenChannelsPayload
   | AddToTeamPayload

--- a/shared/actions/teams-gen.tsx
+++ b/shared/actions/teams-gen.tsx
@@ -8,10 +8,10 @@ import {RetentionPolicy} from '../constants/types/retention-policy'
 // Constants
 export const resetStore = 'common:resetStore' // not a part of teams but is handled by every reducer. NEVER dispatch this
 export const typePrefix = 'teams:'
+export const addMembersWizardAddMembers = 'teams:addMembersWizardAddMembers'
 export const addMembersWizardPushMembers = 'teams:addMembersWizardPushMembers'
 export const addMembersWizardRemoveMember = 'teams:addMembersWizardRemoveMember'
 export const addMembersWizardSetDefaultChannels = 'teams:addMembersWizardSetDefaultChannels'
-export const addMembersWizardSetMembers = 'teams:addMembersWizardSetMembers'
 export const addParticipant = 'teams:addParticipant'
 export const addTeamWithChosenChannels = 'teams:addTeamWithChosenChannels'
 export const addToTeam = 'teams:addToTeam'
@@ -126,15 +126,15 @@ export const updateTopic = 'teams:updateTopic'
 export const uploadTeamAvatar = 'teams:uploadTeamAvatar'
 
 // Payload Types
+type _AddMembersWizardAddMembersPayload = {
+  readonly members: Array<Types.AddingMember>
+  readonly assertionsInTeam: Array<string>
+}
 type _AddMembersWizardPushMembersPayload = {readonly members: Array<Types.AddingMember>}
 type _AddMembersWizardRemoveMemberPayload = {readonly assertion: string}
 type _AddMembersWizardSetDefaultChannelsPayload = {
   readonly toAdd?: Array<Types.ChannelNameID>
   readonly toRemove?: Types.ChannelNameID
-}
-type _AddMembersWizardSetMembersPayload = {
-  readonly members: Array<Types.AddingMember>
-  readonly membersAlreadyInTeam: Array<string>
 }
 type _AddParticipantPayload = {
   readonly teamID: Types.TeamID
@@ -404,12 +404,6 @@ type _UploadTeamAvatarPayload = {
 
 // Action Creators
 /**
- * Add list of members to the add members wizard and show the confirm screen.
- */
-export const createAddMembersWizardPushMembers = (
-  payload: _AddMembersWizardPushMembersPayload
-): AddMembersWizardPushMembersPayload => ({payload, type: addMembersWizardPushMembers})
-/**
  * Called by the modal if the key is missing
  */
 export const createRequestInviteLinkDetails = (
@@ -554,12 +548,6 @@ export const createSetActivityLevels = (payload: _SetActivityLevelsPayload): Set
   type: setActivityLevels,
 })
 /**
- * Set member list for add members wizard confirmation screen, and members that are already in team and has been skipped.
- */
-export const createAddMembersWizardSetMembers = (
-  payload: _AddMembersWizardSetMembersPayload
-): AddMembersWizardSetMembersPayload => ({payload, type: addMembersWizardSetMembers})
-/**
  * Set the role for a pending member in the add member wizard.
  */
 export const createSetAddMembersWizardIndividualRole = (
@@ -617,11 +605,23 @@ export const createStartAddMembersWizard = (
   payload: _StartAddMembersWizardPayload
 ): StartAddMembersWizardPayload => ({payload, type: startAddMembersWizard})
 /**
+ * Should be called when user is trying to add new assertions to the wizard
+ */
+export const createAddMembersWizardPushMembers = (
+  payload: _AddMembersWizardPushMembersPayload
+): AddMembersWizardPushMembersPayload => ({payload, type: addMembersWizardPushMembers})
+/**
  * Stop listening for team details for this team
  */
 export const createUnsubscribeTeamDetails = (
   payload: _UnsubscribeTeamDetailsPayload
 ): UnsubscribeTeamDetailsPayload => ({payload, type: unsubscribeTeamDetails})
+/**
+ * Takes a member list and appends it to wizard state, using assertionsInTeam as a filter. When filtering, it also maintains membersAlreadyInTeam list.
+ */
+export const createAddMembersWizardAddMembers = (
+  payload: _AddMembersWizardAddMembersPayload
+): AddMembersWizardAddMembersPayload => ({payload, type: addMembersWizardAddMembers})
 /**
  * Toggle whether invites are collapsed in the member list for this team
  */
@@ -911,6 +911,10 @@ export const createUploadTeamAvatar = (payload: _UploadTeamAvatarPayload): Uploa
 })
 
 // Action Payloads
+export type AddMembersWizardAddMembersPayload = {
+  readonly payload: _AddMembersWizardAddMembersPayload
+  readonly type: typeof addMembersWizardAddMembers
+}
 export type AddMembersWizardPushMembersPayload = {
   readonly payload: _AddMembersWizardPushMembersPayload
   readonly type: typeof addMembersWizardPushMembers
@@ -922,10 +926,6 @@ export type AddMembersWizardRemoveMemberPayload = {
 export type AddMembersWizardSetDefaultChannelsPayload = {
   readonly payload: _AddMembersWizardSetDefaultChannelsPayload
   readonly type: typeof addMembersWizardSetDefaultChannels
-}
-export type AddMembersWizardSetMembersPayload = {
-  readonly payload: _AddMembersWizardSetMembersPayload
-  readonly type: typeof addMembersWizardSetMembers
 }
 export type AddParticipantPayload = {
   readonly payload: _AddParticipantPayload
@@ -1319,10 +1319,10 @@ export type UploadTeamAvatarPayload = {
 // All Actions
 // prettier-ignore
 export type Actions =
+  | AddMembersWizardAddMembersPayload
   | AddMembersWizardPushMembersPayload
   | AddMembersWizardRemoveMemberPayload
   | AddMembersWizardSetDefaultChannelsPayload
-  | AddMembersWizardSetMembersPayload
   | AddParticipantPayload
   | AddTeamWithChosenChannelsPayload
   | AddToTeamPayload

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1601,8 +1601,8 @@ const addMembersWizardPushMembers = async (
 
   return [
     TeamsGen.createAddMembersWizardAddMembers({
-      members: action.payload.members,
       assertionsInTeam: existingAssertions ?? [],
+      members: action.payload.members,
     }),
     RouteTreeGen.createNavigateAppend({path: ['teamAddToTeamConfirm']}),
   ]

--- a/shared/actions/teams.tsx
+++ b/shared/actions/teams.tsx
@@ -1587,6 +1587,9 @@ const addMembersWizardPushMembers = async (
   state: TypedState,
   action: TeamsGen.AddMembersWizardPushMembersPayload
 ) => {
+  // Call FindAssertionsInTeamNoResolve RPC and pass the results along with the
+  // members to addMembersWizardSetMembers action.
+
   const wizardState = state.teams.addMembersWizard
 
   // Find assertions that we are going to call FindAssertionsInTeam~ on to

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -998,6 +998,7 @@ export type TypedActionsMap = {
   'teams:setAddMembersWizardIndividualRole': teams.SetAddMembersWizardIndividualRolePayload
   'teams:setCreatingChannels': teams.SetCreatingChannelsPayload
   'teams:addMembersWizardPushMembers': teams.AddMembersWizardPushMembersPayload
+  'teams:addMembersWizardSetMembers': teams.AddMembersWizardSetMembersPayload
   'teams:addMembersWizardRemoveMember': teams.AddMembersWizardRemoveMemberPayload
   'teams:addMembersWizardSetDefaultChannels': teams.AddMembersWizardSetDefaultChannelsPayload
   'teams:cancelAddMembersWizard': teams.CancelAddMembersWizardPayload

--- a/shared/actions/typed-actions-gen.tsx
+++ b/shared/actions/typed-actions-gen.tsx
@@ -998,7 +998,7 @@ export type TypedActionsMap = {
   'teams:setAddMembersWizardIndividualRole': teams.SetAddMembersWizardIndividualRolePayload
   'teams:setCreatingChannels': teams.SetCreatingChannelsPayload
   'teams:addMembersWizardPushMembers': teams.AddMembersWizardPushMembersPayload
-  'teams:addMembersWizardSetMembers': teams.AddMembersWizardSetMembersPayload
+  'teams:addMembersWizardAddMembers': teams.AddMembersWizardAddMembersPayload
   'teams:addMembersWizardRemoveMember': teams.AddMembersWizardRemoveMemberPayload
   'teams:addMembersWizardSetDefaultChannels': teams.AddMembersWizardSetDefaultChannelsPayload
   'teams:cancelAddMembersWizard': teams.CancelAddMembersWizardPayload

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -199,9 +199,11 @@ export const addMembersWizardEmptyState: Types.State['addMembersWizard'] = {
   addToChannels: undefined,
   addingMembers: [],
   justFinished: false,
+  membersAlreadyInTeam: [],
   role: 'writer',
   teamID: Types.noTeamID,
 }
+
 export const newTeamWizardEmptyState: Types.State['newTeamWizard'] = {
   addYourself: true,
   description: '',

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -1383,6 +1383,10 @@ export type MessageTypes = {
     inParam: {readonly s: Stream; readonly buf: Bytes}
     outParam: Int
   }
+  'keybase.1.teams.findAssertionsInTeamNoResolve': {
+    inParam: {readonly teamID: TeamID; readonly assertions?: Array<String> | null}
+    outParam: Array<String> | null
+  }
   'keybase.1.teams.getAnnotatedTeam': {
     inParam: {readonly teamID: TeamID}
     outParam: AnnotatedTeam
@@ -3931,6 +3935,7 @@ export const signupCheckUsernameAvailableRpcPromise = (params: MessageTypes['key
 export const signupGetInvitationCodeRpcPromise = (params: MessageTypes['keybase.1.signup.getInvitationCode']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.signup.getInvitationCode']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.signup.getInvitationCode', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const signupInviteRequestRpcPromise = (params: MessageTypes['keybase.1.signup.inviteRequest']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.signup.inviteRequest']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.signup.inviteRequest', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const signupSignupRpcSaga = (p: {params: MessageTypes['keybase.1.signup.signup']['inParam']; incomingCallMap: IncomingCallMapType; customResponseIncomingCallMap?: CustomResponseIncomingCallMap; waitingKey?: WaitingKey}) => call(getEngineSaga(), {method: 'keybase.1.signup.signup', params: p.params, incomingCallMap: p.incomingCallMap, customResponseIncomingCallMap: p.customResponseIncomingCallMap, waitingKey: p.waitingKey})
+export const teamsFindAssertionsInTeamNoResolveRpcPromise = (params: MessageTypes['keybase.1.teams.findAssertionsInTeamNoResolve']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.findAssertionsInTeamNoResolve']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.findAssertionsInTeamNoResolve', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetAnnotatedTeamRpcPromise = (params: MessageTypes['keybase.1.teams.getAnnotatedTeam']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getAnnotatedTeam']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getAnnotatedTeam', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetInviteLinkDetailsRpcPromise = (params: MessageTypes['keybase.1.teams.getInviteLinkDetails']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getInviteLinkDetails']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getInviteLinkDetails', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))
 export const teamsGetTarsDisabledRpcPromise = (params: MessageTypes['keybase.1.teams.getTarsDisabled']['inParam'], waitingKey?: WaitingKey) => new Promise<MessageTypes['keybase.1.teams.getTarsDisabled']['outParam']>((resolve, reject) => engine()._rpcOutgoing({method: 'keybase.1.teams.getTarsDisabled', params, callback: (error, result) => (error ? reject(error) : resolve(result)), waitingKey}))

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -199,6 +199,10 @@ export type AddingMember = {
 export type AddMembersWizardState = {
   addToChannels: Array<ChannelNameID> | undefined
   addingMembers: Array<AddingMember>
+  // Assertions that were "added" through "Add people" but will not be added to
+  // the team because they are already in it. This state only holds the list of
+  // redundant assertions from the last "Add people" action.
+  membersAlreadyInTeam: Array<string>
   justFinished: boolean
   role: AddingMemberTeamRoleType | 'setIndividually'
   teamID: TeamID

--- a/shared/constants/types/teams.tsx
+++ b/shared/constants/types/teams.tsx
@@ -194,7 +194,12 @@ export type AddingMemberTeamRoleType = 'owner' | 'admin' | 'reader' | 'writer'
 export type AddingMember = {
   assertion: string
   role: AddingMemberTeamRoleType
-  note?: string // note is for imp tofu assertions that got turned into usernames. It doesn't go to the server but it displays to the user in the confirm screen.
+
+  // If an imptofu assertion got resolved to a username, preserve that
+  // assertion. Will be displayed in the confirmation screen near that
+  // username, and it's also needed to display the "person was already
+  // invited".
+  resolvedFrom?: string
 }
 export type AddMembersWizardState = {
   addToChannels: Array<ChannelNameID> | undefined

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -366,11 +366,10 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
   [TeamsGen.setJustFinishedAddMembersWizard]: (draftState, action) => {
     draftState.addMembersWizard.justFinished = action.payload.justFinished
   },
-  [TeamsGen.addMembersWizardPushMembers]: (draftState, action) => {
-    draftState.addMembersWizard.addingMembers = Constants.dedupAddingMembeers(
-      draftState.addMembersWizard.addingMembers,
-      action.payload.members.map(Constants.coerceAssertionRole)
-    )
+  [TeamsGen.addMembersWizardSetMembers]: (draftState, action) => {
+    draftState.addMembersWizard.addingMembers = action.payload.members
+    draftState.addMembersWizard.membersAlreadyInTeam = action.payload.membersAlreadyInTeam
+
     if (
       ['admin', 'owner'].includes(draftState.addMembersWizard.role) &&
       action.payload.members.some(m => m.assertion.includes('@'))

--- a/shared/reducers/teams.tsx
+++ b/shared/reducers/teams.tsx
@@ -370,6 +370,8 @@ export default Container.makeReducer<Actions, Types.State>(initialState, {
     draftState.addMembersWizard.addingMembers = action.payload.members
     draftState.addMembersWizard.membersAlreadyInTeam = action.payload.membersAlreadyInTeam
 
+    // If add member wizard role is currently set to admin or owner and we are
+    // adding an assertion, change wizard's role to "set individually".
     if (
       ['admin', 'owner'].includes(draftState.addMembersWizard.role) &&
       action.payload.members.some(m => m.assertion.includes('@'))

--- a/shared/teams/add-members-wizard/add-contacts.native.tsx
+++ b/shared/teams/add-members-wizard/add-contacts.native.tsx
@@ -3,11 +3,11 @@ import * as Kb from '../../common-adapters'
 import * as Container from '../../util/container'
 import * as Styles from '../../styles'
 import * as TeamsGen from '../../actions/teams-gen'
+import * as Types from '../../constants/types/teams'
 import * as RPCGen from '../../constants/types/rpc-gen'
 import {pluralize} from '../../util/string'
 import {ModalTitle} from '../common'
 import ContactsList, {useContacts, Contact, EnableContactsPopup} from '../common/contacts-list.native'
-import {formatPhoneNumber} from '../../util/phone-numbers'
 
 const AddContacts = () => {
   const dispatch = Container.useDispatch()
@@ -43,9 +43,10 @@ const AddContacts = () => {
         if (r?.length) {
           dispatch(
             TeamsGen.createAddMembersWizardPushMembers({
-              members: r.map(m => ({
-                assertion: m.foundUser ? m.username : m.assertion,
-                note: m.foundUser ? formatPhoneNumber(m.input) : undefined,
+              members: r.map<Types.AddingMember>(m => ({
+                ...(m.foundUser
+                  ? {assertion: m.username, resolvedFrom: m.assertion}
+                  : {assertion: m.assertion}),
                 role: 'writer',
               })),
             })

--- a/shared/teams/add-members-wizard/add-contacts.native.tsx
+++ b/shared/teams/add-members-wizard/add-contacts.native.tsx
@@ -3,7 +3,6 @@ import * as Kb from '../../common-adapters'
 import * as Container from '../../util/container'
 import * as Styles from '../../styles'
 import * as TeamsGen from '../../actions/teams-gen'
-import * as Types from '../../constants/types/teams'
 import * as RPCGen from '../../constants/types/rpc-gen'
 import {pluralize} from '../../util/string'
 import {ModalTitle} from '../common'
@@ -43,7 +42,7 @@ const AddContacts = () => {
         if (r?.length) {
           dispatch(
             TeamsGen.createAddMembersWizardPushMembers({
-              members: r.map<Types.AddingMember>(m => ({
+              members: r.map(m => ({
                 ...(m.foundUser
                   ? {assertion: m.username, resolvedFrom: m.assertion}
                   : {assertion: m.assertion}),

--- a/shared/teams/add-members-wizard/add-email.tsx
+++ b/shared/teams/add-members-wizard/add-email.tsx
@@ -36,9 +36,10 @@ const AddEmail = (props: Props) => {
         r?.length
           ? dispatch(
               TeamsGen.createAddMembersWizardPushMembers({
-                members: r.map(m => ({
-                  assertion: m.foundUser ? m.username : m.assertion,
-                  note: m.foundUser ? m.assertionValue : undefined,
+                members: r.map<Types.AddingMember>(m => ({
+                  ...(m.foundUser
+                    ? {assertion: m.username, resolvedFrom: m.assertion}
+                    : {assertion: m.assertion}),
                   role: 'writer',
                 })),
               })

--- a/shared/teams/add-members-wizard/add-email.tsx
+++ b/shared/teams/add-members-wizard/add-email.tsx
@@ -36,7 +36,7 @@ const AddEmail = (props: Props) => {
         r?.length
           ? dispatch(
               TeamsGen.createAddMembersWizardPushMembers({
-                members: r.map<Types.AddingMember>(m => ({
+                members: r.map(m => ({
                   ...(m.foundUser
                     ? {assertion: m.username, resolvedFrom: m.assertion}
                     : {assertion: m.assertion}),

--- a/shared/teams/add-members-wizard/add-phone.tsx
+++ b/shared/teams/add-members-wizard/add-phone.tsx
@@ -4,9 +4,9 @@ import * as Styles from '../../styles'
 import * as Container from '../../util/container'
 import * as RPCGen from '../../constants/types/rpc-gen'
 import * as TeamsGen from '../../actions/teams-gen'
+import * as Types from '../../constants/types/teams'
 import * as SettingsGen from '../../actions/settings-gen'
 import {ModalTitle, usePhoneNumberList} from '../common'
-import {formatPhoneNumber} from '../../util/phone-numbers'
 
 const waitingKey = 'phoneLookup'
 
@@ -39,9 +39,10 @@ const AddPhone = () => {
         r?.length
           ? dispatch(
               TeamsGen.createAddMembersWizardPushMembers({
-                members: r.map(m => ({
-                  assertion: m.foundUser ? m.username : m.assertion,
-                  note: m.foundUser ? formatPhoneNumber(m.input) : undefined,
+                members: r.map<Types.AddingMember>(m => ({
+                  ...(m.foundUser
+                    ? {assertion: m.username, resolvedFrom: m.assertion}
+                    : {assertion: m.assertion}),
                   role: 'writer',
                 })),
               })

--- a/shared/teams/add-members-wizard/add-phone.tsx
+++ b/shared/teams/add-members-wizard/add-phone.tsx
@@ -4,7 +4,6 @@ import * as Styles from '../../styles'
 import * as Container from '../../util/container'
 import * as RPCGen from '../../constants/types/rpc-gen'
 import * as TeamsGen from '../../actions/teams-gen'
-import * as Types from '../../constants/types/teams'
 import * as SettingsGen from '../../actions/settings-gen'
 import {ModalTitle, usePhoneNumberList} from '../common'
 
@@ -39,7 +38,7 @@ const AddPhone = () => {
         r?.length
           ? dispatch(
               TeamsGen.createAddMembersWizardPushMembers({
-                members: r.map<Types.AddingMember>(m => ({
+                members: r.map(m => ({
                   ...(m.foundUser
                     ? {assertion: m.username, resolvedFrom: m.assertion}
                     : {assertion: m.assertion}),

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -193,7 +193,7 @@ const AlreadyInTeam = ({assertions}: {assertions: string[]}) => {
     return 'people'
   }, [assertions])
   return (
-    <Kb.Text type="BodySmallSuccess">
+    <Kb.Text type="BodySmallSuccess" selectable={true}>
       Some {noun} were already invited to the team and are not shown here: {invitedStr}
     </Kb.Text>
   )

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -8,6 +8,7 @@ import * as TeamsGen from '../../actions/teams-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as RPCGen from '../../constants/types/rpc-gen'
 import {appendNewTeamBuilder} from '../../actions/typed-routes'
+import {assertionToDisplay} from '../../common-adapters/usernames'
 import capitalize from 'lodash/capitalize'
 import {FloatingRolePicker} from '../role-picker'
 import {useDefaultChannels} from '../team/settings-tab/default-channels'
@@ -31,7 +32,9 @@ const disabledRolesSubteam = {
 const AddMembersConfirm = () => {
   const dispatch = Container.useDispatch()
 
-  const {teamID, addingMembers, addToChannels} = Container.useSelector(s => s.teams.addMembersWizard)
+  const {teamID, addingMembers, addToChannels, membersAlreadyInTeam} = Container.useSelector(
+    s => s.teams.addMembersWizard
+  )
   const isSubteam = Container.useSelector(s => Constants.getTeamMeta(s, teamID)?.teamname.includes('.'))
   const fromNewTeamWizard = teamID === Types.newTeamWizardTeamID
   const isBigTeam = Container.useSelector(s => (fromNewTeamWizard ? false : Constants.isBigTeam(s, teamID)))
@@ -41,7 +44,8 @@ const AddMembersConfirm = () => {
   // TODO: consider useMemoing these
   const anyNonKeybase = addingMembers.some(m => m.assertion.includes('@'))
   const someKeybaseUsers = addingMembers.some(member => !member.assertion.includes('@'))
-  const onlyEmails = !addingMembers.some(member => !member.assertion.endsWith('@email'))
+  const onlyEmails =
+    addingMembers.length > 0 && addingMembers.every(member => member.assertion.endsWith('@email'))
 
   const disabledRoles = isSubteam ? disabledRolesSubteam : undefined
 
@@ -112,6 +116,7 @@ const AddMembersConfirm = () => {
             label={`Invite ${addingMembers.length} ${noun} & finish`}
             waiting={waiting}
             onClick={onComplete}
+            disabled={addingMembers.length === 0}
           />
         ),
       }}
@@ -150,6 +155,7 @@ const AddMembersConfirm = () => {
             )}
           </Kb.Box2>
         )}
+        {membersAlreadyInTeam.length > 0 && <AlreadyInTeam assertions={membersAlreadyInTeam} />}
         {!!error && <Kb.Text type="BodySmallError">{error}</Kb.Text>}
       </Kb.Box2>
     </Kb.Modal>
@@ -157,6 +163,40 @@ const AddMembersConfirm = () => {
 }
 AddMembersConfirm.navigationOptions = {
   gesturesEnabled: false,
+}
+
+const AlreadyInTeam = ({assertions}: {assertions: string[]}) => {
+  const invitedStr = React.useMemo(() => {
+    return assertions.map(x => assertionToDisplay(x)).join(', ')
+  }, [assertions])
+  const noun = React.useMemo(() => {
+    // If all assertions are emails or phone numbers, use "emails" or "phone
+    // numbers" noun. Otherwise, use "people".
+    const types = new Set<string>()
+    for (const assertion of assertions) {
+      if (assertion.includes('@email')) {
+        types.add('email')
+      } else if (assertion.includes('@phone')) {
+        types.add('phone')
+      } else {
+        types.add('other')
+      }
+    }
+    if (types.size === 1) {
+      switch (Array.from(types)[0]) {
+        case 'email':
+          return 'emails'
+        case 'phone':
+          return 'phone numbers'
+      }
+    }
+    return 'people'
+  }, [assertions])
+  return (
+    <Kb.Text type="BodySmallSuccess">
+      Some {noun} were already invited to the team and are not shown here: {invitedStr}
+    </Kb.Text>
+  )
 }
 
 const AddMoreMembers = () => {

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -361,9 +361,9 @@ const AddingMember = (props: Types.AddingMember & {disabledRoles: DisabledRoles;
           containerStyle={styles.flexShrink}
           style={styles.flexShrink}
         />
-        {props.note && (
+        {props.resolvedFrom && (
           <Kb.Text lineClamp={1} type="BodySemibold" style={styles.flexDefinitelyShrink}>
-            ({props.note})
+            ({assertionToDisplay(props.resolvedFrom)})
           </Kb.Text>
         )}
       </Kb.Box2>

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -165,8 +165,16 @@ AddMembersConfirm.navigationOptions = {
   gesturesEnabled: false,
 }
 
+// Show no more than 20 assertions in "already in team" section.
+const alreadyInTeamLimit = 20
+
 const AlreadyInTeam = ({assertions}: {assertions: string[]}) => {
   const invitedStr = React.useMemo(() => {
+    if (assertions.length > alreadyInTeamLimit) {
+      const left = assertions.length - alreadyInTeamLimit
+      const spliced = assertions.slice(0, alreadyInTeamLimit)
+      return spliced.map(x => assertionToDisplay(x)).join(', ') + `... (and ${left} more)`
+    }
     return assertions.map(x => assertionToDisplay(x)).join(', ')
   }, [assertions])
   const noun = React.useMemo(() => {

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -59,6 +59,15 @@ const emailsWithDuplicates = makeCommonStore(
   ['[mike@mike.mike]@email', '[chris@chris.chris]@email', '+12015550123@phone']
 )
 
+// All e-mails provided were already invites - confirmation screen should have
+// empty rows and "alreadyInTeam" message only.
+const onlyAlreadyInTeam = makeCommonStore([], ['[mike@mike.mike]@email', '[chris@chris.chris]@email'])
+
+// We should never see usernames in "alreadyInTeam" because of how the wizard
+// is structured - user knows early that an username can't be added. Same with
+// social assertions. Nevertheless, make sure it renders correctly.
+const alreadyInTeam2 = makeCommonStore([{assertion: 'zapu@rooter', role: 'writer'}], ['zapu', 'zapu@github'])
+
 const load = () => {
   Sb.storiesOf('Teams/Add member wizard', module)
     .addDecorator(story => <Sb.MockStore store={commonStore}>{story()}</Sb.MockStore>)
@@ -72,6 +81,8 @@ const load = () => {
     ['Mixed types', commonStore],
     ['All emails', emailsOnlyStore],
     ['Members already in team', emailsWithDuplicates],
+    ['(Only) members already in team', onlyAlreadyInTeam],
+    ['(Impossible) members already in team', alreadyInTeam2],
   ] as const) {
     sb.add(name, () => (
       <Sb.MockStore store={store}>

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -55,6 +55,28 @@ const emailsOnlyStore = Container.produce(Sb.createStoreWithCommon(), draftState
   }
   draftState.settings.phoneNumbers.defaultCountry = 'FR'
 })
+const emailsWithDuplicates = Container.produce(Sb.createStoreWithCommon(), draftState => {
+  draftState.teams = {
+    ...draftState.teams,
+    addMembersWizard: {
+      ...Constants.addMembersWizardEmptyState,
+      addingMembers: [
+        {assertion: '[danny@danny.danny]@email', role: 'writer'},
+        {assertion: '[max@max.max]@email', role: 'writer'},
+        {assertion: 'zapu', resolvedFrom: '[michal@zapu.zapu]@email', role: 'writer'},
+        {assertion: '+48784123123@phone', role: 'writer'},
+      ],
+      teamID: fakeTeamID,
+      membersAlreadyInTeam: ['[mike@mike.mike]@email', '[chris@chris.chris]@email', '+12015550123@phone'],
+    },
+    teamMeta: new Map([[fakeTeamID, {...Constants.emptyTeamMeta, teamname: 'greenpeace.board'}]]),
+  }
+  draftState.config = {
+    ...draftState.config,
+    username: 'andonuts',
+  }
+  draftState.settings.phoneNumbers.defaultCountry = 'FR'
+})
 
 const load = () => {
   Sb.storiesOf('Teams/Add member wizard', module)
@@ -72,6 +94,11 @@ const load = () => {
     ))
     .add('All emails', () => (
       <Sb.MockStore store={emailsOnlyStore}>
+        <AddMembersConfirm />
+      </Sb.MockStore>
+    ))
+    .add('Members already in team', () => (
+      <Sb.MockStore store={emailsWithDuplicates}>
         <AddMembersConfirm />
       </Sb.MockStore>
     ))

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -59,6 +59,11 @@ const emailsWithDuplicates = makeCommonStore(
   ['[mike@mike.mike]@email', '[chris@chris.chris]@email', '+12015550123@phone']
 )
 
+const oneAlreadyInTeam = makeCommonStore(
+  [{assertion: '[danny@danny.danny]@email', role: 'writer'}],
+  ['[chris@chris.chris]@email']
+)
+
 // All e-mails provided were already invites - confirmation screen should have
 // empty rows and "alreadyInTeam" message only.
 const onlyAlreadyInTeam = makeCommonStore([], ['[mike@mike.mike]@email', '[chris@chris.chris]@email'])
@@ -81,6 +86,7 @@ const load = () => {
     ['Mixed types', commonStore],
     ['All emails', emailsOnlyStore],
     ['Members already in team', emailsWithDuplicates],
+    ['A member already in team', oneAlreadyInTeam],
     ['(Only) members already in team', onlyAlreadyInTeam],
     ['(Impossible) members already in team', alreadyInTeam2],
   ] as const) {

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -16,8 +16,8 @@ function makeCommonStore(addingMembers: Types.AddingMember[], membersAlreadyInTe
       addMembersWizard: {
         ...Constants.addMembersWizardEmptyState,
         addingMembers,
-        teamID: fakeTeamID,
         membersAlreadyInTeam: membersAlreadyInTeam ?? [],
+        teamID: fakeTeamID,
       },
       teamMeta: new Map([[fakeTeamID, {...Constants.emptyTeamMeta, teamname: 'greenpeace.board'}]]),
     }

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -53,7 +53,7 @@ const emailsWithDuplicates = makeCommonStore(
     {assertion: '[danny@danny.danny]@email', role: 'writer'},
     {assertion: '[max@max.max]@email', role: 'writer'},
     {assertion: 'zapu', resolvedFrom: '[michal@zapu.zapu]@email', role: 'writer'},
-    // {assertion: 'test', resolvedFrom: '+12125451231@phone', role: 'writer'},
+    {assertion: 'test', resolvedFrom: '+12125451231@phone', role: 'writer'},
     {assertion: '+48784123123@phone', role: 'writer'},
   ],
   ['[mike@mike.mike]@email', '[chris@chris.chris]@email', '+12015550123@phone']

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -2,81 +2,62 @@ import * as React from 'react'
 import * as Sb from '../../stories/storybook'
 import * as Container from '../../util/container'
 import * as Constants from '../../constants/teams'
+import * as Types from '../../constants/types/teams'
 import AddFromWhere from './add-from-where'
 import AddEmail from './add-email'
 import AddPhone from './add-phone'
 import AddMembersConfirm from './confirm'
 
 const fakeTeamID = 'fakeTeamID'
-const commonStore = Container.produce(Sb.createStoreWithCommon(), draftState => {
-  draftState.teams = {
-    ...draftState.teams,
-    addMembersWizard: {
-      ...Constants.addMembersWizardEmptyState,
-      addingMembers: [
-        {assertion: 'ayoubd', role: 'writer'},
-        {assertion: 'max', role: 'writer'},
-        {assertion: '+12015550123@phone', role: 'writer'},
-        {assertion: '[chris@chris.chris]@email', role: 'writer'},
-        {assertion: 'mlsteeele', role: 'writer'},
-        {assertion: 'karenm', role: 'writer'},
-        {assertion: 'mikem', role: 'writer'},
-        {assertion: 'patrickxb', role: 'writer'},
-        {assertion: 'jakob223', role: 'writer'},
-      ],
-      teamID: fakeTeamID,
-    },
-    teamMeta: new Map([[fakeTeamID, {...Constants.emptyTeamMeta, teamname: 'greenpeace.board'}]]),
-  }
-  draftState.config = {
-    ...draftState.config,
-    username: 'andonuts',
-  }
-  draftState.settings.phoneNumbers.defaultCountry = 'FR'
-})
-const emailsOnlyStore = Container.produce(Sb.createStoreWithCommon(), draftState => {
-  draftState.teams = {
-    ...draftState.teams,
-    addMembersWizard: {
-      ...Constants.addMembersWizardEmptyState,
-      addingMembers: [
-        {assertion: '[danny@danny.danny]@email', role: 'writer'},
-        {assertion: '[max@max.max]@email', role: 'writer'},
-        {assertion: '[mike@mike.mike]@email', role: 'writer'},
-        {assertion: '[chris@chris.chris]@email', role: 'writer'},
-      ],
-      teamID: fakeTeamID,
-    },
-    teamMeta: new Map([[fakeTeamID, {...Constants.emptyTeamMeta, teamname: 'greenpeace.board'}]]),
-  }
-  draftState.config = {
-    ...draftState.config,
-    username: 'andonuts',
-  }
-  draftState.settings.phoneNumbers.defaultCountry = 'FR'
-})
-const emailsWithDuplicates = Container.produce(Sb.createStoreWithCommon(), draftState => {
-  draftState.teams = {
-    ...draftState.teams,
-    addMembersWizard: {
-      ...Constants.addMembersWizardEmptyState,
-      addingMembers: [
-        {assertion: '[danny@danny.danny]@email', role: 'writer'},
-        {assertion: '[max@max.max]@email', role: 'writer'},
-        {assertion: 'zapu', resolvedFrom: '[michal@zapu.zapu]@email', role: 'writer'},
-        {assertion: '+48784123123@phone', role: 'writer'},
-      ],
-      teamID: fakeTeamID,
-      membersAlreadyInTeam: ['[mike@mike.mike]@email', '[chris@chris.chris]@email', '+12015550123@phone'],
-    },
-    teamMeta: new Map([[fakeTeamID, {...Constants.emptyTeamMeta, teamname: 'greenpeace.board'}]]),
-  }
-  draftState.config = {
-    ...draftState.config,
-    username: 'andonuts',
-  }
-  draftState.settings.phoneNumbers.defaultCountry = 'FR'
-})
+function makeCommonStore(addingMembers: Types.AddingMember[], membersAlreadyInTeam?: string[]) {
+  return Container.produce(Sb.createStoreWithCommon(), draftState => {
+    draftState.teams = {
+      ...draftState.teams,
+      addMembersWizard: {
+        ...Constants.addMembersWizardEmptyState,
+        addingMembers,
+        teamID: fakeTeamID,
+        membersAlreadyInTeam: membersAlreadyInTeam ?? [],
+      },
+      teamMeta: new Map([[fakeTeamID, {...Constants.emptyTeamMeta, teamname: 'greenpeace.board'}]]),
+    }
+    draftState.config = {
+      ...draftState.config,
+      username: 'andonuts',
+    }
+    draftState.settings.phoneNumbers.defaultCountry = 'FR'
+  })
+}
+
+const commonStore = makeCommonStore([
+  {assertion: 'ayoubd', role: 'writer'},
+  {assertion: 'max', role: 'writer'},
+  {assertion: '+12015550123@phone', role: 'writer'},
+  {assertion: '[chris@chris.chris]@email', role: 'writer'},
+  {assertion: 'mlsteeele', role: 'writer'},
+  {assertion: 'karenm', role: 'writer'},
+  {assertion: 'mikem', role: 'writer'},
+  {assertion: 'patrickxb', role: 'writer'},
+  {assertion: 'jakob223', role: 'writer'},
+])
+
+const emailsOnlyStore = makeCommonStore([
+  {assertion: '[danny@danny.danny]@email', role: 'writer'},
+  {assertion: '[max@max.max]@email', role: 'writer'},
+  {assertion: '[mike@mike.mike]@email', role: 'writer'},
+  {assertion: '[chris@chris.chris]@email', role: 'writer'},
+])
+
+const emailsWithDuplicates = makeCommonStore(
+  [
+    {assertion: '[danny@danny.danny]@email', role: 'writer'},
+    {assertion: '[max@max.max]@email', role: 'writer'},
+    {assertion: 'zapu', resolvedFrom: '[michal@zapu.zapu]@email', role: 'writer'},
+    // {assertion: 'test', resolvedFrom: '+12125451231@phone', role: 'writer'},
+    {assertion: '+48784123123@phone', role: 'writer'},
+  ],
+  ['[mike@mike.mike]@email', '[chris@chris.chris]@email', '+12015550123@phone']
+)
 
 const load = () => {
   Sb.storiesOf('Teams/Add member wizard', module)
@@ -86,22 +67,18 @@ const load = () => {
     .add('Add by email', () => <AddEmail teamID={fakeTeamID} errorMessage="" />)
     .add('Add by phone', () => <AddPhone />)
 
-  Sb.storiesOf('Teams/Add member wizard/Confirm', module)
-    .add('Mixed types', () => (
-      <Sb.MockStore store={commonStore}>
+  const sb = Sb.storiesOf('Teams/Add member wizard/Confirm', module)
+  for (let [name, store] of [
+    ['Mixed types', commonStore],
+    ['All emails', emailsOnlyStore],
+    ['Members already in team', emailsWithDuplicates],
+  ] as const) {
+    sb.add(name, () => (
+      <Sb.MockStore store={store}>
         <AddMembersConfirm />
       </Sb.MockStore>
     ))
-    .add('All emails', () => (
-      <Sb.MockStore store={emailsOnlyStore}>
-        <AddMembersConfirm />
-      </Sb.MockStore>
-    ))
-    .add('Members already in team', () => (
-      <Sb.MockStore store={emailsWithDuplicates}>
-        <AddMembersConfirm />
-      </Sb.MockStore>
-    ))
+  }
 }
 
 export default load

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -73,6 +73,17 @@ const onlyAlreadyInTeam = makeCommonStore([], ['[mike@mike.mike]@email', '[chris
 // social assertions. Nevertheless, make sure it renders correctly.
 const alreadyInTeam2 = makeCommonStore([{assertion: 'zapu@rooter', role: 'writer'}], ['zapu', 'zapu@github'])
 
+const alreadyInTeamLimit = makeCommonStore(
+  [
+    {assertion: '[danny@danny.danny]@email', role: 'writer'},
+    {assertion: '[max@max.max]@email', role: 'writer'},
+    {assertion: 'zapu', resolvedFrom: '[michal@zapu.zapu]@email', role: 'writer'},
+    {assertion: 'test', resolvedFrom: '+12125451231@phone', role: 'writer'},
+    {assertion: '+48784123123@phone', role: 'writer'},
+  ],
+  Array.from(Array(25)).map((_, i) => `[test${i}@example.org]@email`)
+)
+
 const load = () => {
   Sb.storiesOf('Teams/Add member wizard', module)
     .addDecorator(story => <Sb.MockStore store={commonStore}>{story()}</Sb.MockStore>)
@@ -89,6 +100,7 @@ const load = () => {
     ['A member already in team', oneAlreadyInTeam],
     ['(Only) members already in team', onlyAlreadyInTeam],
     ['(Impossible) members already in team', alreadyInTeam2],
+    ['(Many) members already in team', alreadyInTeamLimit],
   ] as const) {
     sb.add(name, () => (
       <Sb.MockStore store={store}>

--- a/shared/teams/add-members-wizard/index.stories.tsx
+++ b/shared/teams/add-members-wizard/index.stories.tsx
@@ -68,9 +68,9 @@ const oneAlreadyInTeam = makeCommonStore(
 // empty rows and "alreadyInTeam" message only.
 const onlyAlreadyInTeam = makeCommonStore([], ['[mike@mike.mike]@email', '[chris@chris.chris]@email'])
 
-// We should never see usernames in "alreadyInTeam" because of how the wizard
-// is structured - user knows early that an username can't be added. Same with
-// social assertions. Nevertheless, make sure it renders correctly.
+// We should never see usernames in "alreadyInTeam" because of how the
+// wizard is structured - user knows early that an username can't be added.
+// Nevertheless, make sure it renders correctly.
 const alreadyInTeam2 = makeCommonStore([{assertion: 'zapu@rooter', role: 'writer'}], ['zapu', 'zapu@github'])
 
 const alreadyInTeamLimit = makeCommonStore(


### PR DESCRIPTION
This PR adds a step when going to team add member wizard confirmation screen - assertions being added are going to be first checked using `FindAssertionsInTeamNoResolve` RPC to see if any of them are already in the team (works for both team members and team invites). If any of assertions are already in, they are added to `membersAlreadyInTeam` list in `AddMembersWizardState` and are displayed in the confirmation screen as an info message.

cc @keybase/y2ksquad @keybase/react-hackers 