### PR TITLE
kbpages: fix insert bug and add test

### DIFF
--- a/go/kbfs/libpages/stats_mysql.go
+++ b/go/kbfs/libpages/stats_mysql.go
@@ -98,7 +98,7 @@ func (s *mysqlActivityStatsStorer) flushInserts() {
             INSERT INTO stats_tlf (tlf_id, active_time)
                 VALUES (?, ?)
             ON DUPLICATE KEY UPDATE
-                active_time = GREATEST(VALUES(active_time), ?)`,
+                active_time = GREATEST(active_time, ?)`,
 			tlfID.String(), t, t); err != nil {
 			s.logger.Warn("INSERT INTO stats_tlf", zap.Error(err))
 		}
@@ -108,7 +108,7 @@ func (s *mysqlActivityStatsStorer) flushInserts() {
             INSERT INTO stats_host (domain, active_time)
                 VALUES (?, ?) 
             ON DUPLICATE KEY UPDATE
-                active_time = GREATEST(VALUES(active_time), ?)`,
+                active_time = GREATEST(active_time, ?)`,
 			host, t, t); err != nil {
 			s.logger.Warn("INSERT INTO stats_host", zap.Error(err))
 		}

--- a/go/kbfs/libpages/stats_mysql_test.go
+++ b/go/kbfs/libpages/stats_mysql_test.go
@@ -76,13 +76,25 @@ func TestMySQLActivityStatsStorer(t *testing.T) {
 
 	// Now we're at 02:00
 
-	activeTlfs, activeHosts, err := storer.GetActives(time.Minute)
-	require.NoError(t, err)
-	require.Equal(t, 1, activeTlfs)
-	require.Equal(t, 2, activeHosts)
+	check := func() {
+		activeTlfs, activeHosts, err := storer.GetActives(time.Minute)
+		require.NoError(t, err)
+		require.Equal(t, 1, activeTlfs)
+		require.Equal(t, 2, activeHosts)
 
-	activeTlfs, activeHosts, err = storer.GetActives(2 * time.Minute)
-	require.NoError(t, err)
-	require.Equal(t, 2, activeTlfs)
-	require.Equal(t, 3, activeHosts)
+		activeTlfs, activeHosts, err = storer.GetActives(2 * time.Minute)
+		require.NoError(t, err)
+		require.Equal(t, 2, activeTlfs)
+		require.Equal(t, 3, activeHosts)
+	}
+	check()
+
+	t.Logf("make sure older time don't override newer time")
+	clock.Add(-5 * time.Minute)
+	storer.RecordActives(tlfID1, host1)
+	storer.RecordActives(tlfID1, host2)
+	storer.RecordActives(tlfID2, host3)
+	clock.Add(5 * time.Minute)
+	storer.flushInserts()
+	check()
 }


### PR DESCRIPTION
It's intended to only update if the existing value is smaller (older) than the new timestamp. But `VALUES()` refers to the new value.

Also add a regression test.