### PR TITLE
fix keybase chat sends during packaging

### DIFF
--- a/packaging/slack/send.sh
+++ b/packaging/slack/send.sh
@@ -17,6 +17,6 @@ if [ -n "$convid" ]; then
   echo "Sending to Keybase convID: $convid"
   location=${KEYBASE_LOCATION:-"keybase"}
   home=${KEYBASE_HOME:-$HOME}
-  msg=$(echo -n "$@" | awk '{ printf "%s\\\n", $0 }')
+  msg=$(echo -n "$@" | awk '{ printf "%s\\n", $0 }')
   $location --home "$home" chat api -m "{\"method\":\"send\", \"params\": {\"options\": { \"conversation_id\": \"$convid\" , \"message\": { \"body\": \"$msg\" }}}}"
 fi


### PR DESCRIPTION
fixes this which has popped up in the packaging logs:

```
$ KEYBASE_CONV_ID=xxx ./packaging/slack/send.sh "hi \n
asdfa"
hi \n
asdfa
Sending to Keybase convID: xxx
{"error":{"code":0,"message":"invalid character '\\n' in string escape code"}}
```
```
$ KEYBASE_CONV_ID=xxx ./packaging/slack/send.sh "hi"
hi
Sending to Keybase convID: xxx
{"error":{"code":0,"message":"invalid JSON: expected more JSON in input"}}
```

@mmaxim 