### PR TITLE
fix files back not working well

### DIFF
--- a/shared/chat/conversation/input-area/suggestors/suggestion-list.desktop.tsx
+++ b/shared/chat/conversation/input-area/suggestors/suggestion-list.desktop.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react'
-import ReactList from 'react-list'
 import * as Kb from '../../../../common-adapters'
 import * as Styles from '../../../../styles'
 import * as RPCChatTypes from '../../../../constants/types/rpc-chat-gen'
-import {Props} from './suggestion-list'
+import type {Props} from './suggestion-list'
+import SafeReactList from '../../../../common-adapters/safe-react-list'
+import type RL from 'react-list'
 import {BotCommandUpdateStatus} from '../normal/shared'
 
 class SuggestionList extends React.Component<Props> {
-  private listRef = React.createRef<ReactList>()
+  private listRef = React.createRef<RL>()
 
   componentDidMount() {
     // hack to get `ReactList` to render more than one item on initial mount
@@ -31,7 +32,7 @@ class SuggestionList extends React.Component<Props> {
         style={Styles.collapseStyles([styles.listContainer, this.props.style])}
       >
         <Kb.ScrollView style={styles.fullHeight}>
-          <ReactList
+          <SafeReactList
             ref={this.listRef}
             itemRenderer={this.itemRenderer}
             length={this.props.items.length}

--- a/shared/common-adapters/list.desktop.tsx
+++ b/shared/common-adapters/list.desktop.tsx
@@ -1,15 +1,15 @@
-import React, {PureComponent} from 'react'
-import ReactList from 'react-list'
 import * as Styles from '../styles'
+import * as React from 'react'
+import SafeReactList from './safe-react-list'
 import logger from '../logger'
-import throttle from 'lodash/throttle'
 import once from 'lodash/once'
+import throttle from 'lodash/throttle'
+import type RL from 'react-list'
+import type {Props} from './list'
 import {renderElementOrComponentOrNot} from '../util/util'
 
-import {Props} from './list'
-
-class List extends PureComponent<Props<any>> {
-  _list: ReactList | null = null
+class List extends React.PureComponent<Props<any>> {
+  _list: RL | null = null
   _itemRender = (index: number, _: number | string): JSX.Element => {
     // ReactList has an issue where it caches the list length into its own state so can ask
     // for indices outside of the items...
@@ -79,7 +79,7 @@ class List extends PureComponent<Props<any>> {
             onScroll={this.props.onEndReached ? this._onScroll : undefined}
           >
             {renderElementOrComponentOrNot(this.props.ListHeaderComponent)}
-            <ReactList
+            <SafeReactList
               ref={this._setListRef}
               useTranslate3d={false}
               useStaticSize={!!this.props.fixedHeight}

--- a/shared/common-adapters/safe-react-list.tsx
+++ b/shared/common-adapters/safe-react-list.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import ReactList from 'react-list'
+import {useFocusEffect} from '@react-navigation/core'
+
+// Default ReactList will get into a bad state if it redraws while in a hidden parent (like in a stack)
+// to fix we force a redraw when we're back visible
+
+type ItemRenderer = (index: number, key: number | string) => JSX.Element
+type ItemsRenderer = (items: JSX.Element[], ref: string) => JSX.Element
+type ItemSizeEstimator = (index: number, cache: {}) => number
+type ItemSizeGetter = (index: number) => number
+type ScrollParentGetter = () => JSX.Element
+type ReactListProps = {
+  children?: React.ReactNode
+  ref?: React.LegacyRef<ReactList> | undefined
+  axis?: 'x' | 'y' | undefined
+  initialIndex?: number | undefined
+  itemRenderer?: ItemRenderer | undefined
+  itemSizeEstimator?: ItemSizeEstimator | undefined
+  itemSizeGetter?: ItemSizeGetter | undefined
+  itemsRenderer?: ItemsRenderer | undefined
+  length?: number | undefined
+  minSize?: number | undefined
+  pageSize?: number | undefined
+  scrollParentGetter?: ScrollParentGetter | undefined
+  threshold?: number | undefined
+  type?: string | undefined
+  useStaticSize?: boolean | undefined
+  useTranslate3d?: boolean | undefined
+}
+
+const SafeReactList = React.forwardRef<ReactList, ReactListProps>((p, ref) => {
+  const [force, setForce] = React.useState(0)
+
+  useFocusEffect(
+    React.useCallback(() => {
+      setTimeout(() => {
+        setForce(i => i + 1)
+      }, 1)
+    }, [])
+  )
+
+  return (
+    <ReactList
+      // we have to entirely redraw as it has internal caching which is ruined with no way to clear it, this matches the old behavior
+      key={String(force)}
+      {...p}
+      // @ts-ignore ref
+      ref={ref}
+    />
+  )
+})
+
+export default SafeReactList

--- a/shared/common-adapters/section-list.desktop.tsx
+++ b/shared/common-adapters/section-list.desktop.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react'
 import * as Styles from '../styles'
-import ReactList from 'react-list'
+import SafeReactList from './safe-react-list'
 import {Box2} from './box'
 import ScrollView from './scroll-view'
-import {Props, Section, ItemTFromSectionT} from './section-list'
 import debounce from 'lodash/debounce'
 import throttle from 'lodash/throttle'
 import once from 'lodash/once'
 import {memoize} from '../util/memoize'
 import {renderElementOrComponentOrNot} from '../util/util'
+import type RL from 'react-list'
+import type {Props, Section, ItemTFromSectionT} from './section-list'
 
 const Kb = {
   Box2,
@@ -30,19 +31,18 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
   _flat: Array<FlatListElement<T>> = []
   _sectionIndexToFlatIndex: Array<number> = []
   state = {currentSectionFlatIndex: 0}
-  _listRef: React.RefObject<any> = React.createRef()
+  _listRef = React.createRef<RL>()
   _mounted = true
 
   componentDidUpdate(prevProps: Props<T>, _: State) {
     if (this.props.sections !== prevProps.sections) {
       // sections changed so let's also reset the onEndReached call
-      this._onEndReached = once(info => this.props.onEndReached && this.props.onEndReached(info))
+      this._onEndReached = once(info => this.props.onEndReached?.(info))
     }
     if (
       this.props.selectedIndex !== -1 &&
       this.props.selectedIndex !== prevProps.selectedIndex &&
       this.props.selectedIndex !== undefined &&
-      this._listRef &&
       this._listRef.current
     ) {
       const index = this._itemIndexToFlatIndex(this.props.selectedIndex)
@@ -56,7 +56,7 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
   }
 
   /* Methods from native SectionList */
-  scrollToLocation(params) {
+  scrollToLocation(params?: {sectionIndex: number}) {
     // TODO desktop SectionList is limited to sectionIndex
     const sectionIndex = params?.sectionIndex
     const flatIndex = sectionIndex && this._sectionIndexToFlatIndex[sectionIndex]
@@ -124,18 +124,20 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
     } else {
       return (
         <Kb.Box2 direction="vertical" key={`${section.key}:${item.key}`} style={styles.box}>
-          {// @ts-ignore TODO fix this
-          (section.section.renderItem || this.props.renderItem)({
-            index: item.indexWithinSection,
-            item: item.item,
-            section: section.section,
-          })}
+          {
+            // @ts-ignore TODO fix this
+            (section.section.renderItem || this.props.renderItem)({
+              index: item.indexWithinSection,
+              item: item.item,
+              section: section.section,
+            })
+          }
         </Kb.Box2>
       )
     }
   }
 
-  _checkOnEndReached = throttle(target => {
+  _checkOnEndReached = throttle((target: HTMLDivElement) => {
     const diff = target.scrollHeight - (target.scrollTop + target.clientHeight)
     if (diff < 5) {
       this._onEndReached({distanceFromEnd: diff})
@@ -143,7 +145,7 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
   }, 100)
 
   // This matches the way onEndReached works for sectionlist on RN
-  _onEndReached = once(info => this.props.onEndReached && this.props.onEndReached(info))
+  _onEndReached = once(info => this.props.onEndReached?.(info))
 
   _checkSticky = () => {
     if (this._listRef.current) {
@@ -172,7 +174,7 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
       return
     }
     const visibleRange = this._listRef.current?.getVisibleRange()
-    const sectionIndex = this._flat[visibleRange[0]].sectionIndex
+    const sectionIndex = this._flat[visibleRange?.[0] ?? -1]?.sectionIndex ?? -1
     const section = this.props.sections[sectionIndex]
     section && this.props.onSectionChange(section)
   }
@@ -186,7 +188,7 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
     this._checkStickyThrottled()
   }
 
-  private onScroll = e => {
+  private onScroll = (e: {currentTarget?: HTMLDivElement}) => {
     e.currentTarget && this._checkOnEndReached(e.currentTarget)
     // getVisibleRange() is racy, so delay it.
     setTimeout(() => this.onScrollDelayed())
@@ -287,7 +289,7 @@ class SectionList<T extends Section<any, any>> extends React.Component<Props<T>,
           onScroll={this.onScroll}
         >
           {renderElementOrComponentOrNot(this.props.ListHeaderComponent)}
-          <ReactList
+          <SafeReactList
             itemRenderer={(index, key) => this._itemRenderer(index, key, false)}
             itemSizeGetter={this.getItemSizeGetter()}
             length={this._flat.length}

--- a/shared/fs/browser/root.tsx
+++ b/shared/fs/browser/root.tsx
@@ -32,22 +32,24 @@ const rootRows = [
   },
 ]
 
-const getRenderItem = destinationPickerIndex => ({item, section}) =>
-  section.key === 'section-top' ? (
-    <WrapRow>
-      <TlfType name={item.name} destinationPickerIndex={destinationPickerIndex} />
-    </WrapRow>
-  ) : (
-    <WrapRow>
-      <Tlf
-        disabled={false}
-        name={item.name}
-        tlfType={item.tlfType}
-        mixedMode={true}
-        destinationPickerIndex={destinationPickerIndex}
-      />
-    </WrapRow>
-  )
+const getRenderItem =
+  destinationPickerIndex =>
+  ({item, section}) =>
+    section.key === 'section-top' ? (
+      <WrapRow>
+        <TlfType name={item.name} destinationPickerIndex={destinationPickerIndex} />
+      </WrapRow>
+    ) : (
+      <WrapRow>
+        <Tlf
+          disabled={false}
+          name={item.name}
+          tlfType={item.tlfType}
+          mixedMode={true}
+          destinationPickerIndex={destinationPickerIndex}
+        />
+      </WrapRow>
+    )
 
 const renderSectionHeader = ({section}) =>
   section.key === 'banner-sfmi' ? <SfmiBanner /> : <Kb.SectionDivider label={section.title} />
@@ -120,6 +122,7 @@ const Root = ({destinationPickerIndex}: Props) => {
     },
   ]
   const renderItem = React.useMemo(() => getRenderItem(destinationPickerIndex), [destinationPickerIndex])
+
   return (
     <Kb.BoxGrow>
       <Kb.SectionList

--- a/shared/fs/routes.tsx
+++ b/shared/fs/routes.tsx
@@ -4,21 +4,20 @@ import type ConfirmDelete from './common/path-item-action/confirm-delete/contain
 import type KextPermission from './banner/system-file-manager-integration-banner/kext-permission-popup-container'
 import type DestinationPicker from './browser/destination-picker/container'
 
-const fsRoot = {getScreen: (): typeof FsRoot => require('./container').default}
-
-export const newRoutes = {fsRoot}
+export const newRoutes = {fsRoot: {getScreen: () => require('./container').default as typeof FsRoot}}
 
 export const newModalRoutes = {
-  barePreview: {getScreen: (): typeof BarePreview => require('./filepreview').BarePreview},
+  barePreview: {getScreen: () => require('./filepreview').BarePreview as typeof BarePreview},
   confirmDelete: {
-    getScreen: (): typeof ConfirmDelete =>
-      require('./common/path-item-action/confirm-delete/container').default,
+    getScreen: () =>
+      require('./common/path-item-action/confirm-delete/container').default as typeof ConfirmDelete,
   },
   destinationPicker: {
-    getScreen: (): typeof DestinationPicker => require('./browser/destination-picker/container').default,
+    getScreen: () => require('./browser/destination-picker/container').default as typeof DestinationPicker,
   },
   kextPermission: {
-    getScreen: (): typeof KextPermission =>
-      require('./banner/system-file-manager-integration-banner/kext-permission-popup-container').default,
+    getScreen: () =>
+      require('./banner/system-file-manager-integration-banner/kext-permission-popup-container')
+        .default as typeof KextPermission,
   },
 }


### PR DESCRIPTION
In the old nav if you go deeper into a stack the older items don't exist at all
In the new nav, the older items do exist (similar to mobile). This has a nice side effect that your old state isn't lost so if you scroll and go down a level when you come back you're at the correct scroll.

This bug is about `ReactList`. React list can rerender when its in this hidden state (due to say redux). When it renders hidden it sees the parent scroll div as height 0 so it uses that to render and then also caches these values. There isn't a nice clean way to fix this so instead i'm forcing the key to rotate to force a full rerender when `ReactList`s become focused