### PR TITLE
fs-gui: cover barePreview for user in/out

### DIFF
--- a/shared/actions/fs/index.tsx
+++ b/shared/actions/fs/index.tsx
@@ -1102,11 +1102,11 @@ const maybeClearCriticalUpdate = (state: Container.TypedState, action: RouteTree
   return false
 }
 
+const fsRrouteNames = ['fsRoot', 'barePreview']
 const maybeOnFSTab = (action: RouteTreeGen.OnNavChangedPayload) => {
   const {prev, next} = action.payload
-  const routeName = 'fsRoot'
-  const wasScreen = prev[prev.length - 1]?.routeName === routeName
-  const isScreen = next[next.length - 1]?.routeName === routeName
+  const wasScreen = fsRrouteNames.includes(prev[prev.length - 1]?.routeName)
+  const isScreen = fsRrouteNames.includes(next[next.length - 1]?.routeName)
 
   if (wasScreen === isScreen) {
     return false


### PR DESCRIPTION
Unfortunately this doesn't explain the timeout issues we've seen, but still nice to fix ...