### PR TITLE
Stellar: if onClickRequest fires twice, only make one request

### DIFF
--- a/shared/wallets/send-form/footer/container.tsx
+++ b/shared/wallets/send-form/footer/container.tsx
@@ -67,4 +67,4 @@ export default Container.namedConnect(
     worthDescription: s.worthDescription,
   }),
   'Footer'
-)(Footer)
+)(Container.safeSubmit(['onClickRequest'], ['calculating'])(Footer))


### PR DESCRIPTION
@keybase/react-hackers 

The send-form has no safeSubmit protection against the Send or Request button being double tapped, and causing two actions to fire instead of one.

For sending, this isn't a problem -- we designed the send RPC to identify a unique, built send transaction and so trying to execute the transaction multiple times is idempotent.

For requesting Lumens, the RPC doesn't work the same way: we just supply the target username, message and amount.  Firing the action twice results in two requests instead of one.

@mlsteele saw this happen on his account with a single click of the Request button, but now he can't repro it and neither can I.  So this PR hasn't been verified against the live bug, and is my guess at what happened based on the lack of safeSubmit on the form.  I modified the request onClick handler to fire onClickRequest twice instead of once, and verified that this change fixes that problem.