### PR TITLE
fix snippet for exploded messages

### DIFF
--- a/go/chat/utils/utils.go
+++ b/go/chat/utils/utils.go
@@ -1222,8 +1222,7 @@ func GetMsgSnippet(ctx context.Context, g *globals.Context, uid gregor1.UID, msg
 	// assigns a ctime.
 	if msg.IsValid() && !msg.IsValidFull() {
 		if msg.Valid().IsEphemeral() && msg.Valid().IsEphemeralExpired(time.Now()) {
-			return chat1.SnippetDecoration_EXPLODED_MESSAGE,
-				fmt.Sprintf("%s ----------------------------", senderPrefix), ""
+			return chat1.SnippetDecoration_EXPLODED_MESSAGE, "Message exploded.", ""
 		}
 		return chat1.SnippetDecoration_NONE, "", ""
 	}


### PR DESCRIPTION
this makes the snippet match the UI output. when scrolling through the inbox the snippet will change as the inbox localizes, this prevents the change which makes the app feel sluggish