### PR TITLE
fix race in (*subscriptionManagerManager).get

### DIFF
--- a/go/kbfs/libkbfs/subscription_manager.go
+++ b/go/kbfs/libkbfs/subscription_manager.go
@@ -674,6 +674,15 @@ func (smm *subscriptionManagerManager) get(
 	smm.lock.Lock()
 	defer smm.lock.Unlock()
 
+	// Check again under the lock in case we've already created one. This is
+	// important since if we create it twice we'd end up with having the same
+	// clientID appearing twice in purgeableClientIDsFIFO and when we purge the
+	// second one we'd have a panic.
+	sm, ok = smm.subscriptionManagers[clientID]
+	if ok {
+		return sm
+	}
+
 	if purgeable {
 		if len(smm.purgeableClientIDsFIFO) == maxPurgeableSubscriptionManagerClient {
 			toPurge := smm.purgeableClientIDsFIFO[0]


### PR DESCRIPTION
The original ticket was about a panic in https://github.com/keybase/client/blob/3938f8247f2955262d8090ea7da0d20d1b0d374e/go/kbfs/libkbfs/subscription_manager.go#L179 , coming from https://github.com/keybase/client/blob/3938f8247f2955262d8090ea7da0d20d1b0d374e/go/kbfs/libkbfs/subscription_manager.go#L680 . The only explanation I can come up with is a race happened, causing two different goroutines to end up creating subscription manager for the same `clientID`. Then when they're purged, since the `clientID` appears twice in `purgeableClientIDsFIFO`, and it only appears ones in `subscriptionManagers` (since it's a map), we end up calling `Shutdown()` on a `nil` `subscriptionManager` for the second one.

This PR fixes this race by checking again under the write lock, to see whether we've already had a `subscriptionManager` for the `clientID`.