### PR TITLE
Maintain current contextIsolation behavior across electron 11 vs. >=12

### DIFF
--- a/shared/desktop/app/main-window.desktop.tsx
+++ b/shared/desktop/app/main-window.desktop.tsx
@@ -275,6 +275,7 @@ export default () => {
     minWidth: 740,
     show: false,
     webPreferences: {
+      contextIsolation: false,
       backgroundThrottling: false,
       devTools: showDevTools,
       nodeIntegration: true,

--- a/shared/desktop/app/menu-bar.desktop.tsx
+++ b/shared/desktop/app/menu-bar.desktop.tsx
@@ -40,6 +40,7 @@ export default (menubarWindowIDCallback: (id: number) => void) => {
       resizable: false,
       transparent: true,
       webPreferences: {
+        contextIsolation: false,
         nodeIntegration: true,
         nodeIntegrationInWorker: false,
         preload: resolveRoot('dist', `preload-main${__DEV__ ? '.dev' : ''}.bundle.js`),

--- a/shared/desktop/app/node.desktop.tsx
+++ b/shared/desktop/app/node.desktop.tsx
@@ -365,6 +365,7 @@ const plumbEvents = () => {
           show: false, // Start hidden and show when we actually get props
           titleBarStyle: 'customButtonsOnHover' as const,
           webPreferences: {
+            contextIsolation: false,
             nodeIntegration: true,
             nodeIntegrationInWorker: false,
             preload: resolveRoot('dist', `preload-main${__DEV__ ? '.dev' : ''}.bundle.js`),


### PR DESCRIPTION
For what this does, see:

https://www.electronjs.org/docs/breaking-changes#default-changed-contextisolation-defaults-to-true
https://github.com/electron/electron/blob/main/docs/tutorial/context-isolation.md

In electron 11, this logged:

> The default of contextIsolation is deprecated and will be changing from false to true in a future release of Electron.

In electron 12, Keybase refused to start. Explicitly specifying the old behavior makes Keybase run again.

"for the security of your application" Keybase may wish in future to restructure and support context isolation, but that would be in the future.