### PR TITLE
Don't navUp after team building in add members wizard

### DIFF
--- a/shared/actions/team-building.tsx
+++ b/shared/actions/team-building.tsx
@@ -8,8 +8,13 @@ import * as Saga from '../util/saga'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import {TypedState} from '../constants/reducer'
 import {validateEmailAddress} from '../util/email-address'
+import flags from '../util/feature-flags'
 
-const closeTeamBuilding = () => {
+const closeTeamBuilding = (_: TypedState, {payload: {namespace}}: NSAction) => {
+  if (namespace === 'teams' && flags.teamsRedesign) {
+    // add members wizard handles navigation
+    return false
+  }
   const modals = RouterConstants.getModalStack()
   const routeNames = [...namespaceToRoute.values()]
   const routeName = modals[modals.length - 1]?.routeName


### PR DESCRIPTION
I think this was an existing race exposed by the `findAssertionsInTeam` change. Since we don't push the confirm screen immediately anymore, you would see the nav flash you up to the add-members-how screen. Really team building should not try to handle nav in this context. cc @keybase/y2ksquad @adamjspooner 