### PR TITLE
Badged teams at top of team list

### DIFF
--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -866,6 +866,15 @@ export const annotatedTeamToDetails = (t: RPCTypes.AnnotatedTeam): Types.TeamDet
   }
 }
 
+// Keep in sync with constants/notifications#badgeStateToBadgeCounts
+// Don't count new team because those are shown with a 'NEW' meta instead of badge
+export const getTeamRowBadgeCount = (state: TypedState, teamID: Types.TeamID) => {
+  return (
+    state.teams.newTeamRequests.get(teamID)?.size ??
+    0 + (state.teams.teamIDToResetUsers.get(teamID)?.size ?? 0)
+  )
+}
+
 export const canShowcase = (state: TypedState, teamID: Types.TeamID) => {
   const role = getRole(state, teamID)
   return getTeamMeta(state, teamID).allowPromote || role === 'admin' || role === 'owner'

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -868,11 +868,12 @@ export const annotatedTeamToDetails = (t: RPCTypes.AnnotatedTeam): Types.TeamDet
 
 // Keep in sync with constants/notifications#badgeStateToBadgeCounts
 // Don't count new team because those are shown with a 'NEW' meta instead of badge
-export const getTeamRowBadgeCount = (state: TypedState, teamID: Types.TeamID) => {
-  return (
-    state.teams.newTeamRequests.get(teamID)?.size ??
-    0 + (state.teams.teamIDToResetUsers.get(teamID)?.size ?? 0)
-  )
+export const getTeamRowBadgeCount = (
+  newTeamRequests: Types.State['newTeamRequests'],
+  teamIDToResetUsers: Types.State['teamIDToResetUsers'],
+  teamID: Types.TeamID
+) => {
+  return newTeamRequests.get(teamID)?.size ?? 0 + (teamIDToResetUsers.get(teamID)?.size ?? 0)
 }
 
 export const canShowcase = (state: TypedState, teamID: Types.TeamID) => {

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -35,7 +35,8 @@ const useHeaderActions = (): HeaderActionProps => {
 
 const orderTeamsImpl = (
   teams: Map<string, Types.TeamMeta>,
-  newRequests: Map<Types.TeamID, Set<string>>,
+  newRequests: Types.State['newTeamRequests'],
+  teamIDToResetUsers: Types.State['teamIDToResetUsers'],
   sortOrder: Types.TeamListSort,
   activityLevels: Types.ActivityLevels,
   filter: string
@@ -45,7 +46,9 @@ const orderTeamsImpl = (
     ? [...teams.values()].filter(meta => meta.teamname.toLowerCase().includes(filterLC))
     : [...teams.values()]
   return teamsFiltered.sort((a, b) => {
-    const sizeDiff = (newRequests.get(b.id)?.size ?? 0) - (newRequests.get(a.id)?.size ?? 0)
+    const sizeDiff =
+      Constants.getTeamRowBadgeCount(newRequests, teamIDToResetUsers, b.id) -
+      Constants.getTeamRowBadgeCount(newRequests, teamIDToResetUsers, a.id)
     if (sizeDiff != 0) return sizeDiff
     const nameCompare = a.teamname.localeCompare(b.teamname)
     switch (sortOrder) {
@@ -126,7 +129,6 @@ Reloadable.navigationOptions = {
 
 const Connected = Container.connect(
   (state: Container.TypedState) => ({
-    _teamresetusers: state.teams.teamIDToResetUsers || new Map(),
     _teams: state.teams.teamMeta,
     activityLevels: state.teams.activityLevels,
     deletedTeams: state.teams.deletedTeams,
@@ -136,6 +138,7 @@ const Connected = Container.connect(
     newTeams: state.teams.newTeams,
     sawChatBanner: state.teams.sawChatBanner || false,
     sortOrder: flags.teamsRedesign ? state.teams.teamListSort : 'alphabetical',
+    teamIDToResetUsers: state.teams.teamIDToResetUsers,
   }),
   (dispatch: Container.TypedDispatch) => ({
     onHideChatBanner: () =>
@@ -154,10 +157,11 @@ const Connected = Container.connect(
     newTeamRequests: stateProps.newTeamRequests,
     newTeams: stateProps.newTeams,
     sawChatBanner: stateProps.sawChatBanner,
-    teamresetusers: stateProps._teamresetusers,
+    teamresetusers: stateProps.teamIDToResetUsers, // TODO remove when teamsRedesign flag removed
     teams: orderTeams(
       stateProps._teams,
       stateProps.newTeamRequests,
+      stateProps.teamIDToResetUsers,
       stateProps.sortOrder,
       stateProps.activityLevels,
       stateProps.filter

--- a/shared/teams/container.tsx
+++ b/shared/teams/container.tsx
@@ -37,6 +37,7 @@ const orderTeamsImpl = (
   teams: Map<string, Types.TeamMeta>,
   newRequests: Types.State['newTeamRequests'],
   teamIDToResetUsers: Types.State['teamIDToResetUsers'],
+  newTeams: Types.State['newTeams'],
   sortOrder: Types.TeamListSort,
   activityLevels: Types.ActivityLevels,
   filter: string
@@ -49,7 +50,9 @@ const orderTeamsImpl = (
     const sizeDiff =
       Constants.getTeamRowBadgeCount(newRequests, teamIDToResetUsers, b.id) -
       Constants.getTeamRowBadgeCount(newRequests, teamIDToResetUsers, a.id)
-    if (sizeDiff != 0) return sizeDiff
+    if (sizeDiff !== 0) return sizeDiff
+    const newTeamsDiff = (newTeams.has(b.id) ? 1 : 0) - (newTeams.has(a.id) ? 1 : 0)
+    if (newTeamsDiff !== 0) return newTeamsDiff
     const nameCompare = a.teamname.localeCompare(b.teamname)
     switch (sortOrder) {
       case 'role':
@@ -162,6 +165,7 @@ const Connected = Container.connect(
       stateProps._teams,
       stateProps.newTeamRequests,
       stateProps.teamIDToResetUsers,
+      stateProps.newTeams,
       stateProps.sortOrder,
       stateProps.activityLevels,
       stateProps.filter

--- a/shared/teams/main/team-row.tsx
+++ b/shared/teams/main/team-row.tsx
@@ -40,7 +40,7 @@ const TeamRow = (props: Props) => {
     />
   ))
 
-  const badgeCount = Container.useSelector(s => s.teams.newTeamRequests.get(teamID)?.size ?? 0)
+  const badgeCount = Container.useSelector(s => Constants.getTeamRowBadgeCount(s, teamID))
   const isNew = Container.useSelector(s => s.teams.newTeams.has(teamID))
 
   const crownIconType: Kb.IconType | undefined =

--- a/shared/teams/main/team-row.tsx
+++ b/shared/teams/main/team-row.tsx
@@ -40,7 +40,9 @@ const TeamRow = (props: Props) => {
     />
   ))
 
-  const badgeCount = Container.useSelector(s => Constants.getTeamRowBadgeCount(s, teamID))
+  const badgeCount = Container.useSelector(s =>
+    Constants.getTeamRowBadgeCount(s.teams.newTeamRequests, s.teams.teamIDToResetUsers, teamID)
+  )
   const isNew = Container.useSelector(s => s.teams.newTeams.has(teamID))
 
   const crownIconType: Kb.IconType | undefined =


### PR DESCRIPTION
- Factor out team row badge calc into constants
- Use same func in team sort to put them at top
- Put new teams at top too

cc @keybase/y2ksquad 