### PR TITLE
check bounds before normalizing

### DIFF
--- a/go/engine/cryptocurrency.go
+++ b/go/engine/cryptocurrency.go
@@ -50,6 +50,9 @@ func (e *CryptocurrencyEngine) SubConsumers() []libkb.UIConsumer {
 }
 
 func normalizeAddress(address string) string {
+	if len(address) <= 3 {
+		return address
+	}
 	switch strings.ToLower(address)[0:3] {
 	case "bc1", "zs1":
 		// bech32 addresses require that cases not be mixed

--- a/go/kbfs/data/data_mocks_test.go
+++ b/go/kbfs/data/data_mocks_test.go
@@ -5,8 +5,9 @@
 package data
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBlockWithPtrs is a mock of BlockWithPtrs interface.

--- a/go/kbfs/libkbfs/data_mocks_test.go
+++ b/go/kbfs/libkbfs/data_mocks_test.go
@@ -6,11 +6,12 @@ package libkbfs
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	data "github.com/keybase/client/go/kbfs/data"
 	kbfsblock "github.com/keybase/client/go/kbfs/kbfsblock"
 	tlf "github.com/keybase/client/go/kbfs/tlf"
-	reflect "reflect"
 )
 
 // MockBlockCache is a mock of BlockCache interface.

--- a/go/kbfs/libkbfs/libkbfs_mocks_test.go
+++ b/go/kbfs/libkbfs/libkbfs_mocks_test.go
@@ -6,6 +6,10 @@ package libkbfs
 
 import (
 	context "context"
+	os "os"
+	reflect "reflect"
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	data "github.com/keybase/client/go/kbfs/data"
 	favorites "github.com/keybase/client/go/kbfs/favorites"
@@ -20,9 +24,6 @@ import (
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	go_billy_v4 "gopkg.in/src-d/go-billy.v4"
-	os "os"
-	reflect "reflect"
-	time "time"
 )
 
 // MockBlockOps is a mock of BlockOps interface.

--- a/go/kbfs/libkbfs/libkey_mocks_test.go
+++ b/go/kbfs/libkbfs/libkey_mocks_test.go
@@ -6,11 +6,12 @@ package libkbfs
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	kbfscrypto "github.com/keybase/client/go/kbfs/kbfscrypto"
 	kbfsmd "github.com/keybase/client/go/kbfs/kbfsmd"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
-	reflect "reflect"
 )
 
 // MockKeyOps is a mock of KeyOps interface.


### PR DESCRIPTION
caught a panic here on a bad input. why don't wejust to lower all (or at least "bc1", "zs1") addresses?