### PR TITLE
select only active emoji convs when fetching all available emoji

### DIFF
--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -498,7 +498,7 @@ func (s *HybridConversationSource) maybeNuke(ctx context.Context, convID chat1.C
 			SendLocalAdminNotification: true,
 			Reason:                     "Got unexpected conversation deleted error. Cleared conv and inbox cache",
 		}); ierr != nil {
-			s.Debug(ctx, "unable to Clear conv: %v", err)
+			s.Debug(ctx, "unable to Clear conv: %v", ierr)
 		}
 		if ierr := s.G().InboxSource.Clear(ctx, uid, nil); ierr != nil {
 			s.Debug(ctx, "unable to Clear inbox: %v", ierr)

--- a/go/chat/emojisource.go
+++ b/go/chat/emojisource.go
@@ -555,9 +555,8 @@ func (s *DevConvEmojiSource) getNoSet(ctx context.Context, uid gregor1.UID, conv
 	readTopicName := s.topicName(nil)
 	ibox, _, err := s.G().InboxSource.Read(ctx, uid, types.ConversationLocalizerBlocking,
 		types.InboxSourceDataSourceAll, nil, &chat1.GetInboxLocalQuery{
-			TopicType:    &topicType,
-			MemberStatus: chat1.AllConversationMemberStatuses(),
-			TopicName:    &readTopicName,
+			TopicType: &topicType,
+			TopicName: &readTopicName,
 		})
 	if err != nil {
 		return res, aliasLookup, err


### PR DESCRIPTION
Users are joined into `TopicType_EMOJI` convs by the server, so adding `AllConversationMemberStatuses` doesn't provide any value. In fact, it provides negative value, since it will cause us to attempt to unbox conversations we have been removed from (emoji convs on teams we have left) which will cause a big inbox clear event to happen every time we fetch emojis. 