### PR TITLE
Fix "OPEN" meta vertical alignment on team view

### DIFF
--- a/shared/teams/external-team.tsx
+++ b/shared/teams/external-team.tsx
@@ -173,7 +173,7 @@ const Header = ({info}: ExternalTeamProps) => {
       </Kb.Box2>
     </Kb.Box2>
   )
-  const openMeta = <Kb.Meta title="OPEN" backgroundColor={Styles.globalColors.green} />
+  const openMeta = <Kb.Meta style={styles.meta} title="OPEN" backgroundColor={Styles.globalColors.green} />
   return (
     <Kb.Box2 direction="vertical" gap="small" fullWidth={true} style={styles.headerContainer}>
       <Kb.Box2 direction="horizontal" gap="small" fullWidth={true} alignItems="flex-start">
@@ -257,6 +257,11 @@ const styles = Styles.styleSheetCreate(() => ({
     flex: 1,
     paddingRight: Styles.globalMargins.tiny,
   },
+  meta: Styles.platformStyles({
+    isElectron: {
+      alignSelf: 'center',
+    },
+  }),
   middot: {
     marginLeft: Styles.globalMargins.xtiny,
     marginRight: Styles.globalMargins.xtiny,


### PR DESCRIPTION
@keybase/react-hackers 

Doesn't apply to mobile which uses a different layout.  Before/after:

![Screen Shot 2020-05-13 at 9 58 52 AM](https://user-images.githubusercontent.com/21217/81842566-13540200-9501-11ea-9c1a-afa59c6b5fa8.png)

![Screen Shot 2020-05-13 at 9 58 45 AM](https://user-images.githubusercontent.com/21217/81842583-18b14c80-9501-11ea-971e-dba116021d53.png)
