### PR TITLE
Accept invalid mountpoints like "k" when user wanted "k:"

### DIFF
--- a/go/kbfs/libdokan/start.go
+++ b/go/kbfs/libdokan/start.go
@@ -124,6 +124,14 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 		}
 		log.CInfof(ctx, "Got mount dir from service: -%s-", options.MountPoint)
 	}
+
+	// There is misleading documentation that causes people to set their mount point to
+	// 'K' instead of 'K:'. Fix this here, rather than correct all the users with problems.
+	if len(options.MountPoint) == 1 {
+		options.MountPoint = options.MountPoint + ":"
+		log.CInfof(ctx, "Invalid single letter mount point, patching to %q", options.MountPoint)
+	}
+
 	options.DokanConfig.Path = options.MountPoint
 
 	if !options.SkipMount && !strings.EqualFold(options.MountPoint, "none") {


### PR DESCRIPTION
This user error has been spotted in the wild.