### PR TITLE
minimize pan related closure scope , reduce effects /state

### DIFF
--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -110,7 +110,6 @@ const makePanOnFinalize = (p: {
 
     if (!panLocked) {
       sendRecording()
-      // setVisible(Visible.START_HIDDEN)
       fadeSV.value = withTiming(0, {duration: 200})
     }
   }
@@ -202,7 +201,6 @@ const useIconAndOverlay = (p: {
   const {stageRecording, startRecording, sendRecording, cancelRecording, flashTip, ampSV} = p
   const [visible, setVisible] = React.useState(Visible.HIDDEN)
 
-  // for , react uses the above
   const lockedSV = useSharedValue(0)
   const canceledSV = useSharedValue(0)
   const dragXSV = useSharedValue(0)
@@ -467,7 +465,7 @@ const useRecorder = (p: {
     }
     impl()
       .then(() => {})
-      .catch(e => {
+      .catch(() => {
         onReset()
           .then(() => {})
           .catch(() => {})

--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -43,7 +43,6 @@ enum Visible {
 
 const useTooltip = () => {
   const [showTooltip, setShowTooltip] = React.useState(false)
-  console.log('aaa showTooltip', showTooltip)
   const opacitySV = useSharedValue(0)
 
   const animatedStyles = useAnimatedStyle(() => ({opacity: opacitySV.value}))
@@ -99,7 +98,6 @@ const makePanOnFinalize = (p: {
   const {onCancelRecording, onFlashTip} = p
   const {sendRecording, fadeSV, startedSV, lockedSV, canceledSV} = p
   const onPanFinalizeJS = (needTip: boolean, wasCancel: boolean, panLocked: boolean) => {
-    console.log('aaa onPanFinalizeJS ', {needTip, panLocked, wasCancel})
     if (wasCancel) {
       onCancelRecording()
       return
@@ -149,7 +147,6 @@ const makePanOnUpdate = (p: {lockedSV: SVN; canceledSV: SVN; dragYSV: SVN; dragX
   const {lockedSV, dragYSV, dragXSV, canceledSV} = p
   const onOnUpdateWorklet = (e: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
     if (lockedSV.value || canceledSV.value) {
-      console.log('aaa update bail on locked or canceld', lockedSV.value, canceledSV.value)
       return
     }
     const maxCancelDrift = -120
@@ -172,7 +169,6 @@ const GestureIcon = React.memo(
     panOnUpdate: ReturnType<typeof makePanOnUpdate>
     panOnStart: ReturnType<typeof makePanOnStart>
   }) {
-    console.log('aaaa GestuerIcon render')
     const {panOnStart, panOnUpdate, panOnFinalize} = p
     return (
       <View>
@@ -377,8 +373,6 @@ const useRecorder = (p: {
   const ampTracker = React.useRef(new AmpTracker()).current
   const [staged, setStaged] = React.useState(false)
 
-  console.log('aaa staged', staged)
-
   const stopRecording = React.useCallback(async () => {
     recordEndRef.current = Date.now()
     const recording = recordingRef.current
@@ -474,7 +468,6 @@ const useRecorder = (p: {
     impl()
       .then(() => {})
       .catch(e => {
-        console.log('aaa start recording throw catch', e)
         onReset()
           .then(() => {})
           .catch(() => {})
@@ -548,8 +541,6 @@ const useRecorder = (p: {
   return {audioSend, cancelRecording, sendRecording, stageRecording, staged, startRecording}
 }
 
-let NOJIMA = {}
-
 const AudioRecorder = React.memo(function AudioRecorder(props: Props) {
   const {conversationIDKey, setShowAudioSend, showAudioSend} = props
   const ampSV = useSharedValue(0)
@@ -569,38 +560,6 @@ const AudioRecorder = React.memo(function AudioRecorder(props: Props) {
     stageRecording,
     startRecording,
   })
-
-  console.log('aaa audio recorder render', Math.random())
-  React.useEffect(() => {
-    console.log('aaa mounted')
-    return () => {
-      console.log('aaa UNmounted')
-    }
-  }, [])
-
-  const TEMP = {
-    audioSend,
-    cancelRecording,
-    conversationIDKey,
-    flashTip,
-    icon,
-    overlay,
-    sendRecording,
-    setShowAudioSend,
-    showAudioSend,
-    stageRecording,
-    startRecording,
-    tooltip,
-  }
-
-  if (NOJIMA) {
-    Object.keys(TEMP).forEach(k => {
-      TEMP[k] !== NOJIMA[k] && console.log('aaa DIFF >>>> ', k)
-    })
-  }
-  NOJIMA = TEMP
-
-  console.log('aaaa tooltip', tooltip)
 
   return (
     <>

--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -166,30 +166,34 @@ const makePanOnUpdate = (p: {lockedSV: SVN; canceledSV: SVN; dragYSV: SVN; dragX
   return onOnUpdateWorklet
 }
 
-const GestureIcon = (p: {
-  panOnFinalize: ReturnType<typeof makePanOnFinalize>
-  panOnUpdate: ReturnType<typeof makePanOnUpdate>
-  panOnStart: ReturnType<typeof makePanOnStart>
-}) => {
-  console.log('aaaa GestuerIcon render')
-  const {panOnStart, panOnUpdate, panOnFinalize} = p
-  return (
-    <View>
-      <GestureDetector
-        gesture={Gesture.Pan()
-          .minDistance(0)
-          .minPointers(1)
-          .maxPointers(1)
-          .activateAfterLongPress(200)
-          .onStart(panOnStart)
-          .onFinalize(panOnFinalize)
-          .onUpdate(panOnUpdate)}
-      >
-        <Kb.Icon type="iconfont-mic" style={styles.iconStyle} />
-      </GestureDetector>
-    </View>
-  )
-}
+const GestureIcon = React.memo(
+  function GestureIcon(p: {
+    panOnFinalize: ReturnType<typeof makePanOnFinalize>
+    panOnUpdate: ReturnType<typeof makePanOnUpdate>
+    panOnStart: ReturnType<typeof makePanOnStart>
+  }) {
+    console.log('aaaa GestuerIcon render')
+    const {panOnStart, panOnUpdate, panOnFinalize} = p
+    return (
+      <View>
+        <GestureDetector
+          gesture={Gesture.Pan()
+            .minDistance(0)
+            .minPointers(1)
+            .maxPointers(1)
+            .activateAfterLongPress(200)
+            .onStart(panOnStart)
+            .onFinalize(panOnFinalize)
+            .onUpdate(panOnUpdate)}
+        >
+          <Kb.Icon type="iconfont-mic" style={styles.iconStyle} />
+        </GestureDetector>
+      </View>
+    )
+  },
+  // we never want to rerender the icon, all the helpers are fine at mount
+  () => true
+)
 
 const useIconAndOverlay = (p: {
   flashTip: () => void

--- a/shared/ios/Keybase/AppDelegate.mm
+++ b/shared/ios/Keybase/AppDelegate.mm
@@ -100,9 +100,9 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
 #if DEBUG
-  // uncomment to get a prod bundle. If you set this it remembers so set it back
-  // and re-run to reset it!
-  // [[RCTBundleURLProvider sharedSettings] setEnableDev: false];  
+  [[RCTBundleURLProvider sharedSettings] setEnableDev: true];
+  // uncomment to get a prod bundle.
+//   [[RCTBundleURLProvider sharedSettings] setEnableDev: false];
   return
   [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
 #else

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -53,7 +53,7 @@ let config = {
 
 // Developer settings
 if (__DEV__) {
-  config.enableActionLogging = true
+  config.enableActionLogging = false
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working

--- a/shared/local-debug.native.tsx
+++ b/shared/local-debug.native.tsx
@@ -53,7 +53,7 @@ let config = {
 
 // Developer settings
 if (__DEV__) {
-  config.enableActionLogging = false
+  config.enableActionLogging = true
   config.enableStoreLogging = false
   config.immediateStateLogging = false
   // Move this outside the if statement to get notifications working


### PR DESCRIPTION
Due to sensitivity of accidentally capturing and retaining the gesture in scopes we delegate to new scopes so less is captured.
Additionally we reduce react state to avoid rerenders as we transition within showing the overlay (locked, visible etc)
Also using `useAnimatedReaction` to tie SV to react state