### PR TITLE
fix pdf view blank on tab change. fix circular ref in chat actions

### DIFF
--- a/shared/common-adapters/web-view.native.tsx
+++ b/shared/common-adapters/web-view.native.tsx
@@ -7,6 +7,7 @@ import type {WebViewInjections, WebViewProps} from './web-view'
 import {View as NativeView} from 'react-native'
 import {WebView as NativeWebView} from 'react-native-webview'
 import {useSpring, animated} from 'react-spring'
+import {useFocusEffect} from '@react-navigation/core'
 
 const escape = (str?: string): string => (str ? str.replace(/\\/g, '\\\\').replace(/`/g, '\\`') : '')
 
@@ -53,6 +54,14 @@ const KBWebViewBase = (props: WebViewProps) => {
     [_setLoading, api]
   )
 
+  // on ios when we tab away and back pdfs won't rerender somehow
+  const [forceReload, setForceReload] = React.useState(1)
+  useFocusEffect(
+    React.useCallback(() => {
+      setForceReload(a => a + 1)
+    }, [])
+  )
+
   return (
     <>
       <AnimatedView
@@ -63,6 +72,7 @@ const KBWebViewBase = (props: WebViewProps) => {
         }}
       >
         <NativeWebView
+          key={String(forceReload)}
           allowUniversalAccessFromFileURLs={allowUniversalAccessFromFileURLs}
           originWhitelist={originWhitelist}
           allowFileAccess={allowFileAccess}

--- a/shared/constants/router2.tsx
+++ b/shared/constants/router2.tsx
@@ -2,7 +2,6 @@ import {createNavigationContainerRef, StackActions, CommonActions} from '@react-
 import * as Container from '../util/container'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as Tabs from '../constants/tabs'
-import * as ChatConstants from '../constants/chat2'
 import isEqual from 'lodash/isEqual'
 import logger from '../logger'
 import shallowEqual from 'shallowequal'
@@ -211,6 +210,8 @@ export const getAppPath = () => {
   return findVisibleRoute([rs.routes[0]], root?.state)
 }
 
+const isSplit = !Container.isMobile || Container.isTablet // Whether the inbox and conversation panels are visible side-by-side.
+
 export const navToThread = (conversationIDKey: ConversationIDKey) => {
   const rs = _getNavigator()?.getRootState()
   // some kind of unknown race, just bail
@@ -246,7 +247,7 @@ export const navToThread = (conversationIDKey: ConversationIDKey) => {
       loggedInRoute.state.index = chatTabIdx
     }
 
-    if (ChatConstants.isSplit) {
+    if (isSplit) {
       // set inbox + convo
       chatStack.state = chatStack.state ?? {index: 0, routes: []}
       chatStack.state.index = 0


### PR DESCRIPTION
if you load a pdf in files and go to chat and back the pdf won't show. the webview is there and even the pages count is there. i dived into the native code and its not terminating or deallocing at all. Aka i can still scroll and it'll say i'm on page 2/5 etc so its some deep internal issue specific to pdfs i think
simple workaround for now is to just force a new key and redraw on refocus

cc: @songgao-zoom 