### PR TITLE
Bump go mod nativemessaging to v0.0.0-20220107152903-16b1cdbad484

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.2.2
-	github.com/qrtz/nativemessaging v0.0.0-20161221035708-f4769a80e040
+	github.com/qrtz/nativemessaging v0.0.0-20220107152903-16b1cdbad484
 	github.com/rcrowley/go-metrics v0.0.0-20161128210544-1f30fe9094a5
 	github.com/sergi/go-diff v1.2.0
 	github.com/shirou/gopsutil v2.18.13-0.20181231150826-db425313bfa8+incompatible

--- a/go/go.sum
+++ b/go/go.sum
@@ -871,8 +871,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in3v/bX88wUwgt+U8EA=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
-github.com/qrtz/nativemessaging v0.0.0-20161221035708-f4769a80e040 h1:iKwSrA9BD8ywmJGJy2JbiscEaRrtVY+m/U+ikacZazI=
-github.com/qrtz/nativemessaging v0.0.0-20161221035708-f4769a80e040/go.mod h1:oJXjZgmJiNwg5XtEvky9JCZqd7CZI7iz+mwmTxjIpak=
+github.com/qrtz/nativemessaging v0.0.0-20220107152903-16b1cdbad484 h1:M8SYPQx45Cl84CcOBczSfDriNh3x7/9vSd0A+HO+cRg=
+github.com/qrtz/nativemessaging v0.0.0-20220107152903-16b1cdbad484/go.mod h1:oJXjZgmJiNwg5XtEvky9JCZqd7CZI7iz+mwmTxjIpak=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8/go.mod h1:KsAh3x0e7Fkpgs+Q9pNLS5XpFSvYCEVl5gP9Pp1xp30=
 github.com/quasilyte/go-ruleguard v0.3.13 h1:O1G41cq1jUr3cJmqp7vOUT0SokqjzmS9aESWJuIDRaY=


### PR DESCRIPTION
This version adds support for riscv64.