### PR TITLE
fix tap max duration

### DIFF
--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -21,9 +21,7 @@ const unifyAmp = (amp: number) => {
 }
 
 const AudioRecorder = (props: Props) => {
-  // props
   const {conversationIDKey} = props
-  // state
   const ampScale = React.useRef(new Kb.NativeAnimated.Value(0)).current
   const dragY = React.useRef(new Kb.NativeAnimated.Value(0)).current
   const slideTranslate = React.useRef(new Kb.NativeAnimated.Value(0)).current
@@ -33,7 +31,6 @@ const AudioRecorder = (props: Props) => {
   const audioRecording = Container.useSelector(state => state.chat2.audioRecording.get(conversationIDKey))
   const closingDownRef = React.useRef(false)
 
-  // dispatch
   const dispatch = Container.useDispatch()
   const meteringCb = React.useCallback(
     (inamp: number) => {
@@ -72,10 +69,9 @@ const AudioRecorder = (props: Props) => {
     [dispatch, ampTracker, conversationIDKey]
   )
   const sendRecording = React.useCallback(() => stopRecording(Types.AudioStopType.SEND), [stopRecording])
-  const stageRecording = React.useCallback(
-    () => stopRecording(Types.AudioStopType.STOPBUTTON),
-    [stopRecording]
-  )
+  const stageRecording = React.useCallback(() => {
+    stopRecording(Types.AudioStopType.STOPBUTTON)
+  }, [stopRecording])
 
   // render
   const noShow = !Constants.showAudioRecording(audioRecording)

--- a/shared/chat/audio/audio-starter.native.tsx
+++ b/shared/chat/audio/audio-starter.native.tsx
@@ -91,6 +91,7 @@ const AudioStarter = (props: AudioStarterProps) => {
       </Portal>
       <Kb.TapGestureHandler
         shouldCancelWhenOutside={false}
+        maxDurationMs={Number.MAX_SAFE_INTEGER}
         onHandlerStateChange={({nativeEvent}) => {
           if (!props.recording && nativeEvent.state === Kb.GestureState.BEGAN) {
             tapLive.current = true

--- a/shared/index.ios.js
+++ b/shared/index.ios.js
@@ -1,4 +1,5 @@
 // React-native tooling assumes this file is here, so we just require our real entry point
+/* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access */
 import 'react-native-gesture-handler' // MUST BE FIRST https://github.com/software-mansion/react-native-gesture-handler/issues/320
 import './why-did-you-render'
 import './app/globals.native'
@@ -14,15 +15,13 @@ const NativeEngine = NativeModules.KeybaseEngine
 _setSystemSupported(NativeEngine.darkModeSupported === '1')
 try {
   const obj = JSON.parse(NativeEngine.guiConfig)
-  if (obj && obj.ui) {
-    const dm = obj.ui.darkMode
-    switch (dm) {
-      case 'system': // fallthrough
-      case 'alwaysDark': // fallthrough
-      case 'alwaysLight':
-        _setDarkModePreference(dm)
-        break
-    }
+  const dm = obj?.ui?.darkMode
+  switch (dm) {
+    case 'system': // fallthrough
+    case 'alwaysDark': // fallthrough
+    case 'alwaysLight':
+      _setDarkModePreference(dm)
+      break
   }
 } catch (_) {}
 


### PR DESCRIPTION
the default max duration is 0.5 seconds so if you press and hold to record audio after 0.5 it bails and fails, leaving the recording up and disabling the finger up events.
also added the root gesture view which is required for the new system and some small cleanup