### PR TITLE
load thread on tab switch

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -1027,7 +1027,8 @@ function* loadMoreMessages(
     | Chat2Gen.LoadNewerMessagesDueToScrollPayload
     | Chat2Gen.LoadMessagesCenteredPayload
     | Chat2Gen.MarkConversationsStalePayload
-    | ConfigGen.ChangedFocusPayload,
+    | ConfigGen.ChangedFocusPayload
+    | Chat2Gen.TabSelectedPayload,
   logger: Saga.SagaLogger
 ) {
   // Get the conversationIDKey
@@ -1059,6 +1060,10 @@ function* loadMoreMessages(
         return
       }
       reason = 'got stale'
+      break
+    case Chat2Gen.tabSelected:
+      key = Constants.getSelectedConversation()
+      reason = 'tab selected'
       break
     case Chat2Gen.navigateToThread:
       key = action.payload.conversationIDKey
@@ -3811,6 +3816,7 @@ function* chat2Saga() {
     | Chat2Gen.LoadMessagesCenteredPayload
     | Chat2Gen.MarkConversationsStalePayload
     | ConfigGen.ChangedFocusPayload
+    | Chat2Gen.TabSelectedPayload
   >(
     [
       Chat2Gen.navigateToThread,
@@ -3820,6 +3826,7 @@ function* chat2Saga() {
       Chat2Gen.loadMessagesCentered,
       Chat2Gen.markConversationsStale,
       ConfigGen.changedFocus,
+      Chat2Gen.tabSelected,
     ],
     loadMoreMessages
   )


### PR DESCRIPTION
This forces the desktop app to reload the selected conversation if we switch into the chat tab view. Otherwise, if we were offline and switch into the chat tab after coming back online, we don't get the updated thread contents. For some reason, the `tabSelected` action happens twice, but should be ok since this is just for desktop.