### PR TITLE
Do not crash on bad buffer in isBase64KeybaseV0Sig

### DIFF
--- a/go/libkb/stream_classifier.go
+++ b/go/libkb/stream_classifier.go
@@ -66,6 +66,11 @@ func isBase64KeybaseV0Sig(s string) bool {
 	if err != nil {
 		return false
 	}
+	// If there is a way to feed base64-like data thats longer than that
+	// b64dataBytes but yields an empty buffer, bail out and not crash later.
+	if len(buf) == 0 {
+		return false
+	}
 	// Packet should be an encoded dictionary of 3 values
 	if buf[0] != 0x83 {
 		return false

--- a/go/libkb/stream_classifier_test.go
+++ b/go/libkb/stream_classifier_test.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func newStreamFromBase64String(t *testing.T, s string) io.Reader {
@@ -126,4 +128,10 @@ func TestClassifyTestVectors(t *testing.T) {
 		}
 		assertStreamEqBase64(t, r2, v.msg)
 	}
+}
+
+func TestClassifyBadVectors(t *testing.T) {
+	_, _, err := ClassifyStream(bytes.NewBufferString("\n\n\n\n\n\n\n\n"))
+	require.Error(t, err)
+	require.IsType(t, UnknownStreamError{}, err)
 }


### PR DESCRIPTION
This came up in a log. There is a way to repro this locally if you give bad buffer to e.g. `pgp verify`.