### PR TITLE
use correct conv for expunge call

### DIFF
--- a/go/chat/sync.go
+++ b/go/chat/sync.go
@@ -459,7 +459,7 @@ func (s *Syncer) Sync(ctx context.Context, cli chat1.RemoteInterface, uid gregor
 					types.ConvLoaderPriorityHighest, types.ConvLoaderUnique,
 					func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
 						s.Debug(ctx, "Sync: executing expunge from a sync run: convID: %s", conv.GetConvID())
-						err := s.G().ConvSource.Expunge(ctx, rc, uid, expunge)
+						err := s.G().ConvSource.Expunge(ctx, conv, uid, expunge)
 						if err != nil {
 							s.Debug(ctx, "Sync: failed to expunge: %v", err)
 						}


### PR DESCRIPTION
Broke here: https://github.com/keybase/client/commit/1a8f72d8dd727906fbdff17a3b302e8d394bf20b#diff-91ee9c123e53d8ff38bc21d8e8f3c6c3R462

cc @mlsteele 