### PR TITLE
ios darkmode fixes

### DIFF
--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -58,7 +58,7 @@ const NativeEventsToRedux = (p: {setDarkMode: (d: boolean) => void}) => {
       darkSub.remove()
       linkingSub.remove()
     }
-  }, [dispatch])
+  }, [dispatch, dispatchAndSetDarkmode])
 
   return null
 }

--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -18,9 +18,18 @@ module.hot?.accept(() => {
   console.log('accepted update in shared/index.native')
 })
 
-const NativeEventsToRedux = () => {
+const NativeEventsToRedux = (p: {setDarkMode: (d: boolean) => void}) => {
+  const {setDarkMode} = p
   const dispatch = useDispatch()
-  const appStateRef = React.useRef('unknown')
+  const appStateRef = React.useRef('active')
+
+  const dispatchAndSetDarkmode = React.useCallback(
+    (dark: boolean) => {
+      setDarkMode(dark)
+      dispatch(ConfigGen.createSetSystemDarkMode({dark}))
+    },
+    [dispatch, setDarkMode]
+  )
 
   React.useEffect(() => {
     const appStateChangeSub = AppState.addEventListener('change', nextAppState => {
@@ -30,14 +39,14 @@ const NativeEventsToRedux = () => {
         dispatch(ConfigGen.createMobileAppState({nextAppState}))
 
       if (nextAppState === 'active') {
-        dispatch(ConfigGen.createSetSystemDarkMode({dark: Appearance.getColorScheme() === 'dark'}))
+        dispatchAndSetDarkmode(Appearance.getColorScheme() === 'dark')
       }
     })
 
     // only watch dark changes if in foreground due to ios calling this to take snapshots
     const darkSub = Appearance.addChangeListener(() => {
       if (appStateRef.current === 'active') {
-        dispatch(ConfigGen.createSetSystemDarkMode({dark: Appearance.getColorScheme() === 'dark'}))
+        dispatchAndSetDarkmode(Appearance.getColorScheme() === 'dark')
       }
     })
     const linkingSub = Linking.addEventListener('url', ({url}: {url: string}) => {
@@ -86,6 +95,9 @@ const ensureStore = () => {
 // on android this can be recreated a bunch so our engine/store / etc should live outside
 const Keybase = () => {
   ensureStore()
+
+  const [darkMode, setDarkMode] = React.useState(Styles.isDarkMode())
+
   if (!_store) return null // never happens
 
   // TODO if we use it, add it here
@@ -96,12 +108,14 @@ const Keybase = () => {
       <Provider store={_store.store}>
         <PortalProvider>
           <SafeAreaProvider>
-            <Styles.CanFixOverdrawContext.Provider value={true}>
-              <Main />
-            </Styles.CanFixOverdrawContext.Provider>
+            <Styles.DarkModeContext.Provider value={darkMode}>
+              <Styles.CanFixOverdrawContext.Provider value={true}>
+                <Main />
+              </Styles.CanFixOverdrawContext.Provider>
+            </Styles.DarkModeContext.Provider>
           </SafeAreaProvider>
         </PortalProvider>
-        <NativeEventsToRedux />
+        <NativeEventsToRedux setDarkMode={setDarkMode} />
       </Provider>
     </GestureHandlerRootView>
   )

--- a/shared/common-adapters/icon.native.tsx
+++ b/shared/common-adapters/icon.native.tsx
@@ -123,6 +123,8 @@ const Icon = React.memo<Props>(
     const hasContainer = p.onClick && p.style
     const iconType = Shared.typeToIconMapper(p.type)
 
+    const isDarkMode = React.useContext(Styles.DarkModeContext)
+
     if (!iconType) {
       logger.warn('Null iconType passed')
       return null
@@ -160,7 +162,7 @@ const Icon = React.memo<Props>(
     } else {
       icon = (
         <Image
-          source={(Styles.isDarkMode() && iconMeta[iconType].requireDark) || iconMeta[iconType].require}
+          source={(isDarkMode && iconMeta[iconType].requireDark) || iconMeta[iconType].require}
           style={hasContainer ? null : p.style}
           ref={wrap ? undefined : ref}
         />

--- a/shared/styles/dark-mode.tsx
+++ b/shared/styles/dark-mode.tsx
@@ -1,6 +1,29 @@
 import * as React from 'react'
-// Darkmode is managed by redux but for things (proxies and etc) to get this value simply the value is
-// copied here
+// The current darkMode story is complex and could be cleaned up.
+// Current state: In app/index.native we register for the system events which tell us if the mode changes.
+// You can also manually configure to override this. We also inject it on startup in the root index.ios.js files
+// This then dispatches to redux so it can be in there so we can drive the settings screens. We recently
+// added context which should likely be used instead of isDarkMode (see below)
+//
+// Individual components can then call Styles.isDarkMode() to get the value. Problem is they need to know that
+// that value has changed.
+// To solve this at the router level we increment the navKey to cause an entire redraw. This is very
+// overkill and causes state to be lost (scroll etc).
+// Our Styles.styleSheetCreate takes a function which is called so we can grab the values in both dark and light
+// contexts. We have light/dark colors in styles/colors. So to most components that just use a color, they can
+// just use a 'magic' color which has two versions.
+//
+// Now some peculiarities:
+// ios: ios actually has native support for the 'magic' colors so we use that. This means we actually don't
+// do the navKey thing so we can maintain state and you get native blending when the switch happens.
+// But as a side effect if you call isDarkMode() you never know if that changes and you're not redrawn
+// so you can get out of sync. The solution to this is to use the Styles.DarkModeContext but that was
+// just added.
+// One additional note. The animation system does not work with the magic colors so that code will use
+// the explicit colors/darkColors and not this magic wrapper
+//
+// Future work:
+// Likely move this all out of redux and into context
 export type DarkModePreference = 'system' | 'alwaysDark' | 'alwaysLight'
 
 let darkModePreference: DarkModePreference = 'system'

--- a/shared/styles/dark-mode.tsx
+++ b/shared/styles/dark-mode.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 // Darkmode is managed by redux but for things (proxies and etc) to get this value simply the value is
 // copied here
 export type DarkModePreference = 'system' | 'alwaysDark' | 'alwaysLight'
@@ -33,3 +34,5 @@ export const isDarkMode = () => {
 export const isDarkModeSystemSupported = () => systemSupported
 export const isSystemDarkMode = () => systemDarkMode
 export const isDarkModePreference = () => darkModePreference
+
+export const DarkModeContext = React.createContext(isDarkMode())

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -161,6 +161,5 @@ export type {
 export {default as classNames} from 'classnames'
 export {default as styled} from '@emotion/styled'
 export declare const CanFixOverdrawContext: React.Context<boolean>
-export declare const dontFixOverdraw: {canFixOverdraw: false}
-export declare const yesFixOverdraw: {canFixOverdraw: true}
+export declare const DarkModeContext: React.Context<boolean>
 export declare const undynamicColor: (col: any) => any

--- a/shared/styles/index.desktop.tsx
+++ b/shared/styles/index.desktop.tsx
@@ -231,7 +231,7 @@ export {default as classNames} from 'classnames'
 export type StylesCrossPlatform = CSS.StylesCrossPlatform
 export const dimensionWidth = 0
 export const dimensionHeight = 0
-export {isDarkMode} from './dark-mode'
+export {isDarkMode, DarkModeContext} from './dark-mode'
 export const headerExtraHeight = 0
 export const CanFixOverdrawContext = React.createContext(false)
 export const dontFixOverdraw = {canFixOverdraw: false}

--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -140,13 +140,12 @@ export {
 export {default as styled} from '@emotion/native'
 export {themed as globalColors} from './colors'
 export {default as classNames} from 'classnames'
+export {DarkModeContext} from './dark-mode'
 export const borderRadius = 6
 export const dimensionWidth = Dimensions.get('window').width
 export const dimensionHeight = Dimensions.get('window').height
 export const headerExtraHeight = isTablet ? 16 : 0
 export const CanFixOverdrawContext = React.createContext(false)
-export const dontFixOverdraw = {canFixOverdraw: false}
-export const yesFixOverdraw = {canFixOverdraw: true}
 export const undynamicColor = (col: any) => {
   // try and unwrap, some things (toggle?) don't seems to like mixed dynamic colors
   if (typeof col !== 'string' && col.dynamic) {

--- a/shared/tracker2/assertion/index.tsx
+++ b/shared/tracker2/assertion/index.tsx
@@ -257,6 +257,44 @@ type State = {
   showingMenu: boolean
 }
 
+type SIProps = {
+  full: boolean
+} & Pick<
+  Props,
+  | 'siteIconFullDarkmode'
+  | 'siteIconFull'
+  | 'siteIconDarkmode'
+  | 'siteIcon'
+  | 'onCreateProof'
+  | 'onShowProof'
+  | 'isSuggestion'
+>
+const AssertionSiteIcon = (p: SIProps) => {
+  const {full, siteIconFullDarkmode, siteIconFull, siteIconDarkmode, siteIcon} = p
+  const {onCreateProof, onShowProof, isSuggestion} = p
+  const isDarkMode = React.useContext(Styles.DarkModeContext)
+  const set = full
+    ? isDarkMode
+      ? siteIconFullDarkmode
+      : siteIconFull
+    : isDarkMode
+    ? siteIconDarkmode
+    : siteIcon
+  if (!set) return null
+  let child = <SiteIcon full={full} set={set} />
+  if (full) {
+    return child
+  }
+  if (!Styles.isMobile && isSuggestion) {
+    child = <HoverOpacity>{child}</HoverOpacity>
+  }
+  return (
+    <Kb.ClickableBox onClick={onCreateProof || onShowProof} style={isSuggestion ? styles.halfOpacity : null}>
+      {child}
+    </Kb.ClickableBox>
+  )
+}
+
 class Assertion extends React.PureComponent<Props, State> {
   state = {showingMenu: false}
   _toggleMenu = () => this.setState(s => ({showingMenu: !s.showingMenu}))
@@ -327,7 +365,16 @@ class Assertion extends React.PureComponent<Props, State> {
           fullWidth={true}
         >
           <Kb.Box2 direction="vertical" style={styles.positionRelative}>
-            {this._siteIcon(true)}
+            <AssertionSiteIcon
+              full={true}
+              siteIconFullDarkmode={this.props.siteIconFullDarkmode}
+              siteIconFull={this.props.siteIconFull}
+              siteIconDarkmode={this.props.siteIconDarkmode}
+              siteIcon={this.props.siteIcon}
+              onCreateProof={this.props.onCreateProof}
+              onShowProof={this.props.onShowProof}
+              isSuggestion={this.props.isSuggestion}
+            />
             <Kb.Icon type={stateToDecorationIcon(p.state)} style={styles.siteIconFullDecoration} />
           </Kb.Box2>
           {!!this.props.timestamp && (
@@ -342,31 +389,6 @@ class Assertion extends React.PureComponent<Props, State> {
       ),
       items: [{onClick: p.onShowProof, title: `View ${proofTypeToDesc(p.type)}`}, onRevoke],
     }
-  }
-  _siteIcon = (full: boolean) => {
-    const set = full
-      ? Styles.isDarkMode()
-        ? this.props.siteIconFullDarkmode
-        : this.props.siteIconFull
-      : Styles.isDarkMode()
-      ? this.props.siteIconDarkmode
-      : this.props.siteIcon
-    if (!set) return null
-    let child = <SiteIcon full={full} set={set} />
-    if (full) {
-      return child
-    }
-    if (!Styles.isMobile && this.props.isSuggestion) {
-      child = <HoverOpacity>{child}</HoverOpacity>
-    }
-    return (
-      <Kb.ClickableBox
-        onClick={this.props.onCreateProof || this.props.onShowProof}
-        style={this.props.isSuggestion ? styles.halfOpacity : null}
-      >
-        {child}
-      </Kb.ClickableBox>
-    )
   }
   render() {
     const p = this.props
@@ -388,7 +410,16 @@ class Assertion extends React.PureComponent<Props, State> {
           gapStart={true}
           gapEnd={true}
         >
-          {this._siteIcon(false)}
+          <AssertionSiteIcon
+            full={false}
+            siteIconFullDarkmode={this.props.siteIconFullDarkmode}
+            siteIconFull={this.props.siteIconFull}
+            siteIconDarkmode={this.props.siteIconDarkmode}
+            siteIcon={this.props.siteIcon}
+            onCreateProof={this.props.onCreateProof}
+            onShowProof={this.props.onShowProof}
+            isSuggestion={this.props.isSuggestion}
+          />
           <Kb.Text type="Body" style={styles.textContainer}>
             <Value {...p} />
             {!p.isSuggestion && (


### PR DESCRIPTION
Due to a long ago switch to using the dynamic colors on ios, components that call `Styles.isDarkMode()` but aren't forced to rerender (ios only) can not be aware that darkmode changed. This never happens when its just a pure color changing but if its an actual image or there's other caching it'll be a problem. To fix this I've introduced a darkMode context at the root which is actually how this problem should be solved. I fixed the chat inbox avatars 'shh' icon and the profile page platform icon but there are other places where this is a live problem (but likely people rarely see it). We could later on do a larger cleanup of this given the new context but that'll be for another day.