### PR TITLE
type route params

### DIFF
--- a/shared/chat/blocking/block-modal/container.tsx
+++ b/shared/chat/blocking/block-modal/container.tsx
@@ -1,29 +1,22 @@
-import * as Container from '../../../util/container'
-import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import BlockModal, {BlockType, NewBlocksMap, ReportSettings, BlockModalContext} from '.'
-import * as UsersGen from '../../../actions/users-gen'
-import * as TeamsGen from '../../../actions/teams-gen'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Constants from '../../../constants/users'
+import * as Container from '../../../util/container'
+import * as RouteTreeGen from '../../../actions/route-tree-gen'
+import * as TeamsGen from '../../../actions/teams-gen'
+import * as UsersGen from '../../../actions/users-gen'
+import BlockModal, {type BlockType, type NewBlocksMap, type ReportSettings} from '.'
 import {leaveTeamWaitingKey} from '../../../constants/teams'
 
-type OwnProps = Container.RouteProps<{
-  blockUserByDefault?: boolean
-  context?: BlockModalContext
-  convID?: string
-  others?: Array<string>
-  team?: string
-  username?: string
-}>
+type OwnProps = Container.RouteProps<'chatBlockingModal'>
 
 export default Container.connect(
   (state: Container.TypedState, ownProps: OwnProps) => {
-    const teamname = Container.getRouteProps(ownProps, 'team', undefined)
+    const teamname = ownProps.route.params?.team ?? undefined
     const waitingForLeave = teamname ? Container.anyWaiting(state, leaveTeamWaitingKey(teamname)) : false
     const waitingForBlocking = Container.anyWaiting(state, Constants.setUserBlocksWaitingKey)
     const waitingForReport = Container.anyWaiting(state, Constants.reportUserWaitingKey)
-    let others = Container.getRouteProps(ownProps, 'others', undefined)
-    let adderUsername = Container.getRouteProps(ownProps, 'username', undefined)
+    let others = ownProps.route.params?.others ?? undefined
+    let adderUsername = ownProps.route.params?.username ?? undefined
     if (others?.length === 1 && !adderUsername) {
       adderUsername = others[0]
       others = undefined
@@ -32,9 +25,9 @@ export default Container.connect(
     return {
       _allKnownBlocks: state.users.blockMap,
       adderUsername,
-      blockUserByDefault: Container.getRouteProps(ownProps, 'blockUserByDefault', false),
-      context: Container.getRouteProps(ownProps, 'context', undefined),
-      convID: Container.getRouteProps(ownProps, 'convID', undefined),
+      blockUserByDefault: ownProps.route.params?.blockUserByDefault ?? false,
+      context: ownProps.route.params?.context ?? undefined,
+      convID: ownProps.route.params?.convID ?? undefined,
       finishWaiting: waitingForLeave || waitingForBlocking || waitingForReport,
       loadingWaiting: Container.anyWaiting(state, Constants.getUserBlocksWaitingKey),
       otherUsernames: others && others.length > 0 ? others : undefined,

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -12,11 +12,11 @@ import {imgMaxWidthRaw} from '../messages/attachment/image/image-render'
 
 const blankMessage = Constants.makeMessageAttachment({})
 
-type OwnProps = Container.RouteProps<{conversationIDKey: Types.ConversationIDKey; ordinal: Types.Ordinal}>
+type OwnProps = Container.RouteProps<'chatAttachmentFullscreen'>
 
 const Connected = (props: OwnProps) => {
-  const conversationIDKey = Container.getRouteProps(props, 'conversationIDKey', Constants.noConversationIDKey)
-  const inOrdinal = Container.getRouteProps(props, 'ordinal', 0)
+  const conversationIDKey = props.route.params?.conversationIDKey ?? Constants.noConversationIDKey
+  const inOrdinal = props.route.params?.ordinal ?? 0
   const [ordinal, setOrdinal] = React.useState(inOrdinal)
   const [autoPlay, setAutoPlay] = React.useState(true)
   const dispatch = Container.useDispatch()

--- a/shared/chat/conversation/attachment-get-titles/container.tsx
+++ b/shared/chat/conversation/attachment-get-titles/container.tsx
@@ -1,41 +1,24 @@
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Constants from '../../../constants/chat2'
-import * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
-import * as Types from '../../../constants/types/chat2'
-import * as FsTypes from '../../../constants/types/fs'
-import GetTitles, {Info} from '.'
 import * as Container from '../../../util/container'
+import * as FsTypes from '../../../constants/types/fs'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
+import GetTitles, {type Info} from '.'
+import type * as RPCChatTypes from '../../../constants/types/rpc-chat-gen'
+import type * as Types from '../../../constants/types/chat2'
 
-type OwnProps = Container.RouteProps<{
-  conversationIDKey: Types.ConversationIDKey
-  pathAndOutboxIDs: Array<Types.PathAndOutboxID>
-  selectConversationWithReason?: 'extension' | 'files'
-  // If tlfName is set, we'll use Chat2Gen.createAttachmentsUpload. Otherwise
-  // Chat2Gen.createAttachFromDragAndDrop is used.
-  tlfName?: string
-  // don't use the drag drop functionality, just upload the outbox IDs
-  noDragDrop?: Boolean
-}>
+type OwnProps = Container.RouteProps<'chatAttachmentGetTitles'>
 
 const noOutboxIds: Array<Types.PathAndOutboxID> = []
 
 export default Container.connect(
   () => ({}),
   (dispatch: Container.TypedDispatch, ownProps: OwnProps) => {
-    const conversationIDKey = Container.getRouteProps(
-      ownProps,
-      'conversationIDKey',
-      Constants.noConversationIDKey
-    )
-    const tlfName = Container.getRouteProps(ownProps, 'tlfName', undefined)
-    const noDragDrop = Container.getRouteProps(ownProps, 'noDragDrop', false)
-    const pathAndOutboxIDs = Container.getRouteProps(ownProps, 'pathAndOutboxIDs', noOutboxIds)
-    const selectConversationWithReason = Container.getRouteProps(
-      ownProps,
-      'selectConversationWithReason',
-      undefined
-    )
+    const conversationIDKey = ownProps.route.params?.conversationIDKey ?? Constants.noConversationIDKey
+    const tlfName = ownProps.route.params?.tlfName ?? undefined
+    const noDragDrop = ownProps.route.params?.noDragDrop ?? false
+    const pathAndOutboxIDs = ownProps.route.params?.pathAndOutboxIDs ?? noOutboxIds
+    const selectConversationWithReason = ownProps.route.params?.selectConversationWithReason ?? undefined
     return {
       onCancel: () => {
         dispatch(
@@ -76,7 +59,7 @@ export default Container.connect(
     }
   },
   (_, dispatchProps, ownProps: OwnProps) => {
-    const pathAndOutboxIDs = Container.getRouteProps(ownProps, 'pathAndOutboxIDs', noOutboxIds)
+    const pathAndOutboxIDs = ownProps.route.params?.pathAndOutboxIDs ?? noOutboxIds
     return {
       onCancel: dispatchProps.onCancel,
       onSubmit: dispatchProps.onSubmit,

--- a/shared/chat/conversation/bot/confirm.tsx
+++ b/shared/chat/conversation/bot/confirm.tsx
@@ -1,23 +1,18 @@
 import * as React from 'react'
 import * as Container from '../../../util/container'
-import * as Types from '../../../constants/types/chat2'
 import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Kb from '../../../common-adapters'
 import * as Constants from '../../../constants/chat2'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import * as TeamTypes from '../../../constants/types/teams'
+import type * as Types from '../../../constants/types/chat2'
 import {useBotConversationIDKey} from './install'
 
-type LoaderProps = Container.RouteProps<{
-  botUsername: string
-  conversationIDKey?: Types.ConversationIDKey
-  teamID?: TeamTypes.TeamID
-}>
+type LoaderProps = Container.RouteProps<'chatConfirmRemoveBot'>
 
 const ConfirmBotRemoveLoader = (props: LoaderProps) => {
-  const botUsername = Container.getRouteProps(props, 'botUsername', '')
-  const inConvIDKey = Container.getRouteProps(props, 'conversationIDKey', undefined)
-  const teamID = Container.getRouteProps(props, 'teamID', undefined)
+  const botUsername = props.route.params?.botUsername ?? ''
+  const inConvIDKey = props.route.params?.conversationIDKey ?? undefined
+  const teamID = props.route.params?.teamID ?? undefined
   const conversationIDKey = useBotConversationIDKey(inConvIDKey, teamID)
   return <ConfirmBotRemove botUsername={botUsername} conversationIDKey={conversationIDKey} />
 }

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -34,16 +34,12 @@ export const useBotConversationIDKey = (inConvIDKey?: Types.ConversationIDKey, t
   return conversationIDKey
 }
 
-type LoaderProps = Container.RouteProps<{
-  botUsername: string
-  conversationIDKey?: Types.ConversationIDKey
-  teamID?: TeamTypes.TeamID
-}>
+type LoaderProps = Container.RouteProps<'chatInstallBot'>
 
 const InstallBotPopupLoader = (props: LoaderProps) => {
-  const botUsername = Container.getRouteProps(props, 'botUsername', '')
-  const inConvIDKey = Container.getRouteProps(props, 'conversationIDKey', undefined)
-  const teamID = Container.getRouteProps(props, 'teamID', undefined)
+  const botUsername = props.route.params?.botUsername ?? ''
+  const inConvIDKey = props.route.params?.conversationIDKey ?? undefined
+  const teamID = props.route.params?.teamID ?? undefined
   const conversationIDKey = useBotConversationIDKey(inConvIDKey, teamID)
   return <InstallBotPopup botUsername={botUsername} conversationIDKey={conversationIDKey} />
 }

--- a/shared/chat/conversation/bot/search.tsx
+++ b/shared/chat/conversation/bot/search.tsx
@@ -1,17 +1,15 @@
 import * as React from 'react'
 import * as Container from '../../../util/container'
 import * as Kb from '../../../common-adapters'
-import * as Types from '../../../constants/types/chat2'
 import * as Constants from '../../../constants/bots'
 import * as BotsGen from '../../../actions/bots-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import * as RPCTypes from '../../../constants/types/rpc-gen'
 import * as Styles from '../../../styles'
-import * as TeamTypes from '../../../constants/types/teams'
+import type * as RPCTypes from '../../../constants/types/rpc-gen'
 import {Bot} from '../info-panel/bot'
 import debounce from 'lodash/debounce'
 
-type Props = Container.RouteProps<{conversationIDKey?: Types.ConversationIDKey; teamID?: TeamTypes.TeamID}>
+type Props = Container.RouteProps<'chatSearchBots'>
 
 const renderSectionHeader = ({section}: any) => {
   return <Kb.SectionDivider label={section.title} />
@@ -21,8 +19,8 @@ const userEmptyPlaceholder = '---EMPTYUSERS---'
 const resultEmptyPlaceholder = '---EMPTYRESULT---'
 
 const SearchBotPopup = (props: Props) => {
-  const conversationIDKey = Container.getRouteProps(props, 'conversationIDKey', undefined)
-  const teamID = Container.getRouteProps(props, 'teamID', undefined)
+  const conversationIDKey = props.route.params?.conversationIDKey ?? undefined
+  const teamID = props.route.params?.teamID ?? undefined
   const [lastQuery, setLastQuery] = React.useState('')
   const featuredBotsMap = Container.useSelector(state => state.chat2.featuredBotsMap)
   const results = Container.useSelector(state => state.chat2.botSearchResults)

--- a/shared/chat/conversation/bot/team-picker.tsx
+++ b/shared/chat/conversation/bot/team-picker.tsx
@@ -10,10 +10,10 @@ import {Avatars, TeamAvatar} from '../../avatars'
 import debounce from 'lodash/debounce'
 import logger from '../../../logger'
 
-type Props = Container.RouteProps<{botUsername: string}>
+type Props = Container.RouteProps<'chatInstallBotPick'>
 
 const BotTeamPicker = (props: Props) => {
-  const botUsername = Container.getRouteProps(props, 'botUsername', '')
+  const botUsername = props.route.params?.botUsername ?? ''
   const [term, setTerm] = React.useState('')
   const [results, setResults] = React.useState<Array<RPCChatTypes.ConvSearchHit>>([])
   const [waiting, setWaiting] = React.useState(false)
@@ -93,9 +93,7 @@ const BotTeamPicker = (props: Props) => {
           <Kb.Text type="BodyBigLink" onClick={onClose}>
             {'Cancel'}
           </Kb.Text>
-        ) : (
-          undefined
-        ),
+        ) : undefined,
         title: 'Add to team or chat',
       }}
     >

--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -9,11 +9,11 @@ import Rekey from './rekey/container'
 import {headerNavigationOptions} from './header-area/container'
 import {useFocusEffect, useNavigation} from '@react-navigation/core'
 import {tabBarStyle} from '../../router-v2/common'
-import type * as Types from '../../constants/types/chat2'
+import type {RouteProps} from '../../router-v2/route-params'
 
 type ConvoType = 'error' | 'noConvo' | 'rekey' | 'youAreReset' | 'normal' | 'rekey'
 
-type SwitchProps = Container.RouteProps<{conversationIDKey: Types.ConversationIDKey}>
+type SwitchProps = RouteProps<'chatConversation'>
 const hideTabBarStyle = {display: 'none'}
 
 // due to timing issues if we go between convos we can 'lose track' of focus in / out
@@ -59,7 +59,7 @@ const Conversation = (p: SwitchProps) => {
     }, [tabNav])
   )
 
-  const conversationIDKey = Container.getRouteProps(p, 'conversationIDKey', Constants.noConversationIDKey)
+  const conversationIDKey = p.route.params?.conversationIDKey ?? Constants.noConversationIDKey
   const meta = Container.useSelector(state => Constants.getMeta(state, conversationIDKey))
 
   let type: ConvoType

--- a/shared/chat/conversation/fwd-msg/team-picker.tsx
+++ b/shared/chat/conversation/fwd-msg/team-picker.tsx
@@ -12,11 +12,11 @@ import {Avatars, TeamAvatar} from '../../avatars'
 import debounce from 'lodash/debounce'
 import logger from '../../../logger'
 
-type Props = Container.RouteProps<{srcConvID: Types.ConversationIDKey; ordinal: Types.Ordinal}>
+type Props = Container.RouteProps<'chatForwardMsgPick'>
 
 const TeamPicker = (props: Props) => {
-  const srcConvID = Container.getRouteProps(props, 'srcConvID', '')
-  const ordinal = Container.getRouteProps(props, 'ordinal', 0)
+  const srcConvID = props.route.params?.srcConvID ?? ''
+  const ordinal = props.route.params?.ordinal ?? 0
   const message = Container.useSelector(state => Constants.getMessage(state, srcConvID, ordinal))
   const [term, setTerm] = React.useState('')
   const [results, setResults] = React.useState<Array<RPCChatTypes.ConvSearchHit>>([])

--- a/shared/chat/conversation/header-area/container.native.tsx
+++ b/shared/chat/conversation/header-area/container.native.tsx
@@ -14,6 +14,7 @@ import * as Tabs from '../../../constants/tabs'
 import {Alert} from 'react-native'
 import {DEBUGDump as DEBUGDumpView} from '../list-area/index.native'
 import {DEBUGDump as DEBUGDumpStore} from '../../../store/configure-store'
+import {getRouteParamsFromRoute} from '../../../router-v2/route-params'
 
 type OwnProps = {
   conversationIDKey: Types.ConversationIDKey
@@ -172,13 +173,17 @@ const BadgeHeaderLeftArray = ({conversationIDKey, ...rest}) => {
   return <HeaderLeftArrow badgeNumber={badgeNumber} {...rest} />
 }
 
-export const headerNavigationOptions = (route: any) => ({
-  headerLeft: (props: any) => {
-    const {onLabelLayout, labelStyle, ...rest} = props
-    return <BadgeHeaderLeftArray {...rest} conversationIDKey={route.params?.conversationIDKey} />
-  },
-  headerRight: () => <HeaderAreaRight conversationIDKey={route.params?.conversationIDKey} />,
-  headerTitle: () => <HeaderArea conversationIDKey={route.params?.conversationIDKey} />,
-})
+export const headerNavigationOptions = (route: unknown) => {
+  const conversationIDKey =
+    getRouteParamsFromRoute<'chatConversation'>(route)?.conversationIDKey ?? Constants.noConversationIDKey
+  return {
+    headerLeft: (props: any) => {
+      const {onLabelLayout, labelStyle, ...rest} = props
+      return <BadgeHeaderLeftArray {...rest} conversationIDKey={conversationIDKey} />
+    },
+    headerRight: () => <HeaderAreaRight conversationIDKey={conversationIDKey} />,
+    headerTitle: () => <HeaderArea conversationIDKey={conversationIDKey} />,
+  }
+}
 
 export default HeaderArea

--- a/shared/chat/conversation/info-panel/add-to-channel/index.new.tsx
+++ b/shared/chat/conversation/info-panel/add-to-channel/index.new.tsx
@@ -13,10 +13,7 @@ import {pluralize} from '../../../../util/string'
 import {memoize} from '../../../../util/memoize'
 import {ModalTitle, useChannelParticipants} from '../../../../teams/common'
 
-type Props = Container.RouteProps<{
-  conversationIDKey: ChatTypes.ConversationIDKey
-  teamID: TeamTypes.TeamID
-}>
+type Props = Container.RouteProps<'chatAddToChannel'>
 
 const sortMembers = memoize((members: TeamTypes.TeamDetails['members']) =>
   [...members.values()]
@@ -25,12 +22,8 @@ const sortMembers = memoize((members: TeamTypes.TeamDetails['members']) =>
 )
 
 const AddToChannel = (props: Props) => {
-  const conversationIDKey = Container.getRouteProps(
-    props,
-    'conversationIDKey',
-    ChatConstants.noConversationIDKey
-  )
-  const teamID = Container.getRouteProps(props, 'teamID', TeamTypes.noTeamID)
+  const conversationIDKey = props.route.params?.conversationIDKey ?? ChatConstants.noConversationIDKey
+  const teamID = props.route.params?.teamID ?? TeamTypes.noTeamID
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
 
@@ -81,9 +74,7 @@ const AddToChannel = (props: Props) => {
           <Kb.Text type="BodyBigLink" onClick={onClose}>
             Cancel
           </Kb.Text>
-        ) : (
-          undefined
-        ),
+        ) : undefined,
         rightButton: Styles.isMobile && toAdd.size && (
           <Kb.Text type="BodyBigLink" onClick={waiting ? undefined : onAdd}>
             Add

--- a/shared/chat/conversation/info-panel/container.tsx
+++ b/shared/chat/conversation/info-panel/container.tsx
@@ -2,24 +2,21 @@ import * as Chat2Gen from '../../../actions/chat2-gen'
 import * as Constants from '../../../constants/chat2'
 import * as Container from '../../../util/container'
 import * as React from 'react'
-import * as Types from '../../../constants/types/chat2'
 import * as TeamConstants from '../../../constants/teams'
-import {InfoPanel, Panel} from '.'
+import type * as Types from '../../../constants/types/chat2'
+import {InfoPanel, type Panel} from '.'
 
 type Props = {
   conversationIDKey?: Types.ConversationIDKey
   navigation?: any
-}
+} & Partial<Container.RouteProps<'chatInfoPanel'>>
 
 const InfoPanelConnector = (props: Props) => {
   const storeSelectedTab = Container.useSelector(state => state.chat2.infoPanelSelectedTab)
-  const initialTab =
-    // @ts-ignore
-    typeof props.navigation !== 'undefined' ? Container.getRouteProps(props, 'tab', null) : storeSelectedTab
+  const initialTab = props.route?.params?.tab ?? storeSelectedTab ?? null
 
   const conversationIDKey: Types.ConversationIDKey =
-    props.conversationIDKey ??
-    Container.getRouteProps(props as any, 'conversationIDKey', Constants.noConversationIDKey)
+    props.conversationIDKey ?? props.route?.params?.conversationIDKey ?? Constants.noConversationIDKey
 
   const meta = Container.useSelector(state => Constants.getMeta(state, conversationIDKey))
   const shouldNavigateOut = meta.conversationIDKey === Constants.noConversationIDKey

--- a/shared/chat/conversation/input-area/normal/location-popup.tsx
+++ b/shared/chat/conversation/input-area/normal/location-popup.tsx
@@ -3,7 +3,6 @@ import * as Kb from '../../../../common-adapters'
 import * as Styles from '../../../../styles'
 import * as Container from '../../../../util/container'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
-import type * as Types from '../../../../constants/types/chat2'
 import * as Chat2Gen from '../../../../actions/chat2-gen'
 import * as ConfigGen from '../../../../actions/config-gen'
 import * as Constants from '../../../../constants/chat2'
@@ -11,18 +10,16 @@ import LocationMap from '../../../location-map'
 import HiddenString from '../../../../util/hidden-string'
 import {clearWatchPosition, watchPositionForMap} from '../../../../actions/platform-specific'
 
-type Props = Container.RouteProps<{conversationIDKey: Types.ConversationIDKey}>
+type Props = Container.RouteProps<'chatLocationPreview'>
 
 const LocationPopup = (props: Props) => {
-  // state
-  const conversationIDKey = Container.getRouteProps(props, 'conversationIDKey', Constants.noConversationIDKey)
+  const conversationIDKey = props.route.params?.conversationIDKey ?? Constants.noConversationIDKey
   const httpSrvAddress = Container.useSelector(state => state.config.httpSrvAddress)
   const httpSrvToken = Container.useSelector(state => state.config.httpSrvToken)
   const location = Container.useSelector(state => state.chat2.lastCoord)
   const username = Container.useSelector(state => state.config.username)
   const [mapLoaded, setMapLoaded] = React.useState(false)
   const [locationDenied, setLocationDenied] = React.useState(false)
-  // dispatch
   const dispatch = Container.useDispatch()
   const onClose = () => {
     dispatch(RouteTreeGen.createClearModals())
@@ -39,7 +36,6 @@ const LocationPopup = (props: Props) => {
       })
     )
   }
-  // lifecycle
   React.useEffect(() => {
     let watchID: number | null
     async function watchPosition() {
@@ -55,7 +51,6 @@ const LocationPopup = (props: Props) => {
     }
   }, [])
 
-  // render
   const width = Math.ceil(Styles.dimensionWidth)
   const height = Math.ceil(Styles.dimensionHeight - 320)
   const mapSrc = location

--- a/shared/chat/conversation/input-area/normal/platform-input.native.tsx
+++ b/shared/chat/conversation/input-area/normal/platform-input.native.tsx
@@ -21,7 +21,6 @@ import {isOpen} from '../../../../util/keyboard'
 import {parseUri, launchCameraAsync, launchImageLibraryAsync} from '../../../../util/expo-image-picker'
 import {standardTransformer} from '../suggestors/common'
 import {useSuggestors} from '../suggestors'
-import {AnimatedIcon} from './platform-input-animation.native'
 import {
   skipAnimations,
   useSharedValue,
@@ -136,6 +135,7 @@ const Buttons = (p: ButtonsProps) => {
   )
 }
 
+const AnimatedIcon = Kb.ReAnimated.createAnimatedComponent(Kb.Icon)
 const AnimatedExpand = (() => {
   if (skipAnimations) {
     return React.memo(() => {

--- a/shared/chat/conversation/messages/react-button/emoji-picker/container.tsx
+++ b/shared/chat/conversation/messages/react-button/emoji-picker/container.tsx
@@ -29,7 +29,7 @@ type Props = {
   onPickAction?: (emoji: string, renderableEmoji: RenderableEmoji) => void
 }
 
-type RoutableProps = Container.RouteProps<Props>
+type RoutableProps = Container.RouteProps<'chatChooseEmoji'>
 
 const useReacji = ({conversationIDKey, onDidPick, onPickAction, onPickAddToMessageOrdinal}: Props) => {
   const topReacjis = Container.useSelector(state => state.chat2.userReacjis.topReacjis)
@@ -348,23 +348,13 @@ const styles = Styles.styleSheetCreate(
 )
 
 export const Routable = (routableProps: RoutableProps) => {
-  const conversationIDKey = Container.getRouteProps(
-    routableProps,
-    'conversationIDKey',
-    Constants.noConversationIDKey
-  )
-  const small = Container.getRouteProps(routableProps, 'small', undefined)
-  const hideFrequentEmoji = Container.getRouteProps(routableProps, 'hideFrequentEmoji', undefined)
-  const onlyTeamCustomEmoji = Container.getRouteProps(routableProps, 'onlyTeamCustomEmoji', undefined)
-  const onPickAction = Container.getRouteProps(routableProps, 'onPickAction', undefined)
-  const onPickAddToMessageOrdinal = Container.getRouteProps(
-    routableProps,
-    'onPickAddToMessageOrdinal',
-    undefined
-  )
+  const {params} = routableProps.route
+  const small = params?.small
+  const {hideFrequentEmoji, onlyTeamCustomEmoji, onPickAction, onPickAddToMessageOrdinal} = params ?? {}
+  const conversationIDKey = params?.conversationIDKey ?? Constants.noConversationIDKey
   const dispatch = Container.useDispatch()
   const navigateUp = () => dispatch(RouteTreeGen.createNavigateUp())
-  const _onDidPick = Container.getRouteProps(routableProps, 'onDidPick', undefined)
+  const _onDidPick = params?.onDidPick
   const onDidPick = _onDidPick
     ? () => {
         _onDidPick()

--- a/shared/chat/conversation/messages/wrapper/unfurl/map/popup.tsx
+++ b/shared/chat/conversation/messages/wrapper/unfurl/map/popup.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import * as Kb from '../../../../../../common-adapters/index'
-import * as Types from '../../../../../../constants/types/chat2'
 import * as Container from '../../../../../../util/container'
 import * as RouteTreeGen from '../../../../../../actions/route-tree-gen'
 import * as Chat2Gen from '../../../../../../actions/chat2-gen'
@@ -10,22 +9,16 @@ import openURL from '../../../../../../util/open-url'
 import LocationMap from '../../../../../location-map'
 import HiddenString from '../../../../../../util/hidden-string'
 
-type Props = Container.RouteProps<{
-  conversationIDKey: Types.ConversationIDKey
-  coord: Types.Coordinate
-  isAuthor: boolean
-  author?: string
-  isLiveLocation: boolean
-  url: string
-}>
+type Props = Container.RouteProps<'chatUnfurlMapPopup'>
 
 const UnfurlMapPopup = (props: Props) => {
-  const conversationIDKey = Container.getRouteProps(props, 'conversationIDKey', Constants.noConversationIDKey)
-  const coord = Container.getRouteProps(props, 'coord', {accuracy: 0, lat: 0, lon: 0})
-  const isAuthor = Container.getRouteProps(props, 'isAuthor', false)
-  const author = Container.getRouteProps(props, 'author', '')
-  const isLiveLocation = Container.getRouteProps(props, 'isLiveLocation', false)
-  const url = Container.getRouteProps(props, 'url', '')
+  const {params} = props.route
+  const conversationIDKey = params?.conversationIDKey ?? Constants.noConversationIDKey
+  const coord = params?.coord ?? {accuracy: 0, lat: 0, lon: 0}
+  const isAuthor = params?.isAuthor ?? false
+  const author = params?.author ?? ''
+  const isLiveLocation = params?.isLiveLocation ?? false
+  const url = params?.url ?? ''
   const httpSrvAddress = Container.useSelector(state => state.config.httpSrvAddress)
   const httpSrvToken = Container.useSelector(state => state.config.httpSrvToken)
 

--- a/shared/chat/create-channel/container.tsx
+++ b/shared/chat/create-channel/container.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import * as TeamsGen from '../../actions/teams-gen'
-import CreateChannel from '.'
 import * as Container from '../../util/container'
+import * as React from 'react'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
-import upperFirst from 'lodash/upperFirst'
-import * as TeamsTypes from '../../constants/types/teams'
 import * as TeamsConstants from '../../constants/teams'
+import * as TeamsGen from '../../actions/teams-gen'
+import * as TeamsTypes from '../../constants/types/teams'
+import CreateChannel from '.'
+import upperFirst from 'lodash/upperFirst'
 
-type OwnProps = Container.RouteProps<{navToChatOnSuccess?: boolean; teamID: TeamsTypes.TeamID}>
+type OwnProps = Container.RouteProps<'chatCreateChannel'>
 
 type Props = {
   _onCreateChannel: (o: {channelname: string; description: string; teamID: TeamsTypes.TeamID}) => void
@@ -47,7 +47,7 @@ const Wrapped = (p: Props) => {
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const teamID = Container.getRouteProps(ownProps, 'teamID', TeamsTypes.noTeamID)
+    const teamID = ownProps.route.params?.teamID ?? TeamsTypes.noTeamID
     return {
       errorText: upperFirst(state.teams.errorInChannelCreation),
       teamID,
@@ -68,7 +68,7 @@ export default Container.connect(
         TeamsGen.createCreateChannel({
           channelname,
           description,
-          navToChatOnSuccess: Container.getRouteProps(ownProps, 'navToChatOnSuccess', undefined) ?? true,
+          navToChatOnSuccess: ownProps.route.params?.navToChatOnSuccess ?? true,
           teamID,
         })
       ),

--- a/shared/chat/delete-history-warning/container.tsx
+++ b/shared/chat/delete-history-warning/container.tsx
@@ -1,22 +1,17 @@
-import * as Types from '../../constants/types/chat2'
 import * as Chat2Gen from '../../actions/chat2-gen'
 import * as Constants from '../../constants/chat2'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Container from '../../util/container'
 import DeleteHistoryWarning from '.'
 
-type OwnProps = Container.RouteProps<{conversationIDKey: Types.ConversationIDKey}>
+type OwnProps = Container.RouteProps<'chatDeleteHistoryWarning'>
 
 export default Container.connect(
   () => ({}),
   (dispatch, ownProps: OwnProps) => ({
     onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
     onDeleteHistory: () => {
-      const conversationIDKey = Container.getRouteProps(
-        ownProps,
-        'conversationIDKey',
-        Constants.noConversationIDKey
-      )
+      const conversationIDKey = ownProps.route.params?.conversationIDKey ?? Constants.noConversationIDKey
       dispatch(RouteTreeGen.createClearModals())
       dispatch(Chat2Gen.createMessageDeleteHistory({conversationIDKey}))
     },

--- a/shared/chat/new-team-dialog-container.tsx
+++ b/shared/chat/new-team-dialog-container.tsx
@@ -1,4 +1,3 @@
-import * as Types from '../constants/types/chat2'
 import * as TeamsGen from '../actions/teams-gen'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as ChatConstants from '../constants/chat2'
@@ -6,7 +5,7 @@ import * as Container from '../util/container'
 import NewTeamDialog from '../teams/new-team'
 import upperFirst from 'lodash/upperFirst'
 
-type OwnProps = Container.RouteProps<{conversationIDKey: Types.ConversationIDKey}>
+type OwnProps = Container.RouteProps<'chatShowNewTeamDialog'>
 
 export default Container.connect(
   state => ({
@@ -19,11 +18,7 @@ export default Container.connect(
     onSubmit: (teamname: string) => {
       dispatch(
         TeamsGen.createCreateNewTeamFromConversation({
-          conversationIDKey: Container.getRouteProps(
-            ownProps,
-            'conversationIDKey',
-            ChatConstants.noConversationIDKey
-          ),
+          conversationIDKey: ownProps.route.params?.conversationIDKey ?? ChatConstants.noConversationIDKey,
           teamname,
         })
       )

--- a/shared/chat/pdf/index.d.ts
+++ b/shared/chat/pdf/index.d.ts
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import * as Container from '../../util/container'
+import type * as Container from '../../util/container'
 
-type Props = Container.RouteProps<{title: string; url: string}>
-
+type Props = Container.RouteProps<'chatPDF'>
 export default class ChatPDF extends React.Component<Props> {}

--- a/shared/chat/pdf/index.native.tsx
+++ b/shared/chat/pdf/index.native.tsx
@@ -4,12 +4,12 @@ import * as Styles from '../../styles'
 import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as ConfigGen from '../../actions/config-gen'
-import {Props} from '.'
+import type {Props} from '.'
 import useFixStatusbar from '../../common-adapters/use-fix-statusbar.native'
 
 const ChatPDF = (props: Props) => {
-  const url = Container.getRouteProps(props, 'url', '')
-  const title = Container.getRouteProps(props, 'title', 'PDF')
+  const url = props.route.params?.url ?? ''
+  const title = props.route.params?.title ?? 'PDF'
   const [error, setError] = React.useState('')
 
   useFixStatusbar()
@@ -47,9 +47,7 @@ const styles = Styles.styleSheetCreate(() => ({
     justifyContent: 'center',
     position: 'absolute',
   },
-  webViewContainer: {
-    margin: Styles.globalMargins.xtiny,
-  },
+  webViewContainer: {margin: Styles.globalMargins.xtiny},
 }))
 
 export default ChatPDF

--- a/shared/chat/punycode-link-warning.tsx
+++ b/shared/chat/punycode-link-warning.tsx
@@ -4,16 +4,13 @@ import * as Container from '../util/container'
 import * as Styles from '../styles'
 import openURL from '../util/open-url'
 
-type PunycodeLinkWarningProps = Container.RouteProps<{
-  display: string
-  punycode: string
-  url: string
-}>
+type PunycodeLinkWarningProps = Container.RouteProps<'chatConfirmNavigateExternal'>
 
 const PunycodeLinkWarning = (props: PunycodeLinkWarningProps) => {
-  const url = Container.getRouteProps(props, 'url', '')
-  const display = Container.getRouteProps(props, 'display', '')
-  const punycode = Container.getRouteProps(props, 'punycode', '')
+  const {params} = props.route
+  const url = params?.url ?? ''
+  const display = params?.display ?? ''
+  const punycode = params?.punycode ?? ''
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
   const onCancel = () => dispatch(nav.safeNavigateUpPayload())

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -1,32 +1,33 @@
-import type * as ChatTypes from '../constants/types/chat2'
-import type ChatConversation from './conversation/container'
-import type ChatEnterPaperkey from './conversation/rekey/enter-paper-key'
-import type ChatRoot from './inbox/container'
+import * as ChatConstants from '../constants/chat2'
+import type * as Types from '../constants/types/chat2'
+import type * as TeamBuildingTypes from '../constants/types/team-building'
+import type * as TeamsTypes from '../constants/types/teams'
+import type BlockModal from './blocking/block-modal/container'
 import type ChatAddToChannelNew from './conversation/info-panel/add-to-channel/index.new'
 import type ChatAttachmentFullscreen from './conversation/attachment-fullscreen/container'
 import type ChatAttachmentGetTitles from './conversation/attachment-get-titles/container'
-import type SendToChat from './send-to-chat'
-import type {Routable as ChatChooseEmoji} from './conversation/messages/react-button/emoji-picker/container'
+import type ChatConfirmRemoveBot from './conversation/bot/confirm'
+import type ChatConversation from './conversation/container'
 import type ChatCreateChannel from './create-channel/container'
 import type ChatDeleteHistoryWarning from './delete-history-warning/container'
+import type ChatEnterPaperkey from './conversation/rekey/enter-paper-key'
+import type ChatForwardMsgPick from './conversation/fwd-msg/team-picker'
 import type ChatInfoPanel from './conversation/info-panel/container'
-import type ChatNewChat from '../team-building/container'
-import type ChatPaymentsConfirm from './payments/confirm/container'
-import type ChatShowNewTeamDialog from './new-team-dialog-container'
-import type ChatLocationPopup from './conversation/input-area/normal/location-popup'
-import type ChatUnfurlMapPopup from './conversation/messages/wrapper/unfurl/map/popup'
-import type PunycodeLinkWarning from './punycode-link-warning'
-import type BlockModal from './blocking/block-modal/container'
 import type ChatInstallBot from './conversation/bot/install'
 import type ChatInstallBotPick from './conversation/bot/team-picker'
-import type ChatForwardMsgPick from './conversation/fwd-msg/team-picker'
-import type ChatSearchBot from './conversation/bot/search'
-import type ChatConfirmRemoveBot from './conversation/bot/confirm'
+import type ChatLocationPopup from './conversation/input-area/normal/location-popup'
+import type ChatNewChat from '../team-building/container'
 import type ChatPDF from './pdf'
-import type * as TeamBuildingTypes from '../constants/types/team-building'
-import type * as TeamsTypes from '../constants/types/teams'
+import type ChatPaymentsConfirm from './payments/confirm/container'
+import type ChatRoot from './inbox/container'
+import type ChatSearchBot from './conversation/bot/search'
+import type ChatShowNewTeamDialog from './new-team-dialog-container'
+import type ChatUnfurlMapPopup from './conversation/messages/wrapper/unfurl/map/popup'
+import type PunycodeLinkWarning from './punycode-link-warning'
+import type SendToChat from './send-to-chat'
 import type {RenderableEmoji} from '../util/emoji'
-import * as ChatConstants from '../constants/chat2'
+import type {Routable as ChatChooseEmoji} from './conversation/messages/react-button/emoji-picker/container'
+import type {BlockModalContext} from './blocking/block-modal'
 
 export const newRoutes = {
   chatConversation: {getScreen: (): typeof ChatConversation => require('./conversation/container').default},
@@ -124,19 +125,19 @@ type TeamBuilderProps = Partial<{
 
 export type RootParamListChat = {
   chatNewChat: TeamBuilderProps
-  chatConversation: {conversationIDKey: ChatTypes.ConversationIDKey}
+  chatConversation: {conversationIDKey: Types.ConversationIDKey}
   chatChooseEmoji: {
-    conversationIDKey: ChatTypes.ConversationIDKey
+    conversationIDKey: Types.ConversationIDKey
     small: boolean
     hideFrequentEmoji: boolean
     onlyTeamCustomEmoji: boolean
     onPickAction: (emojiStr: string, renderableEmoji: RenderableEmoji) => void
-    onPickAddToMessageOrdinal: ChatTypes.Ordinal
+    onPickAddToMessageOrdinal: Types.Ordinal
     onDidPick: () => void
   }
   chatUnfurlMapPopup: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-    coord: ChatTypes.Coordinate
+    conversationIDKey: Types.ConversationIDKey
+    coord: Types.Coordinate
     isAuthor: boolean
     author?: string
     isLiveLocation: boolean
@@ -146,12 +147,8 @@ export type RootParamListChat = {
     navToChatOnSuccess?: boolean
     teamID: TeamsTypes.TeamID
   }
-  chatDeleteHistoryWarning: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-  }
-  chatShowNewTeamDialog: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-  }
+  chatDeleteHistoryWarning: {conversationIDKey: Types.ConversationIDKey}
+  chatShowNewTeamDialog: {conversationIDKey: Types.ConversationIDKey}
   chatPDF: {
     title: string
     url: string
@@ -166,5 +163,57 @@ export type RootParamListChat = {
     isFromShareExtension: boolean
     text: string // incoming share (text)
     sendPaths: Array<string> // KBFS or incoming share (files)
+  }
+  chatLocationPreview: {conversationIDKey: Types.ConversationIDKey}
+  chatBlockingModal: {
+    blockUserByDefault?: boolean
+    context?: BlockModalContext
+    convID?: string
+    others?: Array<string>
+    team?: string
+    username?: string
+  }
+  chatAttachmentGetTitles: {
+    conversationIDKey: Types.ConversationIDKey
+    pathAndOutboxIDs: Array<Types.PathAndOutboxID>
+    selectConversationWithReason?: 'extension' | 'files'
+    // If tlfName is set, we'll use Chat2Gen.createAttachmentsUpload. Otherwise
+    // Chat2Gen.createAttachFromDragAndDrop is used.
+    tlfName?: string
+    // don't use the drag drop functionality, just upload the outbox IDs
+    noDragDrop?: Boolean
+  }
+  chatAddToChannel: {
+    conversationIDKey: Types.ConversationIDKey
+    teamID: TeamsTypes.TeamID
+  }
+  chatForwardMsgPick: {
+    srcConvID: Types.ConversationIDKey
+    ordinal: Types.Ordinal
+  }
+  chatAttachmentFullscreen: {
+    conversationIDKey: Types.ConversationIDKey
+    ordinal: Types.Ordinal
+  }
+  chatInstallBot: {
+    botUsername: string
+    conversationIDKey?: Types.ConversationIDKey
+    teamID?: TeamsTypes.TeamID
+  }
+  chatInstallBotPick: {
+    botUsername: string
+  }
+  chatSearchBots: {
+    conversationIDKey?: Types.ConversationIDKey
+    teamID?: TeamsTypes.TeamID
+  }
+  chatConfirmRemoveBot: {
+    botUsername: string
+    conversationIDKey?: Types.ConversationIDKey
+    teamID?: TeamsTypes.TeamID
+  }
+  chatInfoPanel: {
+    conversationIDKey?: Types.ConversationIDKey
+    tab?: 'settings' | 'members' | 'attachments' | 'bots'
   }
 }

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -1,3 +1,4 @@
+import type * as ChatTypes from '../constants/types/chat2'
 import type ChatConversation from './conversation/container'
 import type ChatEnterPaperkey from './conversation/rekey/enter-paper-key'
 import type ChatRoot from './inbox/container'
@@ -22,6 +23,9 @@ import type ChatForwardMsgPick from './conversation/fwd-msg/team-picker'
 import type ChatSearchBot from './conversation/bot/search'
 import type ChatConfirmRemoveBot from './conversation/bot/confirm'
 import type ChatPDF from './pdf'
+import type * as TeamBuildingTypes from '../constants/types/team-building'
+import type * as TeamsTypes from '../constants/types/teams'
+import type {RenderableEmoji} from '../util/emoji'
 import * as ChatConstants from '../constants/chat2'
 
 export const newRoutes = {
@@ -108,4 +112,59 @@ export const newModalRoutes = {
   sendToChat: {
     getScreen: (): typeof SendToChat => require('./send-to-chat').default,
   },
+}
+
+type TeamBuilderProps = Partial<{
+  namespace: TeamBuildingTypes.AllowedNamespace
+  teamID: string
+  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel: TeamBuildingTypes.GoButtonLabel
+  title: string
+}>
+
+export type RootParamListChat = {
+  chatNewChat: TeamBuilderProps
+  chatConversation: {conversationIDKey: ChatTypes.ConversationIDKey}
+  chatChooseEmoji: {
+    conversationIDKey: ChatTypes.ConversationIDKey
+    small: boolean
+    hideFrequentEmoji: boolean
+    onlyTeamCustomEmoji: boolean
+    onPickAction: (emojiStr: string, renderableEmoji: RenderableEmoji) => void
+    onPickAddToMessageOrdinal: ChatTypes.Ordinal
+    onDidPick: () => void
+  }
+  chatUnfurlMapPopup: {
+    conversationIDKey: ChatTypes.ConversationIDKey
+    coord: ChatTypes.Coordinate
+    isAuthor: boolean
+    author?: string
+    isLiveLocation: boolean
+    url: string
+  }
+  chatCreateChannel: {
+    navToChatOnSuccess?: boolean
+    teamID: TeamsTypes.TeamID
+  }
+  chatDeleteHistoryWarning: {
+    conversationIDKey: ChatTypes.ConversationIDKey
+  }
+  chatShowNewTeamDialog: {
+    conversationIDKey: ChatTypes.ConversationIDKey
+  }
+  chatPDF: {
+    title: string
+    url: string
+  }
+  chatConfirmNavigateExternal: {
+    display: string
+    punycode: string
+    url: string
+  }
+  sendToChat: {
+    canBack: boolean
+    isFromShareExtension: boolean
+    text: string // incoming share (text)
+    sendPaths: Array<string> // KBFS or incoming share (files)
+  }
 }

--- a/shared/chat/send-to-chat/index.tsx
+++ b/shared/chat/send-to-chat/index.tsx
@@ -98,7 +98,7 @@ export const MobileSendToChat = (props: Props) => {
 }
 
 const DesktopSendToChat = (props: RoutableProps) => {
-  const sendPaths = Container.getRouteProps(props, 'sendPaths', undefined) ?? []
+  const sendPaths = props.route.params?.sendPaths ?? []
   const [title, setTitle] = React.useState('')
   const [conversationIDKey, setConversationIDKey] = React.useState(ChatConstants.noConversationIDKey)
   const [convName, setConvName] = React.useState('')

--- a/shared/chat/send-to-chat/index.tsx
+++ b/shared/chat/send-to-chat/index.tsx
@@ -5,28 +5,28 @@ import * as Kb from '../../common-adapters'
 import * as Kbfs from '../../fs/common'
 import * as Styles from '../../styles'
 import * as Chat2Gen from '../../actions/chat2-gen'
-import * as ChatTypes from '../../constants/types/chat2'
 import * as ChatConstants from '../../constants/chat2'
 import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
+import type * as ChatTypes from '../../constants/types/chat2'
 import HiddenString from '../../util/hidden-string'
 import ConversationList from './conversation-list/conversation-list'
 import ChooseConversation from './conversation-list/choose-conversation'
 
 type Props = {
   canBack?: boolean
-
   isFromShareExtension?: boolean
   text?: string // incoming share (text)
   sendPaths?: Array<string> // KBFS or incoming share (files)
 }
-type RoutableProps = Container.RouteProps<Props>
+type RoutableProps = Container.RouteProps<'sendToChat'>
 
 const MobileSendToChatRoutable = (props: RoutableProps) => {
-  const canBack = Container.getRouteProps(props, 'canBack', false)
-  const isFromShareExtension = Container.getRouteProps(props, 'isFromShareExtension', undefined)
-  const sendPaths = Container.getRouteProps(props, 'sendPaths', undefined)
-  const text = Container.getRouteProps(props, 'text', undefined)
+  const {params} = props.route
+  const canBack = params?.canBack ?? false
+  const isFromShareExtension = params?.isFromShareExtension ?? undefined
+  const sendPaths = params?.sendPaths ?? undefined
+  const text = params?.text ?? undefined
 
   const dispatch = Container.useDispatch()
   const onCancel = () => dispatch(RouteTreeGen.createClearModals())

--- a/shared/constants/types/team-building.tsx
+++ b/shared/constants/types/team-building.tsx
@@ -1,5 +1,5 @@
-import {TeamRoleType} from './teams'
-import {ServiceId as _ServiceId} from '../../util/platforms'
+import type {TeamRoleType} from './teams'
+import type {ServiceId as _ServiceId} from '../../util/platforms'
 
 export const allowedNamespace = ['chat2', 'crypto', 'teams', 'people', 'wallets'] as const
 export type AllowedNamespace = typeof allowedNamespace[number]

--- a/shared/crypto/routes.d.ts
+++ b/shared/crypto/routes.d.ts
@@ -1,3 +1,15 @@
+import type * as TeamBuildingTypes from '../constants/types/team-building'
 declare const newRoutes: {}
 declare const newModalRoutes: {}
 export {newRoutes, newModalRoutes}
+
+type TeamBuilderProps = Partial<{
+  namespace: TeamBuildingTypes.AllowedNamespace
+  teamID: string
+  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel: TeamBuildingTypes.GoButtonLabel
+  title: string
+}>
+export type RootParamListCrypto = {
+  cryptoTeamBuilder: TeamBuilderProps
+}

--- a/shared/crypto/routes.native.tsx
+++ b/shared/crypto/routes.native.tsx
@@ -1,10 +1,10 @@
-import CryptoSubNav from './sub-nav'
 import * as Constants from '../constants/crypto'
-import TeamBuilder from '../team-building/container'
-import {EncryptInput, EncryptOutput} from './operations/encrypt'
-import {DecryptInput, DecryptOutput} from './operations/decrypt'
-import {SignInput, SignOutput} from './operations/sign'
-import {VerifyInput, VerifyOutput} from './operations/verify'
+import type CryptoSubNav from './sub-nav'
+import type TeamBuilder from '../team-building/container'
+import type {EncryptInput, EncryptOutput} from './operations/encrypt'
+import type {DecryptInput, DecryptOutput} from './operations/decrypt'
+import type {SignInput, SignOutput} from './operations/sign'
+import type {VerifyInput, VerifyOutput} from './operations/verify'
 
 export const newRoutes = {
   cryptoRoot: {

--- a/shared/deeplinks/error.tsx
+++ b/shared/deeplinks/error.tsx
@@ -23,10 +23,10 @@ export const KeybaseLinkErrorBody = (props: KeybaseLinkErrorBodyProps) => {
   )
 }
 
-type OwnProps = Container.RouteProps<{errorSource: 'app' | 'sep6' | 'sep7'}>
+type OwnProps = Container.RouteProps<'keybaseLinkError'>
 
 const KeybaseLinkError = (props: OwnProps) => {
-  const errorSource = Container.getRouteProps(props, 'errorSource', 'app')
+  const errorSource = props.route.params?.errorSource ?? 'app'
   const message = Container.useSelector(s => {
     switch (errorSource) {
       case 'app':

--- a/shared/devices/add-device/container.tsx
+++ b/shared/devices/add-device/container.tsx
@@ -5,8 +5,7 @@ import * as ProvisionGen from '../../actions/provision-gen'
 import * as Constants from '../../constants/devices'
 import AddDevice from '.'
 
-type OwnProps = Container.RouteProps<{highlight: Array<'computer' | 'phone' | 'paper key'>}>
-
+type OwnProps = Container.RouteProps<'deviceAdd'>
 const noHighlight = []
 
 export default Container.connect(
@@ -20,6 +19,6 @@ export default Container.connect(
   (s, d, o: OwnProps) => ({
     ...s,
     ...d,
-    highlight: Container.getRouteProps(o, 'highlight', noHighlight),
+    highlight: o.route.params?.highlight ?? noHighlight,
   })
 )(AddDevice)

--- a/shared/devices/container.tsx
+++ b/shared/devices/container.tsx
@@ -4,13 +4,13 @@ import * as DevicesGen from '../actions/devices-gen'
 import * as Kb from '../common-adapters'
 import * as React from 'react'
 import * as RouteTreeGen from '../actions/route-tree-gen'
-import * as Types from '../constants/types/devices'
-import Devices, {Props, Item} from '.'
+import type * as Types from '../constants/types/devices'
+import Devices, {type Props, type Item} from '.'
 import partition from 'lodash/partition'
 import {HeaderTitle, HeaderRightActions} from './nav-header/container'
 import {intersect} from '../util/set'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 const sortDevices = (a: Types.Device, b: Types.Device) => {
   if (a.currentDevice) return -1

--- a/shared/devices/device-page/container.tsx
+++ b/shared/devices/device-page/container.tsx
@@ -3,11 +3,11 @@ import * as Constants from '../../constants/devices'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import DevicePage from '.'
 
-type OwnProps = Container.RouteProps<{deviceID: string}>
+type OwnProps = Container.RouteProps<'devicePage'>
 
 export default Container.connect(
   (state: Container.TypedState, ownProps: OwnProps) => {
-    const id = Container.getRouteProps(ownProps, 'deviceID', '')
+    const id = ownProps.route.params?.deviceID ?? ''
     return {iconNumber: Constants.getDeviceIconNumber(state, id), id}
   },
   dispatch => ({

--- a/shared/devices/device-revoke/container.tsx
+++ b/shared/devices/device-revoke/container.tsx
@@ -1,16 +1,16 @@
-import * as WaitingConstants from '../../constants/waiting'
-import * as Types from '../../constants/types/devices'
 import * as Constants from '../../constants/devices'
-import * as DevicesGen from '../../actions/devices-gen'
-import DeviceRevoke from '.'
 import * as Container from '../../util/container'
+import * as DevicesGen from '../../actions/devices-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
+import * as WaitingConstants from '../../constants/waiting'
+import DeviceRevoke from '.'
+import type * as Types from '../../constants/types/devices'
 
-type OwnProps = Container.RouteProps<{deviceID: string}>
+type OwnProps = Container.RouteProps<'deviceRevoke'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const selectedDeviceID = Container.getRouteProps(ownProps, 'deviceID', '')
+    const selectedDeviceID = ownProps.route.params?.deviceID ?? ''
     return {
       _endangeredTLFs: Constants.getEndangeredTLFs(state, selectedDeviceID),
       device: Constants.getDevice(state, selectedDeviceID),

--- a/shared/devices/routes.tsx
+++ b/shared/devices/routes.tsx
@@ -16,3 +16,15 @@ export const newModalRoutes = {
   deviceAdd: {getScreen: (): typeof DeviceAdd => require('./add-device/container').default},
   devicePaperKey: {getScreen: (): typeof DevicePaperKey => require('./paper-key').default},
 }
+
+export type RootParamListDevices = {
+  deviceAdd: {
+    highlight: Array<'computer' | 'phone' | 'paper key'>
+  }
+  devicePage: {
+    deviceID: string
+  }
+  deviceRevoke: {
+    deviceID: string
+  }
+}

--- a/shared/fs/browser/destination-picker/container.tsx
+++ b/shared/fs/browser/destination-picker/container.tsx
@@ -1,19 +1,17 @@
-import * as Container from '../../../util/container'
-import {memoize} from '../../../util/memoize'
-import DestinationPicker from '.'
-import * as Types from '../../../constants/types/fs'
 import * as Constants from '../../../constants/fs'
+import * as Container from '../../../util/container'
 import * as FsGen from '../../../actions/fs-gen'
-import {isMobile} from '../../../constants/platform'
-import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as React from 'react'
+import * as RouteTreeGen from '../../../actions/route-tree-gen'
+import * as Types from '../../../constants/types/fs'
+import DestinationPicker from '.'
 import {OriginalOrCompressedButton} from '../../../incoming-share'
+import {isMobile} from '../../../constants/platform'
+import {memoize} from '../../../util/memoize'
 
-type OwnProps = Container.RouteProps<{
-  index: number
-}>
+type OwnProps = Container.RouteProps<'destinationPicker'>
 
-const getIndex = (ownProps: OwnProps) => Container.getRouteProps(ownProps, 'index', 0)
+const getIndex = (ownProps: OwnProps) => ownProps.route.params?.index ?? 0
 const getDestinationParentPath = (dp: Types.DestinationPicker, ownProps: OwnProps): Types.Path =>
   dp.destinationParentPath[getIndex(ownProps)] ||
   (dp.source.type === Types.DestinationPickerSource.MoveOrCopy
@@ -61,9 +59,7 @@ const ConnectedDestinationPicker = (ownProps: OwnProps) => {
   const headerRightButton =
     destPicker.source.type === Types.DestinationPickerSource.IncomingShare ? (
       <OriginalOrCompressedButton incomingShareItems={destPicker.source.source} />
-    ) : (
-      undefined
-    )
+    ) : undefined
 
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()

--- a/shared/fs/common/path-item-action/confirm-delete/container.tsx
+++ b/shared/fs/common/path-item-action/confirm-delete/container.tsx
@@ -1,17 +1,17 @@
+import * as Constants from '../../../../constants/fs'
+import * as Container from '../../../../util/container'
 import * as FsGen from '../../../../actions/fs-gen'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
-import * as Container from '../../../../util/container'
 import ReallyDelete from '.'
-import * as Types from '../../../../constants/types/fs'
-import * as Constants from '../../../../constants/fs'
 
-type OwnProps = Container.RouteProps<{path: Types.Path; mode: 'row' | 'screen'}>
+type OwnProps = Container.RouteProps<'confirmDelete'>
 
 export default Container.connect(
   () => ({}),
   (dispatch, ownProps: OwnProps) => {
-    const path = Container.getRouteProps(ownProps, 'path', null)
-    const mode = Container.getRouteProps(ownProps, 'mode', 'row')
+    const {params} = ownProps.route
+    const path = params?.path ?? null
+    const mode = params?.mode ?? 'row'
     return {
       onBack: () => dispatch(RouteTreeGen.createNavigateUp()),
       onDelete: () => {
@@ -30,7 +30,7 @@ export default Container.connect(
     }
   },
   (_, dispatchProps, ownProps: OwnProps) => {
-    const path = Container.getRouteProps(ownProps, 'path', null)
+    const path = ownProps.route.params?.path ?? null
     return {
       onBack: dispatchProps.onBack,
       onDelete: dispatchProps.onDelete,

--- a/shared/fs/container.tsx
+++ b/shared/fs/container.tsx
@@ -62,7 +62,7 @@ const ChooseComponent = (props: ChooseComponentProps) => {
 }
 
 ChooseComponent.navigationOptions = (ownProps: OwnProps) => {
-  const path = Container.getRouteProps(ownProps, 'path', Constants.defaultPath)
+  const path = ownProps.route.params?.path ?? Constants.defaultPath
   return Container.isMobile
     ? {
         header: () => <MobileHeader path={path} onBack={ownProps.navigation.pop} />,
@@ -76,11 +76,11 @@ ChooseComponent.navigationOptions = (ownProps: OwnProps) => {
       }
 }
 
-type OwnProps = Container.RouteProps<{path: Types.Path}>
+type OwnProps = Container.RouteProps<'fsRoot'>
 
 const Connected = Container.connect(
   (state, ownProps: OwnProps) => {
-    const path = Container.getRouteProps(ownProps, 'path', Constants.defaultPath)
+    const path = ownProps.route.params?.path ?? Constants.defaultPath
     return {
       _pathItem: Constants.getPathItem(state.fs.pathItems, path),
       kbfsDaemonStatus: state.fs.kbfsDaemonStatus,
@@ -88,7 +88,7 @@ const Connected = Container.connect(
   },
   (dispatch, ownProps) => ({
     emitBarePreview: () => {
-      const path = Container.getRouteProps(ownProps, 'path', Constants.defaultPath)
+      const path = ownProps.route.params?.path ?? Constants.defaultPath
       dispatch(RouteTreeGen.createNavigateUp())
       dispatch(
         RouteTreeGen.createNavigateAppend({
@@ -98,7 +98,7 @@ const Connected = Container.connect(
     },
   }),
   (stateProps, dispatchProps, ownProps: OwnProps) => {
-    const path = Container.getRouteProps(ownProps, 'path', Constants.defaultPath)
+    const path = ownProps.route.params?.path ?? Constants.defaultPath
     const isDefinitelyFolder =
       Types.getPathElements(path).length <= 3 && !Constants.hasSpecialFileElement(path)
     return {

--- a/shared/fs/filepreview/bare-preview-container.tsx
+++ b/shared/fs/filepreview/bare-preview-container.tsx
@@ -1,10 +1,9 @@
-import * as Types from '../../constants/types/fs'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/fs'
 import * as Container from '../../util/container'
 import BarePreview from './bare-preview'
 
-type OwnProps = Container.RouteProps<{path: Types.Path}>
+type OwnProps = Container.RouteProps<'barePreview'>
 
 const ConnectedBarePreview = Container.isMobile
   ? Container.connect(
@@ -12,7 +11,7 @@ const ConnectedBarePreview = Container.isMobile
       dispatch => ({onBack: () => dispatch(RouteTreeGen.createNavigateUp())}),
       (_, {onBack}, ownProps: OwnProps) => ({
         onBack,
-        path: Container.getRouteProps(ownProps, 'path', Constants.defaultPath),
+        path: ownProps.route.params?.path ?? Constants.defaultPath,
       })
     )(BarePreview)
   : () => null

--- a/shared/fs/routes.tsx
+++ b/shared/fs/routes.tsx
@@ -1,4 +1,5 @@
 import type FsRoot from './container'
+import type * as FSTypes from '../constants/types/fs'
 import type {BarePreview} from './filepreview'
 import type ConfirmDelete from './common/path-item-action/confirm-delete/container'
 import type KextPermission from './banner/system-file-manager-integration-banner/kext-permission-popup-container'
@@ -20,4 +21,16 @@ export const newModalRoutes = {
       require('./banner/system-file-manager-integration-banner/kext-permission-popup-container')
         .default as typeof KextPermission,
   },
+}
+
+export type RootParamListFS = {
+  destinationPicker: {
+    index: number
+  }
+  confirmDelete: {
+    path: FSTypes.Path
+    mode: 'row' | 'screen'
+  }
+  fsRoot: {path: FSTypes.Path}
+  barePreview: {path: FSTypes.Path}
 }

--- a/shared/git/container.tsx
+++ b/shared/git/container.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react'
-import Git, {Props as GitProps} from '.'
-import * as GitGen from '../actions/git-gen'
-import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as Constants from '../constants/git'
-import * as Types from '../constants/types/git'
-import * as Kb from '../common-adapters'
-import {anyWaiting} from '../constants/waiting'
 import * as Container from '../util/container'
+import * as GitGen from '../actions/git-gen'
+import * as Kb from '../common-adapters'
+import * as React from 'react'
+import * as RouteTreeGen from '../actions/route-tree-gen'
+import Git, {type Props as GitProps} from '.'
 import sortBy from 'lodash/sortBy'
-import {memoize} from '../util/memoize'
+import type * as Types from '../constants/types/git'
 import {HeaderTitle, HeaderRightActions} from './nav-header'
+import {anyWaiting} from '../constants/waiting'
+import {memoize} from '../util/memoize'
 
-type TabsStateOwnProps = Container.RouteProps<{expandedSet: Set<string>}>
+type TabsStateOwnProps = Container.RouteProps<'gitRoot'>
 
-type OwnProps = TabsStateOwnProps & {}
+type OwnProps = TabsStateOwnProps
 
 const getRepos = memoize((git: Map<string, Types.GitInfo>) =>
   sortBy([...git.values()], ['teamname', 'name']).reduce<{personals: Array<string>; teams: Array<string>}>(
@@ -64,7 +64,7 @@ const emptySet = new Set<string>()
 export default Container.connect(
   (state: Container.TypedState, ownProps: OwnProps) => ({
     error: Constants.getError(state),
-    initialExpandedSet: Container.getRouteProps(ownProps, 'expandedSet', emptySet),
+    initialExpandedSet: ownProps.route.params?.expandedSet ?? emptySet,
     loading: anyWaiting(state, Constants.loadingWaitingKey),
     ...getRepos(Constants.getIdToGit(state)),
   }),

--- a/shared/git/delete-repo/container.tsx
+++ b/shared/git/delete-repo/container.tsx
@@ -2,17 +2,17 @@ import * as React from 'react'
 import * as GitGen from '../../actions/git-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/git'
-import DeleteRepo, {Props} from '.'
+import DeleteRepo, {type Props} from '.'
 import * as Container from '../../util/container'
 
-type OwnProps = Container.RouteProps<{id: string}>
+type OwnProps = Container.RouteProps<'gitDeleteRepo'>
 
 const NullWrapper = (props: Props) => (props.name ? <DeleteRepo {...props} /> : null)
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const gitMap = Constants.getIdToGit(state)
-    const id = Container.getRouteProps(ownProps, 'id', '')
+    const id = ownProps.route.params?.id ?? ''
     const git = gitMap.get(id) || Constants.makeGitInfo()
 
     return {

--- a/shared/git/new-repo/container.tsx
+++ b/shared/git/new-repo/container.tsx
@@ -1,18 +1,18 @@
-import * as GitGen from '../../actions/git-gen'
 import * as Constants from '../../constants/git'
+import * as Container from '../../util/container'
+import * as GitGen from '../../actions/git-gen'
+import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as TeamsGen from '../../actions/teams-gen'
 import NewRepo from '.'
-import * as Container from '../../util/container'
-import * as RouteTreeGen from '../../actions/route-tree-gen'
-import {teamsTab} from '../../constants/tabs'
 import {getSortedTeamnames} from '../../constants/teams'
+import {teamsTab} from '../../constants/tabs'
 
-type OwnProps = Container.RouteProps<{isTeam: boolean}>
+type OwnProps = Container.RouteProps<'gitNewRepo'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => ({
     error: Constants.getError(state),
-    isTeam: !!Container.getRouteProps(ownProps, 'isTeam', false),
+    isTeam: !!ownProps.route.params?.isTeam ?? false,
     teams: getSortedTeamnames(state),
     waitingKey: Constants.loadingWaitingKey,
   }),
@@ -20,7 +20,7 @@ export default Container.connect(
     loadTeams: () => dispatch(TeamsGen.createGetTeams()),
     onClose: () => dispatch(RouteTreeGen.createNavigateUp()),
     onCreate: (name: string, teamname: string | null, notifyTeam: boolean) => {
-      const isTeam = !!Container.getRouteProps(ownProps, 'isTeam', false)
+      const isTeam = !!ownProps.route.params?.isTeam ?? false
       const createAction =
         isTeam && teamname
           ? GitGen.createCreateTeamRepo({name, notifyTeam, teamname})

--- a/shared/git/routes.tsx
+++ b/shared/git/routes.tsx
@@ -1,3 +1,4 @@
+import type * as TeamsTypes from '../constants/types/teams'
 import type GitRoot from './container'
 import type GitDeleteRepo from './delete-repo/container'
 import type GitNewRepo from './new-repo/container'
@@ -13,3 +14,19 @@ export const newModalRoutes = {
   gitNewRepo: {getScreen: (): typeof GitNewRepo => require('./new-repo/container').default},
   gitSelectChannel: {getScreen: (): typeof GitSelectChannel => require('./select-channel').default},
 }
+
+// TODO figure out how to enforce this, this works in playground
+// type RouteKeys = keyof typeof newRoutes | keyof typeof newModalRoutes
+
+export type RootParamListGit = {
+  gitRoot: {expandedSet: Set<string>}
+  gitDeleteRepo: {id: string}
+  gitNewRepo: {isTeam: boolean}
+  gitSelectChannel: {
+    teamID: TeamsTypes.TeamID
+    repoID: string
+    selected: string
+  }
+}
+// type ParamKeys = keyof RootParamList
+// export type RootParamListGit = ParamKeys extends RouteKeys ? RootParamList : never

--- a/shared/git/select-channel.tsx
+++ b/shared/git/select-channel.tsx
@@ -1,23 +1,19 @@
+import * as Constants from '../constants/teams'
 import * as Container from '../util/container'
+import * as GitGen from '../actions/git-gen'
 import * as Kb from '../common-adapters'
 import * as React from 'react'
 import * as Styles from '../styles'
-import * as Types from '../constants/types/teams'
 import {useAllChannelMetas} from '../teams/common/channel-hooks'
-import * as GitGen from '../actions/git-gen'
-import * as Constants from '../constants/teams'
 
-type OwnProps = Container.RouteProps<{
-  teamID: Types.TeamID
-  repoID: string
-  selected: string
-}>
+type OwnProps = Container.RouteProps<'gitSelectChannel'>
 
 const SelectChannel = (ownProps: OwnProps) => {
-  const teamID = Container.getRouteProps(ownProps, 'teamID', '')
+  const {params} = ownProps.route
+  const teamID = params?.teamID ?? ''
+  const _selected = params?.selected ?? ''
+  const repoID = params?.repoID ?? ''
   const teamname = Container.useSelector(state => Constants.getTeamNameFromID(state, teamID) ?? '')
-  const _selected = Container.getRouteProps(ownProps, 'selected', '')
-  const repoID = Container.getRouteProps(ownProps, 'repoID', '')
 
   const {channelMetas} = useAllChannelMetas(teamID)
   const waiting = channelMetas === null

--- a/shared/login/reset/waiting.tsx
+++ b/shared/login/reset/waiting.tsx
@@ -7,10 +7,10 @@ import * as Constants from '../../constants/autoreset'
 import * as Container from '../../util/container'
 import * as AutoresetGen from '../../actions/autoreset-gen'
 
-type Props = Container.RouteProps<{pipelineStarted: boolean}>
+type Props = Container.RouteProps<'resetWaiting'>
 
 const Waiting = (props: Props) => {
-  const pipelineStarted = Container.getRouteProps(props, 'pipelineStarted', false)
+  const pipelineStarted = props.route.params?.pipelineStarted ?? false
   const endTime = Container.useSelector(state => state.autoreset.endTime)
   const [formattedTime, setFormattedTime] = React.useState('a bit')
   const [hasSentAgain, setHasSentAgain] = React.useState(false)

--- a/shared/login/routes.tsx
+++ b/shared/login/routes.tsx
@@ -65,3 +65,9 @@ export const newModalRoutes = {
   },
   ...require('./recover-password/routes').newModalRoutes,
 }
+
+export type RootParamListLogin = {
+  resetWaiting: {
+    pipelineStarted: boolean
+  }
+}

--- a/shared/people/routes.ts
+++ b/shared/people/routes.ts
@@ -1,6 +1,7 @@
 import type PeopleRoot from './container'
 import type TeamBuilder from '../team-building/container'
 import type AccountSwitcher from '../router-v2/account-switcher/container'
+import type * as TeamBuildingTypes from '../constants/types/team-building'
 
 export const newRoutes = {
   peopleRoot: {
@@ -14,4 +15,16 @@ export const newModalRoutes = {
     getScreen: (): typeof AccountSwitcher => require('../router-v2/account-switcher/container').default,
   },
   peopleTeamBuilder: {getScreen: (): typeof TeamBuilder => require('../team-building/container').default},
+}
+
+type TeamBuilderProps = Partial<{
+  namespace: TeamBuildingTypes.AllowedNamespace
+  teamID: string
+  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel: TeamBuildingTypes.GoButtonLabel
+  title: string
+}>
+
+export type RootParamListPeople = {
+  peopleTeamBuilder: TeamBuilderProps
 }

--- a/shared/profile/add-to-team/container.tsx
+++ b/shared/profile/add-to-team/container.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import AddToTeam, {AddToTeamProps} from './index'
+import AddToTeam, {type AddToTeamProps} from './index'
 import * as Container from '../../util/container'
 import {memoize} from '../../util/memoize'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
@@ -7,9 +7,9 @@ import * as TeamsGen from '../../actions/teams-gen'
 import * as Constants from '../../constants/teams'
 import * as WaitingConstants from '../../constants/waiting'
 import {sendNotificationFooter} from '../../teams/role-picker'
-import * as Types from '../../constants/types/teams'
+import type * as Types from '../../constants/types/teams'
 
-type OwnProps = Container.RouteProps<{username: string}>
+type OwnProps = Container.RouteProps<'profileAddToTeam'>
 
 const getOwnerDisabledReason = memoize((selected: Set<string>, teamNameToRole) => {
   return [...selected]
@@ -111,7 +111,7 @@ export default Container.connect(
   (state, ownProps: OwnProps) => ({
     _roles: state.teams.teamRoleMap.roles,
     _teams: state.teams.teamMeta,
-    _them: Container.getRouteProps(ownProps, 'username', ''),
+    _them: ownProps.route.params?.username ?? '',
     addUserToTeamsResults: state.teams.addUserToTeamsResults,
     addUserToTeamsState: state.teams.addUserToTeamsState,
     teamProfileAddList: state.teams.teamProfileAddList,
@@ -124,9 +124,7 @@ export default Container.connect(
     },
     clearAddUserToTeamsResults: () => dispatch(TeamsGen.createClearAddUserToTeamsResults()),
     loadTeamList: () =>
-      dispatch(
-        TeamsGen.createGetTeamProfileAddList({username: Container.getRouteProps(ownProps, 'username', '')})
-      ),
+      dispatch(TeamsGen.createGetTeamProfileAddList({username: ownProps.route.params?.username ?? ''})),
     onBack: () => {
       dispatch(RouteTreeGen.createNavigateUp())
       dispatch(TeamsGen.createSetTeamProfileAddList({teamlist: []}))

--- a/shared/profile/edit-avatar/container.tsx
+++ b/shared/profile/edit-avatar/container.tsx
@@ -6,32 +6,23 @@ import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as Constants from '../../constants/profile'
 import * as TeamsConstants from '../../constants/teams'
 import * as Container from '../../util/container'
-import * as Types from '../../constants/types/teams'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
+import type * as Types from '../../constants/types/teams'
 import {anyErrors, anyWaiting} from '../../constants/waiting'
-import * as ImagePicker from 'expo-image-picker'
 
-type OwnProps = Container.RouteProps<{
-  // Mobile-only
-  image?: ImagePicker.ImagePickerResult
-  // Team-only
-  sendChatNotification?: boolean
-  showBack?: boolean
-  teamID?: Types.TeamID
-  createdTeam?: boolean
-  wizard?: boolean
-}>
+type OwnProps = Container.RouteProps<'profileEditAvatar'>
 
 const cancelledImage = {cancelled: true as const}
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const teamID = Container.getRouteProps(ownProps, 'teamID', undefined)
+    const {params} = ownProps.route
+    const teamID = params?.teamID
     return {
-      createdTeam: Container.getRouteProps(ownProps, 'createdTeam', undefined) ?? false,
+      createdTeam: params?.createdTeam ?? false,
       error: anyErrors(state, Constants.uploadAvatarWaitingKey),
-      image: Container.getRouteProps(ownProps, 'image', undefined) ?? cancelledImage,
-      sendChatNotification: Container.getRouteProps(ownProps, 'sendChatNotification', undefined) ?? false,
+      image: params?.image ?? cancelledImage,
+      sendChatNotification: params?.sendChatNotification ?? false,
       submitting: anyWaiting(state, Constants.uploadAvatarWaitingKey),
       teamID,
       teamname: teamID ? TeamsConstants.getTeamNameFromID(state, teamID) : undefined,
@@ -61,6 +52,7 @@ export default Container.connect(
     },
   }),
   (stateProps, dispatchProps, ownProps: OwnProps) => {
+    const {params} = ownProps.route
     let error = ''
     if (stateProps.error) {
       error =
@@ -70,7 +62,7 @@ export default Container.connect(
           ? 'Connection lost. Please check your network and try again.'
           : 'This image format is not supported.'
     }
-    const wizard = Container.getRouteProps(ownProps, 'wizard', false)
+    const wizard = params?.wizard ?? false
     const bothProps = {
       error,
       image: stateProps.image?.cancelled ? undefined : stateProps.image,
@@ -106,7 +98,7 @@ export default Container.connect(
             }
           },
           onSkip: dispatchProps.onSkip,
-          showBack: Container.getRouteProps(ownProps, 'showBack', false),
+          showBack: params?.showBack ?? false,
           teamID: stateProps.teamID,
           teamname: stateProps.teamname!,
           type: 'team' as const,

--- a/shared/profile/generic/enter-username/container.tsx
+++ b/shared/profile/generic/enter-username/container.tsx
@@ -4,7 +4,7 @@ import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import openURL from '../../../util/open-url'
 import EnterUsername from '.'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 const ConnectedEnterUsername = Container.connect(
   state => {

--- a/shared/profile/generic/proofs-list/container.tsx
+++ b/shared/profile/generic/proofs-list/container.tsx
@@ -5,7 +5,7 @@ import ProofsList from '.'
 import openURL from '../../../util/open-url'
 import * as Styles from '../../../styles'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 export default Container.connect(
   state => ({_proofSuggestions: state.tracker2.proofSuggestions}),
   dispatch => ({

--- a/shared/profile/revoke/container.tsx
+++ b/shared/profile/revoke/container.tsx
@@ -4,25 +4,17 @@ import Revoke from '.'
 import * as Constants from '../../constants/profile'
 import * as Waiting from '../../constants/waiting'
 import * as Container from '../../util/container'
-import {PlatformsExpandedType} from '../../constants/types/more'
-import {SiteIconSet} from '../../constants/types/tracker2'
 
-type OwnProps = Container.RouteProps<{
-  icon: SiteIconSet
-  platform: PlatformsExpandedType
-  platformHandle: string
-  proofId: string
-}>
-
+type OwnProps = Container.RouteProps<'profileRevoke'>
 const noIcon = []
 
 export default Container.connect(
   (state, ownProps: OwnProps) => ({
     errorMessage: state.profile.revokeError,
-    icon: Container.getRouteProps(ownProps, 'icon', noIcon),
+    icon: ownProps.route.params?.icon ?? noIcon,
     isWaiting: Waiting.anyWaiting(state, Constants.waitingKey),
-    platform: Container.getRouteProps(ownProps, 'platform', 'http'),
-    platformHandle: Container.getRouteProps(ownProps, 'platformHandle', ''),
+    platform: ownProps.route.params?.platform ?? 'http',
+    platformHandle: ownProps.route.params?.platformHandle ?? '',
   }),
   (dispatch, ownProps: OwnProps) => ({
     onCancel: () => {
@@ -30,7 +22,7 @@ export default Container.connect(
       dispatch(RouteTreeGen.createClearModals())
     },
     onRevoke: () => {
-      const proofId = Container.getRouteProps(ownProps, 'proofId', '')
+      const proofId = ownProps.route.params?.proofId ?? ''
       proofId && dispatch(ProfileGen.createSubmitRevokeProof({proofId}))
       dispatch(RouteTreeGen.createClearModals())
     },

--- a/shared/profile/routes.tsx
+++ b/shared/profile/routes.tsx
@@ -1,4 +1,5 @@
 import {newRoutes as PGPRoutes} from './pgp/routes'
+import type {Question1Answer} from '../profile/wot-author'
 import type Profile from './user/container'
 import type ProfileAddToTeam from './add-to-team/container'
 import type ProfileConfirmOrPending from './confirm-or-pending/container'
@@ -13,6 +14,10 @@ import type ProfileProveWebsiteChoice from './prove-website-choice/container'
 import type ProfileRevoke from './revoke/container'
 import type ProfileShowcaseTeamOffer from './showcase-team-offer/container'
 import type {Question1Wrapper, Question2Wrapper, ReviewWrapper} from './wot-author'
+import type * as ImagePicker from 'expo-image-picker'
+import type * as Types from '../constants/types/teams'
+import type {PlatformsExpandedType} from '../constants/types/more'
+import type {SiteIconSet} from '../constants/types/tracker2'
 
 export const newRoutes = {
   profile: {getScreen: (): typeof Profile => require('./user/container').default},
@@ -56,4 +61,41 @@ export const newModalRoutes = {
     getScreen: (): typeof ReviewWrapper => require('./wot-author').ReviewWrapper,
   },
   ...PGPRoutes,
+}
+
+export type RootParamListProfile = {
+  profileWotReview: {
+    sigID: string // sigID of the vouch.
+  }
+  profileWotAuthor: {
+    username: string
+    guiID: string
+  }
+  profileWotAuthorQ2: {
+    username: string
+    guiID: string
+    question1Answer: Question1Answer
+  }
+  profileAddToTeam: {
+    username: string
+  }
+  profileEditAvatar: {
+    // Mobile-only
+    image?: ImagePicker.ImagePickerResult
+    // Team-only
+    sendChatNotification?: boolean
+    showBack?: boolean
+    teamID?: Types.TeamID
+    createdTeam?: boolean
+    wizard?: boolean
+  }
+  profileRevoke: {
+    icon: SiteIconSet
+    platform: PlatformsExpandedType
+    platformHandle: string
+    proofId: string
+  }
+  profile: {
+    username: string
+  }
 }

--- a/shared/profile/user/container.tsx
+++ b/shared/profile/user/container.tsx
@@ -1,14 +1,14 @@
-import Profile2, {BackgroundColorType} from '.'
+import Profile2, {type BackgroundColorType} from '.'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Tracker2Gen from '../../actions/tracker2-gen'
 import * as Constants from '../../constants/tracker2'
-import * as Types from '../../constants/types/tracker2'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
+import type * as Types from '../../constants/types/tracker2'
 import {memoize} from '../../util/memoize'
 
-export type OwnProps = Container.RouteProps<{username: string}>
+export type OwnProps = Container.RouteProps<'profile'>
 
 const headerBackgroundColorType = (state: Types.DetailsState, followThem: boolean): BackgroundColorType => {
   if (['broken', 'error'].includes(state)) {
@@ -27,7 +27,7 @@ const filterWebOfTrustEntries = memoize(
 
 const connected = Container.connect(
   (state, ownProps: OwnProps) => {
-    const username = Container.getRouteProps(ownProps, 'username', '')
+    const username = ownProps.route.params?.username ?? ''
     const d = Constants.getDetails(state, username)
     const myName = state.config.username
     const notAUser = d.state === 'notAUserYet'

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react'
-import {WebOfTrustVerificationType} from '../../constants/types/more'
+import type {WebOfTrustVerificationType} from '../../constants/types/more'
 import * as Constants from '../../constants/profile'
 import * as UsersConstants from '../../constants/users'
 import * as Kb from '../../common-adapters'
 import * as Styles from '../../styles'
 import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
-import * as Tracker2Types from '../../constants/types/tracker2'
+import type * as Tracker2Types from '../../constants/types/tracker2'
 import {SiteIcon} from '../../profile/generic/shared'
 import * as ProfileGen from '../../actions/profile-gen'
 import * as UsersGen from '../../actions/users-gen'
 import * as Tracker2Constants from '../../constants/tracker2'
 import * as RPCTypes from '../../constants/types/rpc-gen'
 import sortBy from 'lodash/sortBy'
+import type {RouteProps} from 'router-v2/route-params'
 
 // Keep in sync with server limits: https://github.com/keybase/proofs/blob/master/src/wot.iced
 const statementLimit = 700
@@ -91,7 +92,8 @@ export const Question1Wrapper = (
     guiID: string
   }>
 ) => {
-  const voucheeUsername = Container.getRouteProps(props, 'username', '')
+  const voucheeUsername = props.route.params.username
+  Container.getRouteProps(props, 'username', '')
   const guiID = Container.getRouteProps(props, 'guiID', '')
   const nav = Container.useSafeNavigation()
   const dispatch = Container.useDispatch()
@@ -143,16 +145,12 @@ export const Question1Wrapper = (
   )
 }
 
-export const Question2Wrapper = (
-  props: Container.RouteProps<{
-    username: string
-    guiID: string
-    question1Answer: Question1Answer
-  }>
-) => {
-  const voucheeUsername = Container.getRouteProps(props, 'username', '')
-  const guiID = Container.getRouteProps(props, 'guiID', '')
-  const question1Answer = Container.getRoutePropsOr(props, 'question1Answer', 'error')
+export const Question2Wrapper = (props: RouteProps<'profileWotAuthor'>) => {
+  const {params} = props.route
+  const voucheeUsername = params?.username ?? ''
+  const guiID = params?.guiID ?? ''
+  const question1Answer = params?.question1Answer ?? 'error'
+
   const nav = Container.useSafeNavigation()
   const dispatch = Container.useDispatch()
   let error = Container.useSelector(state => state.profile.wotAuthorError)
@@ -590,9 +588,7 @@ const WotModal = (props: WotModalProps) => {
           <Kb.Text onClick={onClose} type="BodyPrimaryLink">
             Cancel
           </Kb.Text>
-        ) : (
-          undefined
-        ),
+        ) : undefined,
         title: 'Web of Trust',
       }}
       mode="DefaultFullHeight"

--- a/shared/profile/wot-author/index.tsx
+++ b/shared/profile/wot-author/index.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react'
-import type {WebOfTrustVerificationType} from '../../constants/types/more'
 import * as Constants from '../../constants/profile'
-import * as UsersConstants from '../../constants/users'
-import * as Kb from '../../common-adapters'
-import * as Styles from '../../styles'
 import * as Container from '../../util/container'
-import * as RouteTreeGen from '../../actions/route-tree-gen'
-import type * as Tracker2Types from '../../constants/types/tracker2'
-import {SiteIcon} from '../../profile/generic/shared'
+import * as Kb from '../../common-adapters'
 import * as ProfileGen from '../../actions/profile-gen'
-import * as UsersGen from '../../actions/users-gen'
-import * as Tracker2Constants from '../../constants/tracker2'
 import * as RPCTypes from '../../constants/types/rpc-gen'
+import * as React from 'react'
+import * as RouteTreeGen from '../../actions/route-tree-gen'
+import * as Styles from '../../styles'
+import * as Tracker2Constants from '../../constants/tracker2'
+import * as UsersConstants from '../../constants/users'
+import * as UsersGen from '../../actions/users-gen'
 import sortBy from 'lodash/sortBy'
+import type * as Tracker2Types from '../../constants/types/tracker2'
 import type {RouteProps} from 'router-v2/route-params'
+import type {WebOfTrustVerificationType} from '../../constants/types/more'
+import {SiteIcon} from '../../profile/generic/shared'
 
 // Keep in sync with server limits: https://github.com/keybase/proofs/blob/master/src/wot.iced
 const statementLimit = 700
@@ -86,15 +86,10 @@ type Checkboxed = {
   onCheck: (_: boolean) => void
 }
 
-export const Question1Wrapper = (
-  props: Container.RouteProps<{
-    username: string
-    guiID: string
-  }>
-) => {
-  const voucheeUsername = props.route.params.username
-  Container.getRouteProps(props, 'username', '')
-  const guiID = Container.getRouteProps(props, 'guiID', '')
+export const Question1Wrapper = (props: Container.RouteProps<'profileWotAuthor'>) => {
+  const {params} = props.route
+  const voucheeUsername = params?.username ?? ''
+  const guiID = params?.guiID ?? ''
   const nav = Container.useSafeNavigation()
   const dispatch = Container.useDispatch()
   let error = Container.useSelector(state => state.profile.wotAuthorError)
@@ -145,7 +140,7 @@ export const Question1Wrapper = (
   )
 }
 
-export const Question2Wrapper = (props: RouteProps<'profileWotAuthor'>) => {
+export const Question2Wrapper = (props: RouteProps<'profileWotAuthorQ2'>) => {
   const {params} = props.route
   const voucheeUsername = params?.username ?? ''
   const guiID = params?.guiID ?? ''
@@ -192,12 +187,8 @@ export const Question2Wrapper = (props: RouteProps<'profileWotAuthor'>) => {
   )
 }
 
-export const ReviewWrapper = (
-  props: Container.RouteProps<{
-    sigID: string // sigID of the vouch.
-  }>
-) => {
-  const sigID = Container.getRouteProps(props, 'sigID', '')
+export const ReviewWrapper = (props: Container.RouteProps<'profileWotReview'>) => {
+  const sigID = props.route.params?.sigID ?? ''
   const dispatch = Container.useDispatch()
   const voucheeUsername = Container.useSelector(state => state.config.username)
   const details = Container.useSelector(state => Tracker2Constants.getDetails(state, voucheeUsername))

--- a/shared/provision/code-page/container.tsx
+++ b/shared/provision/code-page/container.tsx
@@ -1,12 +1,12 @@
+import * as Constants from '../../constants/provision'
+import * as Container from '../../util/container'
+import * as DevicesConstants from '../../constants/devices'
 import * as ProvisionGen from '../../actions/provision-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import CodePage2 from '.'
-import * as Container from '../../util/container'
 import HiddenString from '../../util/hidden-string'
-import * as DevicesConstants from '../../constants/devices'
-import * as Constants from '../../constants/provision'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 const prov = Container.connect(
   (state: Container.TypedState) => {

--- a/shared/provision/routes.tsx
+++ b/shared/provision/routes.tsx
@@ -24,3 +24,7 @@ export const newRoutes = {
 
 // No modal routes while not logged in. More plumbing would be necessary to add them, so there is not
 // an empty newModalRoutes here.
+
+export type RootParamListProvision = {
+  username: {fromReset: boolean}
+}

--- a/shared/provision/username-or-email/container.tsx
+++ b/shared/provision/username-or-email/container.tsx
@@ -8,7 +8,7 @@ import * as RPCTypes from '../../constants/types/rpc-gen'
 import {usernameHint} from '../../constants/signup'
 import {anyWaiting} from '../../constants/waiting'
 
-type OwnProps = Container.RouteProps<{fromReset: boolean}>
+type OwnProps = Container.RouteProps<'username'>
 
 const decodeInlineError = inlineRPCError => {
   let inlineError = ''
@@ -60,7 +60,7 @@ export default Container.compose(
       inlineError: s.inlineError,
       inlineSignUpLink: s.inlineSignUpLink,
       onSubmit: (username: string) => !s.waiting && d.onSubmit(username),
-      resetBannerUser: Container.getRouteProps(o, 'fromReset', false) ? s._resetBannerUser : null,
+      resetBannerUser: o.route.params?.fromReset ? s._resetBannerUser : null,
       submittedUsername: s.submittedUsername,
       waiting: s.waiting,
     })

--- a/shared/router-v2/route-params.tsx
+++ b/shared/router-v2/route-params.tsx
@@ -1,32 +1,51 @@
 import type * as ChatTypes from '../constants/types/chat2'
 import type * as TeamBuildingTypes from '../constants/types/team-building'
 import type * as TeamsTypes from '../constants/types/teams'
+import type * as FSTypes from '../constants/types/fs'
 import type {Question1Answer} from '../profile/wot-author'
-import type {RenderableEmoji} from 'util/emoji'
-import type {RouteProp, NavigationProp} from '@react-navigation/native'
+import type {RenderableEmoji} from '../util/emoji'
+import type {RouteProp} from '@react-navigation/native'
 
-type TeamBuilderProps = {
-  namespace?: TeamBuildingTypes.AllowedNamespace
-  teamID?: string
-  filterServices?: Array<TeamBuildingTypes.ServiceIdWithContact>
-  goButtonLabel?: TeamBuildingTypes.GoButtonLabel
-  title?: string
+type TeamBuilderProps = Partial<{
+  namespace: TeamBuildingTypes.AllowedNamespace
+  teamID: string
+  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel: TeamBuildingTypes.GoButtonLabel
+  title: string
+}>
+
+// TODO move these to the routes?
+type RootParamListGit = {
+  gitRoot: {expandedSet: Set<string>}
+  gitDeleteRepo: {id: string}
+  gitNewRepo: {isTeam: boolean}
 }
-
-// TODO partial could go away when we enforce these params are pushed correctly
-export type RootParamList = Partial<{
-  walletTeamBuilder: TeamBuilderProps
-  teamsTeamBuilder: TeamBuilderProps
+type RootParamListPeople = {
   peopleTeamBuilder: TeamBuilderProps
-  chatNewChat: TeamBuilderProps
-  cryptoTeamBuilder: TeamBuilderProps
-  chatConversation: Partial<{conversationIDKey: ChatTypes.ConversationIDKey}>
-  profileWotAuthor: Partial<{
+  profileWotAuthor: {
     username: string
     guiID: string
     question1Answer: Question1Answer
-  }>
-  chatChooseEmoji: Partial<{
+  }
+}
+type RootParamListFS = {
+  destinationPicker: {
+    index: number
+  }
+  confirmDelete: {
+    path: FSTypes.Path
+    mode: 'row' | 'screen'
+  }
+  fsRoot: {path: FSTypes.Path}
+  barePreview: {path: FSTypes.Path}
+}
+type RootParamListTeams = {
+  teamsTeamBuilder: TeamBuilderProps
+}
+type RootParamListChat = {
+  chatNewChat: TeamBuilderProps
+  chatConversation: {conversationIDKey: ChatTypes.ConversationIDKey}
+  chatChooseEmoji: {
     conversationIDKey: ChatTypes.ConversationIDKey
     small: boolean
     hideFrequentEmoji: boolean
@@ -34,49 +53,83 @@ export type RootParamList = Partial<{
     onPickAction: (emojiStr: string, renderableEmoji: RenderableEmoji) => void
     onPickAddToMessageOrdinal: ChatTypes.Ordinal
     onDidPick: () => void
-  }>
-  chatUnfurlMapPopup: Partial<{
+  }
+  chatUnfurlMapPopup: {
     conversationIDKey: ChatTypes.ConversationIDKey
     coord: ChatTypes.Coordinate
     isAuthor: boolean
     author?: string
     isLiveLocation: boolean
     url: string
-  }>
-  chatCreateChannel: Partial<{
+  }
+  chatCreateChannel: {
     navToChatOnSuccess?: boolean
     teamID: TeamsTypes.TeamID
-  }>
-  chatDeleteHistoryWarning: Partial<{
+  }
+  chatDeleteHistoryWarning: {
     conversationIDKey: ChatTypes.ConversationIDKey
-  }>
-  chatShowNewTeamDialog: Partial<{
+  }
+  chatShowNewTeamDialog: {
     conversationIDKey: ChatTypes.ConversationIDKey
-  }>
-  chatPDF: Partial<{
+  }
+  chatPDF: {
     title: string
     url: string
-  }>
-  chatConfirmNavigateExternal: Partial<{
+  }
+  chatConfirmNavigateExternal: {
     display: string
     punycode: string
     url: string
-  }>
-  sendToChat: Partial<{
+  }
+  sendToChat: {
     canBack: boolean
     isFromShareExtension: boolean
     text: string // incoming share (text)
     sendPaths: Array<string> // KBFS or incoming share (files)
-  }>
-  keybaseLinkError: Partial<{
+  }
+}
+type RootParamListWallet = {
+  walletTeamBuilder: TeamBuilderProps
+  keybaseLinkError: {
     errorSource: 'app' | 'sep6' | 'sep7'
-  }>
-}>
+  }
+}
+type RootParamListCrypto = {
+  cryptoTeamBuilder: TeamBuilderProps
+}
+type RootParamListDevice = {
+  deviceAdd: {
+    highlight: Array<'computer' | 'phone' | 'paper key'>
+  }
+  devicePage: {
+    deviceID: string
+  }
+  deviceRevoke: {
+    deviceID: string
+  }
+}
+// TODO partial could go away when we enforce these params are pushed correctly
+type DeepPartial<Type> = {
+  [Property in keyof Type]?: Partial<Type[Property]>
+}
+
+export type RootParamList = DeepPartial<
+  RootParamListWallet &
+    RootParamListChat &
+    RootParamListTeams &
+    RootParamListFS &
+    RootParamListPeople &
+    RootParamListCrypto &
+    RootParamListDevice &
+    RootParamListGit
+>
 export type RootRouteProps<RouteName extends keyof RootParamList> = RouteProp<RootParamList, RouteName>
 
 export type RouteProps<RouteName extends keyof RootParamList> = {
   route: RouteProp<RootParamList, RouteName>
-  navigation: NavigationProp<RootParamList>
+  navigation: {
+    pop: () => void
+  }
 }
 
 export function getRouteParams<T extends keyof RootParamList>(ownProps: any): RootParamList[T] | undefined {

--- a/shared/router-v2/route-params.tsx
+++ b/shared/router-v2/route-params.tsx
@@ -1,126 +1,30 @@
-import type * as ChatTypes from '../constants/types/chat2'
-import type * as TeamBuildingTypes from '../constants/types/team-building'
-import type * as TeamsTypes from '../constants/types/teams'
-import type * as FSTypes from '../constants/types/fs'
-import type {Question1Answer} from '../profile/wot-author'
-import type {RenderableEmoji} from '../util/emoji'
 import type {RouteProp} from '@react-navigation/native'
+import type {RootParamListGit} from '../git/routes'
+import type {RootParamListPeople} from '../people/routes'
+import type {RootParamListProfile} from '../profile/routes'
+import type {RootParamListFS} from '../fs/routes'
+import type {RootParamListTeams} from '../teams/routes'
+import type {RootParamListChat} from '../chat/routes'
+import type {RootParamListWallets} from '../wallets/routes'
+import type {RootParamListDevices} from '../devices/routes'
+import type {RootParamListCrypto} from '../crypto/routes'
+import type {RootParamListLogin} from '../login/routes'
 
-type TeamBuilderProps = Partial<{
-  namespace: TeamBuildingTypes.AllowedNamespace
-  teamID: string
-  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
-  goButtonLabel: TeamBuildingTypes.GoButtonLabel
-  title: string
-}>
-
-// TODO move these to the routes?
-type RootParamListGit = {
-  gitRoot: {expandedSet: Set<string>}
-  gitDeleteRepo: {id: string}
-  gitNewRepo: {isTeam: boolean}
-}
-type RootParamListPeople = {
-  peopleTeamBuilder: TeamBuilderProps
-  profileWotAuthor: {
-    username: string
-    guiID: string
-    question1Answer: Question1Answer
-  }
-}
-type RootParamListFS = {
-  destinationPicker: {
-    index: number
-  }
-  confirmDelete: {
-    path: FSTypes.Path
-    mode: 'row' | 'screen'
-  }
-  fsRoot: {path: FSTypes.Path}
-  barePreview: {path: FSTypes.Path}
-}
-type RootParamListTeams = {
-  teamsTeamBuilder: TeamBuilderProps
-}
-type RootParamListChat = {
-  chatNewChat: TeamBuilderProps
-  chatConversation: {conversationIDKey: ChatTypes.ConversationIDKey}
-  chatChooseEmoji: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-    small: boolean
-    hideFrequentEmoji: boolean
-    onlyTeamCustomEmoji: boolean
-    onPickAction: (emojiStr: string, renderableEmoji: RenderableEmoji) => void
-    onPickAddToMessageOrdinal: ChatTypes.Ordinal
-    onDidPick: () => void
-  }
-  chatUnfurlMapPopup: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-    coord: ChatTypes.Coordinate
-    isAuthor: boolean
-    author?: string
-    isLiveLocation: boolean
-    url: string
-  }
-  chatCreateChannel: {
-    navToChatOnSuccess?: boolean
-    teamID: TeamsTypes.TeamID
-  }
-  chatDeleteHistoryWarning: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-  }
-  chatShowNewTeamDialog: {
-    conversationIDKey: ChatTypes.ConversationIDKey
-  }
-  chatPDF: {
-    title: string
-    url: string
-  }
-  chatConfirmNavigateExternal: {
-    display: string
-    punycode: string
-    url: string
-  }
-  sendToChat: {
-    canBack: boolean
-    isFromShareExtension: boolean
-    text: string // incoming share (text)
-    sendPaths: Array<string> // KBFS or incoming share (files)
-  }
-}
-type RootParamListWallet = {
-  walletTeamBuilder: TeamBuilderProps
-  keybaseLinkError: {
-    errorSource: 'app' | 'sep6' | 'sep7'
-  }
-}
-type RootParamListCrypto = {
-  cryptoTeamBuilder: TeamBuilderProps
-}
-type RootParamListDevice = {
-  deviceAdd: {
-    highlight: Array<'computer' | 'phone' | 'paper key'>
-  }
-  devicePage: {
-    deviceID: string
-  }
-  deviceRevoke: {
-    deviceID: string
-  }
-}
 // TODO partial could go away when we enforce these params are pushed correctly
 type DeepPartial<Type> = {
   [Property in keyof Type]?: Partial<Type[Property]>
 }
 
 export type RootParamList = DeepPartial<
-  RootParamListWallet &
+  RootParamListLogin &
+    RootParamListWallets &
     RootParamListChat &
     RootParamListTeams &
     RootParamListFS &
     RootParamListPeople &
+    RootParamListProfile &
     RootParamListCrypto &
-    RootParamListDevice &
+    RootParamListDevices &
     RootParamListGit
 >
 export type RootRouteProps<RouteName extends keyof RootParamList> = RouteProp<RootParamList, RouteName>

--- a/shared/router-v2/route-params.tsx
+++ b/shared/router-v2/route-params.tsx
@@ -1,0 +1,43 @@
+import type {RouteProp, NavigationProp} from '@react-navigation/native'
+import type {Question1Answer} from '../profile/wot-author'
+import type {ConversationIDKey} from '../constants/types/chat2'
+import type * as TeamBuildingTypes from '../constants/types/team-building'
+
+type TeamBuilderProps = {
+  namespace?: TeamBuildingTypes.AllowedNamespace
+  teamID?: string
+  filterServices?: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel?: TeamBuildingTypes.GoButtonLabel
+  title?: string
+}
+
+// TODO partial could go away when we enforce these params are pushed correctly
+export type RootParamList = Partial<{
+  walletTeamBuilder: TeamBuilderProps
+  teamsTeamBuilder: TeamBuilderProps
+  peopleTeamBuilder: TeamBuilderProps
+  chatNewChat: TeamBuilderProps
+  cryptoTeamBuilder: TeamBuilderProps
+  chatConversation: {conversationIDKey?: ConversationIDKey}
+  profileWotAuthor: {
+    username?: string
+    guiID?: string
+    question1Answer?: Question1Answer
+  }
+}>
+export type RootRouteProps<RouteName extends keyof RootParamList> = RouteProp<RootParamList, RouteName>
+
+export type RouteProps<RouteName extends keyof RootParamList> = {
+  route: RouteProp<RootParamList, RouteName>
+  navigation: NavigationProp<RootParamList>
+}
+
+export function getRouteParams<T extends keyof RootParamList>(ownProps: any): RootParamList[T] | undefined {
+  return ownProps?.route?.params as RootParamList[T]
+}
+
+export function getRouteParamsFromRoute<T extends keyof RootParamList>(
+  route: any
+): RootParamList[T] | undefined {
+  return route?.params as RootParamList[T]
+}

--- a/shared/router-v2/route-params.tsx
+++ b/shared/router-v2/route-params.tsx
@@ -1,7 +1,9 @@
-import type {RouteProp, NavigationProp} from '@react-navigation/native'
-import type {Question1Answer} from '../profile/wot-author'
-import type {ConversationIDKey} from '../constants/types/chat2'
+import type * as ChatTypes from '../constants/types/chat2'
 import type * as TeamBuildingTypes from '../constants/types/team-building'
+import type * as TeamsTypes from '../constants/types/teams'
+import type {Question1Answer} from '../profile/wot-author'
+import type {RenderableEmoji} from 'util/emoji'
+import type {RouteProp, NavigationProp} from '@react-navigation/native'
 
 type TeamBuilderProps = {
   namespace?: TeamBuildingTypes.AllowedNamespace
@@ -18,12 +20,57 @@ export type RootParamList = Partial<{
   peopleTeamBuilder: TeamBuilderProps
   chatNewChat: TeamBuilderProps
   cryptoTeamBuilder: TeamBuilderProps
-  chatConversation: {conversationIDKey?: ConversationIDKey}
-  profileWotAuthor: {
-    username?: string
-    guiID?: string
-    question1Answer?: Question1Answer
-  }
+  chatConversation: Partial<{conversationIDKey: ChatTypes.ConversationIDKey}>
+  profileWotAuthor: Partial<{
+    username: string
+    guiID: string
+    question1Answer: Question1Answer
+  }>
+  chatChooseEmoji: Partial<{
+    conversationIDKey: ChatTypes.ConversationIDKey
+    small: boolean
+    hideFrequentEmoji: boolean
+    onlyTeamCustomEmoji: boolean
+    onPickAction: (emojiStr: string, renderableEmoji: RenderableEmoji) => void
+    onPickAddToMessageOrdinal: ChatTypes.Ordinal
+    onDidPick: () => void
+  }>
+  chatUnfurlMapPopup: Partial<{
+    conversationIDKey: ChatTypes.ConversationIDKey
+    coord: ChatTypes.Coordinate
+    isAuthor: boolean
+    author?: string
+    isLiveLocation: boolean
+    url: string
+  }>
+  chatCreateChannel: Partial<{
+    navToChatOnSuccess?: boolean
+    teamID: TeamsTypes.TeamID
+  }>
+  chatDeleteHistoryWarning: Partial<{
+    conversationIDKey: ChatTypes.ConversationIDKey
+  }>
+  chatShowNewTeamDialog: Partial<{
+    conversationIDKey: ChatTypes.ConversationIDKey
+  }>
+  chatPDF: Partial<{
+    title: string
+    url: string
+  }>
+  chatConfirmNavigateExternal: Partial<{
+    display: string
+    punycode: string
+    url: string
+  }>
+  sendToChat: Partial<{
+    canBack: boolean
+    isFromShareExtension: boolean
+    text: string // incoming share (text)
+    sendPaths: Array<string> // KBFS or incoming share (files)
+  }>
+  keybaseLinkError: Partial<{
+    errorSource: 'app' | 'sep6' | 'sep7'
+  }>
 }>
 export type RootRouteProps<RouteName extends keyof RootParamList> = RouteProp<RootParamList, RouteName>
 

--- a/shared/router-v2/route-params.tsx
+++ b/shared/router-v2/route-params.tsx
@@ -9,6 +9,7 @@ import type {RootParamListWallets} from '../wallets/routes'
 import type {RootParamListDevices} from '../devices/routes'
 import type {RootParamListCrypto} from '../crypto/routes'
 import type {RootParamListLogin} from '../login/routes'
+import type {RootParamListProvision} from '../provision/routes'
 
 // TODO partial could go away when we enforce these params are pushed correctly
 type DeepPartial<Type> = {
@@ -25,6 +26,7 @@ export type RootParamList = DeepPartial<
     RootParamListProfile &
     RootParamListCrypto &
     RootParamListDevices &
+    RootParamListProvision &
     RootParamListGit
 >
 export type RootRouteProps<RouteName extends keyof RootParamList> = RouteProp<RootParamList, RouteName>

--- a/shared/router-v2/route-params.tsx
+++ b/shared/router-v2/route-params.tsx
@@ -10,6 +10,7 @@ import type {RootParamListDevices} from '../devices/routes'
 import type {RootParamListCrypto} from '../crypto/routes'
 import type {RootParamListLogin} from '../login/routes'
 import type {RootParamListProvision} from '../provision/routes'
+import type {RootParamListSettings} from '../settings/routes'
 
 // TODO partial could go away when we enforce these params are pushed correctly
 type DeepPartial<Type> = {
@@ -27,6 +28,7 @@ export type RootParamList = DeepPartial<
     RootParamListCrypto &
     RootParamListDevices &
     RootParamListProvision &
+    RootParamListSettings &
     RootParamListGit
 >
 export type RootRouteProps<RouteName extends keyof RootParamList> = RouteProp<RootParamList, RouteName>

--- a/shared/settings/account/confirm-delete.tsx
+++ b/shared/settings/account/confirm-delete.tsx
@@ -61,21 +61,16 @@ const ConfirmDeleteAddress = (props: Props) => (
   />
 )
 
-type OwnProps = Container.RouteProps<{
-  address: string
-  searchable: boolean
-  type: 'email' | 'phone'
-  lastEmail?: boolean
-}>
+type OwnProps = Container.RouteProps<'settingsDeleteAddress'>
 
 const DeleteModal = (props: OwnProps) => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
-
-  const itemAddress = Container.getRouteProps(props, 'address', '')
-  const itemType = Container.getRouteProps(props, 'type', 'email')
-  const itemSearchable = Container.getRouteProps(props, 'searchable', false)
-  const lastEmail = Container.getRouteProps(props, 'lastEmail', false)
+  const {params} = props.route
+  const itemAddress = params?.address ?? ''
+  const itemType = params?.type ?? 'email'
+  const itemSearchable = params?.searchable ?? false
+  const lastEmail = params?.lastEmail ?? false
 
   const onCancel = React.useCallback(() => dispatch(nav.safeNavigateUpPayload()), [dispatch, nav])
   const onConfirm = React.useCallback(() => {

--- a/shared/settings/feedback/container.desktop.tsx
+++ b/shared/settings/feedback/container.desktop.tsx
@@ -1,11 +1,11 @@
-import Feedback from './index'
+import * as Constants from '../../constants/settings'
 import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as SettingsGen from '../../actions/settings-gen'
+import Feedback from './index'
 import {anyWaiting} from '../../constants/waiting'
-import * as Constants from '../../constants/settings'
 
-type OwnProps = Container.RouteProps<{heading: string; feedback: string}>
+type OwnProps = Container.RouteProps<'settingsTabs.feedbackTab'>
 
 export default Container.connect(
   state => ({
@@ -21,7 +21,7 @@ export default Container.connect(
   (s, d, o: OwnProps) => ({
     ...s,
     ...d,
-    feedback: Container.getRouteProps(o, 'feedback', ''),
+    feedback: o.route.params?.feedback ?? '',
     onFeedbackDone: () => null,
     showInternalSuccessBanner: true,
   })

--- a/shared/settings/feedback/container.native.tsx
+++ b/shared/settings/feedback/container.native.tsx
@@ -10,7 +10,7 @@ import {Platform} from 'react-native'
 import {NativeModules} from '../../util/native-modules.native'
 import {getExtraChatLogsForLogSend, getPushTokenForLogSend} from '../../constants/settings'
 
-type OwnProps = Container.RouteProps<{heading: string; feedback: string}>
+type OwnProps = Container.RouteProps<'settingsTabs.feedbackTab'>
 
 export type State = {
   sending: boolean
@@ -138,7 +138,7 @@ const connected = Container.connect(
   (s, d, o: OwnProps) => ({
     ...s,
     ...d,
-    feedback: Container.getRouteProps(o, 'feedback', ''),
+    feedback: o.route.params?.feedback ?? '',
   })
 )(FeedbackContainer)
 

--- a/shared/settings/invite-generated/container.tsx
+++ b/shared/settings/invite-generated/container.tsx
@@ -2,12 +2,12 @@ import * as Container from '../../util/container'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import InviteGenerated from '.'
 
-type OwnProps = Container.RouteProps<{email: string; link: string}>
+type OwnProps = Container.RouteProps<'inviteSent'>
 
 export default Container.connect(
   (_, ownProps: OwnProps) => ({
-    email: Container.getRouteProps(ownProps, 'email', ''),
-    link: Container.getRouteProps(ownProps, 'link', ''),
+    email: ownProps.route.params?.email ?? '',
+    link: ownProps.route.params?.link ?? '',
   }),
   dispatch => ({onClose: () => dispatch(RouteTreeGen.createNavigateUp())}),
   (s, d, o: OwnProps) => ({...o, ...s, ...d})

--- a/shared/settings/routes.d.ts
+++ b/shared/settings/routes.d.ts
@@ -1,3 +1,24 @@
 declare const newRoutes: {}
 declare const newModalRoutes: {}
 export {newRoutes, newModalRoutes}
+
+export type RootParamListSettings = {
+  settingsDeleteAddress: {
+    address: string
+    searchable: boolean
+    type: 'email' | 'phone'
+    lastEmail?: boolean
+  }
+  'settingsTabs.feedbackTab': {
+    heading: string
+    feedback: string
+  }
+  inviteSent: {
+    email: string
+    link: string
+  }
+  privacyPolicy: {
+    url: string
+    title: string
+  }
+}

--- a/shared/settings/routes.d.ts
+++ b/shared/settings/routes.d.ts
@@ -13,6 +13,10 @@ export type RootParamListSettings = {
     heading: string
     feedback: string
   }
+  'settingsTabs.feedbackTab': {
+    heading: string
+    feedback: string
+  }
   inviteSent: {
     email: string
     link: string

--- a/shared/settings/routes.d.ts
+++ b/shared/settings/routes.d.ts
@@ -13,10 +13,6 @@ export type RootParamListSettings = {
     heading: string
     feedback: string
   }
-  'settingsTabs.feedbackTab': {
-    heading: string
-    feedback: string
-  }
   inviteSent: {
     email: string
     link: string

--- a/shared/settings/web-links.native.tsx
+++ b/shared/settings/web-links.native.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 import * as Kb from '../common-adapters/mobile.native'
 import * as Container from '../util/container'
 
-type Props = Container.RouteProps<{url: string; title: string}>
+// this is used by acouple of routes, TODO just make this 'webLinks'
+type Props = Container.RouteProps<'privacyPolicy'>
 
 const WebLinks = (props: Props) => {
-  const uri = Container.getRouteProps(props, 'url', '')
+  const uri = props.route.params?.url ?? ''
   const source = React.useMemo(() => ({uri}), [uri])
 
   return (
@@ -16,7 +17,7 @@ const WebLinks = (props: Props) => {
 }
 WebLinks.navigationOptions = ({route}) => ({
   header: undefined,
-  title: route.params.title,
+  title: Container.getRouteParamsFromRoute<'privacyPolicy'>(route)?.title,
 })
 
 export default WebLinks

--- a/shared/team-building/contact-restricted.tsx
+++ b/shared/team-building/contact-restricted.tsx
@@ -3,7 +3,7 @@ import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import * as Container from '../util/container'
 
-type OwnProps = Container.RouteProps<Props>
+type OwnProps = Container.RouteProps<'contactRestricted'>
 
 type Props = {
   source: 'newFolder' | 'teamAddSomeFailed' | 'teamAddAllFailed' | 'walletsRequest' | 'misc'
@@ -135,11 +135,12 @@ const styles = Styles.styleSheetCreate(() => ({
   },
 }))
 
+const noArray = []
 export default Container.connect(
   () => ({}),
   () => ({}),
   (_, __, ownProps: OwnProps) => ({
-    source: Container.getRouteProps(ownProps, 'source', 'misc'),
-    usernames: Container.getRouteProps(ownProps, 'usernames', []),
+    source: ownProps.route.params?.source ?? 'misc',
+    usernames: ownProps.route.params?.usernames ?? noArray,
   })
 )(ContactRestricted)

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -1,14 +1,13 @@
-AAAAAAAAAAAAAAAAA working here
 import logger from '../logger'
 import * as React from 'react'
 import debounce from 'lodash/debounce'
 import trim from 'lodash/trim'
 import TeamBuilding, {
-    RolePickerProps,
-    SearchResult,
-    SearchRecSection,
-    numSectionLabel,
-    Props as TeamBuildingProps,
+  RolePickerProps,
+  SearchResult,
+  SearchRecSection,
+  numSectionLabel,
+  Props as TeamBuildingProps,
 } from '.'
 import * as WaitingConstants from '../constants/waiting'
 import * as ChatConstants from '../constants/chat2'
@@ -18,374 +17,374 @@ import * as Container from '../util/container'
 import * as Constants from '../constants/team-building'
 import * as Types from '../constants/types/team-building'
 import * as TeamTypes from '../constants/types/teams'
-import { requestIdleCallback } from '../util/idle-callback'
-import { memoizeShallow, memoize } from '../util/memoize'
-import { getDisabledReasonsForRolePicker, getTeamDetails, getTeamMeta } from '../constants/teams'
-import { nextRoleDown, nextRoleUp } from '../teams/role-picker'
-import { formatAnyPhoneNumbers } from '../util/phone-numbers'
-import { isMobile } from '../constants/platform'
+import {requestIdleCallback} from '../util/idle-callback'
+import {memoizeShallow, memoize} from '../util/memoize'
+import {getDisabledReasonsForRolePicker, getTeamDetails, getTeamMeta} from '../constants/teams'
+import {nextRoleDown, nextRoleUp} from '../teams/role-picker'
+import {formatAnyPhoneNumbers} from '../util/phone-numbers'
+import {isMobile} from '../constants/platform'
 
 // TODO remove when bots are fully integrated in gui
 type TeamRoleTypeWithoutBots = Exclude<TeamTypes.TeamRoleType, 'bot' | 'restrictedbot'>
 const filterRole = (r: TeamTypes.TeamRoleType): TeamRoleTypeWithoutBots =>
-    r === 'bot' || r === 'restrictedbot' ? 'reader' : r
+  r === 'bot' || r === 'restrictedbot' ? 'reader' : r
 
 type OwnProps = {
-    changeShowRolePicker: (showRolePicker: boolean) => void
-    decHighlightIndex: () => void
-    filterServices?: Array<Types.ServiceIdWithContact>
-    focusInputCounter: number
-    goButtonLabel?: Types.GoButtonLabel
-    recommendedHideYourself?: boolean
-    highlightedIndex: number
-    incFocusInputCounter: () => void
-    incHighlightIndex: (maxIndex: number) => void
-    namespace: Types.AllowedNamespace
-    onChangeService: (newService: Types.ServiceIdWithContact) => void
-    onChangeText: (newText: string) => void
-    resetHighlightIndex: (resetToHidden?: boolean) => void
-    searchString: string
-    selectedService: Types.ServiceIdWithContact
-    showRolePicker: boolean
-    showServiceResultCount: boolean
-    teamID?: TeamTypes.TeamID
-    title: string
+  changeShowRolePicker: (showRolePicker: boolean) => void
+  decHighlightIndex: () => void
+  filterServices?: Array<Types.ServiceIdWithContact>
+  focusInputCounter: number
+  goButtonLabel?: Types.GoButtonLabel
+  recommendedHideYourself?: boolean
+  highlightedIndex: number
+  incFocusInputCounter: () => void
+  incHighlightIndex: (maxIndex: number) => void
+  namespace: Types.AllowedNamespace
+  onChangeService: (newService: Types.ServiceIdWithContact) => void
+  onChangeText: (newText: string) => void
+  resetHighlightIndex: (resetToHidden?: boolean) => void
+  searchString: string
+  selectedService: Types.ServiceIdWithContact
+  showRolePicker: boolean
+  showServiceResultCount: boolean
+  teamID?: TeamTypes.TeamID
+  title: string
 }
 
 type LocalState = {
-    focusInputCounter: number
-    searchString: string
-    selectedService: Types.ServiceIdWithContact
-    highlightedIndex: number
-    showRolePicker: boolean
+  focusInputCounter: number
+  searchString: string
+  selectedService: Types.ServiceIdWithContact
+  highlightedIndex: number
+  showRolePicker: boolean
 }
 
 const initialState: LocalState = {
-    focusInputCounter: 0,
-    highlightedIndex: 0,
-    searchString: '',
-    selectedService: 'keybase',
-    showRolePicker: false,
+  focusInputCounter: 0,
+  highlightedIndex: 0,
+  searchString: '',
+  selectedService: 'keybase',
+  showRolePicker: false,
 }
 
 const expensiveDeriveResults = (
-    searchResults: Array<Types.User> | undefined,
-    teamSoFar: Set<Types.User>,
-    myUsername: string,
-    followingState: Set<string>,
-    preExistingTeamMembers: Map<string, TeamTypes.MemberInfo>
+  searchResults: Array<Types.User> | undefined,
+  teamSoFar: Set<Types.User>,
+  myUsername: string,
+  followingState: Set<string>,
+  preExistingTeamMembers: Map<string, TeamTypes.MemberInfo>
 ) =>
-    searchResults &&
-    searchResults.map(info => {
-        const label = info.label || ''
-        return {
-            contact: !!info.contact,
-            displayLabel: formatAnyPhoneNumbers(label),
-            followingState: Constants.followStateHelperWithId(myUsername, followingState, info.serviceMap.keybase),
-            inTeam: [...teamSoFar].some(u => u.id === info.id),
-            isPreExistingTeamMember: preExistingTeamMembers.has(info.id),
-            isYou: info.username === myUsername,
-            key: [info.id, info.prettyName, info.label, String(!!info.contact)].join('&'),
-            pictureUrl: info.pictureUrl,
-            prettyName: formatAnyPhoneNumbers(info.prettyName),
-            services: info.serviceMap,
-            userId: info.id,
-            username: info.username,
-        }
-    })
+  searchResults &&
+  searchResults.map(info => {
+    const label = info.label || ''
+    return {
+      contact: !!info.contact,
+      displayLabel: formatAnyPhoneNumbers(label),
+      followingState: Constants.followStateHelperWithId(myUsername, followingState, info.serviceMap.keybase),
+      inTeam: [...teamSoFar].some(u => u.id === info.id),
+      isPreExistingTeamMember: preExistingTeamMembers.has(info.id),
+      isYou: info.username === myUsername,
+      key: [info.id, info.prettyName, info.label, String(!!info.contact)].join('&'),
+      pictureUrl: info.pictureUrl,
+      prettyName: formatAnyPhoneNumbers(info.prettyName),
+      services: info.serviceMap,
+      userId: info.id,
+      username: info.username,
+    }
+  })
 
 const deriveSearchResults = memoize(expensiveDeriveResults)
 const deriveRecommendation = memoize(expensiveDeriveResults)
 
 const deriveTeamSoFar = memoize(
-    (teamSoFar: Set<Types.User>): Array<Types.SelectedUser> =>
-        [...teamSoFar].map(userInfo => {
-            let username = ''
-            let serviceId: Types.ServiceIdWithContact
-            if (userInfo.contact && userInfo.serviceMap.keybase) {
-                // resolved contact - pass username @ 'keybase' to teambox
-                // so keybase avatar is rendered.
-                username = userInfo.serviceMap.keybase
-                serviceId = 'keybase'
-            } else if (userInfo.serviceId !== 'keybase' && userInfo.serviceMap.keybase) {
-                // Not a keybase result but has Keybase username. Id will be compound assertion,
-                // but we want to display Keybase username and profile pic in teambox.
-                username = userInfo.serviceMap.keybase
-                serviceId = 'keybase'
-            } else {
-                username = userInfo.username
-                serviceId = userInfo.serviceId
-            }
-            return {
-                pictureUrl: userInfo.pictureUrl,
-                prettyName: userInfo.prettyName !== username ? userInfo.prettyName : '',
-                service: serviceId,
-                userId: userInfo.id,
-                username,
-            }
-        })
+  (teamSoFar: Set<Types.User>): Array<Types.SelectedUser> =>
+    [...teamSoFar].map(userInfo => {
+      let username = ''
+      let serviceId: Types.ServiceIdWithContact
+      if (userInfo.contact && userInfo.serviceMap.keybase) {
+        // resolved contact - pass username @ 'keybase' to teambox
+        // so keybase avatar is rendered.
+        username = userInfo.serviceMap.keybase
+        serviceId = 'keybase'
+      } else if (userInfo.serviceId !== 'keybase' && userInfo.serviceMap.keybase) {
+        // Not a keybase result but has Keybase username. Id will be compound assertion,
+        // but we want to display Keybase username and profile pic in teambox.
+        username = userInfo.serviceMap.keybase
+        serviceId = 'keybase'
+      } else {
+        username = userInfo.username
+        serviceId = userInfo.serviceId
+      }
+      return {
+        pictureUrl: userInfo.pictureUrl,
+        prettyName: userInfo.prettyName !== username ? userInfo.prettyName : '',
+        service: serviceId,
+        userId: userInfo.id,
+        username,
+      }
+    })
 )
 
 const _deriveServiceResultCount = memoize((searchResults: Types.SearchResults, query: string) =>
-    [...(searchResults.get(trim(query)) ?? new Map<Types.ServiceIdWithContact, Array<Types.User>>()).entries()]
-        .map(([key, results]) => [key, results.length] as const)
-        .reduce<{ [k: string]: number }>((o, [key, num]) => {
-            o[key] = num
-            return o
-        }, {})
+  [...(searchResults.get(trim(query)) ?? new Map<Types.ServiceIdWithContact, Array<Types.User>>()).entries()]
+    .map(([key, results]) => [key, results.length] as const)
+    .reduce<{[k: string]: number}>((o, [key, num]) => {
+      o[key] = num
+      return o
+    }, {})
 )
 const emptyObject = {}
 const deriveServiceResultCount = (searchResults: Types.SearchResults, query: string) => {
-    const val = _deriveServiceResultCount(searchResults, query)
-    if (Object.keys(val)) {
-        return val
-    }
-    return emptyObject
+  const val = _deriveServiceResultCount(searchResults, query)
+  if (Object.keys(val)) {
+    return val
+  }
+  return emptyObject
 }
 
 const deriveShowResults = memoize(searchString => !!searchString)
 
 const deriveUserFromUserIdFn = memoize(
-    (searchResults: Array<Types.User> | undefined, recommendations: Array<Types.User> | undefined) =>
-        (userId: string): Types.User | null =>
-            (searchResults || []).filter(u => u.id === userId)[0] ||
-            (recommendations || []).filter(u => u.id === userId)[0] ||
-            null
+  (searchResults: Array<Types.User> | undefined, recommendations: Array<Types.User> | undefined) =>
+    (userId: string): Types.User | null =>
+      (searchResults || []).filter(u => u.id === userId)[0] ||
+      (recommendations || []).filter(u => u.id === userId)[0] ||
+      null
 )
 
 const emptyObj = {}
 const emptyMap = new Map()
 
 const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
-    const teamBuildingState = state[ownProps.namespace].teamBuilding
-    const teamBuildingSearchResults = teamBuildingState.searchResults
-    const userResults: Array<Types.User> | undefined = teamBuildingState.searchResults
-        .get(trim(ownProps.searchString))
-        ?.get(ownProps.selectedService)
+  const teamBuildingState = state[ownProps.namespace].teamBuilding
+  const teamBuildingSearchResults = teamBuildingState.searchResults
+  const userResults: Array<Types.User> | undefined = teamBuildingState.searchResults
+    .get(trim(ownProps.searchString))
+    ?.get(ownProps.selectedService)
 
-    const maybeTeamMeta = ownProps.teamID ? getTeamMeta(state, ownProps.teamID) : undefined
-    const maybeTeamDetails = ownProps.teamID ? getTeamDetails(state, ownProps.teamID) : undefined
-    const preExistingTeamMembers: TeamTypes.TeamDetails['members'] = maybeTeamDetails?.members ?? emptyMap
-    const disabledRoles = ownProps.teamID
-        ? getDisabledReasonsForRolePicker(state, ownProps.teamID, null)
-        : emptyObj
+  const maybeTeamMeta = ownProps.teamID ? getTeamMeta(state, ownProps.teamID) : undefined
+  const maybeTeamDetails = ownProps.teamID ? getTeamDetails(state, ownProps.teamID) : undefined
+  const preExistingTeamMembers: TeamTypes.TeamDetails['members'] = maybeTeamDetails?.members ?? emptyMap
+  const disabledRoles = ownProps.teamID
+    ? getDisabledReasonsForRolePicker(state, ownProps.teamID, null)
+    : emptyObj
 
-    const contactProps = {
-        contactsImported: state.settings.contacts.importEnabled,
-        contactsPermissionStatus: state.settings.contacts.permissionStatus,
-        isImportPromptDismissed: state.settings.contacts.importPromptDismissed,
-        numContactsImported: state.settings.contacts.importedCount,
-    }
+  const contactProps = {
+    contactsImported: state.settings.contacts.importEnabled,
+    contactsPermissionStatus: state.settings.contacts.permissionStatus,
+    isImportPromptDismissed: state.settings.contacts.importPromptDismissed,
+    numContactsImported: state.settings.contacts.importedCount,
+  }
 
-    return {
-        ...contactProps,
-        disabledRoles,
-        error: teamBuildingState.error,
-        recommendations: deriveRecommendation(
-            teamBuildingState.userRecs,
-            teamBuildingState.teamSoFar,
-            state.config.username,
-            state.config.following,
-            preExistingTeamMembers
-        ),
-        searchResults: deriveSearchResults(
-            userResults,
-            teamBuildingState.teamSoFar,
-            state.config.username,
-            state.config.following,
-            preExistingTeamMembers
-        ),
-        selectedRole: filterRole(teamBuildingState.selectedRole),
-        sendNotification: teamBuildingState.sendNotification,
-        serviceResultCount: deriveServiceResultCount(teamBuildingState.searchResults, ownProps.searchString),
-        showResults: deriveShowResults(ownProps.searchString),
-        showServiceResultCount: !isMobile && deriveShowResults(ownProps.searchString),
-        teamBuildingSearchResults,
-        teamSoFar: deriveTeamSoFar(teamBuildingState.teamSoFar),
-        teamname: maybeTeamMeta?.teamname,
-        userFromUserId: deriveUserFromUserIdFn(userResults, teamBuildingState.userRecs),
-        waitingForCreate: WaitingConstants.anyWaiting(state, ChatConstants.waitingKeyCreating),
-    }
+  return {
+    ...contactProps,
+    disabledRoles,
+    error: teamBuildingState.error,
+    recommendations: deriveRecommendation(
+      teamBuildingState.userRecs,
+      teamBuildingState.teamSoFar,
+      state.config.username,
+      state.config.following,
+      preExistingTeamMembers
+    ),
+    searchResults: deriveSearchResults(
+      userResults,
+      teamBuildingState.teamSoFar,
+      state.config.username,
+      state.config.following,
+      preExistingTeamMembers
+    ),
+    selectedRole: filterRole(teamBuildingState.selectedRole),
+    sendNotification: teamBuildingState.sendNotification,
+    serviceResultCount: deriveServiceResultCount(teamBuildingState.searchResults, ownProps.searchString),
+    showResults: deriveShowResults(ownProps.searchString),
+    showServiceResultCount: !isMobile && deriveShowResults(ownProps.searchString),
+    teamBuildingSearchResults,
+    teamSoFar: deriveTeamSoFar(teamBuildingState.teamSoFar),
+    teamname: maybeTeamMeta?.teamname,
+    userFromUserId: deriveUserFromUserIdFn(userResults, teamBuildingState.userRecs),
+    waitingForCreate: WaitingConstants.anyWaiting(state, ChatConstants.waitingKeyCreating),
+  }
 }
 
 const makeDebouncedSearch = (time: number) =>
-    debounce(
-        (
-            dispatch: Container.TypedDispatch,
-            namespace: Types.AllowedNamespace,
-            query: string,
-            service: Types.ServiceIdWithContact,
-            includeContacts: boolean,
-            limit?: number
-        ) => {
-            requestIdleCallback(() => {
-                dispatch(
-                    TeamBuildingGen.createSearch({
-                        includeContacts,
-                        limit,
-                        namespace,
-                        query,
-                        service,
-                    })
-                )
-            })
-        },
-        time
-    )
+  debounce(
+    (
+      dispatch: Container.TypedDispatch,
+      namespace: Types.AllowedNamespace,
+      query: string,
+      service: Types.ServiceIdWithContact,
+      includeContacts: boolean,
+      limit?: number
+    ) => {
+      requestIdleCallback(() => {
+        dispatch(
+          TeamBuildingGen.createSearch({
+            includeContacts,
+            limit,
+            namespace,
+            query,
+            service,
+          })
+        )
+      })
+    },
+    time
+  )
 
 const debouncedSearch = makeDebouncedSearch(500) // 500ms debounce on social searches
 const debouncedSearchKeybase = makeDebouncedSearch(200) // 200 ms debounce on keybase searches
 
-const mapDispatchToProps = (dispatch: Container.TypedDispatch, { namespace, teamID }: OwnProps) => ({
-    _onAdd: (user: Types.User) =>
-        dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({ namespace, users: [user] })),
-    _onCancelTeamBuilding: () => dispatch(TeamBuildingGen.createCancelTeamBuilding({ namespace })),
-    _onImportContactsPermissionsGranted: () =>
-        dispatch(SettingsGen.createEditContactImportEnabled({ enable: true, fromSettings: false })),
-    _onImportContactsPermissionsNotGranted: () =>
-        dispatch(SettingsGen.createRequestContactPermissions({ fromSettings: false, thenToggleImportOn: true })),
-    _search: (query: string, service: Types.ServiceIdWithContact, limit?: number) => {
-        const func = service === 'keybase' ? debouncedSearchKeybase : debouncedSearch
-        return func(dispatch, namespace, query, service, namespace === 'chat2', limit)
-    },
-    fetchUserRecs: () =>
-        dispatch(TeamBuildingGen.createFetchUserRecs({ includeContacts: namespace === 'chat2', namespace })),
-    onAskForContactsLater: () => dispatch(SettingsGen.createImportContactsLater()),
-    onChangeSendNotification: (sendNotification: boolean) =>
-        namespace === 'teams' &&
-        dispatch(TeamBuildingGen.createChangeSendNotification({ namespace, sendNotification })),
-    onFinishTeamBuilding: () =>
-        dispatch(
-            namespace === 'teams'
-                ? TeamBuildingGen.createFinishTeamBuilding({ namespace, teamID })
-                : TeamBuildingGen.createFinishedTeamBuilding({ namespace })
-        ),
-    onLoadContactsSetting: () => dispatch(SettingsGen.createLoadContactImportEnabled()),
-    onRemove: (userId: string) =>
-        dispatch(TeamBuildingGen.createRemoveUsersFromTeamSoFar({ namespace, users: [userId] })),
-    onSelectRole: (role: TeamTypes.TeamRoleType) =>
-        namespace === 'teams' && dispatch(TeamBuildingGen.createSelectRole({ namespace, role })),
+const mapDispatchToProps = (dispatch: Container.TypedDispatch, {namespace, teamID}: OwnProps) => ({
+  _onAdd: (user: Types.User) =>
+    dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({namespace, users: [user]})),
+  _onCancelTeamBuilding: () => dispatch(TeamBuildingGen.createCancelTeamBuilding({namespace})),
+  _onImportContactsPermissionsGranted: () =>
+    dispatch(SettingsGen.createEditContactImportEnabled({enable: true, fromSettings: false})),
+  _onImportContactsPermissionsNotGranted: () =>
+    dispatch(SettingsGen.createRequestContactPermissions({fromSettings: false, thenToggleImportOn: true})),
+  _search: (query: string, service: Types.ServiceIdWithContact, limit?: number) => {
+    const func = service === 'keybase' ? debouncedSearchKeybase : debouncedSearch
+    return func(dispatch, namespace, query, service, namespace === 'chat2', limit)
+  },
+  fetchUserRecs: () =>
+    dispatch(TeamBuildingGen.createFetchUserRecs({includeContacts: namespace === 'chat2', namespace})),
+  onAskForContactsLater: () => dispatch(SettingsGen.createImportContactsLater()),
+  onChangeSendNotification: (sendNotification: boolean) =>
+    namespace === 'teams' &&
+    dispatch(TeamBuildingGen.createChangeSendNotification({namespace, sendNotification})),
+  onFinishTeamBuilding: () =>
+    dispatch(
+      namespace === 'teams'
+        ? TeamBuildingGen.createFinishTeamBuilding({namespace, teamID})
+        : TeamBuildingGen.createFinishedTeamBuilding({namespace})
+    ),
+  onLoadContactsSetting: () => dispatch(SettingsGen.createLoadContactImportEnabled()),
+  onRemove: (userId: string) =>
+    dispatch(TeamBuildingGen.createRemoveUsersFromTeamSoFar({namespace, users: [userId]})),
+  onSelectRole: (role: TeamTypes.TeamRoleType) =>
+    namespace === 'teams' && dispatch(TeamBuildingGen.createSelectRole({namespace, role})),
 })
 
 const deriveOnEnterKeyDown = memoizeShallow(
-    (p: {
-        changeText: (s: string) => void
-        highlightedIndex: number
-        onAdd: (id: string) => void
-        onFinishTeamBuilding: () => void
-        onRemove: (id: string) => void
-        searchResults: Array<SearchResult>
-        searchStringIsEmpty: string
-        teamSoFar: Array<Types.SelectedUser>
+  (p: {
+      changeText: (s: string) => void
+      highlightedIndex: number
+      onAdd: (id: string) => void
+      onFinishTeamBuilding: () => void
+      onRemove: (id: string) => void
+      searchResults: Array<SearchResult>
+      searchStringIsEmpty: string
+      teamSoFar: Array<Types.SelectedUser>
     }) =>
-        () => {
-            const { onRemove, changeText, searchStringIsEmpty, onFinishTeamBuilding } = p
-            const { searchResults, teamSoFar, highlightedIndex, onAdd } = p
-            const selectedResult = !!searchResults && searchResults[highlightedIndex]
-            if (selectedResult) {
-                // We don't handle cases where they hit enter on someone that is already a
-                // team member
-                if (selectedResult.isPreExistingTeamMember) {
-                    return
-                }
-                if (teamSoFar.filter(u => u.userId === selectedResult.userId).length) {
-                    onRemove(selectedResult.userId)
-                    changeText('')
-                } else {
-                    onAdd(selectedResult.userId)
-                }
-            } else if (searchStringIsEmpty && !!teamSoFar.length) {
-                // They hit enter with an empty search string and a teamSoFar
-                // We'll Finish the team building
-                onFinishTeamBuilding()
-            }
+    () => {
+      const {onRemove, changeText, searchStringIsEmpty, onFinishTeamBuilding} = p
+      const {searchResults, teamSoFar, highlightedIndex, onAdd} = p
+      const selectedResult = !!searchResults && searchResults[highlightedIndex]
+      if (selectedResult) {
+        // We don't handle cases where they hit enter on someone that is already a
+        // team member
+        if (selectedResult.isPreExistingTeamMember) {
+          return
         }
+        if (teamSoFar.filter(u => u.userId === selectedResult.userId).length) {
+          onRemove(selectedResult.userId)
+          changeText('')
+        } else {
+          onAdd(selectedResult.userId)
+        }
+      } else if (searchStringIsEmpty && !!teamSoFar.length) {
+        // They hit enter with an empty search string and a teamSoFar
+        // We'll Finish the team building
+        onFinishTeamBuilding()
+      }
+    }
 )
 
 const deriveOnSearchForMore = memoizeShallow(
-    (p: {
-        search: (q: string, sid: Types.ServiceIdWithContact, limit?: number) => void
-        searchResults: Array<Types.User>
-        searchString: string
-        selectedService: Types.ServiceIdWithContact
+  (p: {
+      search: (q: string, sid: Types.ServiceIdWithContact, limit?: number) => void
+      searchResults: Array<Types.User>
+      searchString: string
+      selectedService: Types.ServiceIdWithContact
     }) =>
-        () => {
-            const { search, searchResults, searchString, selectedService } = p
-            if (searchResults && searchResults.length >= 10) {
-                search(searchString, selectedService, searchResults.length + 20)
-            }
-        }
+    () => {
+      const {search, searchResults, searchString, selectedService} = p
+      if (searchResults && searchResults.length >= 10) {
+        search(searchString, selectedService, searchResults.length + 20)
+      }
+    }
 )
 
 const deriveOnAdd = memoize(
-    (userFromUserId, dispatchOnAdd, changeText, resetHighlightIndex, incFocusInputCounter) =>
-        (userId: string) => {
-            const user = userFromUserId(userId)
-            if (!user) {
-                logger.error(`Couldn't find Types.User to add for ${userId}`)
-                changeText('')
-                return
-            }
-            changeText('')
-            dispatchOnAdd(user)
-            resetHighlightIndex(true)
-            incFocusInputCounter()
-        }
+  (userFromUserId, dispatchOnAdd, changeText, resetHighlightIndex, incFocusInputCounter) =>
+    (userId: string) => {
+      const user = userFromUserId(userId)
+      if (!user) {
+        logger.error(`Couldn't find Types.User to add for ${userId}`)
+        changeText('')
+        return
+      }
+      changeText('')
+      dispatchOnAdd(user)
+      resetHighlightIndex(true)
+      incFocusInputCounter()
+    }
 )
 
 const deriveOnChangeText = memoize(
-    (
-        onChangeText: (newText: string) => void,
-        search: (text: string, service: Types.ServiceIdWithContact) => void,
-        selectedService: Types.ServiceIdWithContact,
-        resetHighlightIndex: Function
+  (
+      onChangeText: (newText: string) => void,
+      search: (text: string, service: Types.ServiceIdWithContact) => void,
+      selectedService: Types.ServiceIdWithContact,
+      resetHighlightIndex: Function
     ) =>
-        (newText: string) => {
-            onChangeText(newText)
-            search(newText, selectedService)
-            resetHighlightIndex()
-        }
+    (newText: string) => {
+      onChangeText(newText)
+      search(newText, selectedService)
+      resetHighlightIndex()
+    }
 )
 
 const deriveOnDownArrowKeyDown = memoize(
-    (maxIndex: number, incHighlightIndex: (maxIndex: number) => void) => () => incHighlightIndex(maxIndex)
+  (maxIndex: number, incHighlightIndex: (maxIndex: number) => void) => () => incHighlightIndex(maxIndex)
 )
 
 const deriveRolePickerArrowKeyFns = memoize(
-    (
-        selectedRole: TeamRoleTypeWithoutBots,
-        disabledRoles: TeamTypes.DisabledReasonsForRolePicker,
-        onSelectRole: (role: TeamRoleTypeWithoutBots) => void
-    ) => ({
-        downArrow: () => {
-            const nextRole = nextRoleDown(selectedRole)
-            if (!disabledRoles[nextRole]) {
-                onSelectRole(nextRole)
-            }
-        },
-        upArrow: () => {
-            const nextRole = nextRoleUp(selectedRole)
-            if (!disabledRoles[nextRole]) {
-                onSelectRole(nextRole)
-            }
-        },
-    })
+  (
+    selectedRole: TeamRoleTypeWithoutBots,
+    disabledRoles: TeamTypes.DisabledReasonsForRolePicker,
+    onSelectRole: (role: TeamRoleTypeWithoutBots) => void
+  ) => ({
+    downArrow: () => {
+      const nextRole = nextRoleDown(selectedRole)
+      if (!disabledRoles[nextRole]) {
+        onSelectRole(nextRole)
+      }
+    },
+    upArrow: () => {
+      const nextRole = nextRoleUp(selectedRole)
+      if (!disabledRoles[nextRole]) {
+        onSelectRole(nextRole)
+      }
+    },
+  })
 )
 
 const deriveOnChangeService = memoize(
-    (
-        onChangeService: OwnProps['onChangeService'],
-        incFocusInputCounter: OwnProps['incFocusInputCounter'],
-        search: (text: string, service: Types.ServiceIdWithContact) => void,
-        searchString: string
+  (
+      onChangeService: OwnProps['onChangeService'],
+      incFocusInputCounter: OwnProps['incFocusInputCounter'],
+      search: (text: string, service: Types.ServiceIdWithContact) => void,
+      searchString: string
     ) =>
-        (service: Types.ServiceIdWithContact) => {
-            onChangeService(service)
-            incFocusInputCounter()
-            if (!Types.isContactServiceId(service)) {
-                search(searchString, service)
-            }
-        }
+    (service: Types.ServiceIdWithContact) => {
+      onChangeService(service)
+      incFocusInputCounter()
+      if (!Types.isContactServiceId(service)) {
+        search(searchString, service)
+      }
+    }
 )
 
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'
@@ -399,75 +398,75 @@ const letterToAlphaIndex = (letter: string) => letter.charCodeAt(0) - aCharCode
 // 1-26 - a-z sections
 // 27 - 0-9 section
 export const sortAndSplitRecommendations = memoize(
-    (
-        results: Unpacked<typeof deriveSearchResults>,
-        showingContactsButton: boolean
-    ): Array<SearchRecSection> | null => {
-        if (!results) return null
+  (
+    results: Unpacked<typeof deriveSearchResults>,
+    showingContactsButton: boolean
+  ): Array<SearchRecSection> | null => {
+    if (!results) return null
 
-        const sections: Array<SearchRecSection> = [
-            ...(showingContactsButton
-                ? [
-                    {
-                        data: [{ isImportButton: true as const }],
-                        label: '',
-                        shortcut: false,
-                    },
-                ]
-                : []),
-
+    const sections: Array<SearchRecSection> = [
+      ...(showingContactsButton
+        ? [
             {
-                data: [],
-                label: 'Recommendations',
-                shortcut: false,
+              data: [{isImportButton: true as const}],
+              label: '',
+              shortcut: false,
             },
-        ]
-        const recSectionIdx = sections.length - 1
-        const numSectionIdx = recSectionIdx + 27
-        results.forEach(rec => {
-            if (!rec.contact) {
-                sections[recSectionIdx].data.push(rec)
-                return
+          ]
+        : []),
+
+      {
+        data: [],
+        label: 'Recommendations',
+        shortcut: false,
+      },
+    ]
+    const recSectionIdx = sections.length - 1
+    const numSectionIdx = recSectionIdx + 27
+    results.forEach(rec => {
+      if (!rec.contact) {
+        sections[recSectionIdx].data.push(rec)
+        return
+      }
+      if (rec.prettyName || rec.displayLabel) {
+        // Use the first letter of the name we will display, but first normalize out
+        // any diacritics.
+        const decodedLetter = /*unidecode*/ rec.prettyName || rec.displayLabel
+        if (decodedLetter && decodedLetter[0]) {
+          const letter = decodedLetter[0].toLowerCase()
+          if (isAlpha(letter)) {
+            // offset 1 to skip recommendations
+            const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1
+            if (!sections[sectionIdx]) {
+              sections[sectionIdx] = {
+                data: [],
+                label: letter.toUpperCase(),
+                shortcut: true,
+              }
             }
-            if (rec.prettyName || rec.displayLabel) {
-                // Use the first letter of the name we will display, but first normalize out
-                // any diacritics.
-                const decodedLetter = /*unidecode*/ rec.prettyName || rec.displayLabel
-                if (decodedLetter && decodedLetter[0]) {
-                    const letter = decodedLetter[0].toLowerCase()
-                    if (isAlpha(letter)) {
-                        // offset 1 to skip recommendations
-                        const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1
-                        if (!sections[sectionIdx]) {
-                            sections[sectionIdx] = {
-                                data: [],
-                                label: letter.toUpperCase(),
-                                shortcut: true,
-                            }
-                        }
-                        sections[sectionIdx].data.push(rec)
-                    } else {
-                        if (!sections[numSectionIdx]) {
-                            sections[numSectionIdx] = {
-                                data: [],
-                                label: numSectionLabel,
-                                shortcut: true,
-                            }
-                        }
-                        sections[numSectionIdx].data.push(rec)
-                    }
-                }
+            sections[sectionIdx].data.push(rec)
+          } else {
+            if (!sections[numSectionIdx]) {
+              sections[numSectionIdx] = {
+                data: [],
+                label: numSectionLabel,
+                shortcut: true,
+              }
             }
-        })
-        if (results.length < 5) {
-            sections.push({
-                data: [{ isSearchHint: true as const }],
-                label: '',
-                shortcut: false,
-            })
+            sections[numSectionIdx].data.push(rec)
+          }
         }
-        return sections.filter(s => s && s.data && s.data.length > 0)
+      }
+    })
+    if (results.length < 5) {
+      sections.push({
+        data: [{isSearchHint: true as const}],
+        label: '',
+        shortcut: false,
+      })
     }
+    return sections.filter(s => s && s.data && s.data.length > 0)
+  }
 )
 
 // Flatten list of recommendation sections. After recommendations are organized
@@ -477,170 +476,170 @@ export const sortAndSplitRecommendations = memoize(
 //
 // Resulting list may have nulls in place of fake rows.
 const flattenRecommendations = memoize((recommendations: Array<SearchRecSection>) => {
-    const result: Array<SearchResult | null> = []
-    for (const section of recommendations) {
-        result.push(...section.data.map(rec => ('isImportButton' in rec || 'isSearchHint' in rec ? null : rec)))
-    }
-    return result
+  const result: Array<SearchResult | null> = []
+  for (const section of recommendations) {
+    result.push(...section.data.map(rec => ('isImportButton' in rec || 'isSearchHint' in rec ? null : rec)))
+  }
+  return result
 })
 
 type TeamBuildingPropsPlusSome = TeamBuildingProps & {
-    [key: string]: any
+  [key: string]: any
 }
 const mergeProps = (
-    stateProps: ReturnType<typeof mapStateToProps>,
-    dispatchProps: ReturnType<typeof mapDispatchToProps>,
-    ownProps: OwnProps
+  stateProps: ReturnType<typeof mapStateToProps>,
+  dispatchProps: ReturnType<typeof mapDispatchToProps>,
+  ownProps: OwnProps
 ): TeamBuildingPropsPlusSome => {
-    const {
-        teamSoFar,
-        searchResults,
-        userFromUserId,
-        serviceResultCount,
-        showServiceResultCount,
-        recommendations,
-        waitingForCreate,
-    } = stateProps
+  const {
+    teamSoFar,
+    searchResults,
+    userFromUserId,
+    serviceResultCount,
+    showServiceResultCount,
+    recommendations,
+    waitingForCreate,
+  } = stateProps
 
-    const showingContactsButton =
-        Container.isMobile &&
-        stateProps.contactsPermissionStatus !== 'never_ask_again' &&
-        !stateProps.contactsImported
+  const showingContactsButton =
+    Container.isMobile &&
+    stateProps.contactsPermissionStatus !== 'never_ask_again' &&
+    !stateProps.contactsImported
 
-    // Contacts props
-    const contactProps = {
-        contactsImported: stateProps.contactsImported,
-        contactsPermissionStatus: stateProps.contactsPermissionStatus,
-        isImportPromptDismissed: stateProps.isImportPromptDismissed,
-        numContactsImported: stateProps.numContactsImported || 0,
-        onAskForContactsLater: dispatchProps.onAskForContactsLater,
-        onImportContacts:
-            stateProps.contactsPermissionStatus === 'never_ask_again'
-                ? undefined
-                : stateProps.contactsPermissionStatus === 'granted'
-                    ? dispatchProps._onImportContactsPermissionsGranted
-                    : dispatchProps._onImportContactsPermissionsNotGranted,
-        onLoadContactsSetting: dispatchProps.onLoadContactsSetting,
-    }
+  // Contacts props
+  const contactProps = {
+    contactsImported: stateProps.contactsImported,
+    contactsPermissionStatus: stateProps.contactsPermissionStatus,
+    isImportPromptDismissed: stateProps.isImportPromptDismissed,
+    numContactsImported: stateProps.numContactsImported || 0,
+    onAskForContactsLater: dispatchProps.onAskForContactsLater,
+    onImportContacts:
+      stateProps.contactsPermissionStatus === 'never_ask_again'
+        ? undefined
+        : stateProps.contactsPermissionStatus === 'granted'
+        ? dispatchProps._onImportContactsPermissionsGranted
+        : dispatchProps._onImportContactsPermissionsNotGranted,
+    onLoadContactsSetting: dispatchProps.onLoadContactsSetting,
+  }
 
-    const showRecs = !ownProps.searchString && !!recommendations && ownProps.selectedService === 'keybase'
-    const recommendationsSections = showRecs
-        ? sortAndSplitRecommendations(recommendations, showingContactsButton)
-        : null
-    const userResultsToShow = showRecs ? flattenRecommendations(recommendationsSections || []) : searchResults
+  const showRecs = !ownProps.searchString && !!recommendations && ownProps.selectedService === 'keybase'
+  const recommendationsSections = showRecs
+    ? sortAndSplitRecommendations(recommendations, showingContactsButton)
+    : null
+  const userResultsToShow = showRecs ? flattenRecommendations(recommendationsSections || []) : searchResults
 
-    const onChangeText = deriveOnChangeText(
-        ownProps.onChangeText,
-        dispatchProps._search,
-        ownProps.selectedService,
-        ownProps.resetHighlightIndex
-    )
+  const onChangeText = deriveOnChangeText(
+    ownProps.onChangeText,
+    dispatchProps._search,
+    ownProps.selectedService,
+    ownProps.resetHighlightIndex
+  )
 
-    const onClear = () => onChangeText('')
+  const onClear = () => onChangeText('')
 
-    const onSearchForMore = deriveOnSearchForMore({
-        search: dispatchProps._search,
-        searchResults,
-        searchString: ownProps.searchString,
-        selectedService: ownProps.selectedService,
-    })
+  const onSearchForMore = deriveOnSearchForMore({
+    search: dispatchProps._search,
+    searchResults,
+    searchString: ownProps.searchString,
+    selectedService: ownProps.selectedService,
+  })
 
-    const onAdd = deriveOnAdd(
-        userFromUserId,
-        dispatchProps._onAdd,
-        ownProps.onChangeText,
-        ownProps.resetHighlightIndex,
-        ownProps.incFocusInputCounter
-    )
+  const onAdd = deriveOnAdd(
+    userFromUserId,
+    dispatchProps._onAdd,
+    ownProps.onChangeText,
+    ownProps.resetHighlightIndex,
+    ownProps.incFocusInputCounter
+  )
 
-    const rolePickerProps: RolePickerProps | undefined =
-        ownProps.namespace === 'teams'
-            ? {
-                changeSendNotification: dispatchProps.onChangeSendNotification,
-                changeShowRolePicker: ownProps.changeShowRolePicker,
-                disabledRoles: stateProps.disabledRoles,
-                onSelectRole: dispatchProps.onSelectRole,
-                selectedRole: stateProps.selectedRole,
-                sendNotification: stateProps.sendNotification,
-                showRolePicker: ownProps.showRolePicker,
-            }
-            : undefined
+  const rolePickerProps: RolePickerProps | undefined =
+    ownProps.namespace === 'teams'
+      ? {
+          changeSendNotification: dispatchProps.onChangeSendNotification,
+          changeShowRolePicker: ownProps.changeShowRolePicker,
+          disabledRoles: stateProps.disabledRoles,
+          onSelectRole: dispatchProps.onSelectRole,
+          selectedRole: stateProps.selectedRole,
+          sendNotification: stateProps.sendNotification,
+          showRolePicker: ownProps.showRolePicker,
+        }
+      : undefined
 
-    // TODO this should likely live with the role picker if we need this
-    // functionality elsewhere. Right now it's easier to keep here since the input
-    // already catches all keypresses
-    const rolePickerArrowKeyFns =
-        ownProps.showRolePicker &&
-        deriveRolePickerArrowKeyFns(stateProps.selectedRole, stateProps.disabledRoles, dispatchProps.onSelectRole)
+  // TODO this should likely live with the role picker if we need this
+  // functionality elsewhere. Right now it's easier to keep here since the input
+  // already catches all keypresses
+  const rolePickerArrowKeyFns =
+    ownProps.showRolePicker &&
+    deriveRolePickerArrowKeyFns(stateProps.selectedRole, stateProps.disabledRoles, dispatchProps.onSelectRole)
 
-    const onEnterKeyDown = deriveOnEnterKeyDown({
-        changeText: ownProps.onChangeText,
-        highlightedIndex: ownProps.highlightedIndex,
-        onAdd,
-        onFinishTeamBuilding:
-            rolePickerProps && !ownProps.showRolePicker
-                ? () => ownProps.changeShowRolePicker(true)
-                : dispatchProps.onFinishTeamBuilding,
-        onRemove: dispatchProps.onRemove,
-        searchResults: userResultsToShow,
-        searchStringIsEmpty: !ownProps.searchString,
-        teamSoFar,
-    })
+  const onEnterKeyDown = deriveOnEnterKeyDown({
+    changeText: ownProps.onChangeText,
+    highlightedIndex: ownProps.highlightedIndex,
+    onAdd,
+    onFinishTeamBuilding:
+      rolePickerProps && !ownProps.showRolePicker
+        ? () => ownProps.changeShowRolePicker(true)
+        : dispatchProps.onFinishTeamBuilding,
+    onRemove: dispatchProps.onRemove,
+    searchResults: userResultsToShow,
+    searchStringIsEmpty: !ownProps.searchString,
+    teamSoFar,
+  })
 
-    const title = ownProps.namespace === 'teams' ? `Add to ${stateProps.teamname}` : ownProps.title
+  const title = ownProps.namespace === 'teams' ? `Add to ${stateProps.teamname}` : ownProps.title
 
-    return {
-        ...contactProps,
-        error: stateProps.error,
-        fetchUserRecs: dispatchProps.fetchUserRecs,
-        filterServices: ownProps.filterServices,
-        focusInputCounter: ownProps.focusInputCounter,
-        goButtonLabel: ownProps.goButtonLabel,
-        highlightedIndex: ownProps.highlightedIndex,
-        includeContacts: ownProps.namespace === 'chat2',
-        namespace: ownProps.namespace,
-        onAdd,
-        onChangeService: deriveOnChangeService(
-            ownProps.onChangeService,
-            ownProps.incFocusInputCounter,
-            dispatchProps._search,
-            ownProps.searchString
-        ),
-        onChangeText,
-        onClear,
-        onClose: dispatchProps._onCancelTeamBuilding,
-        onClosePopup: dispatchProps._onCancelTeamBuilding,
-        onDownArrowKeyDown:
-            ownProps.showRolePicker && rolePickerArrowKeyFns
-                ? rolePickerArrowKeyFns.downArrow
-                : deriveOnDownArrowKeyDown((userResultsToShow || []).length - 1, ownProps.incHighlightIndex),
-        onEnterKeyDown,
-        onFinishTeamBuilding: dispatchProps.onFinishTeamBuilding,
-        onMakeItATeam: () => console.log('todo'),
-        onRemove: dispatchProps.onRemove,
-        onSearchForMore,
-        onUpArrowKeyDown:
-            ownProps.showRolePicker && rolePickerArrowKeyFns
-                ? rolePickerArrowKeyFns.upArrow
-                : ownProps.decHighlightIndex,
-        recommendations: recommendationsSections,
-        recommendedHideYourself: ownProps.recommendedHideYourself,
-        rolePickerProps,
-        search: dispatchProps._search,
-        searchResults,
-        searchString: ownProps.searchString,
-        selectedService: ownProps.selectedService,
-        serviceResultCount,
-        showRecs,
-        showResults: stateProps.showResults,
-        showServiceResultCount: showServiceResultCount && ownProps.showServiceResultCount,
-        teamBuildingSearchResults: stateProps.teamBuildingSearchResults,
-        teamID: ownProps.teamID,
-        teamSoFar,
-        teamname: stateProps.teamname,
-        title,
-        waitingForCreate,
-    }
+  return {
+    ...contactProps,
+    error: stateProps.error,
+    fetchUserRecs: dispatchProps.fetchUserRecs,
+    filterServices: ownProps.filterServices,
+    focusInputCounter: ownProps.focusInputCounter,
+    goButtonLabel: ownProps.goButtonLabel,
+    highlightedIndex: ownProps.highlightedIndex,
+    includeContacts: ownProps.namespace === 'chat2',
+    namespace: ownProps.namespace,
+    onAdd,
+    onChangeService: deriveOnChangeService(
+      ownProps.onChangeService,
+      ownProps.incFocusInputCounter,
+      dispatchProps._search,
+      ownProps.searchString
+    ),
+    onChangeText,
+    onClear,
+    onClose: dispatchProps._onCancelTeamBuilding,
+    onClosePopup: dispatchProps._onCancelTeamBuilding,
+    onDownArrowKeyDown:
+      ownProps.showRolePicker && rolePickerArrowKeyFns
+        ? rolePickerArrowKeyFns.downArrow
+        : deriveOnDownArrowKeyDown((userResultsToShow || []).length - 1, ownProps.incHighlightIndex),
+    onEnterKeyDown,
+    onFinishTeamBuilding: dispatchProps.onFinishTeamBuilding,
+    onMakeItATeam: () => console.log('todo'),
+    onRemove: dispatchProps.onRemove,
+    onSearchForMore,
+    onUpArrowKeyDown:
+      ownProps.showRolePicker && rolePickerArrowKeyFns
+        ? rolePickerArrowKeyFns.upArrow
+        : ownProps.decHighlightIndex,
+    recommendations: recommendationsSections,
+    recommendedHideYourself: ownProps.recommendedHideYourself,
+    rolePickerProps,
+    search: dispatchProps._search,
+    searchResults,
+    searchString: ownProps.searchString,
+    selectedService: ownProps.selectedService,
+    serviceResultCount,
+    showRecs,
+    showResults: stateProps.showResults,
+    showServiceResultCount: showServiceResultCount && ownProps.showServiceResultCount,
+    teamBuildingSearchResults: stateProps.teamBuildingSearchResults,
+    teamID: ownProps.teamID,
+    teamSoFar,
+    teamname: stateProps.teamname,
+    title,
+    waitingForCreate,
+  }
 }
 
 const Connected: any = Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(TeamBuilding)
@@ -648,59 +647,59 @@ const Connected: any = Container.connect(mapStateToProps, mapDispatchToProps, me
 type RealOwnProps = Container.RouteProps<'teamsRoot'>
 
 class StateWrapperForTeamBuilding extends React.Component<RealOwnProps, LocalState> {
-    static navigationOptions = Connected.navigationOptions
-    state: LocalState = initialState
+  static navigationOptions = Connected.navigationOptions
+  state: LocalState = initialState
 
-    changeShowRolePicker = (showRolePicker: boolean) => this.setState({ showRolePicker })
+  changeShowRolePicker = (showRolePicker: boolean) => this.setState({showRolePicker})
 
-    onChangeService = (selectedService: Types.ServiceIdWithContact) => this.setState({ selectedService })
+  onChangeService = (selectedService: Types.ServiceIdWithContact) => this.setState({selectedService})
 
-    onChangeText = (newText: string) => {
-        if (newText !== this.state.searchString) {
-            this.setState({ searchString: newText, showRolePicker: false })
-        }
+  onChangeText = (newText: string) => {
+    if (newText !== this.state.searchString) {
+      this.setState({searchString: newText, showRolePicker: false})
     }
+  }
 
-    incHighlightIndex = (maxIndex: number) =>
-        this.setState((state: LocalState) => ({
-            highlightedIndex: Math.min(state.highlightedIndex + 1, maxIndex),
-        }))
+  incHighlightIndex = (maxIndex: number) =>
+    this.setState((state: LocalState) => ({
+      highlightedIndex: Math.min(state.highlightedIndex + 1, maxIndex),
+    }))
 
-    decHighlightIndex = () =>
-        this.setState((state: LocalState) => ({
-            highlightedIndex: state.highlightedIndex < 1 ? 0 : state.highlightedIndex - 1,
-        }))
+  decHighlightIndex = () =>
+    this.setState((state: LocalState) => ({
+      highlightedIndex: state.highlightedIndex < 1 ? 0 : state.highlightedIndex - 1,
+    }))
 
-    resetHighlightIndex = (resetToHidden?: boolean) =>
-        this.setState({ highlightedIndex: resetToHidden ? -1 : initialState.highlightedIndex })
+  resetHighlightIndex = (resetToHidden?: boolean) =>
+    this.setState({highlightedIndex: resetToHidden ? -1 : initialState.highlightedIndex})
 
-    _incFocusInputCounter = () => this.setState(s => ({ focusInputCounter: s.focusInputCounter + 1 }))
+  _incFocusInputCounter = () => this.setState(s => ({focusInputCounter: s.focusInputCounter + 1}))
 
-    render() {
-        return (
-            <Connected
-                namespace={Container.getRouteProps(this.props, 'namespace', 'chat2')}
-                teamID={Container.getRouteProps(this.props, 'teamID', undefined)}
-                filterServices={Container.getRouteProps(this.props, 'filterServices', undefined)}
-                onChangeService={this.onChangeService}
-                onChangeText={this.onChangeText}
-                incHighlightIndex={this.incHighlightIndex}
-                decHighlightIndex={this.decHighlightIndex}
-                resetHighlightIndex={this.resetHighlightIndex}
-                searchString={this.state.searchString}
-                selectedService={this.state.selectedService}
-                highlightedIndex={this.state.highlightedIndex}
-                changeShowRolePicker={this.changeShowRolePicker}
-                showRolePicker={this.state.showRolePicker}
-                showServiceResultCount={false}
-                focusInputCounter={this.state.focusInputCounter}
-                incFocusInputCounter={this._incFocusInputCounter}
-                title={Container.getRouteProps(this.props as any, 'title', '')}
-                goButtonLabel={Container.getRouteProps(this.props as any, 'goButtonLabel', 'Start')}
-                recommendedHideYourself={Container.getRouteProps(this.props as any, 'recommendedHideYourself', false)}
-            />
-        )
-    }
+  render() {
+    return (
+      <Connected
+        namespace={this.props.route.params?.namespace ?? 'chat2'}
+        teamID={this.props.route.params?.teamID ?? undefined}
+        filterServices={this.props.route.params?.filterServices ?? undefined}
+        onChangeService={this.onChangeService}
+        onChangeText={this.onChangeText}
+        incHighlightIndex={this.incHighlightIndex}
+        decHighlightIndex={this.decHighlightIndex}
+        resetHighlightIndex={this.resetHighlightIndex}
+        searchString={this.state.searchString}
+        selectedService={this.state.selectedService}
+        highlightedIndex={this.state.highlightedIndex}
+        changeShowRolePicker={this.changeShowRolePicker}
+        showRolePicker={this.state.showRolePicker}
+        showServiceResultCount={false}
+        focusInputCounter={this.state.focusInputCounter}
+        incFocusInputCounter={this._incFocusInputCounter}
+        title={this.props.route.params?.title ?? ''}
+        goButtonLabel={this.props.route.params?.goButtonLabel ?? 'Start'}
+        recommendedHideYourself={this.props.route.params?.recommendedHideYourself ?? false}
+      />
+    )
+  }
 }
 
 export default StateWrapperForTeamBuilding

--- a/shared/team-building/container.tsx
+++ b/shared/team-building/container.tsx
@@ -1,13 +1,14 @@
+AAAAAAAAAAAAAAAAA working here
 import logger from '../logger'
 import * as React from 'react'
 import debounce from 'lodash/debounce'
 import trim from 'lodash/trim'
 import TeamBuilding, {
-  RolePickerProps,
-  SearchResult,
-  SearchRecSection,
-  numSectionLabel,
-  Props as TeamBuildingProps,
+    RolePickerProps,
+    SearchResult,
+    SearchRecSection,
+    numSectionLabel,
+    Props as TeamBuildingProps,
 } from '.'
 import * as WaitingConstants from '../constants/waiting'
 import * as ChatConstants from '../constants/chat2'
@@ -17,374 +18,374 @@ import * as Container from '../util/container'
 import * as Constants from '../constants/team-building'
 import * as Types from '../constants/types/team-building'
 import * as TeamTypes from '../constants/types/teams'
-import {requestIdleCallback} from '../util/idle-callback'
-import {memoizeShallow, memoize} from '../util/memoize'
-import {getDisabledReasonsForRolePicker, getTeamDetails, getTeamMeta} from '../constants/teams'
-import {nextRoleDown, nextRoleUp} from '../teams/role-picker'
-import {formatAnyPhoneNumbers} from '../util/phone-numbers'
-import {isMobile} from '../constants/platform'
+import { requestIdleCallback } from '../util/idle-callback'
+import { memoizeShallow, memoize } from '../util/memoize'
+import { getDisabledReasonsForRolePicker, getTeamDetails, getTeamMeta } from '../constants/teams'
+import { nextRoleDown, nextRoleUp } from '../teams/role-picker'
+import { formatAnyPhoneNumbers } from '../util/phone-numbers'
+import { isMobile } from '../constants/platform'
 
 // TODO remove when bots are fully integrated in gui
 type TeamRoleTypeWithoutBots = Exclude<TeamTypes.TeamRoleType, 'bot' | 'restrictedbot'>
 const filterRole = (r: TeamTypes.TeamRoleType): TeamRoleTypeWithoutBots =>
-  r === 'bot' || r === 'restrictedbot' ? 'reader' : r
+    r === 'bot' || r === 'restrictedbot' ? 'reader' : r
 
 type OwnProps = {
-  changeShowRolePicker: (showRolePicker: boolean) => void
-  decHighlightIndex: () => void
-  filterServices?: Array<Types.ServiceIdWithContact>
-  focusInputCounter: number
-  goButtonLabel?: Types.GoButtonLabel
-  recommendedHideYourself?: boolean
-  highlightedIndex: number
-  incFocusInputCounter: () => void
-  incHighlightIndex: (maxIndex: number) => void
-  namespace: Types.AllowedNamespace
-  onChangeService: (newService: Types.ServiceIdWithContact) => void
-  onChangeText: (newText: string) => void
-  resetHighlightIndex: (resetToHidden?: boolean) => void
-  searchString: string
-  selectedService: Types.ServiceIdWithContact
-  showRolePicker: boolean
-  showServiceResultCount: boolean
-  teamID?: TeamTypes.TeamID
-  title: string
+    changeShowRolePicker: (showRolePicker: boolean) => void
+    decHighlightIndex: () => void
+    filterServices?: Array<Types.ServiceIdWithContact>
+    focusInputCounter: number
+    goButtonLabel?: Types.GoButtonLabel
+    recommendedHideYourself?: boolean
+    highlightedIndex: number
+    incFocusInputCounter: () => void
+    incHighlightIndex: (maxIndex: number) => void
+    namespace: Types.AllowedNamespace
+    onChangeService: (newService: Types.ServiceIdWithContact) => void
+    onChangeText: (newText: string) => void
+    resetHighlightIndex: (resetToHidden?: boolean) => void
+    searchString: string
+    selectedService: Types.ServiceIdWithContact
+    showRolePicker: boolean
+    showServiceResultCount: boolean
+    teamID?: TeamTypes.TeamID
+    title: string
 }
 
 type LocalState = {
-  focusInputCounter: number
-  searchString: string
-  selectedService: Types.ServiceIdWithContact
-  highlightedIndex: number
-  showRolePicker: boolean
+    focusInputCounter: number
+    searchString: string
+    selectedService: Types.ServiceIdWithContact
+    highlightedIndex: number
+    showRolePicker: boolean
 }
 
 const initialState: LocalState = {
-  focusInputCounter: 0,
-  highlightedIndex: 0,
-  searchString: '',
-  selectedService: 'keybase',
-  showRolePicker: false,
+    focusInputCounter: 0,
+    highlightedIndex: 0,
+    searchString: '',
+    selectedService: 'keybase',
+    showRolePicker: false,
 }
 
 const expensiveDeriveResults = (
-  searchResults: Array<Types.User> | undefined,
-  teamSoFar: Set<Types.User>,
-  myUsername: string,
-  followingState: Set<string>,
-  preExistingTeamMembers: Map<string, TeamTypes.MemberInfo>
+    searchResults: Array<Types.User> | undefined,
+    teamSoFar: Set<Types.User>,
+    myUsername: string,
+    followingState: Set<string>,
+    preExistingTeamMembers: Map<string, TeamTypes.MemberInfo>
 ) =>
-  searchResults &&
-  searchResults.map(info => {
-    const label = info.label || ''
-    return {
-      contact: !!info.contact,
-      displayLabel: formatAnyPhoneNumbers(label),
-      followingState: Constants.followStateHelperWithId(myUsername, followingState, info.serviceMap.keybase),
-      inTeam: [...teamSoFar].some(u => u.id === info.id),
-      isPreExistingTeamMember: preExistingTeamMembers.has(info.id),
-      isYou: info.username === myUsername,
-      key: [info.id, info.prettyName, info.label, String(!!info.contact)].join('&'),
-      pictureUrl: info.pictureUrl,
-      prettyName: formatAnyPhoneNumbers(info.prettyName),
-      services: info.serviceMap,
-      userId: info.id,
-      username: info.username,
-    }
-  })
+    searchResults &&
+    searchResults.map(info => {
+        const label = info.label || ''
+        return {
+            contact: !!info.contact,
+            displayLabel: formatAnyPhoneNumbers(label),
+            followingState: Constants.followStateHelperWithId(myUsername, followingState, info.serviceMap.keybase),
+            inTeam: [...teamSoFar].some(u => u.id === info.id),
+            isPreExistingTeamMember: preExistingTeamMembers.has(info.id),
+            isYou: info.username === myUsername,
+            key: [info.id, info.prettyName, info.label, String(!!info.contact)].join('&'),
+            pictureUrl: info.pictureUrl,
+            prettyName: formatAnyPhoneNumbers(info.prettyName),
+            services: info.serviceMap,
+            userId: info.id,
+            username: info.username,
+        }
+    })
 
 const deriveSearchResults = memoize(expensiveDeriveResults)
 const deriveRecommendation = memoize(expensiveDeriveResults)
 
 const deriveTeamSoFar = memoize(
-  (teamSoFar: Set<Types.User>): Array<Types.SelectedUser> =>
-    [...teamSoFar].map(userInfo => {
-      let username = ''
-      let serviceId: Types.ServiceIdWithContact
-      if (userInfo.contact && userInfo.serviceMap.keybase) {
-        // resolved contact - pass username @ 'keybase' to teambox
-        // so keybase avatar is rendered.
-        username = userInfo.serviceMap.keybase
-        serviceId = 'keybase'
-      } else if (userInfo.serviceId !== 'keybase' && userInfo.serviceMap.keybase) {
-        // Not a keybase result but has Keybase username. Id will be compound assertion,
-        // but we want to display Keybase username and profile pic in teambox.
-        username = userInfo.serviceMap.keybase
-        serviceId = 'keybase'
-      } else {
-        username = userInfo.username
-        serviceId = userInfo.serviceId
-      }
-      return {
-        pictureUrl: userInfo.pictureUrl,
-        prettyName: userInfo.prettyName !== username ? userInfo.prettyName : '',
-        service: serviceId,
-        userId: userInfo.id,
-        username,
-      }
-    })
+    (teamSoFar: Set<Types.User>): Array<Types.SelectedUser> =>
+        [...teamSoFar].map(userInfo => {
+            let username = ''
+            let serviceId: Types.ServiceIdWithContact
+            if (userInfo.contact && userInfo.serviceMap.keybase) {
+                // resolved contact - pass username @ 'keybase' to teambox
+                // so keybase avatar is rendered.
+                username = userInfo.serviceMap.keybase
+                serviceId = 'keybase'
+            } else if (userInfo.serviceId !== 'keybase' && userInfo.serviceMap.keybase) {
+                // Not a keybase result but has Keybase username. Id will be compound assertion,
+                // but we want to display Keybase username and profile pic in teambox.
+                username = userInfo.serviceMap.keybase
+                serviceId = 'keybase'
+            } else {
+                username = userInfo.username
+                serviceId = userInfo.serviceId
+            }
+            return {
+                pictureUrl: userInfo.pictureUrl,
+                prettyName: userInfo.prettyName !== username ? userInfo.prettyName : '',
+                service: serviceId,
+                userId: userInfo.id,
+                username,
+            }
+        })
 )
 
 const _deriveServiceResultCount = memoize((searchResults: Types.SearchResults, query: string) =>
-  [...(searchResults.get(trim(query)) ?? new Map<Types.ServiceIdWithContact, Array<Types.User>>()).entries()]
-    .map(([key, results]) => [key, results.length] as const)
-    .reduce<{[k: string]: number}>((o, [key, num]) => {
-      o[key] = num
-      return o
-    }, {})
+    [...(searchResults.get(trim(query)) ?? new Map<Types.ServiceIdWithContact, Array<Types.User>>()).entries()]
+        .map(([key, results]) => [key, results.length] as const)
+        .reduce<{ [k: string]: number }>((o, [key, num]) => {
+            o[key] = num
+            return o
+        }, {})
 )
 const emptyObject = {}
 const deriveServiceResultCount = (searchResults: Types.SearchResults, query: string) => {
-  const val = _deriveServiceResultCount(searchResults, query)
-  if (Object.keys(val)) {
-    return val
-  }
-  return emptyObject
+    const val = _deriveServiceResultCount(searchResults, query)
+    if (Object.keys(val)) {
+        return val
+    }
+    return emptyObject
 }
 
 const deriveShowResults = memoize(searchString => !!searchString)
 
 const deriveUserFromUserIdFn = memoize(
-  (searchResults: Array<Types.User> | undefined, recommendations: Array<Types.User> | undefined) =>
-    (userId: string): Types.User | null =>
-      (searchResults || []).filter(u => u.id === userId)[0] ||
-      (recommendations || []).filter(u => u.id === userId)[0] ||
-      null
+    (searchResults: Array<Types.User> | undefined, recommendations: Array<Types.User> | undefined) =>
+        (userId: string): Types.User | null =>
+            (searchResults || []).filter(u => u.id === userId)[0] ||
+            (recommendations || []).filter(u => u.id === userId)[0] ||
+            null
 )
 
 const emptyObj = {}
 const emptyMap = new Map()
 
 const mapStateToProps = (state: Container.TypedState, ownProps: OwnProps) => {
-  const teamBuildingState = state[ownProps.namespace].teamBuilding
-  const teamBuildingSearchResults = teamBuildingState.searchResults
-  const userResults: Array<Types.User> | undefined = teamBuildingState.searchResults
-    .get(trim(ownProps.searchString))
-    ?.get(ownProps.selectedService)
+    const teamBuildingState = state[ownProps.namespace].teamBuilding
+    const teamBuildingSearchResults = teamBuildingState.searchResults
+    const userResults: Array<Types.User> | undefined = teamBuildingState.searchResults
+        .get(trim(ownProps.searchString))
+        ?.get(ownProps.selectedService)
 
-  const maybeTeamMeta = ownProps.teamID ? getTeamMeta(state, ownProps.teamID) : undefined
-  const maybeTeamDetails = ownProps.teamID ? getTeamDetails(state, ownProps.teamID) : undefined
-  const preExistingTeamMembers: TeamTypes.TeamDetails['members'] = maybeTeamDetails?.members ?? emptyMap
-  const disabledRoles = ownProps.teamID
-    ? getDisabledReasonsForRolePicker(state, ownProps.teamID, null)
-    : emptyObj
+    const maybeTeamMeta = ownProps.teamID ? getTeamMeta(state, ownProps.teamID) : undefined
+    const maybeTeamDetails = ownProps.teamID ? getTeamDetails(state, ownProps.teamID) : undefined
+    const preExistingTeamMembers: TeamTypes.TeamDetails['members'] = maybeTeamDetails?.members ?? emptyMap
+    const disabledRoles = ownProps.teamID
+        ? getDisabledReasonsForRolePicker(state, ownProps.teamID, null)
+        : emptyObj
 
-  const contactProps = {
-    contactsImported: state.settings.contacts.importEnabled,
-    contactsPermissionStatus: state.settings.contacts.permissionStatus,
-    isImportPromptDismissed: state.settings.contacts.importPromptDismissed,
-    numContactsImported: state.settings.contacts.importedCount,
-  }
+    const contactProps = {
+        contactsImported: state.settings.contacts.importEnabled,
+        contactsPermissionStatus: state.settings.contacts.permissionStatus,
+        isImportPromptDismissed: state.settings.contacts.importPromptDismissed,
+        numContactsImported: state.settings.contacts.importedCount,
+    }
 
-  return {
-    ...contactProps,
-    disabledRoles,
-    error: teamBuildingState.error,
-    recommendations: deriveRecommendation(
-      teamBuildingState.userRecs,
-      teamBuildingState.teamSoFar,
-      state.config.username,
-      state.config.following,
-      preExistingTeamMembers
-    ),
-    searchResults: deriveSearchResults(
-      userResults,
-      teamBuildingState.teamSoFar,
-      state.config.username,
-      state.config.following,
-      preExistingTeamMembers
-    ),
-    selectedRole: filterRole(teamBuildingState.selectedRole),
-    sendNotification: teamBuildingState.sendNotification,
-    serviceResultCount: deriveServiceResultCount(teamBuildingState.searchResults, ownProps.searchString),
-    showResults: deriveShowResults(ownProps.searchString),
-    showServiceResultCount: !isMobile && deriveShowResults(ownProps.searchString),
-    teamBuildingSearchResults,
-    teamSoFar: deriveTeamSoFar(teamBuildingState.teamSoFar),
-    teamname: maybeTeamMeta?.teamname,
-    userFromUserId: deriveUserFromUserIdFn(userResults, teamBuildingState.userRecs),
-    waitingForCreate: WaitingConstants.anyWaiting(state, ChatConstants.waitingKeyCreating),
-  }
+    return {
+        ...contactProps,
+        disabledRoles,
+        error: teamBuildingState.error,
+        recommendations: deriveRecommendation(
+            teamBuildingState.userRecs,
+            teamBuildingState.teamSoFar,
+            state.config.username,
+            state.config.following,
+            preExistingTeamMembers
+        ),
+        searchResults: deriveSearchResults(
+            userResults,
+            teamBuildingState.teamSoFar,
+            state.config.username,
+            state.config.following,
+            preExistingTeamMembers
+        ),
+        selectedRole: filterRole(teamBuildingState.selectedRole),
+        sendNotification: teamBuildingState.sendNotification,
+        serviceResultCount: deriveServiceResultCount(teamBuildingState.searchResults, ownProps.searchString),
+        showResults: deriveShowResults(ownProps.searchString),
+        showServiceResultCount: !isMobile && deriveShowResults(ownProps.searchString),
+        teamBuildingSearchResults,
+        teamSoFar: deriveTeamSoFar(teamBuildingState.teamSoFar),
+        teamname: maybeTeamMeta?.teamname,
+        userFromUserId: deriveUserFromUserIdFn(userResults, teamBuildingState.userRecs),
+        waitingForCreate: WaitingConstants.anyWaiting(state, ChatConstants.waitingKeyCreating),
+    }
 }
 
 const makeDebouncedSearch = (time: number) =>
-  debounce(
-    (
-      dispatch: Container.TypedDispatch,
-      namespace: Types.AllowedNamespace,
-      query: string,
-      service: Types.ServiceIdWithContact,
-      includeContacts: boolean,
-      limit?: number
-    ) => {
-      requestIdleCallback(() => {
-        dispatch(
-          TeamBuildingGen.createSearch({
-            includeContacts,
-            limit,
-            namespace,
-            query,
-            service,
-          })
-        )
-      })
-    },
-    time
-  )
+    debounce(
+        (
+            dispatch: Container.TypedDispatch,
+            namespace: Types.AllowedNamespace,
+            query: string,
+            service: Types.ServiceIdWithContact,
+            includeContacts: boolean,
+            limit?: number
+        ) => {
+            requestIdleCallback(() => {
+                dispatch(
+                    TeamBuildingGen.createSearch({
+                        includeContacts,
+                        limit,
+                        namespace,
+                        query,
+                        service,
+                    })
+                )
+            })
+        },
+        time
+    )
 
 const debouncedSearch = makeDebouncedSearch(500) // 500ms debounce on social searches
 const debouncedSearchKeybase = makeDebouncedSearch(200) // 200 ms debounce on keybase searches
 
-const mapDispatchToProps = (dispatch: Container.TypedDispatch, {namespace, teamID}: OwnProps) => ({
-  _onAdd: (user: Types.User) =>
-    dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({namespace, users: [user]})),
-  _onCancelTeamBuilding: () => dispatch(TeamBuildingGen.createCancelTeamBuilding({namespace})),
-  _onImportContactsPermissionsGranted: () =>
-    dispatch(SettingsGen.createEditContactImportEnabled({enable: true, fromSettings: false})),
-  _onImportContactsPermissionsNotGranted: () =>
-    dispatch(SettingsGen.createRequestContactPermissions({fromSettings: false, thenToggleImportOn: true})),
-  _search: (query: string, service: Types.ServiceIdWithContact, limit?: number) => {
-    const func = service === 'keybase' ? debouncedSearchKeybase : debouncedSearch
-    return func(dispatch, namespace, query, service, namespace === 'chat2', limit)
-  },
-  fetchUserRecs: () =>
-    dispatch(TeamBuildingGen.createFetchUserRecs({includeContacts: namespace === 'chat2', namespace})),
-  onAskForContactsLater: () => dispatch(SettingsGen.createImportContactsLater()),
-  onChangeSendNotification: (sendNotification: boolean) =>
-    namespace === 'teams' &&
-    dispatch(TeamBuildingGen.createChangeSendNotification({namespace, sendNotification})),
-  onFinishTeamBuilding: () =>
-    dispatch(
-      namespace === 'teams'
-        ? TeamBuildingGen.createFinishTeamBuilding({namespace, teamID})
-        : TeamBuildingGen.createFinishedTeamBuilding({namespace})
-    ),
-  onLoadContactsSetting: () => dispatch(SettingsGen.createLoadContactImportEnabled()),
-  onRemove: (userId: string) =>
-    dispatch(TeamBuildingGen.createRemoveUsersFromTeamSoFar({namespace, users: [userId]})),
-  onSelectRole: (role: TeamTypes.TeamRoleType) =>
-    namespace === 'teams' && dispatch(TeamBuildingGen.createSelectRole({namespace, role})),
+const mapDispatchToProps = (dispatch: Container.TypedDispatch, { namespace, teamID }: OwnProps) => ({
+    _onAdd: (user: Types.User) =>
+        dispatch(TeamBuildingGen.createAddUsersToTeamSoFar({ namespace, users: [user] })),
+    _onCancelTeamBuilding: () => dispatch(TeamBuildingGen.createCancelTeamBuilding({ namespace })),
+    _onImportContactsPermissionsGranted: () =>
+        dispatch(SettingsGen.createEditContactImportEnabled({ enable: true, fromSettings: false })),
+    _onImportContactsPermissionsNotGranted: () =>
+        dispatch(SettingsGen.createRequestContactPermissions({ fromSettings: false, thenToggleImportOn: true })),
+    _search: (query: string, service: Types.ServiceIdWithContact, limit?: number) => {
+        const func = service === 'keybase' ? debouncedSearchKeybase : debouncedSearch
+        return func(dispatch, namespace, query, service, namespace === 'chat2', limit)
+    },
+    fetchUserRecs: () =>
+        dispatch(TeamBuildingGen.createFetchUserRecs({ includeContacts: namespace === 'chat2', namespace })),
+    onAskForContactsLater: () => dispatch(SettingsGen.createImportContactsLater()),
+    onChangeSendNotification: (sendNotification: boolean) =>
+        namespace === 'teams' &&
+        dispatch(TeamBuildingGen.createChangeSendNotification({ namespace, sendNotification })),
+    onFinishTeamBuilding: () =>
+        dispatch(
+            namespace === 'teams'
+                ? TeamBuildingGen.createFinishTeamBuilding({ namespace, teamID })
+                : TeamBuildingGen.createFinishedTeamBuilding({ namespace })
+        ),
+    onLoadContactsSetting: () => dispatch(SettingsGen.createLoadContactImportEnabled()),
+    onRemove: (userId: string) =>
+        dispatch(TeamBuildingGen.createRemoveUsersFromTeamSoFar({ namespace, users: [userId] })),
+    onSelectRole: (role: TeamTypes.TeamRoleType) =>
+        namespace === 'teams' && dispatch(TeamBuildingGen.createSelectRole({ namespace, role })),
 })
 
 const deriveOnEnterKeyDown = memoizeShallow(
-  (p: {
-      changeText: (s: string) => void
-      highlightedIndex: number
-      onAdd: (id: string) => void
-      onFinishTeamBuilding: () => void
-      onRemove: (id: string) => void
-      searchResults: Array<SearchResult>
-      searchStringIsEmpty: string
-      teamSoFar: Array<Types.SelectedUser>
+    (p: {
+        changeText: (s: string) => void
+        highlightedIndex: number
+        onAdd: (id: string) => void
+        onFinishTeamBuilding: () => void
+        onRemove: (id: string) => void
+        searchResults: Array<SearchResult>
+        searchStringIsEmpty: string
+        teamSoFar: Array<Types.SelectedUser>
     }) =>
-    () => {
-      const {onRemove, changeText, searchStringIsEmpty, onFinishTeamBuilding} = p
-      const {searchResults, teamSoFar, highlightedIndex, onAdd} = p
-      const selectedResult = !!searchResults && searchResults[highlightedIndex]
-      if (selectedResult) {
-        // We don't handle cases where they hit enter on someone that is already a
-        // team member
-        if (selectedResult.isPreExistingTeamMember) {
-          return
+        () => {
+            const { onRemove, changeText, searchStringIsEmpty, onFinishTeamBuilding } = p
+            const { searchResults, teamSoFar, highlightedIndex, onAdd } = p
+            const selectedResult = !!searchResults && searchResults[highlightedIndex]
+            if (selectedResult) {
+                // We don't handle cases where they hit enter on someone that is already a
+                // team member
+                if (selectedResult.isPreExistingTeamMember) {
+                    return
+                }
+                if (teamSoFar.filter(u => u.userId === selectedResult.userId).length) {
+                    onRemove(selectedResult.userId)
+                    changeText('')
+                } else {
+                    onAdd(selectedResult.userId)
+                }
+            } else if (searchStringIsEmpty && !!teamSoFar.length) {
+                // They hit enter with an empty search string and a teamSoFar
+                // We'll Finish the team building
+                onFinishTeamBuilding()
+            }
         }
-        if (teamSoFar.filter(u => u.userId === selectedResult.userId).length) {
-          onRemove(selectedResult.userId)
-          changeText('')
-        } else {
-          onAdd(selectedResult.userId)
-        }
-      } else if (searchStringIsEmpty && !!teamSoFar.length) {
-        // They hit enter with an empty search string and a teamSoFar
-        // We'll Finish the team building
-        onFinishTeamBuilding()
-      }
-    }
 )
 
 const deriveOnSearchForMore = memoizeShallow(
-  (p: {
-      search: (q: string, sid: Types.ServiceIdWithContact, limit?: number) => void
-      searchResults: Array<Types.User>
-      searchString: string
-      selectedService: Types.ServiceIdWithContact
+    (p: {
+        search: (q: string, sid: Types.ServiceIdWithContact, limit?: number) => void
+        searchResults: Array<Types.User>
+        searchString: string
+        selectedService: Types.ServiceIdWithContact
     }) =>
-    () => {
-      const {search, searchResults, searchString, selectedService} = p
-      if (searchResults && searchResults.length >= 10) {
-        search(searchString, selectedService, searchResults.length + 20)
-      }
-    }
+        () => {
+            const { search, searchResults, searchString, selectedService } = p
+            if (searchResults && searchResults.length >= 10) {
+                search(searchString, selectedService, searchResults.length + 20)
+            }
+        }
 )
 
 const deriveOnAdd = memoize(
-  (userFromUserId, dispatchOnAdd, changeText, resetHighlightIndex, incFocusInputCounter) =>
-    (userId: string) => {
-      const user = userFromUserId(userId)
-      if (!user) {
-        logger.error(`Couldn't find Types.User to add for ${userId}`)
-        changeText('')
-        return
-      }
-      changeText('')
-      dispatchOnAdd(user)
-      resetHighlightIndex(true)
-      incFocusInputCounter()
-    }
+    (userFromUserId, dispatchOnAdd, changeText, resetHighlightIndex, incFocusInputCounter) =>
+        (userId: string) => {
+            const user = userFromUserId(userId)
+            if (!user) {
+                logger.error(`Couldn't find Types.User to add for ${userId}`)
+                changeText('')
+                return
+            }
+            changeText('')
+            dispatchOnAdd(user)
+            resetHighlightIndex(true)
+            incFocusInputCounter()
+        }
 )
 
 const deriveOnChangeText = memoize(
-  (
-      onChangeText: (newText: string) => void,
-      search: (text: string, service: Types.ServiceIdWithContact) => void,
-      selectedService: Types.ServiceIdWithContact,
-      resetHighlightIndex: Function
+    (
+        onChangeText: (newText: string) => void,
+        search: (text: string, service: Types.ServiceIdWithContact) => void,
+        selectedService: Types.ServiceIdWithContact,
+        resetHighlightIndex: Function
     ) =>
-    (newText: string) => {
-      onChangeText(newText)
-      search(newText, selectedService)
-      resetHighlightIndex()
-    }
+        (newText: string) => {
+            onChangeText(newText)
+            search(newText, selectedService)
+            resetHighlightIndex()
+        }
 )
 
 const deriveOnDownArrowKeyDown = memoize(
-  (maxIndex: number, incHighlightIndex: (maxIndex: number) => void) => () => incHighlightIndex(maxIndex)
+    (maxIndex: number, incHighlightIndex: (maxIndex: number) => void) => () => incHighlightIndex(maxIndex)
 )
 
 const deriveRolePickerArrowKeyFns = memoize(
-  (
-    selectedRole: TeamRoleTypeWithoutBots,
-    disabledRoles: TeamTypes.DisabledReasonsForRolePicker,
-    onSelectRole: (role: TeamRoleTypeWithoutBots) => void
-  ) => ({
-    downArrow: () => {
-      const nextRole = nextRoleDown(selectedRole)
-      if (!disabledRoles[nextRole]) {
-        onSelectRole(nextRole)
-      }
-    },
-    upArrow: () => {
-      const nextRole = nextRoleUp(selectedRole)
-      if (!disabledRoles[nextRole]) {
-        onSelectRole(nextRole)
-      }
-    },
-  })
+    (
+        selectedRole: TeamRoleTypeWithoutBots,
+        disabledRoles: TeamTypes.DisabledReasonsForRolePicker,
+        onSelectRole: (role: TeamRoleTypeWithoutBots) => void
+    ) => ({
+        downArrow: () => {
+            const nextRole = nextRoleDown(selectedRole)
+            if (!disabledRoles[nextRole]) {
+                onSelectRole(nextRole)
+            }
+        },
+        upArrow: () => {
+            const nextRole = nextRoleUp(selectedRole)
+            if (!disabledRoles[nextRole]) {
+                onSelectRole(nextRole)
+            }
+        },
+    })
 )
 
 const deriveOnChangeService = memoize(
-  (
-      onChangeService: OwnProps['onChangeService'],
-      incFocusInputCounter: OwnProps['incFocusInputCounter'],
-      search: (text: string, service: Types.ServiceIdWithContact) => void,
-      searchString: string
+    (
+        onChangeService: OwnProps['onChangeService'],
+        incFocusInputCounter: OwnProps['incFocusInputCounter'],
+        search: (text: string, service: Types.ServiceIdWithContact) => void,
+        searchString: string
     ) =>
-    (service: Types.ServiceIdWithContact) => {
-      onChangeService(service)
-      incFocusInputCounter()
-      if (!Types.isContactServiceId(service)) {
-        search(searchString, service)
-      }
-    }
+        (service: Types.ServiceIdWithContact) => {
+            onChangeService(service)
+            incFocusInputCounter()
+            if (!Types.isContactServiceId(service)) {
+                search(searchString, service)
+            }
+        }
 )
 
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'
@@ -398,75 +399,75 @@ const letterToAlphaIndex = (letter: string) => letter.charCodeAt(0) - aCharCode
 // 1-26 - a-z sections
 // 27 - 0-9 section
 export const sortAndSplitRecommendations = memoize(
-  (
-    results: Unpacked<typeof deriveSearchResults>,
-    showingContactsButton: boolean
-  ): Array<SearchRecSection> | null => {
-    if (!results) return null
+    (
+        results: Unpacked<typeof deriveSearchResults>,
+        showingContactsButton: boolean
+    ): Array<SearchRecSection> | null => {
+        if (!results) return null
 
-    const sections: Array<SearchRecSection> = [
-      ...(showingContactsButton
-        ? [
+        const sections: Array<SearchRecSection> = [
+            ...(showingContactsButton
+                ? [
+                    {
+                        data: [{ isImportButton: true as const }],
+                        label: '',
+                        shortcut: false,
+                    },
+                ]
+                : []),
+
             {
-              data: [{isImportButton: true as const}],
-              label: '',
-              shortcut: false,
+                data: [],
+                label: 'Recommendations',
+                shortcut: false,
             },
-          ]
-        : []),
-
-      {
-        data: [],
-        label: 'Recommendations',
-        shortcut: false,
-      },
-    ]
-    const recSectionIdx = sections.length - 1
-    const numSectionIdx = recSectionIdx + 27
-    results.forEach(rec => {
-      if (!rec.contact) {
-        sections[recSectionIdx].data.push(rec)
-        return
-      }
-      if (rec.prettyName || rec.displayLabel) {
-        // Use the first letter of the name we will display, but first normalize out
-        // any diacritics.
-        const decodedLetter = /*unidecode*/ rec.prettyName || rec.displayLabel
-        if (decodedLetter && decodedLetter[0]) {
-          const letter = decodedLetter[0].toLowerCase()
-          if (isAlpha(letter)) {
-            // offset 1 to skip recommendations
-            const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1
-            if (!sections[sectionIdx]) {
-              sections[sectionIdx] = {
-                data: [],
-                label: letter.toUpperCase(),
-                shortcut: true,
-              }
+        ]
+        const recSectionIdx = sections.length - 1
+        const numSectionIdx = recSectionIdx + 27
+        results.forEach(rec => {
+            if (!rec.contact) {
+                sections[recSectionIdx].data.push(rec)
+                return
             }
-            sections[sectionIdx].data.push(rec)
-          } else {
-            if (!sections[numSectionIdx]) {
-              sections[numSectionIdx] = {
-                data: [],
-                label: numSectionLabel,
-                shortcut: true,
-              }
+            if (rec.prettyName || rec.displayLabel) {
+                // Use the first letter of the name we will display, but first normalize out
+                // any diacritics.
+                const decodedLetter = /*unidecode*/ rec.prettyName || rec.displayLabel
+                if (decodedLetter && decodedLetter[0]) {
+                    const letter = decodedLetter[0].toLowerCase()
+                    if (isAlpha(letter)) {
+                        // offset 1 to skip recommendations
+                        const sectionIdx = letterToAlphaIndex(letter) + recSectionIdx + 1
+                        if (!sections[sectionIdx]) {
+                            sections[sectionIdx] = {
+                                data: [],
+                                label: letter.toUpperCase(),
+                                shortcut: true,
+                            }
+                        }
+                        sections[sectionIdx].data.push(rec)
+                    } else {
+                        if (!sections[numSectionIdx]) {
+                            sections[numSectionIdx] = {
+                                data: [],
+                                label: numSectionLabel,
+                                shortcut: true,
+                            }
+                        }
+                        sections[numSectionIdx].data.push(rec)
+                    }
+                }
             }
-            sections[numSectionIdx].data.push(rec)
-          }
+        })
+        if (results.length < 5) {
+            sections.push({
+                data: [{ isSearchHint: true as const }],
+                label: '',
+                shortcut: false,
+            })
         }
-      }
-    })
-    if (results.length < 5) {
-      sections.push({
-        data: [{isSearchHint: true as const}],
-        label: '',
-        shortcut: false,
-      })
+        return sections.filter(s => s && s.data && s.data.length > 0)
     }
-    return sections.filter(s => s && s.data && s.data.length > 0)
-  }
 )
 
 // Flatten list of recommendation sections. After recommendations are organized
@@ -476,235 +477,230 @@ export const sortAndSplitRecommendations = memoize(
 //
 // Resulting list may have nulls in place of fake rows.
 const flattenRecommendations = memoize((recommendations: Array<SearchRecSection>) => {
-  const result: Array<SearchResult | null> = []
-  for (const section of recommendations) {
-    result.push(...section.data.map(rec => ('isImportButton' in rec || 'isSearchHint' in rec ? null : rec)))
-  }
-  return result
+    const result: Array<SearchResult | null> = []
+    for (const section of recommendations) {
+        result.push(...section.data.map(rec => ('isImportButton' in rec || 'isSearchHint' in rec ? null : rec)))
+    }
+    return result
 })
 
 type TeamBuildingPropsPlusSome = TeamBuildingProps & {
-  [key: string]: any
+    [key: string]: any
 }
 const mergeProps = (
-  stateProps: ReturnType<typeof mapStateToProps>,
-  dispatchProps: ReturnType<typeof mapDispatchToProps>,
-  ownProps: OwnProps
+    stateProps: ReturnType<typeof mapStateToProps>,
+    dispatchProps: ReturnType<typeof mapDispatchToProps>,
+    ownProps: OwnProps
 ): TeamBuildingPropsPlusSome => {
-  const {
-    teamSoFar,
-    searchResults,
-    userFromUserId,
-    serviceResultCount,
-    showServiceResultCount,
-    recommendations,
-    waitingForCreate,
-  } = stateProps
+    const {
+        teamSoFar,
+        searchResults,
+        userFromUserId,
+        serviceResultCount,
+        showServiceResultCount,
+        recommendations,
+        waitingForCreate,
+    } = stateProps
 
-  const showingContactsButton =
-    Container.isMobile &&
-    stateProps.contactsPermissionStatus !== 'never_ask_again' &&
-    !stateProps.contactsImported
+    const showingContactsButton =
+        Container.isMobile &&
+        stateProps.contactsPermissionStatus !== 'never_ask_again' &&
+        !stateProps.contactsImported
 
-  // Contacts props
-  const contactProps = {
-    contactsImported: stateProps.contactsImported,
-    contactsPermissionStatus: stateProps.contactsPermissionStatus,
-    isImportPromptDismissed: stateProps.isImportPromptDismissed,
-    numContactsImported: stateProps.numContactsImported || 0,
-    onAskForContactsLater: dispatchProps.onAskForContactsLater,
-    onImportContacts:
-      stateProps.contactsPermissionStatus === 'never_ask_again'
-        ? undefined
-        : stateProps.contactsPermissionStatus === 'granted'
-        ? dispatchProps._onImportContactsPermissionsGranted
-        : dispatchProps._onImportContactsPermissionsNotGranted,
-    onLoadContactsSetting: dispatchProps.onLoadContactsSetting,
-  }
+    // Contacts props
+    const contactProps = {
+        contactsImported: stateProps.contactsImported,
+        contactsPermissionStatus: stateProps.contactsPermissionStatus,
+        isImportPromptDismissed: stateProps.isImportPromptDismissed,
+        numContactsImported: stateProps.numContactsImported || 0,
+        onAskForContactsLater: dispatchProps.onAskForContactsLater,
+        onImportContacts:
+            stateProps.contactsPermissionStatus === 'never_ask_again'
+                ? undefined
+                : stateProps.contactsPermissionStatus === 'granted'
+                    ? dispatchProps._onImportContactsPermissionsGranted
+                    : dispatchProps._onImportContactsPermissionsNotGranted,
+        onLoadContactsSetting: dispatchProps.onLoadContactsSetting,
+    }
 
-  const showRecs = !ownProps.searchString && !!recommendations && ownProps.selectedService === 'keybase'
-  const recommendationsSections = showRecs
-    ? sortAndSplitRecommendations(recommendations, showingContactsButton)
-    : null
-  const userResultsToShow = showRecs ? flattenRecommendations(recommendationsSections || []) : searchResults
+    const showRecs = !ownProps.searchString && !!recommendations && ownProps.selectedService === 'keybase'
+    const recommendationsSections = showRecs
+        ? sortAndSplitRecommendations(recommendations, showingContactsButton)
+        : null
+    const userResultsToShow = showRecs ? flattenRecommendations(recommendationsSections || []) : searchResults
 
-  const onChangeText = deriveOnChangeText(
-    ownProps.onChangeText,
-    dispatchProps._search,
-    ownProps.selectedService,
-    ownProps.resetHighlightIndex
-  )
+    const onChangeText = deriveOnChangeText(
+        ownProps.onChangeText,
+        dispatchProps._search,
+        ownProps.selectedService,
+        ownProps.resetHighlightIndex
+    )
 
-  const onClear = () => onChangeText('')
+    const onClear = () => onChangeText('')
 
-  const onSearchForMore = deriveOnSearchForMore({
-    search: dispatchProps._search,
-    searchResults,
-    searchString: ownProps.searchString,
-    selectedService: ownProps.selectedService,
-  })
+    const onSearchForMore = deriveOnSearchForMore({
+        search: dispatchProps._search,
+        searchResults,
+        searchString: ownProps.searchString,
+        selectedService: ownProps.selectedService,
+    })
 
-  const onAdd = deriveOnAdd(
-    userFromUserId,
-    dispatchProps._onAdd,
-    ownProps.onChangeText,
-    ownProps.resetHighlightIndex,
-    ownProps.incFocusInputCounter
-  )
+    const onAdd = deriveOnAdd(
+        userFromUserId,
+        dispatchProps._onAdd,
+        ownProps.onChangeText,
+        ownProps.resetHighlightIndex,
+        ownProps.incFocusInputCounter
+    )
 
-  const rolePickerProps: RolePickerProps | undefined =
-    ownProps.namespace === 'teams'
-      ? {
-          changeSendNotification: dispatchProps.onChangeSendNotification,
-          changeShowRolePicker: ownProps.changeShowRolePicker,
-          disabledRoles: stateProps.disabledRoles,
-          onSelectRole: dispatchProps.onSelectRole,
-          selectedRole: stateProps.selectedRole,
-          sendNotification: stateProps.sendNotification,
-          showRolePicker: ownProps.showRolePicker,
-        }
-      : undefined
+    const rolePickerProps: RolePickerProps | undefined =
+        ownProps.namespace === 'teams'
+            ? {
+                changeSendNotification: dispatchProps.onChangeSendNotification,
+                changeShowRolePicker: ownProps.changeShowRolePicker,
+                disabledRoles: stateProps.disabledRoles,
+                onSelectRole: dispatchProps.onSelectRole,
+                selectedRole: stateProps.selectedRole,
+                sendNotification: stateProps.sendNotification,
+                showRolePicker: ownProps.showRolePicker,
+            }
+            : undefined
 
-  // TODO this should likely live with the role picker if we need this
-  // functionality elsewhere. Right now it's easier to keep here since the input
-  // already catches all keypresses
-  const rolePickerArrowKeyFns =
-    ownProps.showRolePicker &&
-    deriveRolePickerArrowKeyFns(stateProps.selectedRole, stateProps.disabledRoles, dispatchProps.onSelectRole)
+    // TODO this should likely live with the role picker if we need this
+    // functionality elsewhere. Right now it's easier to keep here since the input
+    // already catches all keypresses
+    const rolePickerArrowKeyFns =
+        ownProps.showRolePicker &&
+        deriveRolePickerArrowKeyFns(stateProps.selectedRole, stateProps.disabledRoles, dispatchProps.onSelectRole)
 
-  const onEnterKeyDown = deriveOnEnterKeyDown({
-    changeText: ownProps.onChangeText,
-    highlightedIndex: ownProps.highlightedIndex,
-    onAdd,
-    onFinishTeamBuilding:
-      rolePickerProps && !ownProps.showRolePicker
-        ? () => ownProps.changeShowRolePicker(true)
-        : dispatchProps.onFinishTeamBuilding,
-    onRemove: dispatchProps.onRemove,
-    searchResults: userResultsToShow,
-    searchStringIsEmpty: !ownProps.searchString,
-    teamSoFar,
-  })
+    const onEnterKeyDown = deriveOnEnterKeyDown({
+        changeText: ownProps.onChangeText,
+        highlightedIndex: ownProps.highlightedIndex,
+        onAdd,
+        onFinishTeamBuilding:
+            rolePickerProps && !ownProps.showRolePicker
+                ? () => ownProps.changeShowRolePicker(true)
+                : dispatchProps.onFinishTeamBuilding,
+        onRemove: dispatchProps.onRemove,
+        searchResults: userResultsToShow,
+        searchStringIsEmpty: !ownProps.searchString,
+        teamSoFar,
+    })
 
-  const title = ownProps.namespace === 'teams' ? `Add to ${stateProps.teamname}` : ownProps.title
+    const title = ownProps.namespace === 'teams' ? `Add to ${stateProps.teamname}` : ownProps.title
 
-  return {
-    ...contactProps,
-    error: stateProps.error,
-    fetchUserRecs: dispatchProps.fetchUserRecs,
-    filterServices: ownProps.filterServices,
-    focusInputCounter: ownProps.focusInputCounter,
-    goButtonLabel: ownProps.goButtonLabel,
-    highlightedIndex: ownProps.highlightedIndex,
-    includeContacts: ownProps.namespace === 'chat2',
-    namespace: ownProps.namespace,
-    onAdd,
-    onChangeService: deriveOnChangeService(
-      ownProps.onChangeService,
-      ownProps.incFocusInputCounter,
-      dispatchProps._search,
-      ownProps.searchString
-    ),
-    onChangeText,
-    onClear,
-    onClose: dispatchProps._onCancelTeamBuilding,
-    onClosePopup: dispatchProps._onCancelTeamBuilding,
-    onDownArrowKeyDown:
-      ownProps.showRolePicker && rolePickerArrowKeyFns
-        ? rolePickerArrowKeyFns.downArrow
-        : deriveOnDownArrowKeyDown((userResultsToShow || []).length - 1, ownProps.incHighlightIndex),
-    onEnterKeyDown,
-    onFinishTeamBuilding: dispatchProps.onFinishTeamBuilding,
-    onMakeItATeam: () => console.log('todo'),
-    onRemove: dispatchProps.onRemove,
-    onSearchForMore,
-    onUpArrowKeyDown:
-      ownProps.showRolePicker && rolePickerArrowKeyFns
-        ? rolePickerArrowKeyFns.upArrow
-        : ownProps.decHighlightIndex,
-    recommendations: recommendationsSections,
-    recommendedHideYourself: ownProps.recommendedHideYourself,
-    rolePickerProps,
-    search: dispatchProps._search,
-    searchResults,
-    searchString: ownProps.searchString,
-    selectedService: ownProps.selectedService,
-    serviceResultCount,
-    showRecs,
-    showResults: stateProps.showResults,
-    showServiceResultCount: showServiceResultCount && ownProps.showServiceResultCount,
-    teamBuildingSearchResults: stateProps.teamBuildingSearchResults,
-    teamID: ownProps.teamID,
-    teamSoFar,
-    teamname: stateProps.teamname,
-    title,
-    waitingForCreate,
-  }
+    return {
+        ...contactProps,
+        error: stateProps.error,
+        fetchUserRecs: dispatchProps.fetchUserRecs,
+        filterServices: ownProps.filterServices,
+        focusInputCounter: ownProps.focusInputCounter,
+        goButtonLabel: ownProps.goButtonLabel,
+        highlightedIndex: ownProps.highlightedIndex,
+        includeContacts: ownProps.namespace === 'chat2',
+        namespace: ownProps.namespace,
+        onAdd,
+        onChangeService: deriveOnChangeService(
+            ownProps.onChangeService,
+            ownProps.incFocusInputCounter,
+            dispatchProps._search,
+            ownProps.searchString
+        ),
+        onChangeText,
+        onClear,
+        onClose: dispatchProps._onCancelTeamBuilding,
+        onClosePopup: dispatchProps._onCancelTeamBuilding,
+        onDownArrowKeyDown:
+            ownProps.showRolePicker && rolePickerArrowKeyFns
+                ? rolePickerArrowKeyFns.downArrow
+                : deriveOnDownArrowKeyDown((userResultsToShow || []).length - 1, ownProps.incHighlightIndex),
+        onEnterKeyDown,
+        onFinishTeamBuilding: dispatchProps.onFinishTeamBuilding,
+        onMakeItATeam: () => console.log('todo'),
+        onRemove: dispatchProps.onRemove,
+        onSearchForMore,
+        onUpArrowKeyDown:
+            ownProps.showRolePicker && rolePickerArrowKeyFns
+                ? rolePickerArrowKeyFns.upArrow
+                : ownProps.decHighlightIndex,
+        recommendations: recommendationsSections,
+        recommendedHideYourself: ownProps.recommendedHideYourself,
+        rolePickerProps,
+        search: dispatchProps._search,
+        searchResults,
+        searchString: ownProps.searchString,
+        selectedService: ownProps.selectedService,
+        serviceResultCount,
+        showRecs,
+        showResults: stateProps.showResults,
+        showServiceResultCount: showServiceResultCount && ownProps.showServiceResultCount,
+        teamBuildingSearchResults: stateProps.teamBuildingSearchResults,
+        teamID: ownProps.teamID,
+        teamSoFar,
+        teamname: stateProps.teamname,
+        title,
+        waitingForCreate,
+    }
 }
 
 const Connected: any = Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(TeamBuilding)
 
-type RealOwnProps = Container.RouteProps<{
-  namespace: Types.AllowedNamespace
-  teamID?: TeamTypes.TeamID
-  filterServices?: Array<Types.ServiceIdWithContact>
-  title: string
-}>
+type RealOwnProps = Container.RouteProps<'teamsRoot'>
 
 class StateWrapperForTeamBuilding extends React.Component<RealOwnProps, LocalState> {
-  static navigationOptions = Connected.navigationOptions
-  state: LocalState = initialState
+    static navigationOptions = Connected.navigationOptions
+    state: LocalState = initialState
 
-  changeShowRolePicker = (showRolePicker: boolean) => this.setState({showRolePicker})
+    changeShowRolePicker = (showRolePicker: boolean) => this.setState({ showRolePicker })
 
-  onChangeService = (selectedService: Types.ServiceIdWithContact) => this.setState({selectedService})
+    onChangeService = (selectedService: Types.ServiceIdWithContact) => this.setState({ selectedService })
 
-  onChangeText = (newText: string) => {
-    if (newText !== this.state.searchString) {
-      this.setState({searchString: newText, showRolePicker: false})
+    onChangeText = (newText: string) => {
+        if (newText !== this.state.searchString) {
+            this.setState({ searchString: newText, showRolePicker: false })
+        }
     }
-  }
 
-  incHighlightIndex = (maxIndex: number) =>
-    this.setState((state: LocalState) => ({
-      highlightedIndex: Math.min(state.highlightedIndex + 1, maxIndex),
-    }))
+    incHighlightIndex = (maxIndex: number) =>
+        this.setState((state: LocalState) => ({
+            highlightedIndex: Math.min(state.highlightedIndex + 1, maxIndex),
+        }))
 
-  decHighlightIndex = () =>
-    this.setState((state: LocalState) => ({
-      highlightedIndex: state.highlightedIndex < 1 ? 0 : state.highlightedIndex - 1,
-    }))
+    decHighlightIndex = () =>
+        this.setState((state: LocalState) => ({
+            highlightedIndex: state.highlightedIndex < 1 ? 0 : state.highlightedIndex - 1,
+        }))
 
-  resetHighlightIndex = (resetToHidden?: boolean) =>
-    this.setState({highlightedIndex: resetToHidden ? -1 : initialState.highlightedIndex})
+    resetHighlightIndex = (resetToHidden?: boolean) =>
+        this.setState({ highlightedIndex: resetToHidden ? -1 : initialState.highlightedIndex })
 
-  _incFocusInputCounter = () => this.setState(s => ({focusInputCounter: s.focusInputCounter + 1}))
+    _incFocusInputCounter = () => this.setState(s => ({ focusInputCounter: s.focusInputCounter + 1 }))
 
-  render() {
-    return (
-      <Connected
-        namespace={Container.getRouteProps(this.props, 'namespace', 'chat2')}
-        teamID={Container.getRouteProps(this.props, 'teamID', undefined)}
-        filterServices={Container.getRouteProps(this.props, 'filterServices', undefined)}
-        onChangeService={this.onChangeService}
-        onChangeText={this.onChangeText}
-        incHighlightIndex={this.incHighlightIndex}
-        decHighlightIndex={this.decHighlightIndex}
-        resetHighlightIndex={this.resetHighlightIndex}
-        searchString={this.state.searchString}
-        selectedService={this.state.selectedService}
-        highlightedIndex={this.state.highlightedIndex}
-        changeShowRolePicker={this.changeShowRolePicker}
-        showRolePicker={this.state.showRolePicker}
-        showServiceResultCount={false}
-        focusInputCounter={this.state.focusInputCounter}
-        incFocusInputCounter={this._incFocusInputCounter}
-        title={Container.getRouteProps(this.props as any, 'title', '')}
-        goButtonLabel={Container.getRouteProps(this.props as any, 'goButtonLabel', 'Start')}
-        recommendedHideYourself={Container.getRouteProps(this.props as any, 'recommendedHideYourself', false)}
-      />
-    )
-  }
+    render() {
+        return (
+            <Connected
+                namespace={Container.getRouteProps(this.props, 'namespace', 'chat2')}
+                teamID={Container.getRouteProps(this.props, 'teamID', undefined)}
+                filterServices={Container.getRouteProps(this.props, 'filterServices', undefined)}
+                onChangeService={this.onChangeService}
+                onChangeText={this.onChangeText}
+                incHighlightIndex={this.incHighlightIndex}
+                decHighlightIndex={this.decHighlightIndex}
+                resetHighlightIndex={this.resetHighlightIndex}
+                searchString={this.state.searchString}
+                selectedService={this.state.selectedService}
+                highlightedIndex={this.state.highlightedIndex}
+                changeShowRolePicker={this.changeShowRolePicker}
+                showRolePicker={this.state.showRolePicker}
+                showServiceResultCount={false}
+                focusInputCounter={this.state.focusInputCounter}
+                incFocusInputCounter={this._incFocusInputCounter}
+                title={Container.getRouteProps(this.props as any, 'title', '')}
+                goButtonLabel={Container.getRouteProps(this.props as any, 'goButtonLabel', 'Start')}
+                recommendedHideYourself={Container.getRouteProps(this.props as any, 'recommendedHideYourself', false)}
+            />
+        )
+    }
 }
 
 export default StateWrapperForTeamBuilding

--- a/shared/teams/channel/create-channels.tsx
+++ b/shared/teams/channel/create-channels.tsx
@@ -5,10 +5,10 @@ import * as TeamsGen from '../../actions/teams-gen'
 import * as Container from '../../util/container'
 import CreateChannelsModal from '../new-team/wizard/create-channels'
 
-type Props = Container.RouteProps<{teamID: TeamsTypes.TeamID}>
+type Props = Container.RouteProps<'teamCreateChannels'>
 
 const CreateChannels = (props: Props) => {
-  const teamID = Container.getRouteProps(props, 'teamID', TeamsTypes.noTeamID)
+  const teamID = props.route.params?.teamID ?? TeamsTypes.noTeamID
   const dispatch = Container.useDispatch()
   React.useEffect(
     () => () => {

--- a/shared/teams/channel/index.tsx
+++ b/shared/teams/channel/index.tsx
@@ -21,11 +21,7 @@ import SettingsList from '../../chat/conversation/info-panel/settings'
 import EmptyRow from '../team/rows/empty-row'
 import isEqual from 'lodash/isEqual'
 
-export type OwnProps = Container.RouteProps<{
-  teamID: Types.TeamID
-  conversationIDKey: ChatTypes.ConversationIDKey
-  selectedTab?: TabKey
-}>
+export type OwnProps = Container.RouteProps<'teamChannel'>
 
 const useLoadDataForChannelPage = (
   teamID: Types.TeamID,
@@ -109,9 +105,9 @@ const SectionList: typeof Kb.SectionList = Styles.isMobile
 
 const emptyMapForUseSelector = new Map<string, Types.MemberInfo>()
 const Channel = (props: OwnProps) => {
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
-  const conversationIDKey = Container.getRouteProps(props, 'conversationIDKey', '')
-  const providedTab = Container.getRouteProps(props, 'selectedTab', undefined)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
+  const conversationIDKey = props.route.params?.conversationIDKey ?? ''
+  const providedTab = props.route.params?.selectedTab ?? undefined
 
   const {bots, participants: _participants} = Container.useSelector(
     state => ChatConstants.getBotsAndParticipants(state, conversationIDKey, true /* sort */),

--- a/shared/teams/confirm-modals/confirm-kick-out.tsx
+++ b/shared/teams/confirm-modals/confirm-kick-out.tsx
@@ -8,7 +8,7 @@ import * as TeamsGen from '../../actions/teams-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {memoize} from '../../util/memoize'
 
-type Props = Container.RouteProps<{members: string[]; teamID: Types.TeamID}>
+type Props = Container.RouteProps<'teamReallyRemoveMember'>
 
 const getSubteamNames = memoize(
   (state: Container.TypedState, teamID: Types.TeamID): [string[], Types.TeamID[]] => {
@@ -18,8 +18,8 @@ const getSubteamNames = memoize(
 )
 
 const ConfirmKickOut = (props: Props) => {
-  const members = Container.getRouteProps(props, 'members', [])
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const members = props.route.params?.members ?? []
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
   const [subteamsToo, setSubteamsToo] = React.useState(false)
 
   const [subteams, subteamIDs] = Container.useSelector(state => getSubteamNames(state, teamID))

--- a/shared/teams/confirm-modals/confirm-remove-from-channel.tsx
+++ b/shared/teams/confirm-modals/confirm-remove-from-channel.tsx
@@ -9,20 +9,12 @@ import * as ChatConstants from '../../constants/chat2'
 import * as TeamsGen from '../../actions/teams-gen'
 import * as RPCChatGen from '../../constants/types/rpc-chat-gen'
 
-type Props = Container.RouteProps<{
-  members: string[]
-  conversationIDKey: ChatTypes.ConversationIDKey
-  teamID: Types.TeamID
-}>
+type Props = Container.RouteProps<'teamReallyRemoveChannelMember'>
 
 const ConfirmRemoveFromChannel = (props: Props) => {
-  const members = Container.getRouteProps(props, 'members', [])
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
-  const conversationIDKey = Container.getRouteProps(
-    props,
-    'conversationIDKey',
-    ChatConstants.noConversationIDKey
-  )
+  const members = props.route.params?.members ?? []
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
+  const conversationIDKey = props.route.params?.conversationIDKey ?? ChatConstants.noConversationIDKey
 
   const [waiting, setWaiting] = React.useState(false)
   const [error, setError] = React.useState('')

--- a/shared/teams/confirm-modals/delete-channel/index.tsx
+++ b/shared/teams/confirm-modals/delete-channel/index.tsx
@@ -1,20 +1,16 @@
-import * as React from 'react'
-import * as Styles from '../../../styles'
 import * as Constants from '../../../constants/teams'
-import * as Types from '../../../constants/types/teams'
-import * as ChatTypes from '../../../constants/types/chat2'
-import * as TeamsGen from '../../../actions/teams-gen'
-import * as Kb from '../../../common-adapters'
 import * as Container from '../../../util/container'
-import {useAllChannelMetas} from '../../common/channel-hooks'
-import {pluralize} from '../../../util/string'
+import * as Kb from '../../../common-adapters'
+import * as React from 'react'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
+import * as Styles from '../../../styles'
+import * as TeamsGen from '../../../actions/teams-gen'
+import * as Types from '../../../constants/types/teams'
+import type * as ChatTypes from '../../../constants/types/chat2'
+import {pluralize} from '../../../util/string'
+import {useAllChannelMetas} from '../../common/channel-hooks'
 
-type Props = Container.RouteProps<{
-  teamID: Types.TeamID
-  // undefined means use the currently selected channels in the store (under the channel tab of the team page)
-  conversationIDKey: ChatTypes.ConversationIDKey | undefined
-}>
+type Props = Container.RouteProps<'teamDeleteChannel'>
 
 const Header = () => (
   <>
@@ -28,8 +24,8 @@ const getTeamSelectedCount = (state: Container.TypedState, teamID: Types.TeamID)
 }
 
 const DeleteChannel = (props: Props) => {
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
-  const routePropChannel = Container.getRouteProps(props, 'conversationIDKey', undefined)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
+  const routePropChannel = props.route.params?.conversationIDKey ?? undefined
   const storeSelectedChannels = Container.useSelector(state => getTeamSelectedCount(state, teamID))
 
   // When the channels get deleted, the values in the store are gone but we should keep displaying the same thing.

--- a/shared/teams/confirm-modals/really-leave-team/container.tsx
+++ b/shared/teams/confirm-modals/really-leave-team/container.tsx
@@ -4,12 +4,12 @@ import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as Container from '../../../util/container'
 import * as Constants from '../../../constants/teams'
 import * as Types from '../../../constants/types/teams'
-import ReallyLeaveTeam, {Props} from '.'
+import ReallyLeaveTeam, {type Props} from '.'
 import LastOwnerDialog from './last-owner'
 import {anyWaiting} from '../../../constants/waiting'
 import {useTeamDetailsSubscribeMountOnly} from '../../subscriber'
 
-type OwnProps = Container.RouteProps<{teamID: Types.TeamID}>
+type OwnProps = Container.RouteProps<'teamReallyLeaveTeam'>
 type ExtraProps = {_leaving: boolean; lastOwner: boolean; stillLoadingTeam: boolean; teamID: Types.TeamID}
 
 const RenderLastOwner = (p: Props & ExtraProps) => {
@@ -29,7 +29,7 @@ const RenderLastOwner = (p: Props & ExtraProps) => {
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const teamID = Container.getRouteProps(ownProps, 'teamID', Types.noTeamID)
+    const teamID = ownProps.route.params?.teamID ?? Types.noTeamID
     const {teamname} = Constants.getTeamMeta(state, teamID)
     const {settings, members} = Constants.getTeamDetails(state, teamID)
     const lastOwner = Constants.isLastOwner(state, teamID)

--- a/shared/teams/delete-team/container.tsx
+++ b/shared/teams/delete-team/container.tsx
@@ -6,11 +6,11 @@ import * as Types from '../../constants/types/teams'
 import ReallyDeleteTeam from '.'
 import {anyWaiting} from '../../constants/waiting'
 
-type OwnProps = Container.RouteProps<{teamID: Types.TeamID}>
+type OwnProps = Container.RouteProps<'teamDeleteTeam'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const teamID = Container.getRouteProps(ownProps, 'teamID', Types.noTeamID)
+    const teamID = ownProps.route.params?.teamID ?? Types.noTeamID
     const {teamname} = Constants.getTeamMeta(state, teamID)
     const teamDetails = Constants.getTeamDetails(state, teamID)
     return {

--- a/shared/teams/edit-team-description/index.tsx
+++ b/shared/teams/edit-team-description/index.tsx
@@ -7,10 +7,10 @@ import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 import {ModalTitle} from '../common'
 
-type Props = Container.RouteProps<{teamID: Types.TeamID}>
+type Props = Container.RouteProps<'teamEditTeamDescription'>
 
 const EditTeamDescription = (props: Props) => {
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
 
   const teamname = Container.useSelector(state => Constants.getTeamNameFromID(state, teamID))
   const waitingKey = Constants.teamWaitingKey(teamID)

--- a/shared/teams/edit-team-welcome-message/index.tsx
+++ b/shared/teams/edit-team-welcome-message/index.tsx
@@ -7,14 +7,14 @@ import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 import {computeWelcomeMessageTextRaw} from '../../chat/conversation/messages/cards/team-journey/util'
 
-type Props = Container.RouteProps<{teamID: Types.TeamID}>
+type Props = Container.RouteProps<'teamEditWelcomeMessage'>
 
 // welcomeMessageMaxLen is duplicated at
 // go/chat/server.go:welcomeMessageMaxLen; keep the values in sync!
 const welcomeMessageMaxLen = 400
 
 const EditTeamWelcomeMessage = (props: Props) => {
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
 
   if (teamID === Types.noTeamID) {
     throw new Error(`There was a problem loading the welcome message page, please report this error.`)

--- a/shared/teams/emojis/add-alias.tsx
+++ b/shared/teams/emojis/add-alias.tsx
@@ -8,8 +8,8 @@ import * as ChatTypes from '../../constants/types/chat2'
 import * as ChatConstants from '../../constants/chat2'
 import {EmojiPickerDesktop} from '../../chat/conversation/messages/react-button/emoji-picker/container'
 import {
-  EmojiData,
-  RenderableEmoji,
+  type EmojiData,
+  type RenderableEmoji,
   emojiDataToRenderableEmoji,
   getEmojiStr,
   renderEmoji,
@@ -22,7 +22,7 @@ type Props = {
   onChange?: () => void
   defaultSelected?: EmojiData
 }
-type RoutableProps = Container.RouteProps<Props>
+type RoutableProps = Container.RouteProps<'teamAddEmojiAlias'>
 
 type ChosenEmoji = {
   emojiStr: string
@@ -230,13 +230,10 @@ const styles = Styles.styleSheetCreate(() => ({
 }))
 
 const AddEmojiAliasWrapper = (routableProps: RoutableProps) => {
-  const conversationIDKey = Container.getRouteProps(
-    routableProps,
-    'conversationIDKey',
-    ChatConstants.noConversationIDKey
-  )
-  const defaultSelected = Container.getRouteProps(routableProps, 'defaultSelected', undefined)
-  const onChange = Container.getRouteProps(routableProps, 'onChange', undefined)
+  const {params} = routableProps.route
+  const conversationIDKey = params?.conversationIDKey ?? ChatConstants.noConversationIDKey
+  const defaultSelected = params?.defaultSelected
+  const onChange = params?.onChange
   return (
     <AddAliasModal
       conversationIDKey={conversationIDKey}

--- a/shared/teams/emojis/add-emoji.tsx
+++ b/shared/teams/emojis/add-emoji.tsx
@@ -20,7 +20,7 @@ type Props = {
   onChange?: () => void
   teamID: TeamsTypes.TeamID // not supported yet
 }
-type RoutableProps = Container.RouteProps<Props>
+type RoutableProps = Container.RouteProps<'teamAddEmoji'>
 
 // don't prefill on mobile since it's always a long random string.
 const filePathToDefaultAlias = Styles.isMobile
@@ -196,13 +196,9 @@ export const AddEmojiModal = (props: Props) => {
 }
 
 const AddEmojiModalWrapper = (routableProps: RoutableProps) => {
-  const conversationIDKey = Container.getRouteProps(
-    routableProps,
-    'conversationIDKey',
-    ChatConstants.noConversationIDKey
-  )
-  const teamID = Container.getRouteProps(routableProps, 'teamID', TeamsTypes.noTeamID)
-  const onChange = Container.getRouteProps(routableProps, 'onChange', undefined)
+  const conversationIDKey = routableProps.route.params?.conversationIDKey ?? ChatConstants.noConversationIDKey
+  const teamID = routableProps.route.params?.teamID ?? TeamsTypes.noTeamID
+  const onChange = routableProps.route.params?.onChange ?? undefined
   return <AddEmojiModal conversationIDKey={conversationIDKey} teamID={teamID} onChange={onChange} />
 }
 export default AddEmojiModalWrapper

--- a/shared/teams/external-team.tsx
+++ b/shared/teams/external-team.tsx
@@ -11,10 +11,10 @@ import {pluralize} from '../util/string'
 import {memoize} from '../util/memoize'
 import capitalize from 'lodash/capitalize'
 
-type Props = Container.RouteProps<{teamname: string}>
+type Props = Container.RouteProps<'teamExternalTeam'>
 
 const ExternalTeam = (props: Props) => {
-  const teamname = Container.getRouteProps(props, 'teamname', '')
+  const teamname = props.route.params?.teamname ?? ''
 
   const getTeamInfo = Container.useRPC(RPCGen.teamsGetUntrustedTeamInfoRpcPromise)
   const [teamInfo, setTeamInfo] = React.useState<RPCGen.UntrustedTeamInfo | null>(null)

--- a/shared/teams/invite-by-contact/container.d.ts
+++ b/shared/teams/invite-by-contact/container.d.ts
@@ -1,6 +1,5 @@
-import * as C from '../../util/container'
 import * as React from 'react'
-import * as Types from '../../constants/types/teams'
+import type * as Container from '../../util/container'
 
-export type OwnProps = C.RouteProps<{teamID: string}>
-export default class Container extends React.Component<OwnProps> {}
+export type OwnProps = Container.RouteProps<'teamInviteByContact'>
+export default class InviteByContact extends React.Component<OwnProps> {}

--- a/shared/teams/invite-by-contact/container.native.tsx
+++ b/shared/teams/invite-by-contact/container.native.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import * as Container from '../../util/container'
+import type * as Container from '../../util/container'
 import TeamInviteByContact from './team-invite-by-contacts.native'
 
-type OwnProps = Container.RouteProps<{teamID: string}>
+type OwnProps = Container.RouteProps<'teamInviteByContact'>
 const ConnectedTeamInviteByContact = (props: OwnProps) => {
-  const teamID = Container.getRouteProps(props, 'teamID', '')
+  const teamID = props.route.params?.teamID ?? ''
   return <TeamInviteByContact teamID={teamID} />
 }
 

--- a/shared/teams/invite-by-email/container.tsx
+++ b/shared/teams/invite-by-email/container.tsx
@@ -1,15 +1,15 @@
-import * as TeamsGen from '../../actions/teams-gen'
-import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/teams'
-import * as Types from '../../constants/types/teams'
-import {InviteByEmailDesktop} from '.'
 import * as Container from '../../util/container'
+import * as RouteTreeGen from '../../actions/route-tree-gen'
+import * as TeamsGen from '../../actions/teams-gen'
+import type * as Types from '../../constants/types/teams'
+import {InviteByEmailDesktop} from '.'
 
-type OwnProps = Container.RouteProps<{teamID: string}>
+type OwnProps = Container.RouteProps<'teamInviteByEmail'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const teamID = Container.getRouteProps(ownProps, 'teamID', '')
+    const teamID = ownProps.route.params?.teamID ?? ''
     const {teamname} = Constants.getTeamMeta(state, teamID)
     const inviteError = Constants.getEmailInviteError(state)
     return {
@@ -32,7 +32,7 @@ export default Container.connect(
     onClearInviteError: d.onClearInviteError,
     onClose: d.onClose,
     onInvite: (invitees: string, role: Types.TeamRoleType) => {
-      const teamID = Container.getRouteProps(o, 'teamID', '')
+      const teamID = o.route.params?.teamID ?? ''
       d._onInvite(s.name, teamID, invitees, role)
     },
   })

--- a/shared/teams/join-team/container.tsx
+++ b/shared/teams/join-team/container.tsx
@@ -4,12 +4,12 @@ import JoinTeam from '.'
 import upperFirst from 'lodash/upperFirst'
 import * as Container from '../../util/container'
 
-type OwnProps = Container.RouteProps<{initialTeamname?: string}>
+type OwnProps = Container.RouteProps<'teamJoinTeamDialog'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => ({
     errorText: upperFirst(state.teams.errorInTeamJoin),
-    initialTeamname: Container.getRouteProps(ownProps, 'initialTeamname', undefined),
+    initialTeamname: ownProps.route.params?.initialTeamname ?? undefined,
     open: state.teams.teamJoinSuccessOpen,
     success: state.teams.teamJoinSuccess,
     successTeamName: state.teams.teamJoinSuccessTeamName,

--- a/shared/teams/new-team/container.tsx
+++ b/shared/teams/new-team/container.tsx
@@ -6,11 +6,11 @@ import upperFirst from 'lodash/upperFirst'
 import * as Constants from '../../constants/teams'
 import * as Types from '../../constants/types/teams'
 
-type OwnProps = Container.RouteProps<{subteamOf?: Types.TeamID}>
+type OwnProps = Container.RouteProps<'teamNewTeamDialog'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const subteamOf = Container.getRouteProps(ownProps, 'subteamOf', undefined) || Types.noTeamID
+    const subteamOf = ownProps.route.params?.subteamOf ?? Types.noTeamID
     const baseTeam = Constants.getTeamMeta(state, subteamOf).teamname
     return {
       baseTeam,

--- a/shared/teams/rename-team/container.tsx
+++ b/shared/teams/rename-team/container.tsx
@@ -5,12 +5,12 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Constants from '../../constants/teams'
 import RenameTeam from '.'
 
-type OwnProps = Container.RouteProps<{teamname: string}>
+type OwnProps = Container.RouteProps<'teamRename'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => ({
     error: Container.anyErrors(state, Constants.teamRenameWaitingKey),
-    teamname: Container.getRouteProps(ownProps, 'teamname', ''),
+    teamname: ownProps.route.params?.teamname ?? '',
     waiting: Container.anyWaiting(state, Constants.teamRenameWaitingKey),
   }),
   dispatch => ({

--- a/shared/teams/routes.tsx
+++ b/shared/teams/routes.tsx
@@ -39,6 +39,7 @@ import type TeamAddToTeamConfirm from './add-members-wizard/confirm'
 import type TeamInviteHistory from './team/invites/invite-history'
 import type Team from './team'
 import type ExternalTeam from './external-team'
+import type * as TeamBuildingTypes from '../constants/types/team-building'
 
 export const newRoutes = {
   team: {getScreen: (): typeof Team => require('./team').default},
@@ -167,4 +168,16 @@ export const newModalRoutes = {
   teamsTeamBuilder: {
     getScreen: (): typeof TeamsTeamBuilder => require('../team-building/container').default,
   },
+}
+
+type TeamBuilderProps = Partial<{
+  namespace: TeamBuildingTypes.AllowedNamespace
+  teamID: string
+  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel: TeamBuildingTypes.GoButtonLabel
+  title: string
+}>
+
+export type RootParamListTeams = {
+  teamsTeamBuilder: TeamBuilderProps
 }

--- a/shared/teams/routes.tsx
+++ b/shared/teams/routes.tsx
@@ -40,7 +40,12 @@ import type TeamInviteHistory from './team/invites/invite-history'
 import type Team from './team'
 import type ExternalTeam from './external-team'
 import type * as TeamBuildingTypes from '../constants/types/team-building'
-import type * as TeamTypes from '../constants/types/teams'
+import type * as Types from '../constants/types/teams'
+import type * as ChatTypes from '../constants/types/chat2'
+import {type EmojiData} from '../util/emoji'
+import type {RetentionEntityType} from './team/settings-tab/retention'
+import type {RetentionPolicy} from '../constants/types/retention-policy'
+import type {TabKey} from './channel/tabs'
 
 export const newRoutes = {
   team: {getScreen: (): typeof Team => require('./team').default},
@@ -187,8 +192,98 @@ export type RootParamListTeams = {
   }
   teamsRoot: {
     namespace: TeamBuildingTypes.AllowedNamespace
-    teamID?: TeamTypes.TeamID
+    teamID?: Types.TeamID
     filterServices?: Array<TeamBuildingTypes.ServiceIdWithContact>
     title: string
+    recommendedHideYourself?: boolean
+    goButtonLabel?: TeamBuildingTypes.GoButtonLabel
+  }
+  teamAddEmojiAlias: {
+    conversationIDKey: ChatTypes.ConversationIDKey
+    onChange?: () => void
+    defaultSelected?: EmojiData
+  }
+  teamInviteByEmail: {
+    teamID: string
+  }
+  teamInviteByContact: {
+    teamID: string
+  }
+  teamEditWelcomeMessage: {
+    teamID: Types.TeamID
+  }
+  teamJoinTeamDialog: {
+    initialTeamname?: string
+  }
+  teamAddEmoji: {
+    conversationIDKey: ChatTypes.ConversationIDKey
+    onChange?: () => void
+    teamID: Types.TeamID // not supported yet
+  }
+  teamReallyRemoveMember: {
+    members: string[]
+    teamID: Types.TeamID
+  }
+  teamReallyRemoveChannelMember: {
+    members: string[]
+    conversationIDKey: ChatTypes.ConversationIDKey
+    teamID: Types.TeamID
+  }
+  teamDeleteChannel: {
+    teamID: Types.TeamID
+    // undefined means use the currently selected channels in the store (under the channel tab of the team page)
+    conversationIDKey: ChatTypes.ConversationIDKey | undefined
+  }
+  teamReallyLeaveTeam: {
+    teamID: Types.TeamID
+  }
+  teamRename: {
+    teamname: string
+  }
+  teamExternalTeam: {
+    teamname: string
+  }
+  teamEditTeamDescription: {teamID: Types.TeamID}
+  teamInviteLinksGenerate: {teamID: Types.TeamID}
+  openTeamWarning: {
+    isOpenTeam: boolean
+    teamname: string
+    onCancel: () => void
+    onConfirm: () => void
+  }
+  teamInviteHistory: {teamID: Types.TeamID}
+  retentionWarning: {
+    policy: RetentionPolicy
+    entityType: RetentionEntityType
+    onCancel: (() => void) | null
+    onConfirm: (() => void) | null
+  }
+  teamEditTeamInfo: {teamID: Types.TeamID}
+  team: {
+    teamID: Types.TeamID
+    initialTab?: Types.TabKey
+  }
+  teamEditChannel: {
+    afterEdit?: () => void
+    channelname: string
+    description: string
+    teamID: Types.TeamID
+    conversationIDKey: ChatTypes.ConversationIDKey
+  }
+  teamAddToChannels: {
+    teamID: Types.TeamID
+    usernames: Array<string> | undefined // undefined means the user themself
+  }
+  teamMember: {
+    teamID: Types.TeamID
+    username: string
+  }
+  teamCreateChannels: {teamID: Types.TeamID}
+  teamNewTeamDialog: {subteamOf?: Types.TeamID}
+  teamDeleteTeam: {teamID: Types.TeamID}
+  teamChannel: {
+    teamID: Types.TeamID
+    conversationIDKey: ChatTypes.ConversationIDKey
+    selectedTab?: TabKey
   }
 }

--- a/shared/teams/routes.tsx
+++ b/shared/teams/routes.tsx
@@ -40,6 +40,7 @@ import type TeamInviteHistory from './team/invites/invite-history'
 import type Team from './team'
 import type ExternalTeam from './external-team'
 import type * as TeamBuildingTypes from '../constants/types/team-building'
+import type * as TeamTypes from '../constants/types/teams'
 
 export const newRoutes = {
   team: {getScreen: (): typeof Team => require('./team').default},
@@ -180,4 +181,14 @@ type TeamBuilderProps = Partial<{
 
 export type RootParamListTeams = {
   teamsTeamBuilder: TeamBuilderProps
+  contactRestricted: {
+    source: 'newFolder' | 'teamAddSomeFailed' | 'teamAddAllFailed' | 'walletsRequest' | 'misc'
+    usernames: Array<string>
+  }
+  teamsRoot: {
+    namespace: TeamBuildingTypes.AllowedNamespace
+    teamID?: TeamTypes.TeamID
+    filterServices?: Array<TeamBuildingTypes.ServiceIdWithContact>
+    title: string
+  }
 }

--- a/shared/teams/team/index.tsx
+++ b/shared/teams/team/index.tsx
@@ -24,7 +24,7 @@ import {
 } from './rows'
 import isEqual from 'lodash/isEqual'
 
-type Props = Container.RouteProps<{teamID: Types.TeamID; initialTab?: Types.TabKey}>
+type Props = Container.RouteProps<'team'>
 
 // keep track during session
 const lastSelectedTabs = {}
@@ -84,8 +84,8 @@ const SectionList: typeof Kb.SectionList = Styles.isMobile
   : Kb.SectionList
 
 const Team = (props: Props) => {
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
-  const initialTab = Container.getRouteProps(props, 'initialTab', undefined)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
+  const initialTab = props.route.params?.initialTab ?? undefined
   const [selectedTab, setSelectedTab] = useTabsState(teamID, initialTab)
 
   const teamDetails = Container.useSelector(state => Constants.getTeamDetails(state, teamID))

--- a/shared/teams/team/invites/generate-link.tsx
+++ b/shared/teams/team/invites/generate-link.tsx
@@ -13,7 +13,7 @@ import {InlineDropdown} from '../../../common-adapters/dropdown'
 import {pluralize} from '../../../util/string'
 import {InviteItem} from './invite-item'
 
-type Props = Container.RouteProps<{teamID: Types.TeamID}>
+type Props = Container.RouteProps<'teamInviteLinksGenerate'>
 
 type RolePickerProps = {
   isRolePickerOpen: boolean
@@ -72,7 +72,7 @@ const GenerateLinkModal = (props: Props) => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
 
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
   const teamname = Container.useSelector(state => Constants.getTeamMeta(state, teamID).teamname)
   useTeamDetailsSubscribe(teamID)
   const teamDetails = Container.useSelector(s => s.teams.teamDetails.get(teamID))

--- a/shared/teams/team/invites/invite-history.tsx
+++ b/shared/teams/team/invites/invite-history.tsx
@@ -4,23 +4,27 @@ import * as Styles from '../../../styles'
 import * as Container from '../../../util/container'
 import * as Types from '../../../constants/types/teams'
 import {memoize} from '../../../util/memoize'
-import {Section} from '../../../common-adapters/section-list'
 import {useTeamDetailsSubscribe} from '../../subscriber'
 import {ModalTitle} from '../../common'
 import {InviteItem} from './invite-item'
+import type {Section} from '../../../common-adapters/section-list'
 
-type Props = Container.RouteProps<{teamID: Types.TeamID}>
+type Props = Container.RouteProps<'teamInviteHistory'>
 
-const splitInviteLinks = memoize((inviteLinks?: Array<Types.InviteLink>): {
-  invalid: Array<Types.InviteLink>
-  valid: Array<Types.InviteLink>
-} => ({
-  invalid: [...(inviteLinks || [])].filter(i => !i.isValid),
-  valid: [...(inviteLinks || [])].filter(i => i.isValid),
-}))
+const splitInviteLinks = memoize(
+  (
+    inviteLinks?: Array<Types.InviteLink>
+  ): {
+    invalid: Array<Types.InviteLink>
+    valid: Array<Types.InviteLink>
+  } => ({
+    invalid: [...(inviteLinks || [])].filter(i => !i.isValid),
+    valid: [...(inviteLinks || [])].filter(i => i.isValid),
+  })
+)
 
 const InviteHistory = (props: Props) => {
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
   useTeamDetailsSubscribe(teamID)
   const teamDetails = Container.useSelector(s => s.teams.teamDetails.get(teamID))
   const loading = !teamDetails
@@ -75,12 +79,8 @@ const InviteHistory = (props: Props) => {
           <Kb.Text type="BodyBigLink" onClick={onClose}>
             Close
           </Kb.Text>
-        ) : (
-          undefined
-        ),
-        rightButton: Styles.isMobile ? (
-          undefined
-        ) : (
+        ) : undefined,
+        rightButton: Styles.isMobile ? undefined : (
           <Kb.Button mode="Secondary" label="Generate link" small={true} onClick={onGenerate} />
         ),
         title: <ModalTitle title="Invite links" teamID={teamID} />,

--- a/shared/teams/team/member/add-to-channels.tsx
+++ b/shared/teams/team/member/add-to-channels.tsx
@@ -14,10 +14,7 @@ import {pluralize} from '../../../util/string'
 import {memoize} from '../../../util/memoize'
 import {useAllChannelMetas} from '../../common/channel-hooks'
 
-type Props = Container.RouteProps<{
-  teamID: Types.TeamID
-  usernames: Array<string> | undefined // undefined means the user themself
-}>
+type Props = Container.RouteProps<'teamAddToChannels'>
 
 const getChannelsForList = memoize(
   (
@@ -50,10 +47,10 @@ const getChannelsForList = memoize(
 const AddToChannels = (props: Props) => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
   const myUsername = Container.useSelector(state => state.config.username)
-  const usernames = Container.getRouteProps(props, 'usernames', undefined) ?? [myUsername]
-  const mode = Container.getRouteProps(props, 'usernames', undefined) ? 'others' : 'self'
+  const usernames = props.route.params?.usernames ?? undefined ?? [myUsername]
+  const mode = props.route.params?.usernames ?? undefined ? 'others' : 'self'
 
   const {channelMetas, loadingChannels, reloadChannels} = useAllChannelMetas(teamID)
   const participantMap = Container.useSelector(s => s.chat2.participantMap)

--- a/shared/teams/team/member/edit-channel.tsx
+++ b/shared/teams/team/member/edit-channel.tsx
@@ -1,31 +1,24 @@
-import * as React from 'react'
-import * as Kb from '../../../common-adapters'
-import * as Container from '../../../util/container'
 import * as Constants from '../../../constants/teams'
-import * as Styles from '../../../styles'
-import {ModalTitle} from '../../common'
-import * as Types from '../../../constants/types/teams'
-import * as TeamsGen from '../../../actions/teams-gen'
+import * as Container from '../../../util/container'
+import * as Kb from '../../../common-adapters'
+import * as React from 'react'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
-import type * as ChatTypes from '../../../constants/types/chat2'
+import * as Styles from '../../../styles'
+import * as TeamsGen from '../../../actions/teams-gen'
+import * as Types from '../../../constants/types/teams'
+import {ModalTitle} from '../../common'
 
-type Props = Container.RouteProps<{
-  afterEdit?: () => void
-  channelname: string
-  description: string
-  teamID: Types.TeamID
-  conversationIDKey: ChatTypes.ConversationIDKey
-}>
+type Props = Container.RouteProps<'teamEditChannel'>
 
 const EditChannel = (props: Props) => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
 
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
-  const conversationIDKey = Container.getRouteProps(props, 'conversationIDKey', '')
-  const oldName = Container.getRouteProps(props, 'channelname', '')
-  const oldDescription = Container.getRouteProps(props, 'description', '')
-  const onFinish = Container.getRouteProps(props, 'afterEdit', undefined)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
+  const conversationIDKey = props.route.params?.conversationIDKey ?? ''
+  const oldName = props.route.params?.channelname ?? ''
+  const oldDescription = props.route.params?.description ?? ''
+  const onFinish = props.route.params?.afterEdit ?? undefined
 
   const [name, _setName] = React.useState(oldName)
   const setName = (newName: string) => _setName(newName.replace(/[^a-zA-Z0-9_-]/, ''))

--- a/shared/teams/team/member/index.new.tsx
+++ b/shared/teams/team/member/index.new.tsx
@@ -1,28 +1,28 @@
-import * as React from 'react'
-import * as Kb from '../../../common-adapters'
-import * as Styles from '../../../styles'
-import * as RPCTypes from '../../../constants/types/rpc-gen'
-import * as Constants from '../../../constants/teams'
-import * as Types from '../../../constants/types/teams'
-import * as Container from '../../../util/container'
 import * as Chat2Gen from '../../../actions/chat2-gen'
+import * as Constants from '../../../constants/teams'
+import * as Container from '../../../util/container'
+import * as Kb from '../../../common-adapters'
 import * as ProfileGen from '../../../actions/profile-gen'
-import {useAllChannelMetas} from '../../common/channel-hooks'
-import logger from '../../../logger'
-import {pluralize} from '../../../util/string'
-import {FloatingRolePicker} from '../../role-picker'
-import RoleButton from '../../role-button'
+import * as RPCTypes from '../../../constants/types/rpc-gen'
+import * as React from 'react'
+import * as Styles from '../../../styles'
 import * as TeamsGen from '../../../actions/teams-gen'
-import {useTeamDetailsSubscribe} from '../../subscriber'
-import {formatTimeForTeamMember, formatTimeRelativeToNow} from '../../../util/timestamp'
-import {Section as _Section} from '../../../common-adapters/section-list'
+import * as Types from '../../../constants/types/teams'
+import RoleButton from '../../role-button'
 import isEqual from 'lodash/isEqual'
+import logger from '../../../logger'
+import type {Section as _Section} from '../../../common-adapters/section-list'
+import {FloatingRolePicker} from '../../role-picker'
+import {formatTimeForTeamMember, formatTimeRelativeToNow} from '../../../util/timestamp'
+import {pluralize} from '../../../util/string'
+import {useAllChannelMetas} from '../../common/channel-hooks'
+import {useTeamDetailsSubscribe} from '../../subscriber'
 
 type Props = {
   teamID: Types.TeamID
   username: string
 }
-type OwnProps = Container.RouteProps<Props>
+type OwnProps = Container.RouteProps<'teamMember'>
 
 type TeamTreeRowNotIn = {
   teamID: Types.TeamID
@@ -142,8 +142,8 @@ const SectionList: typeof Kb.SectionList = Styles.isMobile
 
 const TeamMember = (props: OwnProps) => {
   const dispatch = Container.useDispatch()
-  const username = Container.getRouteProps(props, 'username', '')
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const username = props.route.params?.username ?? ''
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
 
   const isMe = username == Container.useSelector(state => state.config.username)
   const loading = Container.useSelector(state => {

--- a/shared/teams/team/settings-tab/open-team-warning/index.tsx
+++ b/shared/teams/team/settings-tab/open-team-warning/index.tsx
@@ -4,12 +4,7 @@ import * as Styles from '../../../../styles'
 import * as Container from '../../../../util/container'
 import * as RouteTreeGen from '../../../../actions/route-tree-gen'
 
-type Props = Container.RouteProps<{
-  isOpenTeam: boolean
-  teamname: string
-  onCancel: () => void
-  onConfirm: () => void
-}>
+type Props = Container.RouteProps<'openTeamWarning'>
 
 const Wrapper = ({children, onBack}: {children: React.ReactNode; onBack: () => void}) =>
   Styles.isMobile ? (
@@ -24,9 +19,9 @@ const Wrapper = ({children, onBack}: {children: React.ReactNode; onBack: () => v
 
 const OpenTeamWarning = (props: Props) => {
   const [enabled, setEnabled] = React.useState(false)
-  const isOpenTeam = Container.getRouteProps(props, 'isOpenTeam', false)
-  const teamname = Container.getRouteProps(props, 'teamname', '')
-  const onConfirmCallback = Container.getRouteProps(props, 'onConfirm', () => undefined)
+  const isOpenTeam = props.route.params?.isOpenTeam ?? false
+  const teamname = props.route.params?.teamname ?? ''
+  const onConfirmCallback = props.route.params?.onConfirm ?? (() => undefined)
 
   const dispatch = Container.useDispatch()
 

--- a/shared/teams/team/settings-tab/retention/warning/container.tsx
+++ b/shared/teams/team/settings-tab/retention/warning/container.tsx
@@ -1,37 +1,30 @@
 import * as Container from '../../../../../util/container'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
-import RetentionWarning from '.'
-import {RetentionEntityType} from '..'
-import {RetentionPolicy} from '../../../../../constants/types/retention-policy'
 import * as Constants from '../../../../../constants/teams'
+import RetentionWarning from '.'
 
-type OwnProps = Container.RouteProps<{
-  policy: RetentionPolicy
-  entityType: RetentionEntityType
-  onCancel: (() => void) | null
-  onConfirm: (() => void) | null
-}>
+type OwnProps = Container.RouteProps<'retentionWarning'>
 
 export default Container.connect(
   () => ({}),
   (dispatch, ownProps: OwnProps) => ({
     onBack: () => {
       dispatch(RouteTreeGen.createNavigateUp())
-      const onCancel: (() => void) | null = Container.getRouteProps(ownProps, 'onCancel', null)
-      onCancel && onCancel()
+      const onCancel = ownProps.route.params?.onCancel ?? null
+      onCancel?.()
     },
     onConfirm: () => {
       dispatch(RouteTreeGen.createNavigateUp())
-      const cb: (() => void) | null = Container.getRouteProps(ownProps, 'onConfirm', null)
-      cb && cb()
+      const cb = ownProps.route.params?.onConfirm ?? null
+      cb?.()
     },
   }),
   (_s, d, ownProps: OwnProps) => {
-    const policy = Container.getRouteProps(ownProps, 'policy', Constants.retentionPolicies.policyInherit)
+    const policy = ownProps.route.params?.policy ?? Constants.retentionPolicies.policyInherit
     return {
       ...ownProps,
       ...d,
-      entityType: Container.getRouteProps(ownProps, 'entityType', 'adhoc'),
+      entityType: ownProps.route.params?.entityType ?? 'adhoc',
       exploding: policy.type === 'explode',
       timePeriod: policy.title,
     }

--- a/shared/teams/team/team-info.tsx
+++ b/shared/teams/team/team-info.tsx
@@ -7,13 +7,13 @@ import {ModalTitle} from '../common'
 import * as Types from '../../constants/types/teams'
 import * as TeamsGen from '../../actions/teams-gen'
 
-type Props = Container.RouteProps<{teamID: Types.TeamID}>
+type Props = Container.RouteProps<'teamEditTeamInfo'>
 
 const TeamInfo = (props: Props) => {
   const dispatch = Container.useDispatch()
   const nav = Container.useSafeNavigation()
 
-  const teamID = Container.getRouteProps(props, 'teamID', Types.noTeamID)
+  const teamID = props.route.params?.teamID ?? Types.noTeamID
   const teamMeta = Container.useSelector(s => Constants.getTeamMeta(s, teamID))
   const teamDetails = Container.useSelector(s => Constants.getTeamDetails(s, teamID))
 

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -45,15 +45,6 @@ export function getRouteProps<O extends _RouteProps<any>, R extends GetRouteType
   return val === undefined ? notSetVal : val
 }
 
-export function getRoutePropsOr<O extends _RouteProps<any>, R extends GetRouteType<O>, K extends keyof R, D>(
-  ownProps: O,
-  key: K,
-  notSetVal: D
-): R[K] | D {
-  const val = ownProps.route.params?.[key]
-  return val === undefined ? notSetVal : val
-}
-
 export type RemoteWindowSerializeProps<P> = {[K in keyof P]-?: (val: P[K], old?: P[K]) => any}
 
 export type TypedDispatch = (action: _TypedActions) => void

--- a/shared/util/container.tsx
+++ b/shared/util/container.tsx
@@ -3,7 +3,6 @@ import {type Draft as _Draft, setAutoFreeze} from 'immer'
 import type {TypedActions as _TypedActions} from '../actions/typed-actions-gen'
 import type {ActionHandler as _ActionHandler} from './make-reducer'
 import type {TypedState as _TypedState} from '../constants/reducer'
-import type {RouteProps as _RouteProps, GetRouteType} from '../route-tree/render-route'
 import {StatusCode} from '../constants/types/rpc-gen'
 import {anyWaiting, anyErrors} from '../constants/waiting'
 import {
@@ -16,6 +15,7 @@ import flowRight from 'lodash/flowRight'
 import typedConnect from './typed-connect'
 import type {Route} from '../constants/types/route-tree'
 import type {NavigationContainerRef} from '@react-navigation/core'
+export {type RouteProps, getRouteParams, getRouteParamsFromRoute} from '../router-v2/route-params'
 
 // don't pay for this in prod builds
 if (!__DEV__) {
@@ -35,15 +35,6 @@ export const networkErrorCodes = [
 ]
 
 export const isNetworkErr = (code: number) => networkErrorCodes.includes(code)
-
-export function getRouteProps<O extends _RouteProps<any>, R extends GetRouteType<O>, K extends keyof R>(
-  ownProps: O,
-  key: K,
-  notSetVal: R[K] // this could go away if we type the routes better and ensure its always passed as a prop
-): R[K] {
-  const val = ownProps.route.params?.[key]
-  return val === undefined ? notSetVal : val
-}
 
 export type RemoteWindowSerializeProps<P> = {[K in keyof P]-?: (val: P[K], old?: P[K]) => any}
 
@@ -101,7 +92,6 @@ export {isMobile, isIOS, isAndroid, isPhone, isTablet} from '../constants/platfo
 export {anyWaiting, anyErrors} from '../constants/waiting'
 export {safeSubmit, safeSubmitPerMount} from './safe-submit'
 export {useSafeNavigation} from './safe-navigation'
-export type RouteProps<P = {}> = _RouteProps<P>
 export type TypedActions = _TypedActions
 export type TypedState = _TypedState
 export const compose = flowRight

--- a/shared/wallets/confirm-form/container.tsx
+++ b/shared/wallets/confirm-form/container.tsx
@@ -1,15 +1,15 @@
-import ConfirmSend from '.'
 import * as Constants from '../../constants/wallets'
+import * as Container from '../../util/container'
 import * as ProfileGen from '../../actions/profile-gen'
+import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Tracker2Gen from '../../actions/tracker2-gen'
 import * as WalletsGen from '../../actions/wallets-gen'
-import * as RouteTreeGen from '../../actions/route-tree-gen'
+import ConfirmSend from '.'
 import Participants from './participants/container'
+import type * as Types from '../../constants/types/wallets'
 import {anyWaiting} from '../../constants/waiting'
-import * as Container from '../../util/container'
-import * as Types from '../../constants/types/wallets'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 export default Container.connect(
   state => {

--- a/shared/wallets/create-account/container.tsx
+++ b/shared/wallets/create-account/container.tsx
@@ -6,7 +6,7 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {anyWaiting} from '../../constants/waiting'
 import CreateAccount from '.'
 
-type OwnProps = Container.RouteProps<{fromSendForm?: boolean; showOnCreation?: boolean}>
+type OwnProps = Container.RouteProps<'createNewAccount'>
 
 export default Container.connect(
   state => ({
@@ -22,8 +22,8 @@ export default Container.connect(
       dispatch(
         WalletsGen.createCreateNewAccount({
           name,
-          setBuildingTo: Container.getRouteProps(ownProps, 'fromSendForm', undefined),
-          showOnCreation: Container.getRouteProps(ownProps, 'showOnCreation', undefined),
+          setBuildingTo: ownProps.route.params?.fromSendForm,
+          showOnCreation: ownProps.route.params?.showOnCreation,
         })
       )
       dispatch(RouteTreeGen.createNavigateUp())

--- a/shared/wallets/link-existing/container.tsx
+++ b/shared/wallets/link-existing/container.tsx
@@ -6,7 +6,7 @@ import {anyWaiting} from '../../constants/waiting'
 import HiddenString from '../../util/hidden-string'
 import {Wrapper as LinkExisting} from '.'
 
-type OwnProps = Container.RouteProps<{fromSendForm?: boolean; showOnCreation?: boolean}>
+type OwnProps = Container.RouteProps<'linkExisting'>
 
 export default Container.connect(
   state => ({
@@ -23,7 +23,7 @@ export default Container.connect(
     ),
   }),
   (dispatch, ownProps: OwnProps) => ({
-    fromSendForm: Container.getRouteProps(ownProps, 'fromSendForm', undefined),
+    fromSendForm: ownProps.route.params?.fromSendForm ?? undefined,
     onCancel: () => dispatch(RouteTreeGen.createNavigateUp()),
     onCheckKey: (key: string) => {
       dispatch(
@@ -41,8 +41,8 @@ export default Container.connect(
         WalletsGen.createLinkExistingAccount({
           name,
           secretKey: new HiddenString(sk),
-          setBuildingTo: Container.getRouteProps(ownProps, 'fromSendForm', undefined),
-          showOnCreation: Container.getRouteProps(ownProps, 'showOnCreation', undefined),
+          setBuildingTo: ownProps.route.params?.fromSendForm ?? undefined,
+          showOnCreation: ownProps.route.params?.showOnCreation ?? undefined,
         })
       )
 

--- a/shared/wallets/onboarding/container.tsx
+++ b/shared/wallets/onboarding/container.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as Constants from '../../constants/wallets'
 import * as Container from '../../util/container'
-import * as Types from '../../constants/types/wallets'
+import type * as Types from '../../constants/types/wallets'
 import {anyErrors} from '../../constants/waiting'
 import Onboarding from '.'
 
@@ -15,7 +15,7 @@ const ConnectedOnboarding = Container.connect(
     const error = anyErrors(state, Constants.acceptDisclaimerWaitingKey)
     const {acceptingDisclaimerDelay} = state.wallets
     return {
-      acceptDisclaimerError: error && error.message ? error.message : '',
+      acceptDisclaimerError: error?.message ?? '',
       acceptingDisclaimerDelay: acceptingDisclaimerDelay,
     }
   },
@@ -37,9 +37,9 @@ const ConnectedOnboarding = Container.connect(
 
 // A wrapper to harmonize the type of OwnProps between the
 // routed case and <Onboarding /> case.
-type RoutedOnboardingProps = Container.RouteProps<OwnProps>
+type RoutedOnboardingProps = Container.RouteProps<'walletOnboarding'>
 export const RoutedOnboarding = (ownProps: RoutedOnboardingProps) => (
-  <ConnectedOnboarding nextScreen={Container.getRouteProps(ownProps, 'nextScreen', 'openWallet')} />
+  <ConnectedOnboarding nextScreen={ownProps.route.params?.nextScreen ?? 'openWallet'} />
 )
 
 export default ConnectedOnboarding

--- a/shared/wallets/qr-scan/container.tsx
+++ b/shared/wallets/qr-scan/container.tsx
@@ -4,7 +4,7 @@ import * as Container from '../../util/container'
 import * as WalletsGen from '../../actions/wallets-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 const mapStateToProps = () => ({})
 const mapDispatchToProps = dispatch => ({

--- a/shared/wallets/receive-modal/container.tsx
+++ b/shared/wallets/receive-modal/container.tsx
@@ -5,37 +5,35 @@ import * as WalletsGen from '../../actions/wallets-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import Receive from '.'
 
-export type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
+export type OwnProps = Container.RouteProps<'receive'>
 
-const mapStateToProps = (state, ownProps) => {
-  const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
-  const account = Constants.getAccount(state, accountID)
-  return {
-    accountName: account.name,
-    federatedAddress: Constants.getFederatedAddress(state, accountID),
-    isDefaultAccount: account.isDefault,
-    stellarAddress: accountID,
-  }
-}
-
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  navigateUp: () => dispatch(RouteTreeGen.createNavigateUp()),
-  onRequest: () => {
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
-    dispatch(RouteTreeGen.createNavigateUp())
-    dispatch(
-      WalletsGen.createOpenSendRequestForm({
-        from: accountID,
-        isRequest: true,
-      })
-    )
+export default Container.connect(
+  (state, ownProps: OwnProps) => {
+    const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
+    const account = Constants.getAccount(state, accountID)
+    return {
+      accountName: account.name,
+      federatedAddress: Constants.getFederatedAddress(state, accountID),
+      isDefaultAccount: account.isDefault,
+      stellarAddress: accountID,
+    }
   },
-})
-
-const mergeProps = (stateProps, dispatchProps) => ({
-  ...stateProps,
-  onClose: dispatchProps.navigateUp,
-  onRequest: dispatchProps.onRequest,
-})
-
-export default Container.connect(mapStateToProps, mapDispatchToProps, mergeProps)(Receive)
+  (dispatch, ownProps: OwnProps) => ({
+    navigateUp: () => dispatch(RouteTreeGen.createNavigateUp()),
+    onRequest: () => {
+      const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
+      dispatch(RouteTreeGen.createNavigateUp())
+      dispatch(
+        WalletsGen.createOpenSendRequestForm({
+          from: accountID,
+          isRequest: true,
+        })
+      )
+    },
+  }),
+  (stateProps, dispatchProps) => ({
+    ...stateProps,
+    onClose: dispatchProps.navigateUp,
+    onRequest: dispatchProps.onRequest,
+  })
+)(Receive)

--- a/shared/wallets/routes-send-request-form.tsx
+++ b/shared/wallets/routes-send-request-form.tsx
@@ -1,9 +1,9 @@
 import * as Constants from '../constants/wallets'
-import ChooseAsset from './send-form/choose-asset/container'
-import PickAsset from './send-form/pick-asset'
-import ConfirmForm from './confirm-form/container'
-import QRScan from './qr-scan/container'
-import SendForm from './send-form/container'
+import type ChooseAsset from './send-form/choose-asset/container'
+import type PickAsset from './send-form/pick-asset'
+import type ConfirmForm from './confirm-form/container'
+import type QRScan from './qr-scan/container'
+import type SendForm from './send-form/container'
 
 export const newModalRoutes = {
   [Constants.chooseAssetFormRouteKey]: {

--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -16,6 +16,7 @@ import type WhatIsStellarModal from './what-is-stellar-modal'
 import type Settings from './wallet/settings/container'
 import type TransactionDetails from './transaction-details/container'
 import type TeamBuilder from '../team-building/container'
+import type * as TeamBuildingTypes from '../constants/types/team-building'
 
 export const sharedRoutes = {
   // TODO connect broken
@@ -69,4 +70,19 @@ export const newModalRoutes = {
   whatIsStellarModal: {
     getScreen: (): typeof WhatIsStellarModal => require('./what-is-stellar-modal').default,
   },
+}
+
+type TeamBuilderProps = Partial<{
+  namespace: TeamBuildingTypes.AllowedNamespace
+  teamID: string
+  filterServices: Array<TeamBuildingTypes.ServiceIdWithContact>
+  goButtonLabel: TeamBuildingTypes.GoButtonLabel
+  title: string
+}>
+
+export type RootParamListWallets = {
+  walletTeamBuilder: TeamBuilderProps
+  keybaseLinkError: {
+    errorSource: 'app' | 'sep6' | 'sep7'
+  }
 }

--- a/shared/wallets/routes.tsx
+++ b/shared/wallets/routes.tsx
@@ -17,6 +17,7 @@ import type Settings from './wallet/settings/container'
 import type TransactionDetails from './transaction-details/container'
 import type TeamBuilder from '../team-building/container'
 import type * as TeamBuildingTypes from '../constants/types/team-building'
+import type * as Types from '../constants/types/wallets'
 
 export const sharedRoutes = {
   // TODO connect broken
@@ -80,9 +81,53 @@ type TeamBuilderProps = Partial<{
   title: string
 }>
 
+// TODO fix up the missing prefix on these routes
 export type RootParamListWallets = {
   walletTeamBuilder: TeamBuilderProps
   keybaseLinkError: {
     errorSource: 'app' | 'sep6' | 'sep7'
+  }
+  setDefaultAccount: {
+    accountID: Types.AccountID
+  }
+  walletOnboarding: {
+    nextScreen: Types.NextScreenAfterAcceptance
+  }
+  transactionDetails: {
+    accountID: Types.AccountID
+    paymentID: Types.PaymentID
+  }
+  sendReceiveForm: {
+    isAdvanced: boolean
+  }
+  pickAssetForm: {
+    // ignored if username is set or isSender===true
+    accountID: string
+    // ignored if isSender===true; if empty, we assume this is for a non-keybaseUser account and just say "this account"
+    username: string
+    isSender: boolean
+  }
+  removeAccount: {
+    accountID: Types.AccountID
+  }
+  createNewAccount: {
+    fromSendForm?: boolean
+    showOnCreation?: boolean
+  }
+  trustline: {
+    accountID: Types.AccountID
+  }
+  receive: {
+    accountID: Types.AccountID
+  }
+  linkExisting: {
+    fromSendForm?: boolean
+    showOnCreation?: boolean
+  }
+  reallyRemoveAccount: {
+    accountID: Types.AccountID
+  }
+  renameAccount: {
+    accountID: Types.AccountID
   }
 }

--- a/shared/wallets/send-form/choose-asset/container.tsx
+++ b/shared/wallets/send-form/choose-asset/container.tsx
@@ -5,7 +5,7 @@ import * as RouteTreeGen from '../../../actions/route-tree-gen'
 import * as Constants from '../../../constants/wallets'
 import * as Types from '../../../constants/types/wallets'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 export default Container.connect(
   state => {

--- a/shared/wallets/send-form/container.tsx
+++ b/shared/wallets/send-form/container.tsx
@@ -3,12 +3,12 @@ import * as WalletsGen from '../../actions/wallets-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as Container from '../../util/container'
 
-type OwnProps = Container.RouteProps<{isAdvanced: boolean}>
+type OwnProps = Container.RouteProps<'sendReceiveForm'>
 
 export default Container.connect(
   state => ({isRequest: state.wallets.building.isRequest}),
   (dispatch, ownProps: OwnProps) => {
-    const isAdvanced = Container.getRouteProps(ownProps, 'isAdvanced', false)
+    const isAdvanced = ownProps.route.params?.isAdvanced ?? false
     return {
       onBack: isAdvanced
         ? () => dispatch(RouteTreeGen.createNavigateUp())
@@ -19,7 +19,7 @@ export default Container.connect(
     }
   },
   ({isRequest}, {onBack, onClose}, ownProps) => ({
-    isAdvanced: Container.getRouteProps(ownProps, 'isAdvanced', false),
+    isAdvanced: ownProps.route.params?.isAdvanced ?? false,
     isRequest,
     onBack,
     onClose,

--- a/shared/wallets/send-form/pick-asset.tsx
+++ b/shared/wallets/send-form/pick-asset.tsx
@@ -8,13 +8,7 @@ import * as RouteTreeGen from '../../actions/route-tree-gen'
 import * as WalletsGen from '../../actions/wallets-gen'
 import Header from './header'
 
-type Props = Container.RouteProps<{
-  // ignored if username is set or isSender===true
-  accountID: string
-  // ignored if isSender===true; if empty, we assume this is for a non-keybaseUser account and just say "this account"
-  username: string
-  isSender: boolean
-}>
+type Props = Container.RouteProps<'pickAssetForm'>
 
 const AssetList = ({accountID, isSender, username}) => {
   const acceptedAssets = Container.useSelector(state =>
@@ -100,9 +94,9 @@ const AssetList = ({accountID, isSender, username}) => {
 }
 
 const PickAsset = (props: Props) => {
-  const accountID = Container.getRouteProps(props, 'accountID', Types.noAccountID)
-  const isSender = Container.getRouteProps(props, 'isSender', false)
-  const username = Container.getRouteProps(props, 'username', '')
+  const accountID = props.route.params?.accountID ?? Types.noAccountID
+  const isSender = props.route.params?.isSender ?? false
+  const username = props.route.params?.username ?? ''
 
   const dispatch = Container.useDispatch()
   const onBack = React.useCallback(() => dispatch(RouteTreeGen.createNavigateUp()), [dispatch])

--- a/shared/wallets/transaction-details/container.tsx
+++ b/shared/wallets/transaction-details/container.tsx
@@ -7,16 +7,17 @@ import * as WalletsGen from '../../actions/wallets-gen'
 import * as RouteTreeGen from '../../actions/route-tree-gen'
 import {getFullname} from '../../constants/users'
 import openURL from '../../util/open-url'
-import TransactionDetails, {NotLoadingProps} from '.'
+import TransactionDetails, {type NotLoadingProps} from '.'
 import {anyWaiting} from '../../constants/waiting'
 
-type OwnProps = Container.RouteProps<{accountID: Types.AccountID; paymentID: Types.PaymentID}>
+type OwnProps = Container.RouteProps<'transactionDetails'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
     const you = state.config.username
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
-    const paymentID = Container.getRouteProps(ownProps, 'paymentID', Types.noPaymentID)
+    const {params} = ownProps.route
+    const accountID = params?.accountID ?? Types.noAccountID
+    const paymentID = params?.paymentID ?? Types.noPaymentID
     const _transaction = Constants.getPayment(state, accountID, paymentID)
     const yourInfoAndCounterparty = Constants.paymentToYourInfoAndCounterparty(_transaction)
     // Transaction can briefly be empty when status changes
@@ -43,7 +44,7 @@ export default Container.connect(
     onCancelPayment: () =>
       dispatch(
         WalletsGen.createCancelPayment({
-          paymentID: Container.getRouteProps(ownProps, 'paymentID', Types.noPaymentID),
+          paymentID: ownProps.route.params?.paymentID ?? Types.noPaymentID,
           showAccount: true,
         })
       ),
@@ -52,8 +53,8 @@ export default Container.connect(
     onLoadPaymentDetail: () =>
       dispatch(
         WalletsGen.createLoadPaymentDetail({
-          accountID: Container.getRouteProps(ownProps, 'accountID', Types.noAccountID),
-          paymentID: Container.getRouteProps(ownProps, 'paymentID', Types.noPaymentID),
+          accountID: ownProps.route.params?.accountID ?? Types.noAccountID,
+          paymentID: ownProps.route.params?.paymentID ?? Types.noPaymentID,
         })
       ),
     onShowProfile: (username: string) => dispatch(ProfileGen.createShowUserProfile({username})),

--- a/shared/wallets/trustline/container.tsx
+++ b/shared/wallets/trustline/container.tsx
@@ -7,13 +7,13 @@ import * as Waiting from '../../constants/waiting'
 import debounce from 'lodash/debounce'
 import Trustline from '.'
 
-type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
+type OwnProps = Container.RouteProps<'trustline'>
 
 const emptyAccountAsset = Constants.makeAssets()
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
+    const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
     return {
       accountAssets: Constants.getAssets(state, accountID),
       canAddTrustline: Constants.getAccount(state, accountID).canAddTrustline,
@@ -30,7 +30,7 @@ export default Container.connect(
     ),
   }),
   (s, d, o: OwnProps) => {
-    const accountID = Container.getRouteProps(o, 'accountID', Types.noAccountID)
+    const accountID = o.route.params?.accountID ?? Types.noAccountID
     const acceptedAssets = s.trustline.acceptedAssets.get(accountID) ?? Constants.emptyAccountAcceptedAssets
     return {
       acceptedAssets: [...acceptedAssets.keys()],

--- a/shared/wallets/wallet/settings/container.tsx
+++ b/shared/wallets/wallet/settings/container.tsx
@@ -1,14 +1,14 @@
-import Settings from '.'
-import * as Container from '../../../util/container'
-import {anyWaiting} from '../../../constants/waiting'
 import * as Constants from '../../../constants/wallets'
-import {IconType} from '../../../common-adapters/icon.constants-gen'
+import * as Container from '../../../util/container'
 import * as IconUtils from '../../../common-adapters/icon.shared'
-import * as Types from '../../../constants/types/wallets'
-import * as WalletsGen from '../../../actions/wallets-gen'
 import * as RouteTreeGen from '../../../actions/route-tree-gen'
+import * as WalletsGen from '../../../actions/wallets-gen'
+import Settings from '.'
+import type * as Types from '../../../constants/types/wallets'
+import type {IconType} from '../../../common-adapters/icon.constants-gen'
+import {anyWaiting} from '../../../constants/waiting'
 
-type OwnProps = Container.RouteProps
+type OwnProps = {}
 
 // Note: `props.user` is only the Keybase username if this is the primary
 // account. Non-primary accounts are not associated with usernames.

--- a/shared/wallets/wallet/settings/popups/really-remove-account/container.tsx
+++ b/shared/wallets/wallet/settings/popups/really-remove-account/container.tsx
@@ -7,13 +7,12 @@ import * as Types from '../../../../../constants/types/wallets'
 import {anyWaiting} from '../../../../../constants/waiting'
 import ReallyRemoveAccountPopup from '.'
 
-type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
+type OwnProps = Container.RouteProps<'reallyRemoveAccount'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
+    const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
     const secretKey = Constants.getSecretKey(state, accountID).stringValue()
-
     return {
       accountID,
       name: Constants.getAccount(state, accountID).name,

--- a/shared/wallets/wallet/settings/popups/remove-account/container.tsx
+++ b/shared/wallets/wallet/settings/popups/remove-account/container.tsx
@@ -4,13 +4,12 @@ import * as Types from '../../../../../constants/types/wallets'
 import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import RemoveAccountPopup from '.'
 
-type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
+type OwnProps = Container.RouteProps<'removeAccount'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
+    const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
     const account = Constants.getAccount(state, accountID)
-
     return {
       accountID,
       balance: account.balanceDescription,

--- a/shared/wallets/wallet/settings/popups/rename-account/container.tsx
+++ b/shared/wallets/wallet/settings/popups/rename-account/container.tsx
@@ -7,11 +7,11 @@ import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import {anyWaiting} from '../../../../../constants/waiting'
 import RenameAccount from '.'
 
-type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
+type OwnProps = Container.RouteProps<'renameAccount'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
+    const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
     const selectedAccount = Constants.getAccount(state, accountID)
     return {
       accountID,

--- a/shared/wallets/wallet/settings/popups/set-default/container.tsx
+++ b/shared/wallets/wallet/settings/popups/set-default/container.tsx
@@ -6,12 +6,11 @@ import * as RouteTreeGen from '../../../../../actions/route-tree-gen'
 import {anyWaiting} from '../../../../../constants/waiting'
 import SetDefaultAccountPopup from '.'
 
-type OwnProps = Container.RouteProps<{accountID: Types.AccountID}>
+type OwnProps = Container.RouteProps<'setDefaultAccount'>
 
 export default Container.connect(
   (state, ownProps: OwnProps) => {
-    const accountID = Container.getRouteProps(ownProps, 'accountID', Types.noAccountID)
-
+    const accountID = ownProps.route.params?.accountID ?? Types.noAccountID
     return {
       accountID,
       accountName: Constants.getAccount(state, accountID).name,


### PR DESCRIPTION
This PR adds type safety to pulling things out of the react navigation routing. It's mostly mechanical moving the type defs into the routes and using a string to get the type

There will be a followup PR to ensure you're actually dispatching the params correctly