### PR TITLE
fix windows titles

### DIFF
--- a/shared/constants/tabs.tsx
+++ b/shared/constants/tabs.tsx
@@ -55,6 +55,18 @@ export const tabletTabs = [peopleTab, chatTab, fsTab, teamsTab, walletsTab, sett
 export const settingsTabChildrenPhone = [gitTab, devicesTab, walletsTab, settingsTab] as const
 export const settingsTabChildrenTablet = [gitTab, devicesTab, settingsTab] as const
 
+export const desktopTabMeta = {
+  [chatTab]: {icon: 'iconfont-nav-2-chat', label: 'Chat'},
+  [cryptoTab]: {icon: 'iconfont-nav-2-crypto', label: 'Crypto'},
+  [devicesTab]: {icon: 'iconfont-nav-2-devices', label: 'Devices'},
+  [fsTab]: {icon: 'iconfont-nav-2-files', label: 'Files'},
+  [gitTab]: {icon: 'iconfont-nav-2-git', label: 'Git'},
+  [peopleTab]: {icon: 'iconfont-nav-2-people', label: 'People'},
+  [settingsTab]: {icon: 'iconfont-nav-2-settings', label: 'Settings'},
+  [teamsTab]: {icon: 'iconfont-nav-2-teams', label: 'Teams'},
+  [walletsTab]: {icon: 'iconfont-nav-2-wallets', label: 'Wallet'},
+} as const
+
 export function isValidInitialTab(tab: Tab | null) {
   return isValidInitialTabString(tab)
 }

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -11,6 +11,7 @@ import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
 import * as Shim from './shim.desktop'
 import * as Common from './common.desktop'
 import {HeaderLeftCancel} from '../common-adapters/header-hoc'
+import type {Route} from '../constants/types/route-tree'
 
 export const headerDefaultStyle = Common.headerDefaultStyle
 const Tab = createLeftTabNavigator()
@@ -105,6 +106,12 @@ const LoggedOut = React.memo(() => (
 
 const RootStack = createNoDupeStackNavigator()
 const ModalScreens = makeNavScreens(Shim.shim(modalRoutes, true, false), RootStack.Screen, true)
+const documentTitle = {
+  formatter: () => {
+    const tabLabel = Tabs.desktopTabMeta[Constants.getCurrentTab() ?? '']?.label ?? ''
+    return `Keybase: ${tabLabel}`
+  },
+}
 const ElectronApp = () => {
   const {loggedInLoaded, loggedIn, appState, onStateChange, navKey, initialState} = Shared.useShared()
   Shared.useSharedAfter(appState)
@@ -116,6 +123,7 @@ const ElectronApp = () => {
       theme={Shared.theme}
       initialState={initialState}
       onStateChange={onStateChange}
+      documentTitle={documentTitle}
     >
       <RootStack.Navigator
         key="root"

--- a/shared/router-v2/tab-bar.desktop.tsx
+++ b/shared/router-v2/tab-bar.desktop.tsx
@@ -30,18 +30,6 @@ export type Props = {
   state: any
 }
 
-const data = {
-  [Tabs.chatTab]: {icon: 'iconfont-nav-2-chat', label: 'Chat'},
-  [Tabs.cryptoTab]: {icon: 'iconfont-nav-2-crypto', label: 'Crypto'},
-  [Tabs.devicesTab]: {icon: 'iconfont-nav-2-devices', label: 'Devices'},
-  [Tabs.fsTab]: {icon: 'iconfont-nav-2-files', label: 'Files'},
-  [Tabs.gitTab]: {icon: 'iconfont-nav-2-git', label: 'Git'},
-  [Tabs.peopleTab]: {icon: 'iconfont-nav-2-people', label: 'People'},
-  [Tabs.settingsTab]: {icon: 'iconfont-nav-2-settings', label: 'Settings'},
-  [Tabs.teamsTab]: {icon: 'iconfont-nav-2-teams', label: 'Teams'},
-  [Tabs.walletsTab]: {icon: 'iconfont-nav-2-wallets', label: 'Wallet'},
-} as const
-
 const FilesTabBadge = () => {
   const uploadIcon = FsConstants.getUploadIconForFilesTab(Container.useSelector(state => state.fs.badge))
   return uploadIcon ? <Kbfs.UploadIcon uploadIcon={uploadIcon} style={styles.badgeIconUpload} /> : null
@@ -214,7 +202,7 @@ type TabProps = {
 
 const Tab = React.memo((props: TabProps) => {
   const {tab, index, isSelected, onTabClick, badge} = props
-  const {label} = data[tab]
+  const {label} = Tabs.desktopTabMeta[tab]
 
   const dispatch = Container.useDispatch()
 
@@ -290,7 +278,7 @@ const Tab = React.memo((props: TabProps) => {
         >
           <Kb.Box2 className="tab-highlight" direction="vertical" fullHeight={true} />
           <Kb.Box2 style={styles.iconBox} direction="horizontal">
-            <Kb.Icon className="tab-icon" type={data[tab].icon} sizeType="Big" />
+            <Kb.Icon className="tab-icon" type={Tabs.desktopTabMeta[tab].icon} sizeType="Big" />
             {tab === Tabs.fsTab && <FilesTabBadge />}
           </Kb.Box2>
           <Kb.Text className="tab-label" type="BodySmallSemibold">


### PR DESCRIPTION
New router pulls the current route into the top level title. Instead use the tab