### PR TITLE
fix image forward

### DIFF
--- a/shared/android/app/src/main/cpp/rpc.cpp
+++ b/shared/android/app/src/main/cpp/rpc.cpp
@@ -72,16 +72,19 @@ Value convertMPToJSI(Runtime &runtime, msgpack::object &o) {
   case msgpack::type::BIN: {
     auto ptr = o.via.bin.ptr;
     int size = o.via.bin.size;
+    // make ArrayBuffer and copy in data
     Function arrayBufferCtor =
         runtime.global().getPropertyAsFunction(runtime, "ArrayBuffer");
     Value ab = arrayBufferCtor.callAsConstructor(runtime, size);
     Object abo = ab.getObject(runtime);
     ArrayBuffer abbuf = abo.getArrayBuffer(runtime);
     std::copy(ptr, ptr + size, abbuf.data(runtime));
+
+    // Wrap in Buffer like framed-msg-pack
     Object bufObj =
         runtime.global().getPropertyAsObject(runtime, "Buffer");
     Function bufFrom = bufObj.getPropertyAsFunction(runtime, "from");
-    Value buf = bufFrom.callWithThis(runtime, bufObj, std::move(ab));
+    Value buf = bufFrom.callWithThis(runtime, bufObj, std::move(ab)); // Buffer shares the memory and just wraps
     return buf;
   }
   case msgpack::type::ARRAY: {

--- a/shared/android/app/src/main/cpp/rpc.cpp
+++ b/shared/android/app/src/main/cpp/rpc.cpp
@@ -74,11 +74,15 @@ Value convertMPToJSI(Runtime &runtime, msgpack::object &o) {
     int size = o.via.bin.size;
     Function arrayBufferCtor =
         runtime.global().getPropertyAsFunction(runtime, "ArrayBuffer");
-    Value v = arrayBufferCtor.callAsConstructor(runtime, size);
-    Object o = v.getObject(runtime);
-    ArrayBuffer buf = o.getArrayBuffer(runtime);
-    std::copy(ptr, ptr + size, buf.data(runtime));
-    return v;
+    Value ab = arrayBufferCtor.callAsConstructor(runtime, size);
+    Object abo = ab.getObject(runtime);
+    ArrayBuffer abbuf = abo.getArrayBuffer(runtime);
+    std::copy(ptr, ptr + size, abbuf.data(runtime));
+    Object bufObj =
+        runtime.global().getPropertyAsObject(runtime, "Buffer");
+    Function bufFrom = bufObj.getPropertyAsFunction(runtime, "from");
+    Value buf = bufFrom.callWithThis(runtime, bufObj, std::move(ab));
+    return buf;
   }
   case msgpack::type::ARRAY: {
     auto size = o.via.array.size;


### PR DESCRIPTION
likely affect other things as well
framed-msg-pack decodes msgpack raw bytes as buffers. We now do the same thing in the jsi layer