### PR TITLE
sent misses text

### DIFF
--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -20,10 +20,8 @@ import type * as TeamTypes from '../types/teams'
 import type * as UserTypes from '../types/users'
 import type {TypedState} from '../reducer'
 
-export const getMessageRenderType = (m: Types.Message): Types.RenderMessageType | undefined => {
+export const getMessageRenderType = (m: Types.Message): Types.RenderMessageType => {
   switch (m.type) {
-    case 'text':
-      return undefined
     case 'attachment':
       return `attachment:${m.attachmentType}`
     default:

--- a/shared/reducers/chat2.tsx
+++ b/shared/reducers/chat2.tsx
@@ -372,7 +372,7 @@ const attachmentActions: Container.ActionHandler<Actions, Types.State> = {
       map.set(ordinal, m ? Constants.upgradeMessage(m, message) : message)
       const typemap = mapGetEnsureValue(messageTypeMap, conversationIDKey, new Map())
       const subType = Constants.getMessageRenderType(message)
-      subType && typemap.set(ordinal, subType)
+      typemap.set(ordinal, subType)
     }
   },
   [EngineGen.chat1NotifyChatChatAttachmentDownloadComplete]: (draftState, action) => {
@@ -849,7 +849,7 @@ const reducer = Container.makeReducer<Actions, Types.State>(initialState, {
         typemap.delete(toSet.ordinal)
       } else {
         const subType = Constants.getMessageRenderType(toSet)
-        subType && typemap.set(toSet.ordinal, subType)
+        typemap.set(toSet.ordinal, subType)
       }
     })
 


### PR DESCRIPTION
changes the getRenderType to return 'text' instead of null. it shoudn't care about the messagesType optimization