### PR TITLE
fix broken links regarding email/phone usage

### DIFF
--- a/shared/settings/account/index.tsx
+++ b/shared/settings/account/index.tsx
@@ -69,7 +69,7 @@ const EmailPhone = (props: Props) => (
       <Kb.Text type="BodySmall">
         Secures your account by letting us send important notifications, and allows friends and teammates to
         find you by phone number or email.{' '}
-        <Kb.Text type="BodySmallPrimaryLink" onClickURL="https://keybase.io/docs/chat/phones_and_emails">
+        <Kb.Text type="BodySmallPrimaryLink" onClickURL="https://keybase.io/docs/chat/phones-and-emails">
           Read more{' '}
           <Kb.Icon
             type="iconfont-open-browser"

--- a/shared/whats-new/versions.tsx
+++ b/shared/whats-new/versions.tsx
@@ -152,7 +152,7 @@ export const LastLast = ({seen, onNavigate, onNavigateExternal}: VersionProps) =
         }}
         secondaryButtonText="Read the doc"
         onSecondaryButtonClick={() => {
-          onNavigateExternal('https://keybase.io/docs/chat/phones_and_emails')
+          onNavigateExternal('https://keybase.io/docs/chat/phones-and-emails')
         }}
       >
         You can now start a conversation with a phone number or email address.


### PR DESCRIPTION
the links to the "[Phone Numbers and Emails](https://book.keybase.io/docs/chat/phones-and-emails)" page were incorrect

Fixes: #24263