### PR TITLE
Progress on attachment view

### DIFF
--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -11,7 +11,6 @@ export const resetStore = 'common:resetStore' // not a part of chat2 but is hand
 export const typePrefix = 'chat2:'
 export const addAttachmentViewMessage = 'chat2:addAttachmentViewMessage'
 export const addBotMember = 'chat2:addBotMember'
-export const addToMessageMap = 'chat2:addToMessageMap'
 export const addUserToChannel = 'chat2:addUserToChannel'
 export const addUsersToChannel = 'chat2:addUsersToChannel'
 export const attachFromDragAndDrop = 'chat2:attachFromDragAndDrop'
@@ -1316,10 +1315,6 @@ export const createSetLoadedBotPage = (payload: {readonly page: number}) => ({
   payload,
   type: setLoadedBotPage as typeof setLoadedBotPage,
 })
-export const createAddToMessageMap = (payload: {readonly message: Types.Message}) => ({
-  payload,
-  type: addToMessageMap as typeof addToMessageMap,
-})
 export const createAttachFromDragAndDrop = (payload: {
   readonly conversationIDKey: Types.ConversationIDKey
   readonly paths: Array<Types.PathAndOutboxID>
@@ -1416,7 +1411,6 @@ export const createUpdateUserReacjis = (payload: {readonly userReacjis: RPCTypes
 // Action Payloads
 export type AddAttachmentViewMessagePayload = ReturnType<typeof createAddAttachmentViewMessage>
 export type AddBotMemberPayload = ReturnType<typeof createAddBotMember>
-export type AddToMessageMapPayload = ReturnType<typeof createAddToMessageMap>
 export type AddUserToChannelPayload = ReturnType<typeof createAddUserToChannel>
 export type AddUsersToChannelPayload = ReturnType<typeof createAddUsersToChannel>
 export type AttachFromDragAndDropPayload = ReturnType<typeof createAttachFromDragAndDrop>
@@ -1586,7 +1580,6 @@ export type UpdateUserReacjisPayload = ReturnType<typeof createUpdateUserReacjis
 export type Actions =
   | AddAttachmentViewMessagePayload
   | AddBotMemberPayload
-  | AddToMessageMapPayload
   | AddUserToChannelPayload
   | AddUsersToChannelPayload
   | AttachFromDragAndDropPayload

--- a/shared/actions/chat2-gen.tsx
+++ b/shared/actions/chat2-gen.tsx
@@ -1012,10 +1012,10 @@ export const createUpdateReactions = (payload: {
 /**
  * The user has selected an attachment with a preview
  */
-export const createAttachmentPreviewSelect = (payload: {readonly message: Types.MessageAttachment}) => ({
-  payload,
-  type: attachmentPreviewSelect as typeof attachmentPreviewSelect,
-})
+export const createAttachmentPreviewSelect = (payload: {
+  readonly conversationIDKey: Types.ConversationIDKey
+  readonly ordinal: Types.Ordinal
+}) => ({payload, type: attachmentPreviewSelect as typeof attachmentPreviewSelect})
 /**
  * Toggle /giphy text to trigger preview window
  */
@@ -1195,10 +1195,10 @@ export const createUpdateMoreToLoad = (payload: {
 /**
  * We want to save an attachment to the local disk
  */
-export const createAttachmentDownload = (payload: {readonly message: Types.Message}) => ({
-  payload,
-  type: attachmentDownload as typeof attachmentDownload,
-})
+export const createAttachmentDownload = (payload: {
+  readonly conversationIDKey: Types.ConversationIDKey
+  readonly ordinal: Types.Ordinal
+}) => ({payload, type: attachmentDownload as typeof attachmentDownload})
 /**
  * We want to unbox an inbox row
  */

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2096,13 +2096,15 @@ const downloadAttachment = async (
 
 // Download an attachment to your device
 const attachmentDownload = async (
-  _: Container.TypedState,
+  state: Container.TypedState,
   action: Chat2Gen.AttachmentDownloadPayload,
   listenerApi: Container.ListenerApi
 ) => {
-  const {message} = action.payload
+  const {conversationIDKey, ordinal} = action.payload
 
-  if (message.type !== 'attachment') {
+  const message = state.chat2.messageMap.get(conversationIDKey)?.get(ordinal)
+
+  if (message?.type !== 'attachment') {
     throw new Error('Trying to download missing / incorrect message?')
   }
 
@@ -2116,13 +2118,13 @@ const attachmentDownload = async (
 }
 
 const attachmentPreviewSelect = (_: unknown, action: Chat2Gen.AttachmentPreviewSelectPayload) => [
-  Chat2Gen.createAddToMessageMap({message: action.payload.message}),
+  // Chat2Gen.createAddToMessageMap({message: action.payload.message}),
   RouteTreeGen.createNavigateAppend({
     path: [
       {
         props: {
-          conversationIDKey: action.payload.message.conversationIDKey,
-          ordinal: action.payload.message.ordinal,
+          conversationIDKey: action.payload.conversationIDKey,
+          ordinal: action.payload.ordinal,
         },
         selected: 'chatAttachmentFullscreen',
       },

--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2117,8 +2117,7 @@ const attachmentDownload = async (
   await downloadAttachment(false, message, listenerApi)
 }
 
-const attachmentPreviewSelect = (_: unknown, action: Chat2Gen.AttachmentPreviewSelectPayload) => [
-  // Chat2Gen.createAddToMessageMap({message: action.payload.message}),
+const attachmentPreviewSelect = (_: unknown, action: Chat2Gen.AttachmentPreviewSelectPayload) =>
   RouteTreeGen.createNavigateAppend({
     path: [
       {
@@ -2129,8 +2128,7 @@ const attachmentPreviewSelect = (_: unknown, action: Chat2Gen.AttachmentPreviewS
         selected: 'chatAttachmentFullscreen',
       },
     ],
-  }),
-]
+  })
 
 // Handle an image pasted into a conversation
 const attachmentPasted = async (_: unknown, action: Chat2Gen.AttachmentPastedPayload) => {

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -314,11 +314,13 @@
     },
     "attachmentPreviewSelect": {
       "_description": "The user has selected an attachment with a preview",
-      "message": "Types.MessageAttachment"
+      "conversationIDKey": "Types.ConversationIDKey",
+      "ordinal": "Types.Ordinal"
     },
     "attachmentDownload": {
       "_description": "We want to save an attachment to the local disk",
-      "message": "Types.Message"
+      "conversationIDKey": "Types.ConversationIDKey",
+      "ordinal": "Types.Ordinal"
     },
     "attachmentMobileSave": {
       "_description": "Saving an attachment to mobile storage",

--- a/shared/actions/json/chat2.json
+++ b/shared/actions/json/chat2.json
@@ -904,9 +904,6 @@
       "cardType": "RPCChatTypes.JourneycardType",
       "ordinal": "Types.Ordinal"
     },
-    "addToMessageMap": {
-      "message": "Types.Message"
-    },
     "refreshMutualTeamsInConv": {
       "_description": "Refresh loaded mutual teams for a conversation",
       "conversationIDKey": "Types.ConversationIDKey"

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -54,9 +54,6 @@ const Connected = (props: OwnProps) => {
     previewHeight,
     imgMaxWidthRaw()
   )
-  // const addToMessageMap = (message: Types.Message) => {
-  //   dispatch(Chat2Gen.createAddToMessageMap({message}))
-  // }
 
   const submit = Container.useRPC(RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise)
 
@@ -83,7 +80,6 @@ const Connected = (props: OwnProps) => {
             )
             if (goodMessage && goodMessage.type === 'attachment') {
               setAutoPlay(false)
-              // addToMessageMap(goodMessage)
               setOrdinal(goodMessage.ordinal)
             }
           }

--- a/shared/chat/conversation/attachment-fullscreen/container.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/container.tsx
@@ -54,9 +54,9 @@ const Connected = (props: OwnProps) => {
     previewHeight,
     imgMaxWidthRaw()
   )
-  const addToMessageMap = (message: Types.Message) => {
-    dispatch(Chat2Gen.createAddToMessageMap({message}))
-  }
+  // const addToMessageMap = (message: Types.Message) => {
+  //   dispatch(Chat2Gen.createAddToMessageMap({message}))
+  // }
 
   const submit = Container.useRPC(RPCChatTypes.localGetNextAttachmentMessageLocalRpcPromise)
 
@@ -83,7 +83,7 @@ const Connected = (props: OwnProps) => {
             )
             if (goodMessage && goodMessage.type === 'attachment') {
               setAutoPlay(false)
-              addToMessageMap(goodMessage)
+              // addToMessageMap(goodMessage)
               setOrdinal(goodMessage.ordinal)
             }
           }
@@ -106,7 +106,16 @@ const Connected = (props: OwnProps) => {
       }
       onClose={() => dispatch(RouteTreeGen.createNavigateUp())}
       onDownloadAttachment={
-        message.downloadPath ? undefined : () => dispatch(Chat2Gen.createAttachmentDownload({message}))
+        message.downloadPath
+          ? undefined
+          : () => {
+              dispatch(
+                Chat2Gen.createAttachmentDownload({
+                  conversationIDKey: message.conversationIDKey,
+                  ordinal: message.id,
+                })
+              )
+            }
       }
       onNextAttachment={() => {
         onSwitchAttachment(false)

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -443,14 +443,24 @@ export const useAttachmentSections = (
   }
 
   const onMediaClick = (message: Types.MessageAttachment) =>
-    dispatch(Chat2Gen.createAttachmentPreviewSelect({message}))
+    dispatch(
+      Chat2Gen.createAttachmentPreviewSelect({
+        conversationIDKey: message.conversationIDKey,
+        ordinal: message.id,
+      })
+    )
 
   const onDocDownload = (message: Types.MessageAttachment) => {
     if (Styles.isMobile) {
       dispatch(Chat2Gen.createMessageAttachmentNativeShare({message}))
     } else {
       if (!message.downloadPath) {
-        dispatch(Chat2Gen.createAttachmentDownload({message}))
+        dispatch(
+          Chat2Gen.createAttachmentDownload({
+            conversationIDKey: message.conversationIDKey,
+            ordinal: message.id,
+          })
+        )
       }
     }
   }

--- a/shared/chat/conversation/list-area/index.desktop.tsx
+++ b/shared/chat/conversation/list-area/index.desktop.tsx
@@ -426,7 +426,7 @@ const useItems = (p: {
   centeredOrdinal: Types.Ordinal | undefined
   resizeObserve: ReturnType<typeof useResizeObserver>
   intersectionObserve: ReturnType<typeof useIntersectionObserver>
-  messageTypeMap: Map<Types.Ordinal, Types.MessageType> | undefined
+  messageTypeMap: Map<Types.Ordinal, Types.RenderMessageType> | undefined
 }) => {
   const {messageOrdinals, centeredOrdinal} = p
   const {resizeObserve, intersectionObserve, messageTypeMap} = p

--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -79,8 +79,6 @@ const Sent = React.memo(function Sent({ordinal}: SentProps) {
   const key = `${conversationIDKey}:${ordinal}`
   const state = animatingMap.get(key)
 
-  console.log('aaa sent missing', ordinal, subType)
-
   if (!subType) return null
 
   // if its animating always show it

--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -67,26 +67,28 @@ type SentProps = {
   children?: React.ReactElement
   ordinal: Types.Ordinal
 }
-const Sent_ = ({ordinal}: SentProps) => {
+const Sent = React.memo(function Sent({ordinal}: SentProps) {
   const conversationIDKey = React.useContext(ConvoIDContext)
-  const {type, youSent} = Container.useSelector(state => {
+  const {subType, youSent} = Container.useSelector(state => {
     const you = state.config.username
     const message = state.chat2.messageMap.get(conversationIDKey)?.get(ordinal)
     const youSent = message && message.author === you && message.ordinal !== message.id
-    const type = state.chat2.messageMap.get(conversationIDKey)?.get(ordinal)?.type
-    return {type, youSent}
+    const subType = message ? Constants.getMessageRenderType(message) : undefined
+    return {subType, youSent}
   }, shallowEqual)
   const key = `${conversationIDKey}:${ordinal}`
   const state = animatingMap.get(key)
 
-  if (!type) return null
+  console.log('aaa sent missing', ordinal, subType)
+
+  if (!subType) return null
 
   // if its animating always show it
   if (state) {
     return state
   }
 
-  const Clazz = getMessageRender(type)
+  const Clazz = getMessageRender(subType)
   if (!Clazz) return null
   const children = <Clazz ordinal={ordinal} />
 
@@ -98,8 +100,7 @@ const Sent_ = ({ordinal}: SentProps) => {
   } else {
     return children || null
   }
-}
-const Sent = React.memo(Sent_)
+})
 
 // We load the first thread automatically so in order to mark it read
 // we send an action on the first mount once

--- a/shared/chat/conversation/messages/attachment/file/container.tsx
+++ b/shared/chat/conversation/messages/attachment/file/container.tsx
@@ -68,7 +68,13 @@ const FileContainer = React.memo(function FileContainer(p: OwnProps) {
               return
             default:
           }
-          message && dispatch(Chat2Gen.createAttachmentDownload({message}))
+          message &&
+            dispatch(
+              Chat2Gen.createAttachmentDownload({
+                conversationIDKey: message.conversationIDKey,
+                ordinal: message.id,
+              })
+            )
         }
       }
     }

--- a/shared/chat/conversation/messages/attachment/wrapper.tsx
+++ b/shared/chat/conversation/messages/attachment/wrapper.tsx
@@ -1,45 +1,41 @@
-import * as Container from '../../../../util/container'
-import * as Constants from '../../../../constants/chat2'
 import * as React from 'react'
-import {ConvoIDContext} from '../ids-context'
 import {WrapperMessage, useCommon, type Props} from '../wrapper/wrapper'
 import type FileAttachmentType from './file/container'
 import type ImageAttachmentType from './image/container'
 import type AudioAttachmentType from './audio'
 
-const WrapperAttachment = React.memo(function WrapperAttachment(p: Props) {
+export const WrapperAttachmentAudio = React.memo(function WrapperAttachmentAudio(p: Props) {
   const {ordinal} = p
-  const conversationIDKey = React.useContext(ConvoIDContext)
   const common = useCommon(ordinal)
-  const {showCenteredHighlight, toggleShowingPopup} = common
-
-  const attachmentType = Container.useSelector(
-    state => Constants.getMessage(state, conversationIDKey, ordinal)?.attachmentType
-  )
-
-  let child: React.ReactNode = null
-  switch (attachmentType) {
-    case 'image': {
-      const ImageAttachment = require('./image/container').default as typeof ImageAttachmentType
-      child = <ImageAttachment toggleMessageMenu={toggleShowingPopup} isHighlighted={showCenteredHighlight} />
-      break
-    }
-    case 'audio': {
-      const AudioAttachment = require('./audio').default as typeof AudioAttachmentType
-      child = <AudioAttachment />
-      break
-    }
-    default: {
-      const FileAttachment = require('./file/container').default as typeof FileAttachmentType
-      child = <FileAttachment isHighlighted={showCenteredHighlight} />
-    }
-  }
-
+  const AudioAttachment = require('./audio').default as typeof AudioAttachmentType
   return (
     <WrapperMessage {...p} {...common}>
-      {child}
+      <AudioAttachment />
     </WrapperMessage>
   )
 })
+export const WrapperAttachmentFile = React.memo(function WrapperAttachmentFile(p: Props) {
+  const {ordinal} = p
+  const common = useCommon(ordinal)
+  const {showCenteredHighlight} = common
 
-export default WrapperAttachment
+  const FileAttachment = require('./file/container').default as typeof FileAttachmentType
+
+  return (
+    <WrapperMessage {...p} {...common}>
+      <FileAttachment isHighlighted={showCenteredHighlight} />
+    </WrapperMessage>
+  )
+})
+export const WrapperAttachmentImage = React.memo(function WrapperAttachmentImage(p: Props) {
+  const {ordinal} = p
+  const common = useCommon(ordinal)
+  const {showCenteredHighlight, toggleShowingPopup} = common
+  const ImageAttachment = require('./image/container').default as typeof ImageAttachmentType
+
+  return (
+    <WrapperMessage {...p} {...common}>
+      <ImageAttachment toggleMessageMenu={toggleShowingPopup} isHighlighted={showCenteredHighlight} />
+    </WrapperMessage>
+  )
+})

--- a/shared/chat/conversation/messages/message-popup/attachment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.tsx
@@ -90,7 +90,8 @@ export default Container.connect(
     _onDownload: (message: Types.MessageAttachment) => {
       dispatch(
         Chat2Gen.createAttachmentDownload({
-          message,
+          conversationIDKey: message.conversationIDKey,
+          ordinal: message.id,
         })
       )
     },

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -101,7 +101,13 @@ export default Container.connect(
     _onCopy: (h: Container.HiddenString) => {
       dispatch(ConfigGen.createCopyToClipboard({text: h.stringValue()}))
     },
-    _onDownload: (message: Types.Message) => dispatch(Chat2Gen.createAttachmentDownload({message})),
+    _onDownload: (message: Types.Message) =>
+      dispatch(
+        Chat2Gen.createAttachmentDownload({
+          conversationIDKey: message.conversationIDKey,
+          ordinal: message.id,
+        })
+      ),
     _onEdit: () =>
       dispatch(
         Chat2Gen.createMessageSetEditing({

--- a/shared/chat/conversation/messages/wrapper/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/index.tsx
@@ -1,5 +1,5 @@
 import Text from '../text/wrapper'
-import Attachment from '../attachment/wrapper'
+import {WrapperAttachmentAudio, WrapperAttachmentFile, WrapperAttachmentImage} from '../attachment/wrapper'
 import JourneyCard from '../cards/team-journey/wrapper'
 import Placeholder from '../placeholder/wrapper'
 import Payment from '../account-payment/wrapper'
@@ -23,7 +23,9 @@ import {type Props} from './wrapper'
 import type * as Types from '../../../../constants/types/chat2'
 
 const typeMap = {
-  attachment: Attachment,
+  'attachment:audio': WrapperAttachmentAudio,
+  'attachment:file': WrapperAttachmentFile,
+  'attachment:image': WrapperAttachmentImage,
   journeycard: JourneyCard,
   pin: Pin,
   placeholder: Placeholder,
@@ -45,11 +47,11 @@ const typeMap = {
   systemText: SystemText,
   systemUsersAddedToConversation: SystemUsersAddedToConv,
   text: Text,
-} satisfies Partial<Record<Types.MessageType, React.NamedExoticComponent<Props>>> as Record<
-  Types.MessageType,
+} satisfies Partial<Record<Types.RenderMessageType, React.NamedExoticComponent<Props>>> as Record<
+  Types.RenderMessageType,
   React.NamedExoticComponent<Props> | undefined
 >
 
-export const getMessageRender = (type: Types.MessageType) => {
+export const getMessageRender = (type: Types.RenderMessageType) => {
   return type === 'deleted' ? undefined : typeMap[type]
 }

--- a/shared/chat/pdf/index.desktop.tsx
+++ b/shared/chat/pdf/index.desktop.tsx
@@ -12,7 +12,13 @@ const ChatPDF = (props: Props) => {
   const url = message?.fileURL
   const dispatch = Container.useDispatch()
   const onDownload = React.useCallback(() => {
-    message && dispatch(Chat2Gen.createAttachmentDownload({message}))
+    message &&
+      dispatch(
+        Chat2Gen.createAttachmentDownload({
+          conversationIDKey: message.conversationIDKey,
+          ordinal: message.id,
+        })
+      )
     dispatch(FsGen.createOpenLocalPathInSystemFileManager({localPath: downloadFolder}))
   }, [dispatch, message])
   return (

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -20,6 +20,17 @@ import type * as TeamTypes from '../types/teams'
 import type * as UserTypes from '../types/users'
 import type {TypedState} from '../reducer'
 
+export const getMessageRenderType = (m: Types.Message): Types.RenderMessageType | undefined => {
+  switch (m.type) {
+    case 'text':
+      return undefined
+    case 'attachment':
+      return `attachment:${m.attachmentType}`
+    default:
+      return m.type
+  }
+}
+
 export const formatTextForQuoting = (text: string) =>
   text
     .split('\n')

--- a/shared/constants/types/chat2/index.tsx
+++ b/shared/constants/types/chat2/index.tsx
@@ -201,6 +201,12 @@ export const SkinToneToDotColor = (skinTone: undefined | EmojiSkinTone): string 
   }
 }
 
+export type RenderMessageType =
+  | _Message.MessageType
+  | 'attachment:image'
+  | 'attachment:audio'
+  | 'attachment:file'
+
 export type State = {
   readonly accountsInfoMap: Map<
     Common.ConversationIDKey,
@@ -250,7 +256,7 @@ export type State = {
   readonly maybeMentionMap: Map<string, RPCChatTypes.UIMaybeMentionInfo>
   readonly messageCenterOrdinals: Map<Common.ConversationIDKey, CenterOrdinal> // ordinals to center threads on,
   readonly messageMap: Map<Common.ConversationIDKey, Map<_Message.Ordinal, _Message.Message>> // messages in a thread,
-  readonly messageTypeMap: Map<Common.ConversationIDKey, Map<_Message.Ordinal, _Message.MessageType>> // messages types to help the thread, text is never used
+  readonly messageTypeMap: Map<Common.ConversationIDKey, Map<_Message.Ordinal, RenderMessageType>> // messages types to help the thread, text is never used
   readonly messageOrdinals: Map<Common.ConversationIDKey, Array<_Message.Ordinal>> // ordered ordinals in a thread,
   readonly metaMap: MetaMap // metadata about a thread, There is a special node for the pending conversation,
   readonly moreToLoadMap: Map<Common.ConversationIDKey, boolean> // if we have more data to load,

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -274,10 +274,16 @@ const attachmentActions: Container.ActionHandler<Actions, Types.State> = {
   },
   [Chat2Gen.addAttachmentViewMessage]: (draftState, action) => {
     const {conversationIDKey, viewType, message} = action.payload
-    const {attachmentViewMap} = draftState
+    const {attachmentViewMap, messageMap} = draftState
     const viewMap = mapGetEnsureValue(attachmentViewMap, conversationIDKey, new Map())
     const info = mapGetEnsureValue(viewMap, viewType, Constants.makeAttachmentViewInfo())
     viewMap.set(viewType, info)
+
+    // inject them into the message map
+    const mm = mapGetEnsureValue(messageMap, conversationIDKey, new Map())
+    info.messages.forEach(m => {
+      mm.set(m.id, m)
+    })
 
     if (info.messages.findIndex((item: any) => item.id === action.payload.message.id) < 0) {
       info.messages = info.messages.concat(message).sort((l: any, r: any) => r.id - l.id)
@@ -665,17 +671,6 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
         }
       }
     }
-  },
-  [Chat2Gen.addToMessageMap]: (draftState, action) => {
-    const {message} = action.payload
-    const convMap =
-      draftState.messageMap.get(message.conversationIDKey) ?? new Map<Types.Ordinal, Types.Message>()
-    convMap.set(message.ordinal, message)
-    draftState.messageMap.set(message.conversationIDKey, convMap)
-
-    const typemap = mapGetEnsureValue(draftState.messageTypeMap, message.conversationIDKey, new Map())
-    const subType = Constants.getMessageRenderType(message)
-    subType && typemap.set(message.ordinal, subType)
   },
   [Chat2Gen.messagesAdd]: (draftState, action) => {
     const {context, conversationIDKey, shouldClearOthers} = action.payload

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -342,10 +342,10 @@ const attachmentActions: Container.ActionHandler<Actions, Types.State> = {
     }
   },
   [Chat2Gen.attachmentDownload]: (draftState, action) => {
-    const {message} = action.payload
+    const {conversationIDKey, ordinal} = action.payload
     const {messageMap} = draftState
-    const map = messageMap.get(message.conversationIDKey)
-    const m = map?.get(message.ordinal)
+    const map = messageMap.get(conversationIDKey)
+    const m = map?.get(ordinal)
     if (m?.type === 'attachment') {
       m.transferState = 'downloading'
       m.transferErrMsg = null
@@ -365,7 +365,8 @@ const attachmentActions: Container.ActionHandler<Actions, Types.State> = {
       const m = map.get(ordinal)
       map.set(ordinal, m ? Constants.upgradeMessage(m, message) : message)
       const typemap = mapGetEnsureValue(messageTypeMap, conversationIDKey, new Map())
-      typemap.set(ordinal, message.type)
+      const subType = Constants.getMessageRenderType(message)
+      subType && typemap.set(ordinal, subType)
     }
   },
   [EngineGen.chat1NotifyChatChatAttachmentDownloadComplete]: (draftState, action) => {
@@ -673,9 +674,8 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
     draftState.messageMap.set(message.conversationIDKey, convMap)
 
     const typemap = mapGetEnsureValue(draftState.messageTypeMap, message.conversationIDKey, new Map())
-    if (message.type !== 'text') {
-      typemap.set(message.ordinal, message.type)
-    }
+    const subType = Constants.getMessageRenderType(message)
+    subType && typemap.set(message.ordinal, subType)
   },
   [Chat2Gen.messagesAdd]: (draftState, action) => {
     const {context, conversationIDKey, shouldClearOthers} = action.payload
@@ -853,7 +853,8 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
       if (toSet.type === 'text') {
         typemap.delete(toSet.ordinal)
       } else {
-        typemap.set(toSet.ordinal, toSet.type)
+        const subType = Constants.getMessageRenderType(toSet)
+        subType && typemap.set(toSet.ordinal, subType)
       }
     })
 


### PR DESCRIPTION
The initial goal was to start to optimize image to image recycling but this got big enough to get it in on its own

1. Cleanup the attachment connector. This work will continue next
2. Split the attachment types into subtypes. Message.type === 'attachment' but there really are 3 sub types, so we now make those first class citizens and have 3 new wrappers (audio/file/image)
3. There was a weird one off flow where if you go into the info panel and load up previews from messages you haven't loaded yet we'd call an action to inject it into the message map so the preview window could work with it. This is ok, maybe this stuff shouldn't even be in redux (a larger issue) but its simpler to just take the results of this rpc and inject it directly into the message map instead of doing it one at a time as you click between them. This way we reduce the flow and remove the action and it reduces the latency when you click