### PR TITLE
bump go-updater

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19
 	github.com/keybase/go-triplesec v0.0.0-20211109205539-1f96eeacbd86
 	github.com/keybase/go-triplesec-insecure v0.0.0-20211118164850-99654891ba7c
-	github.com/keybase/go-updater v0.0.0-20221221194633-9e97736a0b42
+	github.com/keybase/go-updater v0.0.0-20221221215057-da7f21f4d90b
 	github.com/keybase/go-winio v0.4.12-0.20180913221037-b1d96ab97b58
 	github.com/keybase/golang-ico v0.0.0-20181117022008-819cbeb217c9
 	github.com/keybase/gomounts v0.0.0-20180302000443-349507f4d353

--- a/go/go.sum
+++ b/go/go.sum
@@ -507,8 +507,8 @@ github.com/keybase/go-triplesec v0.0.0-20211109205539-1f96eeacbd86 h1:WBkAiUyX6s
 github.com/keybase/go-triplesec v0.0.0-20211109205539-1f96eeacbd86/go.mod h1:V+gy/TqD8lamMW/PhByZdxZ+bWDiVW4nWBPH81/4aek=
 github.com/keybase/go-triplesec-insecure v0.0.0-20211118164850-99654891ba7c h1:/xY+gqu46T+7FRItBIXHA3E/I42eKTtVTETouCSCzUQ=
 github.com/keybase/go-triplesec-insecure v0.0.0-20211118164850-99654891ba7c/go.mod h1:nCWPdCjs0Me3jva/igideWkFVjBiCgCDBPt2DK3COd4=
-github.com/keybase/go-updater v0.0.0-20221221194633-9e97736a0b42 h1:Lix6VfHewZcmtVSc9Dp1CsDXjNigKjP+7p0j5MhR5xQ=
-github.com/keybase/go-updater v0.0.0-20221221194633-9e97736a0b42/go.mod h1:ne1BruxmXYg/q6pZcNm4Lk5mNMaLZoVFzkUkXILMNzE=
+github.com/keybase/go-updater v0.0.0-20221221215057-da7f21f4d90b h1:TJDwWkgpDNDlyBbACZQzRCGVGB0UA8jyit7M0t2G9Aw=
+github.com/keybase/go-updater v0.0.0-20221221215057-da7f21f4d90b/go.mod h1:ne1BruxmXYg/q6pZcNm4Lk5mNMaLZoVFzkUkXILMNzE=
 github.com/keybase/go-winio v0.4.12-0.20180913221037-b1d96ab97b58 h1:W3c3cQc7Fe2LWwa9gz1qyOBfJwuMNcnVIoHP9joEUzI=
 github.com/keybase/go-winio v0.4.12-0.20180913221037-b1d96ab97b58/go.mod h1:Rcswqyeiwun4CF+RpzSNllKs3nO8Es5HZIhl+8YCm94=
 github.com/keybase/golang-ico v0.0.0-20181117022008-819cbeb217c9 h1:O4kEXd3yzbpHCRqwjbsBNKlanp52zXjKP6nFh9VSGy0=


### PR DESCRIPTION
incorporate detection when running in rosetta  to upgrade to native arm pkg https://github.com/keybase/go-updater/pull/209

@mmaxim 