### PR TITLE
remove i386 builds

### DIFF
--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -9,12 +9,11 @@ LABEL maintainer="Keybase <admin@keybase.io>"
 #   - 'curl' and 'wget' are for downloading Go and Node
 #   - 'build-essential' pulls in gcc etc., which Go requires.
 #   - python and pip for recent versions of s3cmd
-#   - libc6-dev-i386 for the i386 cgo part of the build
 #   - gnupg1 to avoid a password issue in key import
 #   - unzip because electron6 packager requires it
 RUN apt-get update
 RUN apt-get install -y fakeroot reprepro rpm createrepo git wget \
-  build-essential curl python python-pip libc6-dev-i386 gnupg1 unzip
+  build-essential curl python python-pip gnupg1 unzip
 
 # Install s3cmd. See this issue for why we need a version newer than what's in
 # the Debian repos: https://github.com/s3tools/s3cmd/issues/437

--- a/packaging/linux/arch/PKGBUILD.bin.in
+++ b/packaging/linux/arch/PKGBUILD.bin.in
@@ -19,18 +19,13 @@ depends=(fuse libxss gtk3 lsof) # don't change this without changing the SRCINFO
 provides=(keybase keybase-gui kbfs)
 # keybase-release is a deprecated AUR package
 conflicts=(keybase keybase-release keybase-git keybase-gui kbfs)
-source_i686=(
-  "${src_prefix}/keybase_${deb_pkgver}_i386.deb"
-)
 source_x86_64=(
   "${src_prefix}/keybase_${deb_pkgver}_amd64.deb"
 )
 install=keybase.install
 
 package() {
-  if [ "$CARCH" = "i686" ] ; then
-    deb_arch="i386"
-  elif [ "$CARCH" = "x86_64" ] ; then
+  if [ "$CARCH" = "x86_64" ] ; then
     deb_arch="amd64"
   else
     echo "Unknown arch: $CARCH"
@@ -48,6 +43,4 @@ package() {
 
 # You can cross reference these hashes with Keybase Debian repo metadata:
 # https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
-# https://prerelease.keybase.io/deb/dists/stable/main/binary-i386/Packages
-sha256sums_i686=(@@SUM_i686@@)
 sha256sums_x86_64=(@@SUM_x86_64@@)

--- a/packaging/linux/arch/PKGBUILD.bin.in
+++ b/packaging/linux/arch/PKGBUILD.bin.in
@@ -13,7 +13,6 @@ src_prefix=@@SRC_PREFIX@@
 deb_pkgver="${pkgver/_/-}"
 deb_pkgver="${deb_pkgver/+/.}"
 pkgrel=1
-arch=('i686' 'x86_64')
 depends=(fuse libxss gtk3 lsof) # don't change this without changing the SRCINFO template too
                                 # also make sure to change the keybase-git PKGBUILD
 provides=(keybase keybase-gui kbfs)

--- a/packaging/linux/arch/arch_common.sh
+++ b/packaging/linux/arch/arch_common.sh
@@ -31,20 +31,15 @@ setup_arch_build() {
     # https://aur.archlinux.org/packages/keybase-bin.
     debver="$(cat "$build_root/VERSION" | sed s/+/./)"
 
-    deb_i386="$(ls "$build_root"/deb/i386/*.deb)"
-    sum_i386="$(sha256sum "$deb_i386" | awk '{print $1}')"
-
     deb_amd64="$(ls "$build_root"/deb/amd64/*.deb)"
     sum_amd64="$(sha256sum "$deb_amd64" | awk '{print $1}')"
 
     if [ "$src_prefix" = "." ]; then
-        cp $deb_i386 $keybase_bin_repo/keybase_${debver}_i386.deb
         cp $deb_amd64 $keybase_bin_repo/keybase_${debver}_amd64.deb
     fi
 
     cat "$here/PKGBUILD.bin.in" \
         | sed "s/@@PKGVER@@/$pkgver/g" \
-        | sed "s/@@SUM_i686@@/$sum_i386/g" \
         | sed "s/@@SUM_x86_64@@/$sum_amd64/g" \
         | sed "s|@@SRC_PREFIX@@|$src_prefix|g" \
               > "$keybase_bin_repo/PKGBUILD"
@@ -52,7 +47,6 @@ setup_arch_build() {
     cat "$here/DOT_SRCINFO.bin.in" \
         | sed "s/@@PKGVER@@/$pkgver/g" \
         | sed "s/@@DEBVER@@/$debver/g" \
-        | sed "s/@@SUM_i686@@/$sum_i386/g" \
         | sed "s/@@SUM_x86_64@@/$sum_amd64/g" \
         | sed "s|@@SRC_PREFIX@@|$src_prefix|g" \
               > "$keybase_bin_repo/.SRCINFO"

--- a/packaging/linux/deb/layout_repo.sh
+++ b/packaging/linux/deb/layout_repo.sh
@@ -37,11 +37,11 @@ mkdir -p "$repo_root/repo/conf"
 cat > "$repo_root/repo/conf/distributions" << END
 Codename: stable
 Components: main
-Architectures: i386 amd64
+Architectures: amd64
 SignWith: $code_signing_fingerprint
 END
 
-for debian_arch in amd64 i386 ; do
+for debian_arch in amd64 ; do
   echo Creating the Debian repo hierarchy.
   # Create/update the Debian repository hierarchy. The layout of this is
   # described here: https://wiki.debian.org/RepositoryFormat We use the

--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -1,9 +1,8 @@
 #! /usr/bin/env bash
 
-# Builds the keybase binary and packages it into two ".deb" files, one for i386
-# and one for amd64. The argument to this script is the output directory of a
-# build_binaries.sh build. The package files are created there, in their
-# respective architecture folders.
+# Builds the keybase binary and packages it into a ".deb" file for amd64. The
+# argument to this script is the output directory of a build_binaries.sh build.
+# The package files are created there, in their respective architecture folders.
 #
 # Usage:
 #   ./package_binaries.sh <build_root>
@@ -97,7 +96,4 @@ build_one_architecture() {
 }
 
 export debian_arch=amd64
-build_one_architecture
-
-export debian_arch=i386
 build_one_architecture

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -58,7 +58,7 @@ gpg_tempfile="$gpg_tempdir/code_signing_key"
 gpg --export-secret-key --armor "$code_signing_fingerprint" > "$gpg_tempfile"
 
 # Make sure the Docker image is built.
-image=keybase_packaging_v36
+image=keybase_packaging_v37
 if [ -z "$(sudo docker images -q "$image")" ] ; then
   echo "Docker image '$image' not yet built. Building..."
   sudo docker build -t "$image" "$clientdir/packaging/linux"

--- a/packaging/linux/rpm/layout_repo.sh
+++ b/packaging/linux/rpm/layout_repo.sh
@@ -54,7 +54,7 @@ fi
 # Copy the RPM files into our repo. This is flatter than the way Debian's
 # reprepro does things, and it's allowed to contain multiple copies of the same
 # package.
-for arch in i386 x86_64 ; do
+for arch in x86_64 ; do
   rpmfile="$(ls "$build_root/rpm/$arch/RPMS/$arch"/*.rpm)"  # keybase, kdstage, or kbdev
   rpmname="$(basename "$rpmfile")"
   destdir="$repo_root/repo/$arch"

--- a/packaging/linux/rpm/package_binaries.sh
+++ b/packaging/linux/rpm/package_binaries.sh
@@ -1,9 +1,8 @@
 #! /usr/bin/env bash
 
-# Builds the keybase binary and packages it into two ".rpm" files, one for i386
-# and one for amd64. The argument to this script is the output directory of a
-# build_binaries.sh build. The package files are created there, in their
-# respective architecture folders.
+# Builds the keybase binary and packages it into a ".rpm" file for amd64. The
+# argument to this script is the output directory of a build_binaries.sh build.
+# The package files are created there, in their respective architecture folders.
 #
 # Usage:
 #   ./package_binaries.sh <build_root>
@@ -106,17 +105,6 @@ build_one_architecture() {
 
   rpmbuild --define "_topdir $dest" --target "$rpm_arch" -bb "$spec"
 }
-
-export rpm_arch=i386
-export debian_arch=i386
-# On Fedora, it would be more correct to require "libXScrnSaver",
-# which provides libXss.so. Unfortunately that doesn't work on
-# OpenSUSE. This is the most compatible set of dependencies we've
-# found.  "psmisc" provides "killall", which is used in run_keybase.
-# "initscripts" provides "service", which is used to start atd in the
-# post-install.
-dependencies="Requires: at, fuse, libXss.so.1, /sbin/service, psmisc, lsof, procps"
-build_one_architecture
 
 export rpm_arch=x86_64
 export debian_arch=amd64

--- a/packaging/linux/rpm/updateinfo.xml
+++ b/packaging/linux/rpm/updateinfo.xml
@@ -10,7 +10,6 @@
       <collection>
         <name>Keybase</name>
         <package arch="x86_64" name="keybase" release="1" version="2.11.0.20181115195458.06d3f3f3c4"></package>
-        <package arch="i386" name="keybase" release="1" version="2.11.0.20181115195458.06d3f3f3c4"></package>
       </collection>
     </pkglist>
   </update>
@@ -27,9 +26,6 @@
       <collection>
         <name>Keybase</name>
         <package arch="x86_64" name="keybase" release="1" version="2.8.0.20181023124437.06221a8264">
-            <reboot_suggested>True</reboot_suggested>
-        </package>
-        <package arch="i386" name="keybase" release="1" version="2.8.0.20181023124437.06221a8264">
             <reboot_suggested>True</reboot_suggested>
         </package>
       </collection>

--- a/packaging/windows/readme.md
+++ b/packaging/windows/readme.md
@@ -3,17 +3,20 @@
 ## Install Prereqs
 
 ### Go
+
 - [go for windows](https://golang.org/dl)
 - Environment: `set GOPATH=C:\work`
 
 ### Git
 
 - [git for windows](https://git-scm.com/downloads)
+
   - Select "Use Git and optional Unix tools from the Command Prompt" (so scripts with `rm` will work)
   - Checkout as-is, conmmit Unix style line endings
   - Use Windows' default console window (especially on Windows 10)
 
 - Open a command console and make a directory for cloning the repo, e.g.:
+
 ```
 git clone https://github.com/keybase/client.git c:\work\src\github.com\keybase\client
 git clone https://github.com/keybase/go-updater.git c:\work\src\github.com\keybase\go-updater
@@ -46,7 +49,7 @@ git clone https://github.com/keybase/go-updater.git c:\work\src\github.com\keyba
 > npm i -g yarn
 ```
 
-###  Mingpw
+### Mingpw
 
 - [GCC via Mingw-64](https://sourceforge.net/projects/mingw-w64/) (for building kbfsdokan)
   - Be sure and choose architecture x86-64, NOT i686
@@ -54,11 +57,14 @@ git clone https://github.com/keybase/go-updater.git c:\work\src\github.com\keyba
     - Try `C:\mingw-w64\.... instead`
 
 ## Building
+
 [GCC via Mingw-64](https://sourceforge.net/projects/mingw-w64/) (for building kbfsdokan)
+
 - Be sure and choose architecture x86-64, NOT i686
 - Also recommend not installing in `program files`, e.g. `C:\mingw-w64\...` instead of `C:\Program Files (x86)\mingw-w64\...`
 
 Environment:
+
 ```
 set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH%
 set CC=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin\gcc
@@ -68,7 +74,7 @@ set CPATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\include
 ## Building Installers
 
 - [Visual Studio 2015 Professional](https://visualstudio.microsoft.com/vs/older-downloads/)
-(may require live.com account)
+  (may require live.com account)
 
 - Environment:
   - `call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat"`
@@ -79,6 +85,7 @@ set CPATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\include
 ## Building a debug installer without codesigning
 
 - Environment:
+
   - `set KEYBASE_WINBUILD=0`
 
 - Invoke the scripts to build the executables:
@@ -90,18 +97,21 @@ doinstaller_wix.cmd debug
 ```
 
 - OR, there's a little script that combines the above:
-   - `.\build_debug_installer.cmd`
+
+  - `.\build_debug_installer.cmd`
 
 - Make sure you restart `CMD.exe` after doing the above installs; otherwise, these scripts
   won't be able to find WIX.
 
 ## Production CMD Scripts
+
 - `build_prerelease.cmd` builds most of the client executables
 - `buildui.cmd` builds the ui
 - `doinstaller_wix.cmd` does codesigning on all the executabls and builds the installer (requires signing certificate)
 - `dorelease.cmd` calls the above scripts and copies to s3. Invoked by the build bot.
 
 # Upgrading Dokan
+
 Download `DokanSetup_redist.exe` from https://github.com/dokan-dev/dokany/releases
 Upload to S3 at prerelease.keybase.io/windows-support/dokan-dev/[VERSION]/DokanSetup_redist.exe
 Get the sha1 hash of DokanSetup_redist.exe:
@@ -111,15 +121,19 @@ Change the version the service considers new enough: https://github.com/keybase/
 Optional: change the minimum version KBFS will work with: https://github.com/keybase/client/blob/master/go/kbfs/dokan/loaddll.go#L110
 
 # Windows VMs
+
 - available [here](https://dev.windows.com/en-us/microsoft-edge/tools/vms/windows/)
 - full isos [here](https://www.microsoft.com/en-gb/software-download/windows10ISO), which might need product keys
 
-#  Might be Useful...
+# Might be Useful...
+
 - [Chocolatey](https://chocolatey.org/install) (helpful for yarn)
   - then: `choco install yarn`
 
 # Installed Product Layout and Functionality
+
 The installer places/updates all the files and adds:
+
 - startup shortcut for
 - start menu shortcut
 - background tile color
@@ -141,4 +155,3 @@ Notable executables
 `prompter.exe` - updater GUI
 `upd.exe` - updater
 `Gui\Keybase.exe` - GUI
-


### PR DESCRIPTION
follow up to https://github.com/keybase/client/pull/25312

```
Dec 06 22:59:30 buster go[17751]: Making .deb package for amd64.
Dec 06 22:59:32 buster go[17751]: dpkg-deb: building package 'keybase' in '/root/build/deb/amd64/keybase-6.1.1-20221206225252.310e8bc534-amd64.deb'.
Dec 06 23:01:39 buster go[17751]: Making .deb package for i386.
Dec 06 23:01:39 buster go[17751]: cp: cannot stat '/root/build/binaries/i386/*': No such file or directory
```

@heronhaye 