### PR TITLE
force entire stack redraw on convo id change

### DIFF
--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -81,7 +81,7 @@ const Conversation = (p: SwitchProps) => {
 
   switch (type) {
     case 'error':
-      return <Error conversationIDKey={conversationIDKey} />
+      return <Error key={conversationIDKey} conversationIDKey={conversationIDKey} />
     case 'noConvo':
       // When navigating back to the inbox on mobile, we deselect
       // conversationIDKey by called mobileChangeSelection. This results in
@@ -95,11 +95,12 @@ const Conversation = (p: SwitchProps) => {
       // To solve this we render a blank screen on mobile conversation views with "noConvo"
       return Container.isPhone ? null : <NoConversation />
     case 'normal':
-      return <Normal conversationIDKey={conversationIDKey} />
+      // the id as key is so we entirely force a top down redraw to ensure nothing is possibly from another convo
+      return <Normal key={conversationIDKey} conversationIDKey={conversationIDKey} />
     case 'youAreReset':
       return <YouAreReset />
     case 'rekey':
-      return <Rekey conversationIDKey={conversationIDKey} />
+      return <Rekey key={conversationIDKey} conversationIDKey={conversationIDKey} />
     default:
       return <NoConversation />
   }

--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -202,9 +202,9 @@ class ConversationList extends React.PureComponent<Props> {
     return -1
   }
 
-  private getItemCount = (messageOrdinals: Array<Types.Ordinal>) => {
+  private getItemCount = (messageOrdinals: Array<Types.Ordinal> | null) => {
     if (this.mounted) {
-      return messageOrdinals.length + 2
+      return (messageOrdinals?.length ?? 0) + 2
     } else {
       // needed else VirtualizedList will yellowbox
       return 0

--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -202,6 +202,7 @@ class ConversationList extends React.PureComponent<Props> {
     return -1
   }
 
+  // the component can pass null here sometimes
   private getItemCount = (messageOrdinals: Array<Types.Ordinal> | null) => {
     if (this.mounted) {
       return (messageOrdinals?.length ?? 0) + 2

--- a/shared/constants/platform.d.ts
+++ b/shared/constants/platform.d.ts
@@ -21,7 +21,6 @@ export const isDebuggingInChrome: boolean // only useful in RN
 export const isAndroidNewerThanN: boolean
 export const defaultUseNativeFrame: boolean
 export const isTestDevice: boolean
-export const isRemoteDebuggerAttached: boolean
 
 export declare const downloadFolder: string
 export declare const fileUIName: string

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -117,8 +117,6 @@ export const pprofDir = ''
 export const version = 'TODO'
 export {runMode}
 
-export const isRemoteDebuggerAttached = false
-
 const getTimeLocale = () => {
   if (!isLinux) {
     return Intl.DateTimeFormat().resolvedOptions().locale

--- a/shared/constants/platform.native.tsx
+++ b/shared/constants/platform.native.tsx
@@ -29,8 +29,6 @@ export const isDeviceSecureAndroid: boolean =
     ? nativeBridge.isDeviceSecure
     : nativeBridge.isDeviceSecure === 'true' || false
 
-// @ts-ignore
-export const isRemoteDebuggerAttached: boolean = typeof DedicatedWorkerGlobalScope !== 'undefined'
 export const runMode = 'prod'
 
 export const isIOS = Platform.OS === 'ios'

--- a/shared/engine/transport-shared.tsx
+++ b/shared/engine/transport-shared.tsx
@@ -4,7 +4,6 @@ import {printRPC, printRPCWaitingSession} from '../local-debug'
 import {requestIdleCallback} from '../util/idle-callback'
 import * as LocalConsole from '../util/local-console'
 import * as Stats from './stats'
-import {isRemoteDebuggerAttached, isMobile} from '../constants/platform'
 
 const RobustTransport = rpc.transport.RobustTransport
 const RpcClient = rpc.client.Client
@@ -66,9 +65,7 @@ function rpcLog(info: {method: string; reason: string; extra?: Object; type: str
   requestIdleCallback(
     () => {
       const params = [info.reason, info.method, info.extra].filter(Boolean)
-      if (!isMobile || isRemoteDebuggerAttached) {
-        LocalConsole.green(prefix, info.method, info.reason, ...params)
-      }
+      LocalConsole.green(prefix, info.method, info.reason, ...params)
     },
     {timeout: 1e3}
   )

--- a/shared/logger/index.tsx
+++ b/shared/logger/index.tsx
@@ -1,14 +1,14 @@
 import {
-  AggregateLogger,
-  LogLevel,
-  Logger,
-  LogFn,
-  LogLineWithLevel,
-  LogLineWithLevelISOTimestamp,
-  Loggers,
+  type AggregateLogger,
+  type LogLevel,
+  type Logger,
+  type LogFn,
+  type LogLineWithLevel,
+  type LogLineWithLevelISOTimestamp,
+  type Loggers,
   toISOTimestamp,
 } from './types'
-import {isMobile, isRemoteDebuggerAttached} from '../constants/platform'
+import {isMobile} from '../constants/platform'
 import ConsoleLogger from './console-logger'
 import TeeLogger from './tee-logger'
 import RingLogger from './ring-logger'
@@ -86,10 +86,7 @@ class AggregateLoggerImpl implements AggregateLogger {
 
 const devLoggers = () => ({
   // We already pretty print the actions when we have an actual console.
-  action:
-    !isMobile || isRemoteDebuggerAttached
-      ? new TeeLogger(new RingLogger(100), new ConsoleLogger('log', 'Dispatching Action'))
-      : new NullLogger(),
+  action: new TeeLogger(new RingLogger(100), new ConsoleLogger('log', 'Dispatching Action')),
   debug: new TeeLogger(
     isMobile
       ? new NativeLogger('d')


### PR DESCRIPTION
This fixes the issue where if you make a new convo on mobile you can get in a stuck state
I think what happened before was due to some incorrect behavior we'd rerender a lot
As those were fixed it left some things in place that only worked due to these accidental re-renders
Instead when the convoId changes in a conversation we force the entire component to rerender using the `key`.
Later on it likely makes sense to use `Context` to plumb this which would force all the components which care to redraw

additionally
- [x] just assume logging in mobile dev, we can't really differentiate between flipper and chrome debugger effectively so just turn it on
- [x] the virtual list can ask for itemCount with null data sometimes

cc: @joshblum @mmaxim 