### PR TITLE
bump updater version

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19
 	github.com/keybase/go-triplesec v0.0.0-20211109205539-1f96eeacbd86
 	github.com/keybase/go-triplesec-insecure v0.0.0-20211118164850-99654891ba7c
-	github.com/keybase/go-updater v0.0.0-20221220221613-1f73fc2aff5c
+	github.com/keybase/go-updater v0.0.0-20221221194633-9e97736a0b42
 	github.com/keybase/go-winio v0.4.12-0.20180913221037-b1d96ab97b58
 	github.com/keybase/golang-ico v0.0.0-20181117022008-819cbeb217c9
 	github.com/keybase/gomounts v0.0.0-20180302000443-349507f4d353

--- a/go/go.sum
+++ b/go/go.sum
@@ -507,8 +507,8 @@ github.com/keybase/go-triplesec v0.0.0-20211109205539-1f96eeacbd86 h1:WBkAiUyX6s
 github.com/keybase/go-triplesec v0.0.0-20211109205539-1f96eeacbd86/go.mod h1:V+gy/TqD8lamMW/PhByZdxZ+bWDiVW4nWBPH81/4aek=
 github.com/keybase/go-triplesec-insecure v0.0.0-20211118164850-99654891ba7c h1:/xY+gqu46T+7FRItBIXHA3E/I42eKTtVTETouCSCzUQ=
 github.com/keybase/go-triplesec-insecure v0.0.0-20211118164850-99654891ba7c/go.mod h1:nCWPdCjs0Me3jva/igideWkFVjBiCgCDBPt2DK3COd4=
-github.com/keybase/go-updater v0.0.0-20221220221613-1f73fc2aff5c h1:+oo95HVcg+jJ9nJPU7++d+ZniCrbPi99yY7Od7OIOVw=
-github.com/keybase/go-updater v0.0.0-20221220221613-1f73fc2aff5c/go.mod h1:ne1BruxmXYg/q6pZcNm4Lk5mNMaLZoVFzkUkXILMNzE=
+github.com/keybase/go-updater v0.0.0-20221221194633-9e97736a0b42 h1:Lix6VfHewZcmtVSc9Dp1CsDXjNigKjP+7p0j5MhR5xQ=
+github.com/keybase/go-updater v0.0.0-20221221194633-9e97736a0b42/go.mod h1:ne1BruxmXYg/q6pZcNm4Lk5mNMaLZoVFzkUkXILMNzE=
 github.com/keybase/go-winio v0.4.12-0.20180913221037-b1d96ab97b58 h1:W3c3cQc7Fe2LWwa9gz1qyOBfJwuMNcnVIoHP9joEUzI=
 github.com/keybase/go-winio v0.4.12-0.20180913221037-b1d96ab97b58/go.mod h1:Rcswqyeiwun4CF+RpzSNllKs3nO8Es5HZIhl+8YCm94=
 github.com/keybase/golang-ico v0.0.0-20181117022008-819cbeb217c9 h1:O4kEXd3yzbpHCRqwjbsBNKlanp52zXjKP6nFh9VSGy0=


### PR DESCRIPTION
bring in https://github.com/keybase/go-updater/pull/208, https://github.com/keybase/go-updater/pull/207
@mmaxim 