### PR TITLE
folder_branch_ops: add a crude way to cancel uploads 

### DIFF
--- a/go/client/cmd_simplefs.go
+++ b/go/client/cmd_simplefs.go
@@ -53,6 +53,7 @@ func NewCmdSimpleFS(cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Comm
 			NewCmdSimpleFSFinishResolvingConflicts(cl, g),
 			NewCmdSimpleFSSync(cl, g),
 			NewCmdSimpleFSUploads(cl, g),
+			NewCmdSimpleFSCancelUploads(cl, g),
 			NewCmdSimpleFSSearch(cl, g),
 			NewCmdSimpleFSResetIndex(cl, g),
 			NewCmdSimpleFSIndexProgress(cl, g),

--- a/go/client/cmd_simplefs_cancel_uploads.go
+++ b/go/client/cmd_simplefs_cancel_uploads.go
@@ -1,0 +1,110 @@
+// Copyright 2020 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keybase/cli"
+	"github.com/keybase/client/go/libcmdline"
+	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+)
+
+// CmdSimpleFSCancelUploads is the 'fs cancel-uploads' command.
+type CmdSimpleFSCancelUploads struct {
+	libkb.Contextified
+	path   keybase1.Path
+	filter keybase1.ListFilter
+}
+
+// NewCmdSimpleFSCancelUploads creates a new cli.Command.
+func NewCmdSimpleFSCancelUploads(
+	cl *libcmdline.CommandLine, g *libkb.GlobalContext) cli.Command {
+	return cli.Command{
+		Name:         "cancel-uploads",
+		ArgumentHelp: "[path-to-folder]",
+		Usage:        "cancel all outstanding uploads in a folder",
+		Action: func(c *cli.Context) {
+			cl.ChooseCommand(&CmdSimpleFSCancelUploads{
+				Contextified: libkb.NewContextified(g)}, "cancel-uploads", c)
+			cl.SetNoStandalone()
+		},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "a, all",
+				Usage: "display entries starting with '.'",
+			},
+		},
+	}
+}
+
+// Run runs the command in client/server mode.
+func (c *CmdSimpleFSCancelUploads) Run() error {
+	prefix := mountDir + c.path.String()
+
+	areUploads, err := printUploads(c.G(), c.filter, prefix)
+	if err != nil {
+		return err
+	}
+	ui := c.G().UI.GetTerminalUI()
+	if !areUploads {
+		ui.Printf("There are currently no uploads for %s", prefix)
+		return nil
+	}
+
+	ui.Printf(
+		"\nDo you really want to cancel the above uploads in progress for "+
+			"%s?\n", prefix)
+	ui.Printf("You may end up with partially-uploaded changes.\n")
+	err = ui.PromptForConfirmation("Continue canceling the uploads?")
+	if err != nil {
+		return err
+	}
+
+	cli, err := GetSimpleFSClient(c.G())
+	if err != nil {
+		return err
+	}
+	return cli.SimpleFSCancelJournalUploads(context.TODO(), c.path)
+}
+
+// ParseArgv gets the optional -a switch, and the path.
+func (c *CmdSimpleFSCancelUploads) ParseArgv(ctx *cli.Context) error {
+	if ctx.Bool("all") {
+		c.filter = keybase1.ListFilter_NO_FILTER
+	} else {
+		c.filter = keybase1.ListFilter_FILTER_ALL_HIDDEN
+	}
+
+	if len(ctx.Args()) > 1 {
+		return fmt.Errorf("wrong number of arguments")
+	} else if len(ctx.Args()) == 1 {
+		p, err := makeSimpleFSPath(ctx.Args()[0])
+		if err != nil {
+			return err
+		}
+
+		// Make sure this is an exact TLF.
+		s := strings.Split(p.String(), "/")
+		if len(s) != 3 && (len(s) != 4 || s[3] != "") {
+			return fmt.Errorf("Invalid folder path: %s", p.String())
+		}
+
+		c.path = p
+	}
+
+	return nil
+}
+
+// GetUsage says what this command needs to operate.
+func (c *CmdSimpleFSCancelUploads) GetUsage() libkb.Usage {
+	return libkb.Usage{
+		Config:    true,
+		KbKeyring: true,
+		API:       true,
+	}
+}

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -424,6 +424,11 @@ func (s SimpleFSMock) SimpleFSGetIndexProgress(
 	return keybase1.SimpleFSIndexProgress{}, nil
 }
 
+func (s SimpleFSMock) SimpleFSCancelJournalUploads(
+	_ context.Context, _ keybase1.Path) (err error) {
+	return nil
+}
+
 /*
  file source cases:
  1. file

--- a/go/client/simplefs_test.go
+++ b/go/client/simplefs_test.go
@@ -425,7 +425,7 @@ func (s SimpleFSMock) SimpleFSGetIndexProgress(
 }
 
 func (s SimpleFSMock) SimpleFSCancelJournalUploads(
-	_ context.Context, _ keybase1.Path) (err error) {
+	_ context.Context, _ keybase1.KBFSPath) (err error) {
 	return nil
 }
 

--- a/go/kbfs/libkbfs/interfaces.go
+++ b/go/kbfs/libkbfs/interfaces.go
@@ -635,6 +635,11 @@ type KBFSOps interface {
 	// TLF into a stuck conflict view, in order to test the above
 	// `ClearConflictView` method and related state changes.
 	ForceStuckConflictForTesting(ctx context.Context, tlfID tlf.ID) error
+	// CancelUploads stops journal uploads for the given TLF, reverts
+	// the local view of the TLF to the server's view, and clears the
+	// journal from the disk.  Note that this could result in
+	// partially-uploaded changes, and may leak blocks on the bserver.
+	CancelUploads(ctx context.Context, fb data.FolderBranch) error
 	// Reset completely resets the given folder.  Should only be
 	// called after explicit user confirmation.  After the call,
 	// `handle` has the new TLF ID.  If `*newTlfID` is non-nil, that

--- a/go/kbfs/libkbfs/kbfs_cr_test.go
+++ b/go/kbfs/libkbfs/kbfs_cr_test.go
@@ -2018,6 +2018,10 @@ func TestForceStuckConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, children, 1+(maxConflictResolutionAttempts+1))
 
+	t.Log("Ensure uploads can't be canceled")
+	err = kbfsOps.CancelUploads(ctx, rootNode.GetFolderBranch())
+	require.Error(t, err)
+
 	t.Log("Clear conflict view")
 	err = kbfsOps.ClearConflictView(ctx, tlfID)
 	require.NoError(t, err)

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -1920,6 +1920,16 @@ func (fs *KBFSOpsStandard) ForceStuckConflictForTesting(
 	return fbo.forceStuckConflictForTesting(ctx)
 }
 
+// CancelUploads implements the KBFSOps interface for KBFSOpsStandard.
+func (fs *KBFSOpsStandard) CancelUploads(
+	ctx context.Context, folderBranch data.FolderBranch) error {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	ops := fs.getOps(ctx, folderBranch, FavoritesOpAdd)
+	return ops.CancelUploads(ctx, folderBranch)
+}
+
 // GetSyncConfig implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetSyncConfig(
 	ctx context.Context, tlfID tlf.ID) (keybase1.FolderSyncConfig, error) {

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -920,6 +920,20 @@ func (mr *MockKBFSOpsMockRecorder) AddRootNodeWrapper(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootNodeWrapper", reflect.TypeOf((*MockKBFSOps)(nil).AddRootNodeWrapper), arg0)
 }
 
+// CancelUploads mocks base method.
+func (m *MockKBFSOps) CancelUploads(arg0 context.Context, arg1 data.FolderBranch) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelUploads", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CancelUploads indicates an expected call of CancelUploads.
+func (mr *MockKBFSOpsMockRecorder) CancelUploads(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUploads", reflect.TypeOf((*MockKBFSOps)(nil).CancelUploads), arg0, arg1)
+}
+
 // CheckMigrationPerms mocks base method.
 func (m *MockKBFSOps) CheckMigrationPerms(arg0 context.Context, arg1 tlf.ID) error {
 	m.ctrl.T.Helper()

--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -3520,8 +3520,9 @@ func (k *SimpleFS) SimpleFSDismissUpload(
 
 // SimpleFSCancelJournalUploads implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSCancelJournalUploads(
-	ctx context.Context, path keybase1.Path) (err error) {
-	ctx, err = populateIdentifyBehaviorIfNeeded(ctx, &path, nil)
+	ctx context.Context, path keybase1.KBFSPath) (err error) {
+	wrappedPath := keybase1.NewPathWithKbfs(path)
+	ctx, err = populateIdentifyBehaviorIfNeeded(ctx, &wrappedPath, nil)
 	if err != nil {
 		return err
 	}
@@ -3535,7 +3536,7 @@ func (k *SimpleFS) SimpleFSCancelJournalUploads(
 			k.log.CDebugf(ctx, "Error cancelling delayer: %+v", err)
 		}
 	}()
-	t, tlfName, _, _, err := remoteTlfAndPath(path)
+	t, tlfName, _, _, err := remoteTlfAndPath(wrappedPath)
 	if err != nil {
 		return err
 	}
@@ -3549,7 +3550,7 @@ func (k *SimpleFS) SimpleFSCancelJournalUploads(
 		return err
 	}
 	tlfID := tlfHandle.TlfID()
-	branch, err := k.branchNameFromPath(ctx, tlfHandle, path)
+	branch, err := k.branchNameFromPath(ctx, tlfHandle, wrappedPath)
 	if err != nil {
 		return err
 	}

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1982,6 +1982,10 @@ type SimpleFSResetIndexArg struct {
 type SimpleFSGetIndexProgressArg struct {
 }
 
+type SimpleFSCancelJournalUploadsArg struct {
+	Path Path `codec:"path" json:"path"`
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path.
 	// Retrieve results with readList().
@@ -2119,6 +2123,7 @@ type SimpleFSInterface interface {
 	SimpleFSSearch(context.Context, SimpleFSSearchArg) (SimpleFSSearchResults, error)
 	SimpleFSResetIndex(context.Context) error
 	SimpleFSGetIndexProgress(context.Context) (SimpleFSIndexProgress, error)
+	SimpleFSCancelJournalUploads(context.Context, Path) error
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -3085,6 +3090,21 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 					return
 				},
 			},
+			"simpleFSCancelJournalUploads": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSCancelJournalUploadsArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SimpleFSCancelJournalUploadsArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSCancelJournalUploadsArg)(nil), args)
+						return
+					}
+					err = i.SimpleFSCancelJournalUploads(ctx, typedArgs[0].Path)
+					return
+				},
+			},
 		},
 	}
 }
@@ -3532,5 +3552,11 @@ func (c SimpleFSClient) SimpleFSResetIndex(ctx context.Context) (err error) {
 
 func (c SimpleFSClient) SimpleFSGetIndexProgress(ctx context.Context) (res SimpleFSIndexProgress, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSGetIndexProgress", []interface{}{SimpleFSGetIndexProgressArg{}}, &res, 0*time.Millisecond)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSCancelJournalUploads(ctx context.Context, path Path) (err error) {
+	__arg := SimpleFSCancelJournalUploadsArg{Path: path}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelJournalUploads", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return
 }

--- a/go/protocol/keybase1/simple_fs.go
+++ b/go/protocol/keybase1/simple_fs.go
@@ -1983,7 +1983,7 @@ type SimpleFSGetIndexProgressArg struct {
 }
 
 type SimpleFSCancelJournalUploadsArg struct {
-	Path Path `codec:"path" json:"path"`
+	Path KBFSPath `codec:"path" json:"path"`
 }
 
 type SimpleFSInterface interface {
@@ -2123,7 +2123,7 @@ type SimpleFSInterface interface {
 	SimpleFSSearch(context.Context, SimpleFSSearchArg) (SimpleFSSearchResults, error)
 	SimpleFSResetIndex(context.Context) error
 	SimpleFSGetIndexProgress(context.Context) (SimpleFSIndexProgress, error)
-	SimpleFSCancelJournalUploads(context.Context, Path) error
+	SimpleFSCancelJournalUploads(context.Context, KBFSPath) error
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -3555,7 +3555,7 @@ func (c SimpleFSClient) SimpleFSGetIndexProgress(ctx context.Context) (res Simpl
 	return
 }
 
-func (c SimpleFSClient) SimpleFSCancelJournalUploads(ctx context.Context, path Path) (err error) {
+func (c SimpleFSClient) SimpleFSCancelJournalUploads(ctx context.Context, path KBFSPath) (err error) {
 	__arg := SimpleFSCancelJournalUploadsArg{Path: path}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSCancelJournalUploads", []interface{}{__arg}, nil, 0*time.Millisecond)
 	return

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -894,3 +894,15 @@ func (s *SimpleFSHandler) SimpleFSDismissUpload(
 	defer cancel()
 	return cli.SimpleFSDismissUpload(ctx, uploadID)
 }
+
+// SimpleFSDismissUpload implements the SimpleFSInterface.
+func (s *SimpleFSHandler) SimpleFSCancelJournalUploads(
+	ctx context.Context, path keybase1.Path) (err error) {
+	cli, err := s.client(ctx)
+	if err != nil {
+		return err
+	}
+	// No timeouts since this can be a long operation if the folder is
+	// large or the disk is slow, and this is a synchronous operation.
+	return cli.SimpleFSCancelJournalUploads(ctx, path)
+}

--- a/go/service/simplefs.go
+++ b/go/service/simplefs.go
@@ -897,7 +897,7 @@ func (s *SimpleFSHandler) SimpleFSDismissUpload(
 
 // SimpleFSDismissUpload implements the SimpleFSInterface.
 func (s *SimpleFSHandler) SimpleFSCancelJournalUploads(
-	ctx context.Context, path keybase1.Path) (err error) {
+	ctx context.Context, path keybase1.KBFSPath) (err error) {
 	cli, err := s.client(ctx)
 	if err != nil {
 		return err

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -749,5 +749,5 @@ protocol SimpleFS {
 
   // Cancel all uploads from the journal, which may result in
   // partially-uploaded changes, and leaked blocks on the bserver.
-  void simpleFSCancelJournalUploads(Path path);
+  void simpleFSCancelJournalUploads(KBFSPath path);
 }

--- a/protocol/avdl/keybase1/simple_fs.avdl
+++ b/protocol/avdl/keybase1/simple_fs.avdl
@@ -746,4 +746,8 @@ protocol SimpleFS {
   }
 
   SimpleFSIndexProgress simpleFSGetIndexProgress();
+
+  // Cancel all uploads from the journal, which may result in
+  // partially-uploaded changes, and leaked blocks on the bserver.
+  void simpleFSCancelJournalUploads(Path path);
 }

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1856,6 +1856,15 @@
     "simpleFSGetIndexProgress": {
       "request": [],
       "response": "SimpleFSIndexProgress"
+    },
+    "simpleFSCancelJournalUploads": {
+      "request": [
+        {
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "response": null
     }
   },
   "namespace": "keybase.1"

--- a/protocol/json/keybase1/simple_fs.json
+++ b/protocol/json/keybase1/simple_fs.json
@@ -1861,7 +1861,7 @@
       "request": [
         {
           "name": "path",
-          "type": "Path"
+          "type": "KBFSPath"
         }
       ],
       "response": null

--- a/shared/constants/types/rpc-gen.tsx
+++ b/shared/constants/types/rpc-gen.tsx
@@ -4359,6 +4359,7 @@ export const wotWotVouchRpcPromise = (params: MessageTypes['keybase.1.wot.wotVou
 // 'keybase.1.SimpleFS.simpleFSSearch'
 // 'keybase.1.SimpleFS.simpleFSResetIndex'
 // 'keybase.1.SimpleFS.simpleFSGetIndexProgress'
+// 'keybase.1.SimpleFS.simpleFSCancelJournalUploads'
 // 'keybase.1.streamUi.close'
 // 'keybase.1.streamUi.read'
 // 'keybase.1.streamUi.reset'


### PR DESCRIPTION
If the user accidentally added a bunch of stuff they don't want uploaded, they can use this to cancel them and clear the journal space.  But it may result in partially-uploaded changes and will likely leak blocks on the bserver.

Also adds a `keybase fs cancel-uploads` command for canceling the uploads of a particular TLF.

Issue: HOTPOT-2605