### PR TITLE
make new version info for each build

### DIFF
--- a/packaging/prerelease/build_app.sh
+++ b/packaging/prerelease/build_app.sh
@@ -89,24 +89,25 @@ if [ "$smoke_test" = "1" ]; then
   number_of_builds=2
 fi
 
-# required for cross compilation to arm64 on darwin amd64 machine.
-export CGO_ENABLED=1
-current_date=`date -u +%Y%m%d%H%M%S` # UTC
-commit_short=`git log -1 --pretty=format:%h`
-build="$current_date+$commit_short"
-# Consumed by build_keybase.sh and on darwin-arm64 builds below. We the value
-# here so it is consistent across the build compilation and build announcement
-# since we can't echo the version of the binary when cross compiling.
-KEYBASE_BUILD=${KEYBASE_BUILD:-$build}
-KBNM_BUILD=${KBNM_BUILD:-$build}
-KBFS_BUILD=${KBFS_BUILD:-$build}
-kb_version="$(grep 'Version = ' $client_dir/go/libkb/version.go | sed 's/.*Version = \"\(.*\)\"/\1/')"
-KEYBASE_VERSION=${KEYBASE_VERSION:-"$kb_version-$KEYBASE_BUILD"}
-KBNM_VERSION=${KBNM_VERSION:-"$kb_version-$KBNM_BUILD"}
-KBFS_VERSION=${KBFS_VERSION:-"$kb_version-$KBFS_BUILD"}
-
 # Okay, here's where we start generating version numbers and doing builds.
 for ((i=1; i<=$number_of_builds; i++)); do
+
+  # required for cross compilation to arm64 on darwin amd64 machine.
+  export CGO_ENABLED=1
+  current_date=`date -u +%Y%m%d%H%M%S` # UTC
+  commit_short=`git log -1 --pretty=format:%h`
+  build="$current_date+$commit_short"
+  # Consumed by build_keybase.sh and on darwin-arm64 builds below. We the value
+  # here so it is consistent across the build compilation and build announcement
+  # since we can't echo the version of the binary when cross compiling.
+  KEYBASE_BUILD=${KEYBASE_BUILD:-$build}
+  KBNM_BUILD=${KBNM_BUILD:-$build}
+  KBFS_BUILD=${KBFS_BUILD:-$build}
+  kb_version="$(grep 'Version = ' $client_dir/go/libkb/version.go | sed 's/.*Version = \"\(.*\)\"/\1/')"
+  KEYBASE_VERSION=${KEYBASE_VERSION:-"$kb_version-$KEYBASE_BUILD"}
+  KBNM_VERSION=${KBNM_VERSION:-"$kb_version-$KBNM_BUILD"}
+  KBFS_VERSION=${KBFS_VERSION:-"$kb_version-$KBFS_BUILD"}
+
   if [ ! "$nobuild" = "1" ]; then
     KEYBASE_BUILD="$KEYBASE_BUILD" BUILD_DIR="$build_dir_keybase" "$dir/build_keybase.sh"
     KBFS_BUILD="$KBFS_BUILD" BUILD_DIR="$build_dir_kbfs" CLIENT_DIR="$client_dir" "$dir/build_kbfs.sh"


### PR DESCRIPTION
Otherwise each smoke build gets the same version and it doesn't work.