### PR TITLE
fix mobile build

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -138,6 +138,7 @@
         "typedarray-to-buffer": "4.0.0",
         "url-parse": "1.5.10",
         "use-memo-one": "1.1.2",
+        "process": "keybase/nullModule",
         "util": "0.12.4"
     },
     "devDependencies": {

--- a/shared/rn-transformer.js
+++ b/shared/rn-transformer.js
@@ -5,6 +5,14 @@ module.exports.transform = function (p) {
   if (p.filename.endsWith('.desktop.tsx')) {
     throw new Error('Electron polluting RN' + p.filename)
   }
+  console.log('aaa', p.filename)
+  if (p.filename === 'process') {
+    return upstreamTransformer.transform({
+      filename: p.filename,
+      options: p.options,
+      src: 'module.export = ""',
+    })
+  }
   if (p.filename.endsWith('css')) {
     return upstreamTransformer.transform({
       filename: p.filename,

--- a/shared/rn-transformer.js
+++ b/shared/rn-transformer.js
@@ -5,14 +5,6 @@ module.exports.transform = function (p) {
   if (p.filename.endsWith('.desktop.tsx')) {
     throw new Error('Electron polluting RN' + p.filename)
   }
-  console.log('aaa', p.filename)
-  if (p.filename === 'process') {
-    return upstreamTransformer.transform({
-      filename: p.filename,
-      options: p.options,
-      src: 'module.export = ""',
-    })
-  }
   if (p.filename.endsWith('css')) {
     return upstreamTransformer.transform({
       filename: p.filename,

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -7341,7 +7341,7 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-msgpack@keybase/nullModule, net@keybase/nullModule, purepack@>=1, purepack@keybase/nullModule, tls@keybase/nullModule:
+msgpack@keybase/nullModule, net@keybase/nullModule, process@keybase/nullModule, purepack@>=1, purepack@keybase/nullModule, tls@keybase/nullModule:
   version "0.0.0"
   resolved "https://codeload.github.com/keybase/nullModule/tar.gz/e0d7d7874eb4d1fd82056f92f146589186fe94f0"
 


### PR DESCRIPTION
msgpack needs process for parts we don't use. after removing our old hot loader it removed a process polyfill, instead we use a nulone