### PR TITLE
favorites: don't refresh on mtime when last ID was the same

### DIFF
--- a/go/kbfs/libkbfs/folder_branch_ops.go
+++ b/go/kbfs/libkbfs/folder_branch_ops.go
@@ -9760,7 +9760,7 @@ func (fbo *folderBranchOps) handleEditActivity(
 		if rmd != (ImmutableRootMetadata{}) {
 			_ = fbo.kickOffEditActivityPartialSync(ctx, lState, rmd)
 		}
-		fbo.favs.RefreshCacheWhenMTimeChanged(ctx)
+		fbo.favs.RefreshCacheWhenMTimeChanged(ctx, fbo.id())
 		fbo.editActivity.Done()
 	}()
 

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1770,7 +1770,7 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 			"Handle %s for existing folder unexpectedly has no TLF ID",
 			handle.GetCanonicalName())
 	}
-	fs.favs.RefreshCacheWhenMTimeChanged(ctx)
+	fs.favs.RefreshCacheWhenMTimeChanged(ctx, handle.TlfID())
 }
 
 // Reset implements the KBFSOps interface for KBFSOpsStandard.


### PR DESCRIPTION
There's no point in refreshing the favorites list when the mtime of a TLF changes, if that's the same TLF that we refreshed for previously. We only use the mtime to relatively order TLFs among themselves, so if the same one changes again, that won't change the relative order.

Issue: HOTPOT-2582