### PR TITLE
Fix emoji rendering with plain (non-format) strings

### DIFF
--- a/go/client/chat_cli_rendering.go
+++ b/go/client/chat_cli_rendering.go
@@ -756,7 +756,7 @@ func newMessageViewNoMessages() (mv messageView) {
 // newMessageView extracts from a message the parts for display
 // It may fetch the superseding message. So that for example a TEXT message will show its EDIT text.
 func newMessageView(g *libkb.GlobalContext, conversationID chat1.ConversationID, m chat1.MessageUnboxed) (mv messageView, err error) {
-	defer func() { mv.Body = emoji.Sprintf(mv.Body) }()
+	defer func() { mv.Body = emoji.Sprint(mv.Body) }()
 	state, err := m.State()
 	if err != nil {
 		return mv, fmt.Errorf("unexpected empty message")

--- a/go/client/cmd_chat_featured_bots.go
+++ b/go/client/cmd_chat_featured_bots.go
@@ -110,11 +110,11 @@ func displayFeaturedBots(g *libkb.GlobalContext, bots []keybase1.FeaturedBot) er
 			},
 			flexibletable.Cell{
 				Alignment: flexibletable.Left,
-				Content:   flexibletable.SingleCell{Item: emoji.Sprintf(bot.Description)},
+				Content:   flexibletable.SingleCell{Item: emoji.Sprint(bot.Description)},
 			},
 			flexibletable.Cell{
 				Alignment: flexibletable.Left,
-				Content:   flexibletable.SingleCell{Item: strings.ReplaceAll(emoji.Sprintf(bot.ExtendedDescriptionRaw), "\n", " ") + "\n\n"},
+				Content:   flexibletable.SingleCell{Item: strings.ReplaceAll(emoji.Sprint(bot.ExtendedDescriptionRaw), "\n", " ") + "\n\n"},
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
emoji.Sprintf also interprets percent sequences, use emoji.Sprint (with no "f") instead.

---

Note: I haven't tested this PR. Please check that with this change, `keybase chat read <conversation>` displays messages that contain `%` correctly instead of inserting e.g. `%!x(MISSING)`.