### PR TITLE
fix kbfs links

### DIFF
--- a/shared/chat/conversation/messages/text/container.tsx
+++ b/shared/chat/conversation/messages/text/container.tsx
@@ -1,10 +1,10 @@
 import * as Constants from '../../../../constants/chat2'
-import * as Types from '../../../../constants/types/chat2'
+import type * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as Container from '../../../../util/container'
 import * as WalletConstants from '../../../../constants/wallets'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
-import TextMessage, {ReplyProps} from '.'
+import TextMessage, {type ReplyProps} from '.'
 
 type OwnProps = {
   isHighlighted?: boolean

--- a/shared/common-adapters/markdown/service-decoration.tsx
+++ b/shared/common-adapters/markdown/service-decoration.tsx
@@ -19,12 +19,8 @@ import {StyleOverride} from '.'
 import WithTooltip from '../with-tooltip'
 
 const linkStyle = Styles.platformStyles({
-  isElectron: {
-    fontWeight: 'inherit',
-  },
-  isMobile: {
-    fontWeight: undefined,
-  },
+  isElectron: {fontWeight: 'inherit'},
+  isMobile: {fontWeight: undefined},
 })
 
 type KeybaseLinkProps = {

--- a/shared/common-adapters/markdown/shared.tsx
+++ b/shared/common-adapters/markdown/shared.tsx
@@ -3,7 +3,7 @@ import React, {PureComponent} from 'react'
 import SimpleMarkdown from 'simple-markdown'
 import Text from '../text'
 import logger from '../../logger'
-import {Props as MarkdownProps} from '.'
+import type {Props as MarkdownProps} from '.'
 import {emojiIndexByChar, emojiRegex, commonTlds} from './emoji-gen'
 import {reactOutput, previewOutput, bigEmojiOutput, markdownStyles, serviceOnlyOutput} from './react'
 
@@ -370,9 +370,7 @@ class SimpleMarkdownComponent extends PureComponent<MarkdownProps, {hasError: bo
 
 const styles = Styles.styleSheetCreate(() => ({
   rootWrapper: Styles.platformStyles({
-    isElectron: {
-      whiteSpace: 'pre',
-    },
+    isElectron: {whiteSpace: 'pre'},
   }),
 }))
 

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -18,7 +18,7 @@ const Tab = createLeftTabNavigator()
 
 type DesktopTabs = typeof Tabs.desktopTabs[number]
 
-const tabRootsVals = Object.values(tabRoots)
+const tabRootsVals = Object.values(tabRoots).filter(root => root != tabRoots[Tabs.fsTab]) // we allow fs root anywhere
 // we don't want the other roots in other stacks
 const routesMinusRoots = (tab: DesktopTabs) => {
   const keepVal = tabRoots[tab]


### PR DESCRIPTION
i removed going to other tab roots from other tabs (to solve some other issues) but the `fs` routes use the `fsRoot` so it should be allowed anywhere