### PR TITLE
load max messages on background loader, and fix handling of cached deleted messages

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -963,7 +963,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 		// will never actually cache it. Detect this case here and put a load of the messages onto the
 		// background loader so we can get these messages cached with the full checks on UnboxMessage.
 		if reason == chat1.GetThreadReason_LOCALIZE && globals.CtxUnboxMode(ctx) == types.UnboxModeQuick {
-			s.Debug(ctx, "GetMessages: cache miss on localizer mode with UnboxQuickMode, queuing job")
+			s.Debug(ctx, "GetMessages: convID: %s remoteMsgs: %d: cache miss on localizer mode with UnboxQuickMode, queuing job", convID, len(remoteMsgs))
 			if err := s.G().ConvLoader.Queue(ctx, types.NewConvLoaderJob(convID, &chat1.Pagination{Num: 0},
 				types.ConvLoaderPriorityLowest, types.ConvLoaderUnique,
 				func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
@@ -972,6 +972,7 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 						customRi, resolveSupersedes); err != nil {
 						s.Debug(ctx, "GetMessages: error loading UnboxQuickMode cache misses: ", err)
 					}
+
 				})); err != nil {
 				s.Debug(ctx, "GetMessages: error queuing conv loader job: %+v", err)
 			}

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -964,6 +964,8 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 		// background loader so we can get these messages cached with the full checks on UnboxMessage.
 		if reason == chat1.GetThreadReason_LOCALIZE && globals.CtxUnboxMode(ctx) == types.UnboxModeQuick {
 			s.Debug(ctx, "GetMessages: convID: %s remoteMsgs: %d: cache miss on localizer mode with UnboxQuickMode, queuing job", convID, len(remoteMsgs))
+			// implement the load entirely in the post load hook since we only want to load those
+			// messages in remoteMsgs. We can do that by specifying a 0 length pagination object.
 			if err := s.G().ConvLoader.Queue(ctx, types.NewConvLoaderJob(convID, &chat1.Pagination{Num: 0},
 				types.ConvLoaderPriorityLowest, types.ConvLoaderUnique,
 				func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -957,6 +957,25 @@ func (s *HybridConversationSource) GetMessages(ctx context.Context, convID chat1
 		if err := s.mergeMaybeNotify(ctx, conv, uid, rmsgsUnboxed, reason); err != nil {
 			return nil, err
 		}
+
+		// The localizer uses UnboxQuickMode for unboxing and storing messages. Because of this, if there
+		// is a message in the deep past used for something like a channel name, headline, or pin, then we
+		// will never actually cache it. Detect this case here and put a load of the messages onto the
+		// background loader so we can get these messages cached with the full checks on UnboxMessage.
+		if reason == chat1.GetThreadReason_LOCALIZE && globals.CtxUnboxMode(ctx) == types.UnboxModeQuick {
+			s.Debug(ctx, "GetMessages: cache miss on localizer mode with UnboxQuickMode, queuing job")
+			if err := s.G().ConvLoader.Queue(ctx, types.NewConvLoaderJob(convID, &chat1.Pagination{Num: 0},
+				types.ConvLoaderPriorityLowest, types.ConvLoaderUnique,
+				func(ctx context.Context, tv chat1.ThreadView, job types.ConvLoaderJob) {
+					reason := chat1.GetThreadReason_BACKGROUNDCONVLOAD
+					if _, err := s.G().ConvSource.GetMessages(ctx, convID, uid, remoteMsgs, &reason,
+						customRi, resolveSupersedes); err != nil {
+						s.Debug(ctx, "GetMessages: error loading UnboxQuickMode cache misses: ", err)
+					}
+				})); err != nil {
+				s.Debug(ctx, "GetMessages: error queuing conv loader job: %+v", err)
+			}
+		}
 	}
 
 	// Form final result

--- a/go/chat/localizer.go
+++ b/go/chat/localizer.go
@@ -796,8 +796,9 @@ func (s *localizerPipeline) localizeConversation(ctx context.Context, uid gregor
 				summaries = append(summaries, tlfSummary)
 			}
 		}
+		reason := chat1.GetThreadReason_LOCALIZE
 		msgs, err := s.G().ConvSource.GetMessages(ctx, conversationRemote.GetConvID(),
-			uid, utils.PluckMessageIDs(summaries), nil, nil, false)
+			uid, utils.PluckMessageIDs(summaries), &reason, nil, false)
 		if !s.isErrPermanent(err) {
 			errTyp = chat1.ConversationErrorType_TRANSIENT
 		}

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -119,13 +119,14 @@ func decode(data []byte, res interface{}) error {
 type SimpleResultCollector struct {
 	res                  []chat1.MessageUnboxed
 	target, cur, curScan int
+	countAll             bool
 }
 
 var _ ResultCollector = (*SimpleResultCollector)(nil)
 
 func (s *SimpleResultCollector) Push(msg chat1.MessageUnboxed) {
 	s.res = append(s.res, msg)
-	if !msg.IsValidDeleted() {
+	if s.countAll || !msg.IsValidDeleted() {
 		s.cur++
 	}
 	s.curScan++
@@ -168,9 +169,10 @@ func (s *SimpleResultCollector) SetTarget(num int) {
 	s.target = num
 }
 
-func NewSimpleResultCollector(num int) *SimpleResultCollector {
+func NewSimpleResultCollector(num int, countAll bool) *SimpleResultCollector {
 	return &SimpleResultCollector{
-		target: num,
+		target:   num,
+		countAll: countAll,
 	}
 }
 
@@ -968,7 +970,7 @@ func (s *Storage) ResultCollectorFromQuery(ctx context.Context, query *chat1.Get
 		s.Debug(ctx, "ResultCollectorFromQuery: types: %v", query.MessageTypes)
 		return NewTypedResultCollector(num, query.MessageTypes)
 	}
-	return NewSimpleResultCollector(num)
+	return NewSimpleResultCollector(num, false)
 }
 
 func (s *Storage) fetchUpToMsgIDLocked(ctx context.Context, rc ResultCollector,
@@ -1224,7 +1226,7 @@ func (s *Storage) IsTLFIdentifyBroken(ctx context.Context, tlfID chat1.TLFID) bo
 }
 
 func (s *Storage) getMessage(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgID chat1.MessageID) (*chat1.MessageUnboxed, Error) {
-	rc := NewSimpleResultCollector(1)
+	rc := NewSimpleResultCollector(1, true)
 	if err := s.engine.ReadMessages(ctx, rc, convID, uid, msgID, 0); err != nil {
 		// If we don't have the message, just keep going
 		if _, ok := err.(MissError); ok {

--- a/go/chat/storage/storage.go
+++ b/go/chat/storage/storage.go
@@ -119,7 +119,9 @@ func decode(data []byte, res interface{}) error {
 type SimpleResultCollector struct {
 	res                  []chat1.MessageUnboxed
 	target, cur, curScan int
-	countAll             bool
+
+	// countAll controls whether or not deleted messages should count toward target
+	countAll bool
 }
 
 var _ ResultCollector = (*SimpleResultCollector)(nil)

--- a/go/chat/storage/storage_ephemeral_purge.go
+++ b/go/chat/storage/storage_ephemeral_purge.go
@@ -44,7 +44,7 @@ func (s *Storage) EphemeralPurge(ctx context.Context, convID chat1.ConversationI
 	} else {
 		target = maxHoles
 	}
-	rc := NewHoleyResultCollector(maxHoles, NewSimpleResultCollector(target))
+	rc := NewHoleyResultCollector(maxHoles, NewSimpleResultCollector(target, false))
 	err = s.engine.ReadMessages(ctx, rc, convID, uid, maxMsgID, 0)
 	switch err.(type) {
 	case nil:

--- a/go/protocol/chat1/common.go
+++ b/go/protocol/chat1/common.go
@@ -2006,6 +2006,7 @@ const (
 	GetThreadReason_BOTCOMMANDS        GetThreadReason = 10
 	GetThreadReason_EMOJISOURCE        GetThreadReason = 11
 	GetThreadReason_FORWARDMSG         GetThreadReason = 12
+	GetThreadReason_LOCALIZE           GetThreadReason = 13
 )
 
 func (o GetThreadReason) DeepCopy() GetThreadReason { return o }
@@ -2024,6 +2025,7 @@ var GetThreadReasonMap = map[string]GetThreadReason{
 	"BOTCOMMANDS":        10,
 	"EMOJISOURCE":        11,
 	"FORWARDMSG":         12,
+	"LOCALIZE":           13,
 }
 
 var GetThreadReasonRevMap = map[GetThreadReason]string{
@@ -2040,6 +2042,7 @@ var GetThreadReasonRevMap = map[GetThreadReason]string{
 	10: "BOTCOMMANDS",
 	11: "EMOJISOURCE",
 	12: "FORWARDMSG",
+	13: "LOCALIZE",
 }
 
 func (e GetThreadReason) String() string {

--- a/protocol/avdl/chat1/common.avdl
+++ b/protocol/avdl/chat1/common.avdl
@@ -596,7 +596,8 @@
     COINFLIP_9,
     BOTCOMMANDS_10,
     EMOJISOURCE_11,
-    FORWARDMSG_12
+    FORWARDMSG_12,
+    LOCALIZE_13
   }
 
   enum ReIndexingMode {

--- a/protocol/json/chat1/common.json
+++ b/protocol/json/chat1/common.json
@@ -1535,7 +1535,8 @@
         "COINFLIP_9",
         "BOTCOMMANDS_10",
         "EMOJISOURCE_11",
-        "FORWARDMSG_12"
+        "FORWARDMSG_12",
+        "LOCALIZE_13"
       ]
     },
     {

--- a/shared/constants/types/rpc-chat-gen.tsx
+++ b/shared/constants/types/rpc-chat-gen.tsx
@@ -832,6 +832,7 @@ export enum GetThreadReason {
   botcommands = 10,
   emojisource = 11,
   forwardmsg = 12,
+  localize = 13,
 }
 
 export enum GlobalAppNotificationSetting {


### PR DESCRIPTION
Patch does the following:

1. If we miss a `GetMessages()` local cache hit during localization, then queue up the messages in normal unboxing mode on the background loader so we can eventually cache them.
2. When fetching messages from cache using `Storage.FetchMessages`, configure the `SimpleResultCollector` to count deleted messages toward the total. Otherwise, if we are looking for a deleted message in a sea of messages we don't have cached, we will continually miss on the cache since the original hit isn't counting.