### PR TITLE
Change PGPKeyBundle.MergeKey to keep FlagSign

### DIFF
--- a/go/libkb/keymerge.go
+++ b/go/libkb/keymerge.go
@@ -56,6 +56,13 @@ func (to *PGPKeyBundle) MergeKey(from *PGPKeyBundle) {
 	for _, subkey := range from.Subkeys {
 		if i, ok := existingSubkeys[subkey.PublicKey.Fingerprint]; ok {
 			if subkey.Sig.CreationTime.After(to.Subkeys[i].Sig.CreationTime) {
+				if subkey.Sig.FlagsValid && to.Subkeys[i].Sig.FlagsValid {
+					// If the key previously had a Sign flag, make sure we
+					// don't lose it when merging. This prevents a later key
+					// bundle making the subkey unable to verify signatures
+					// that it has already made in the past to the sigchain.
+					subkey.Sig.FlagSign = subkey.Sig.FlagSign || to.Subkeys[i].Sig.FlagSign
+				}
 				to.Subkeys[i].Sig = subkey.Sig
 				if subkey.Revocation != nil {
 					to.Subkeys[i].Revocation = subkey.Revocation


### PR DESCRIPTION
A user has reported a sigchain replay issue, and I think - based on existing logging and some additional logs / key dumps added for debugging - that it's the following:
1. There is a sigchain link signed by PGP key `2B5693AE179F05C2` at seqno 10. (very old PGP link, doesn't include `kid` in the JSON payload, but it's `01013589cf2db6ae1616f66ea7ab3af6e7ed02452ede1cc97fab3366925121e788490a`)
2. These sigs are so old that we are in PermissivelyMergedKey mode for the PGP key.
3. Some time later a PGP key was updated on the server and subkey flags were changed. See the log (additional printout is "merging: true" as well as a log line when signing flag is cleared⁰). Note that right now I don't know how to check when this key was added.
```
[DEBU keybase keyfamily.go:175] 257 adding PGP kid 01013589cf2db6ae1616f66ea7ab3af6e7ed02452ede1cc97fab3366925121e788490a with full hash 924d898e4c7be5ce6e9b372e6a1bdc71dd4c16d7a45faaaefcfa95b220d8c3ee (merging: true)
subkey 2B5693AE179F05C2 loses signing flag
```
4. With this key present in the key bundle, replaying link 10 will fail because it will pick the PermissivelyMergedKey where the subkey has been overwritten with the one without signing flag. I've added additional debug dump that also prints out export of the final merged key¹  (not just armored key as it was loaded initially) and I confirmed that it fails to verify PGP signature from link 10.

This fixes https://github.com/keybase/client/issues/24372

Debugging code changes for reference:
⁰ Print when key is being merged and when subkey loses signing flag
```
diff --git a/go/libkb/keyfamily.go b/go/libkb/keyfamily.go
index 0f864190a1..5cdce817e1 100644
--- a/go/libkb/keyfamily.go
+++ b/go/libkb/keyfamily.go
@@ -172,7 +172,7 @@ func (s *PGPKeySet) addKey(key *PGPKeyBundle) error {
 	// behavior (for sigchains or sections of sigchains with no specific PGP
 	// key hash) and the new behavior.
 
-	s.G().Log.Debug("adding PGP kid %s with full hash %s", key.GetKID().String(), fullHash)
+	s.G().Log.Debug("adding PGP kid %s with full hash %s (merging: %t)", key.GetKID().String(), fullHash, s.PermissivelyMergedKey != nil)
 	s.KeysByHash[fullHash] = key
 
 	strippedKey := key.StripRevocations()
diff --git a/go/libkb/keymerge.go b/go/libkb/keymerge.go
index 16824a4005..bef0d8690c 100644
--- a/go/libkb/keymerge.go
+++ b/go/libkb/keymerge.go
@@ -61,7 +62,10 @@ func (to *PGPKeyBundle) MergeKey(from *PGPKeyBundle) {
 					// don't lose it when merging. This prevents a later key
 					// bundle making the subkey unable to verify signatures
 					// that it has already made in the past to the sigchain.
-					subkey.Sig.FlagSign = subkey.Sig.FlagSign || to.Subkeys[i].Sig.FlagSign
+					// subkey.Sig.FlagSign = subkey.Sig.FlagSign || to.Subkeys[i].Sig.FlagSign
+				}
+				if !subkey.Sig.FlagSign && to.Subkeys[i].Sig.FlagSign {
+					fmt.Printf("subkey %s loses signing flag\n", subkey.PublicKey.KeyIdString())
 				}
 				to.Subkeys[i].Sig = subkey.Sig
 				if subkey.Revocation != nil {
```
¹ Print export of the key that's actually being used for verification instead of initially loaded key armor
```
diff --git a/go/libkb/pgp_key.go b/go/libkb/pgp_key.go
index 3c59acb78b..459400892f 100644
--- a/go/libkb/pgp_key.go
+++ b/go/libkb/pgp_key.go
@@ -779,6 +779,9 @@ func (k PGPKeyBundle) VerifyStringAndExtract(ctx VerifyContext, sig string) (msg
 		return
 	} else if err = ps.Verify(k); err != nil {
 		ctx.Debug("Failing key----------\n%s", k.ArmoredPublicKey)
+		var buf bytes.Buffer
+		k.EncodeToStream(NopWriteCloser{W: &buf}, false)
+		ctx.Debug("Failing key (export)--------\n%s", buf.String())
 		ctx.Debug("Failing sig----------\n%s", sig)
 		return
 	}
```