### PR TITLE
Set desktop Linux desktop icon in BrowserWindow config

### DIFF
--- a/shared/desktop/app/main-window.desktop.tsx
+++ b/shared/desktop/app/main-window.desktop.tsx
@@ -7,7 +7,7 @@ import menuHelper from './menu-helper.desktop'
 import {mainWindowDispatch} from '../remote/util.desktop'
 import {WindowState} from '../../constants/types/config'
 import {showDevTools} from '../../local-debug.desktop'
-import {guiConfigFilename, isDarwin, isWindows, defaultUseNativeFrame} from '../../constants/platform.desktop'
+import {guiConfigFilename, isDarwin, isWindows, isLinux, defaultUseNativeFrame} from '../../constants/platform.desktop'
 import {resolveRoot, resolveRootAsURL} from './resolve-root.desktop'
 import logger from '../../logger'
 import debounce from 'lodash/debounce'
@@ -285,6 +285,7 @@ export default () => {
     x: windowState.x,
     y: windowState.y,
     ...(isDarwin ? {titleBarStyle: 'hiddenInset'} : {}),
+    ...(isLinux ? {icon: 'desktop/Icon.png'} : {}),
   })
   win.loadURL(htmlFile)
   if (!disableSpellCheck) {


### PR DESCRIPTION
Linux executables do not allow embedding an icon. The icon must instead be set using the icon option in the BrowserWindow constructor. See electron-packager docs:
https://github.com/electron/electron-packager/blob/61f6c0c3/docs/api.md#icon
(git SHA used since the master branch documentation has moved)

Related: electron/electron-packager#128

### Before
![image](https://user-images.githubusercontent.com/195061/88340502-cbb3d880-ccf0-11ea-9365-0c96e9a4ece2.png)

### After
![image](https://user-images.githubusercontent.com/195061/88340523-d3737d00-ccf0-11ea-990c-c1d07872edfe.png)

This icon is also used for alt-tab program switching and multi-workspace previews.
![image](https://user-images.githubusercontent.com/195061/88340543-da01f480-ccf0-11ea-9f60-f16224c7382b.png)
