### PR TITLE
fix golang hash for 1.19.3

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get install -y nodejs yarn
 # the check should not ever fail.
 ENV GOLANG_VERSION 1.19.3
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 18ac263e39210bcf68d85f4370e97fb1734166995a1f63fb38b4f6e07d90d212
+ENV GOLANG_DOWNLOAD_SHA256 74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 RUN wget "$GOLANG_DOWNLOAD_URL" -O /root/go.tar.gz
 RUN echo "$GOLANG_DOWNLOAD_SHA256 /root/go.tar.gz" | sha256sum --check --status --strict -
 RUN tar -C /usr/local -xzf /root/go.tar.gz

--- a/packaging/linux/tuxbot/provision_tuxbot_root
+++ b/packaging/linux/tuxbot/provision_tuxbot_root
@@ -8,7 +8,7 @@ apt-get install -yq git curl vim python3-pip jq
 
 GOLANG_VERSION=1.19.3
 GOLANG_DOWNLOAD_URL=https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=18ac263e39210bcf68d85f4370e97fb1734166995a1f63fb38b4f6e07d90d212
+GOLANG_DOWNLOAD_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 wget "$GOLANG_DOWNLOAD_URL" -O /root/go.tar.gz
 echo "$GOLANG_DOWNLOAD_SHA256 /root/go.tar.gz" | sha256sum --check --status --strict -
 tar -C /usr/local -xzf /root/go.tar.gz


### PR DESCRIPTION
had previously used the go1.19.3.src.tar.gz instead of go1.19.3.linux-amd64.tar.gz hash

cc @heronhaye 