### PR TITLE
image / video layout changes

### DIFF
--- a/shared/chat/conversation/messages/attachment/image2/imageimpl.desktop.tsx
+++ b/shared/chat/conversation/messages/attachment/image2/imageimpl.desktop.tsx
@@ -1,16 +1,38 @@
 import * as React from 'react'
+import * as Kb from '../../../../../common-adapters'
 import * as Styles from '../../../../../styles'
+import {useCollapseIcon} from '../shared'
 import {useRedux} from './use-redux'
 
 // its important we use explicit height/width so we never CLS while loading
 const Image2Impl = () => {
   const {previewURL, height, width} = useRedux()
-  return <img draggable={false} src={previewURL} height={height} width={width} style={styles.image as any} />
+  const collapseIcon = useCollapseIcon(true)
+  return (
+    <>
+      <img draggable={false} src={previewURL} height={height} width={width} style={styles.image as any} />
+      <Kb.Box2 direction="horizontal" alignItems="center" style={styles.actionContainer} gap="xtiny">
+        {collapseIcon}
+      </Kb.Box2>
+    </>
+  )
 }
 
 const styles = Styles.styleSheetCreate(
   () =>
     ({
+      actionContainer: {
+        alignSelf: 'flex-end',
+        backgroundColor: Styles.globalColors.black_50,
+        borderRadius: 2,
+        overflow: 'hidden',
+        padding: 1,
+        paddingLeft: 4,
+        paddingRight: 4,
+        position: 'absolute',
+        right: Styles.globalMargins.tiny,
+        top: Styles.globalMargins.tiny,
+      },
       image: Styles.platformStyles({
         isElectron: {
           ...Styles.globalStyles.rounded,

--- a/shared/chat/conversation/messages/attachment/image2/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image2/index.tsx
@@ -2,7 +2,7 @@ import * as Kb from '../../../../../common-adapters'
 import * as React from 'react'
 import * as Styles from '../../../../../styles'
 import ImageImpl from './imageimpl'
-import {useCollapseLabel, Title, useAttachmentRedux} from '../shared'
+import {Title, useAttachmentRedux, Collapsed} from '../shared'
 
 type Props = {
   toggleMessageMenu: () => void
@@ -13,7 +13,6 @@ const Image2 = React.memo(function Image2(p: Props) {
   const {isHighlighted, toggleMessageMenu} = p
   const {isCollapsed, isEditing, showTitle, openFullscreen} = useAttachmentRedux()
   const containerStyle = isHighlighted || isEditing ? styles.containerHighlighted : styles.container
-  const collapseLabel = useCollapseLabel()
 
   const content = React.useMemo(() => {
     return (
@@ -37,8 +36,7 @@ const Image2 = React.memo(function Image2(p: Props) {
 
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} style={containerStyle} alignItems="flex-start">
-      {collapseLabel}
-      {isCollapsed ? null : content}
+      {isCollapsed ? <Collapsed /> : content}
     </Kb.Box2>
   )
 })
@@ -55,7 +53,7 @@ const styles = Styles.styleSheetCreate(() => {
       backgroundColor: Styles.isAndroid ? undefined : Styles.globalColors.black_05_on_white,
       borderRadius: Styles.borderRadius,
       maxWidth: Styles.isMobile ? '100%' : 330,
-      padding: Styles.globalMargins.tiny,
+      padding: 3,
       position: 'relative',
     },
     imageContainer: {alignSelf: 'center'},

--- a/shared/chat/conversation/messages/attachment/video/index.tsx
+++ b/shared/chat/conversation/messages/attachment/video/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as Kb from '../../../../../common-adapters'
 import * as Styles from '../../../../../styles'
 import VideoImpl from './videoimpl'
-import {useCollapseLabel, Title, useAttachmentRedux} from '../shared'
+import {Title, useAttachmentRedux, Collapsed} from '../shared'
 
 type Props = {
   toggleMessageMenu: () => void
@@ -13,7 +13,6 @@ const Video = React.memo(function Video(p: Props) {
   const {isHighlighted, toggleMessageMenu} = p
   const {isCollapsed, showTitle, openFullscreen} = useAttachmentRedux()
   const containerStyle = isHighlighted ? styles.containerHighlighted : styles.container
-  const collapseLabel = useCollapseLabel()
   const content = React.useMemo(() => {
     return (
       <Kb.Box2
@@ -28,10 +27,10 @@ const Video = React.memo(function Video(p: Props) {
       </Kb.Box2>
     )
   }, [openFullscreen, toggleMessageMenu, showTitle])
+
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} style={containerStyle} alignItems="flex-start">
-      {collapseLabel}
-      {isCollapsed ? null : content}
+      {isCollapsed ? <Collapsed /> : content}
     </Kb.Box2>
   )
 })
@@ -49,7 +48,7 @@ const styles = Styles.styleSheetCreate(
         backgroundColor: Styles.globalColors.black_05_on_white,
         borderRadius: Styles.borderRadius,
         maxWidth: Styles.isMobile ? '100%' : 330,
-        padding: Styles.globalMargins.tiny,
+        padding: 3,
         position: 'relative',
       },
     } as const)

--- a/shared/chat/conversation/messages/attachment/video/videoimpl.desktop.tsx
+++ b/shared/chat/conversation/messages/attachment/video/videoimpl.desktop.tsx
@@ -7,11 +7,12 @@ import * as Styles from '../../../../../styles'
 import type {Props} from './videoimpl'
 import {GetIdsContext} from '../../ids-context'
 import {useRedux} from './use-redux'
+import {useCollapseIcon} from '../shared'
 
 // its important we use explicit height/width so we never CLS while loading
 const VideoImpl = (p: Props) => {
   const {openFullscreen} = p
-  const {downloadPath, previewURL, height, width, url, transferState, videoDuration} = useRedux()
+  const {downloadPath, previewURL, height, width, url, videoDuration} = useRedux()
 
   const onDoubleClick = React.useCallback(() => {
     ref.current?.pause()
@@ -29,13 +30,10 @@ const VideoImpl = (p: Props) => {
     }
   })
 
+  const downloadOrShowIcon = downloadPath ? 'iconfont-finder' : 'iconfont-download'
+  const downloadOrShowTip = downloadPath ? `Show in ${Styles.fileUIName}` : 'Download'
   const ref = React.useRef<HTMLVideoElement | null>(null)
-
-  const downloadOrShow = downloadPath
-    ? `Show in ${Styles.fileUIName}`
-    : transferState === 'downloading'
-    ? 'Downloading...'
-    : 'Download'
+  const collapseIcon = useCollapseIcon(true)
 
   return (
     <>
@@ -53,16 +51,31 @@ const VideoImpl = (p: Props) => {
       >
         <source src={url} />
       </video>
-      <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center" style={styles.textContainer}>
-        <Kb.Text
-          type="BodySmallPrimaryLink"
-          onClick={onDownloadOrShow}
-          style={styles.link}
-          className="hover-underline"
+      <Kb.Box2 direction="horizontal" alignItems="center" style={styles.actionContainer} gap="xtiny">
+        <Kb.WithTooltip
+          tooltip={
+            <Kb.Text type="Body" style={styles.tipText}>
+              {downloadOrShowTip}
+            </Kb.Text>
+          }
         >
-          {downloadOrShow}
-        </Kb.Text>
-        <Kb.Text type="BodyTinyBold">{videoDuration}</Kb.Text>
+          <Kb.Icon
+            type={downloadOrShowIcon}
+            style={styles.downloadIcon}
+            color={Styles.globalColors.white_75}
+            onClick={onDownloadOrShow}
+          />
+        </Kb.WithTooltip>
+        <Kb.WithTooltip
+          tooltip={
+            <Kb.Text type="Body" style={styles.tipText}>
+              {videoDuration}
+            </Kb.Text>
+          }
+        >
+          <Kb.Icon type="iconfont-info" style={styles.infoIcon} color={Styles.globalColors.white_75} />
+        </Kb.WithTooltip>
+        {collapseIcon}
       </Kb.Box2>
     </>
   )
@@ -71,8 +84,37 @@ const VideoImpl = (p: Props) => {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      link: {color: Styles.globalColors.black_50},
-      textContainer: {justifyContent: 'space-between'},
+      actionContainer: {
+        alignSelf: 'flex-end',
+        backgroundColor: Styles.globalColors.black_50,
+        borderRadius: 2,
+        overflow: 'hidden',
+        padding: 1,
+        paddingLeft: 4,
+        paddingRight: 4,
+        position: 'absolute',
+        right: Styles.globalMargins.tiny,
+        top: Styles.globalMargins.tiny,
+      },
+      downloadIcon: Styles.platformStyles({
+        isElectron: {
+          display: 'inline-flex',
+          opacity: 0.75,
+          paddingTop: 2,
+        },
+      }),
+      infoIcon: Styles.platformStyles({
+        isElectron: {
+          display: 'inline-flex',
+          opacity: 0.75,
+          paddingTop: 2,
+        },
+      }),
+      link: {
+        color: Styles.globalColors.black_50,
+        flexGrow: 1,
+      },
+      tipText: {color: Styles.globalColors.white_75},
       video: Styles.platformStyles({
         isElectron: {
           ...Styles.globalStyles.rounded,

--- a/shared/chat/conversation/messages/attachment/video/videoimpl.native.tsx
+++ b/shared/chat/conversation/messages/attachment/video/videoimpl.native.tsx
@@ -11,9 +11,7 @@ const VideoImpl = (_p: Props) => {
   const {previewURL, height, width, url, transferState, videoDuration} = useRedux()
   const source = React.useMemo(() => ({uri: `${url}&contentforce=true`}), [url])
 
-  // const posterSource = React.useMemo(() => ({uri: previewURL}), [previewURL])
   const ref = React.useRef<Video | null>(null)
-
   const [showPoster, setShowPoster] = React.useState(true)
 
   React.useEffect(() => {
@@ -41,10 +39,21 @@ const VideoImpl = (_p: Props) => {
       <ShowToastAfterSaving transferState={transferState} />
       <Pressable onPress={onPress} style={styles.pressable}>
         {showPoster ? (
-          <Kb.NativeFastImage
-            source={fiSrc}
-            style={Styles.collapseStyles([styles.poster, {height, width}])}
-          />
+          <Kb.Box2
+            direction="vertical"
+            style={Styles.collapseStyles([styles.posterContainer, {height, width}])}
+          >
+            <Kb.NativeFastImage
+              source={fiSrc}
+              style={Styles.collapseStyles([styles.poster, {height, width}])}
+            />
+            <Kb.Icon type="icon-play-64" style={styles.playButton} />
+            <Kb.Box2 direction="vertical" style={styles.durationContainer}>
+              <Kb.Text type="BodyTinyBold" style={styles.durationText}>
+                {videoDuration}
+              </Kb.Text>
+            </Kb.Box2>
+          </Kb.Box2>
         ) : (
           <Video
             ref={ref}
@@ -57,34 +66,43 @@ const VideoImpl = (_p: Props) => {
             resizeMode={ResizeMode.CONTAIN}
           />
         )}
-        {showPoster ? <Kb.Icon type="icon-play-64" style={styles.playButton} /> : null}
       </Pressable>
-      <Kb.Text type="BodyTinyBold" style={styles.duration}>
-        {videoDuration}
-      </Kb.Text>
     </>
   )
 }
-
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      duration: {
+      durationContainer: {
         alignSelf: 'flex-end',
-        backgroundColor: Styles.globalColors.black_05_on_white,
+        backgroundColor: Styles.globalColors.black_50,
+        borderRadius: 2,
+        bottom: Styles.globalMargins.tiny,
+        overflow: 'hidden',
+        padding: 1,
+        position: 'absolute',
+        right: Styles.globalMargins.tiny,
+      },
+      durationText: {
+        color: Styles.globalColors.white,
+        paddingLeft: 3,
+        paddingRight: 3,
       },
       playButton: {
-        ...Styles.globalStyles.fillAbsolute,
-        bottom: '50%',
         left: '50%',
-        marginBottom: -32,
         marginLeft: -32,
-        marginRight: -32,
         marginTop: -32,
-        right: '50%',
+        position: 'absolute',
         top: '50%',
       },
-      poster: {backgroundColor: Styles.globalColors.black_05_on_white},
+      poster: {
+        backgroundColor: Styles.globalColors.black_05_on_white,
+        opacity: 0,
+      },
+      posterContainer: {
+        backgroundColor: 'red',
+        position: 'relative',
+      },
       pressable: {position: 'relative'},
       video: {
         maxHeight: 320,

--- a/shared/common-adapters/clickable-box.d.ts
+++ b/shared/common-adapters/clickable-box.d.ts
@@ -32,7 +32,7 @@ declare class ClickableBox extends React.Component<Props> {}
 export type Props2 = {
   // mobile only
   onLongPress?: () => void
-  onClick?: () => void
+  onClick?: (event: React.BaseSyntheticEvent) => void
   children: React.ReactNode
   className?: string
   style?: StylesCrossPlatform

--- a/shared/common-adapters/icon.desktop.tsx
+++ b/shared/common-adapters/icon.desktop.tsx
@@ -129,6 +129,7 @@ const Icon = React.memo<Props>(
           ])}
         >
           <span
+            title={hint}
             style={Styles.collapseStyles([
               mergedStyle,
               padding && Shared.paddingStyles[padding],


### PR DESCRIPTION
This adjusts the margins and metadata presentation on images and videos
On mobile we hide the filenames and collapsing. We move the duration back into the video area
On desktop we move the download/duration/collapse into a small area of icons on the upper right to avoid being near the controls