### PR TITLE
drop 32 bit linux build

### DIFF
--- a/packaging/linux/README.md
+++ b/packaging/linux/README.md
@@ -1,27 +1,29 @@
 # Keybase Linux Packaging
+
 See usage and technical docs at https://keybase.io/docs/linux-user-guide.
 GitHub issues, bug reports, and pull requests welcome, especially if something
 small can be changed to support your distribution or setup.
 
-If you make changes to a shell file, *please run
-[shellcheck](https://www.shellcheck.net/)* and make sure there are no
+If you make changes to a shell file, _please run
+[shellcheck](https://www.shellcheck.net/)_ and make sure there are no
 additional warnings!
 
 ## External packagers
+
 The main cross-platform build file is `build_binaries.sh`.
 
 You can set some environment variables to control what gets built.
 `KEYBASE_BUILD_ARM_ONLY=1` - builds arm64 only
-`KEYBASE_SKIP_64_BIT=1` - builds 32 bit only
-`KEYBASE_SKIP_32_BIT=1` - builds 64 bit only
+`KEYBASE_SKIP_64_BIT=1` - skips the 64 bit build
 
-The default is to build both 32-bit and 64-bit.
+The default is to build 64-bit.
 
 There are test Dockerfiles and a helpful README at
 https://github.com/keybase/client/tree/master/packaging/linux/test that you can
 use to make sure your changes work correctly on different systems.
 
 ## Internal packagers
+
 `build_and_push_packages.sh` also pushes them to our own apt, rpm, and AUR
 repos, but requires credentials that can be tested with `test_all_credentials.sh`
 (note: `s3cmd` required).
@@ -46,12 +48,13 @@ If you want to test the build without pushing live, set `KEYBASE_DRY_RUN=1` in
 the environment. Be very careful not to typo that variable. You should see
 "This build+push is a DRY RUN." after all the git fetches in the build output,
 if you did this right. A dry run will push the package to the s3 bucket
-tests.keybase.io.  You could copy the repo to somewhere in
+tests.keybase.io. You could copy the repo to somewhere in
 prerelease.keybase.io to test a `yum install`, for example.
 
 To make a nightly build, add `KEYBASE_NIGHTLY=1` to the environment.
 
 #### Making changes to the Dockerfile
+
 The most common change is bumping the version of Go we're using. Do that
 in the Dockerfile in this directory. Whenenever you make changes that
 affect the docker image, you also need to bump its version number in
@@ -63,5 +66,6 @@ Increment that number, so that everyone who's running these builds
 automatically rebuilds the docker image with your change.
 
 #### Setting up the automated slackbot
+
 Clone https://github.com/keybase/slackbot and follow the instructions in
 systemd/README.md.

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -202,13 +202,3 @@ if [ -z "${KEYBASE_SKIP_64_BIT:-}" ] ; then
 else
   echo SKIPPING 64-bit build
 fi
-
-if [ -z "${KEYBASE_SKIP_32_BIT:-}" ] ; then
-  echo "Keybase: Building for x86"
-  export GOARCH=386
-  export debian_arch=i386
-  export electron_arch=ia32
-  build_one_architecture
-else
-  echo SKIPPING 32-bit build
-fi

--- a/packaging/linux/docker/alpine/Dockerfile
+++ b/packaging/linux/docker/alpine/Dockerfile
@@ -11,7 +11,6 @@ RUN gpg --import /code_signing_key
 COPY . /go/src/github.com/keybase/client
 RUN SOURCE_COMMIT=${SOURCE_COMMIT} \
     KEYBASE_NO_GUI=1 \
-    KEYBASE_SKIP_32_BIT=1 \
     /go/src/github.com/keybase/client/packaging/linux/build_binaries.sh \
     prerelease /
 RUN gpg --detach-sign --armor --use-agent --local-user "$SIGNING_FINGERPRINT" \

--- a/packaging/linux/docker/standard/Dockerfile
+++ b/packaging/linux/docker/standard/Dockerfile
@@ -9,7 +9,6 @@ RUN gpg --import /code_signing_key
 COPY . /go/src/github.com/keybase/client
 RUN SOURCE_COMMIT=${SOURCE_COMMIT} \
     KEYBASE_NO_GUI=1 \
-    KEYBASE_SKIP_32_BIT=1 \
     /go/src/github.com/keybase/client/packaging/linux/build_binaries.sh \
     prerelease /
 RUN gpg --detach-sign --armor --use-agent --local-user "$SIGNING_FINGERPRINT" \

--- a/packaging/linux/test/README.md
+++ b/packaging/linux/test/README.md
@@ -1,5 +1,4 @@
-Debian/Ubuntu:
-=======
+# Debian/Ubuntu:
 
 To build a package for debian from a local branch in client (on amd64):
 
@@ -19,7 +18,7 @@ Then, from inside the docker environment:
     git remote add localclient /CLIENT
     git fetch localclient
     git checkout localclient/<NAME_OF_LOCAL_BRANCH_TO_TEST>
-    KEYBASE_SKIP_32_BIT=1 packaging/linux/build_binaries.sh prerelease /root/build
+    packaging/linux/build_binaries.sh prerelease /root/build
     packaging/linux/deb/package_binaries.sh /root/build
     packaging/linux/rpm/package_binaries.sh /root/build
     exit
@@ -52,6 +51,7 @@ Then inside it:
     run_keybase
 
 After that you can upgrade it:
+
     exit  # back to root
     cd /root/build/deb/amd64
     dpkg -i `ls -tr *.deb | tail -1`
@@ -85,8 +85,7 @@ The following packages will be upgraded:
   keybase
 ```
 
-Ubuntu with systemd:
-=======
+# Ubuntu with systemd:
 
 Systemd requires that the docker container be run as a daemon:
 
@@ -100,8 +99,7 @@ Then inside the container you can use the same steps as above to
 install and start keybase. Instead of `su`, you may need to `login <user>`
 so the systemd pam config runs.
 
-Centos:
-========
+# Centos:
 
     docker pull centos
     docker build -t keybase-centos-test $GOPATH/src/github.com/keybase/client/packaging/linux/test/keybase-centos-test
@@ -122,6 +120,7 @@ Then inside it:
     run_keybase
 
 After that you can upgrade it:
+
     exit  # back to root
     cd /root/build/rpm/x86_64/RPMS/x86_64
     rpm -Uvh `ls -tr *.rpm | tail -1`
@@ -169,13 +168,12 @@ Note that reinstalling will overwrite this change unless you `sudo touch
 comment out codesigning while testing). You also need to `rm -r /root/build/rpm
 /root/build/rpm_repo` in between `layout_repo`s.
 
-Centos with systemd:
-=======
+# Centos with systemd:
+
 You can use the Dockerfile at https://github.com/xrowgmbh/docker-systemd-example-httpd, but note that centos
 doesn't support systemd user services right now, so Keybase will be using background anyway.
 
-Arch:
-=====
+# Arch:
 
     docker pull base/archlinux
     docker build -t keybase-arch-test $GOPATH/src/github.com/keybase/client/packaging/linux/test/keybase-arch-test


### PR DESCRIPTION
electron dropped support for this, removing it from our build scripts. 

https://www.electronjs.org/blog/linux-32bit-support

i left the `KEYBASE_SKIP_64_BIT` flag in, in case some script depends on it. `packaging/linux/build_binaries.sh` doesn't have any useful output in that case though..

@chrisnojima @heronhaye 