### PR TITLE
Float send indicator

### DIFF
--- a/shared/chat/conversation/messages/wrapper/send-indicator/index.tsx
+++ b/shared/chat/conversation/messages/wrapper/send-indicator/index.tsx
@@ -132,7 +132,14 @@ const styles = Styles.styleSheetCreate(
         common: {height: 20, opacity: 1, width: 20},
         isMobile: {backgroundColor: Styles.globalColors.white},
       }),
-      send: Styles.platformStyles({isElectron: {pointerEvents: 'none'}}),
+      send: Styles.platformStyles({
+        common: {
+          position: 'absolute',
+          right: 16,
+          top: 0,
+        },
+        isElectron: {pointerEvents: 'none'},
+      }),
     } as const)
 )
 

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -394,9 +394,12 @@ type RProps = {
 const RightSide = React.memo(function RightSide(p: RProps) {
   const {showCenteredHighlight, toggleShowingPopup, showSendIndicator, showCoinsIcon} = p
   const {showExplodingCountdown, showRevoked, botname} = p
-  // if we're sending always keep it so we don't change our width after sending
   const hasShownSendIndicator = React.useRef(showSendIndicator)
-  const sendIndicator = hasShownSendIndicator.current ? <SendIndicator /> : null
+  const sendIndicator = showSendIndicator ? (
+    <SendIndicator />
+  ) : hasShownSendIndicator.current ? (
+    <Kb.Box2 direction="vertical" style={styles.sendIndicatorPlaceholder} />
+  ) : null
 
   const explodingCountdown = showExplodingCountdown ? (
     <ExplodingMeta isParentHighlighted={showCenteredHighlight} onClick={toggleShowingPopup} />
@@ -622,6 +625,10 @@ const styles = Styles.styleSheetCreate(
         },
         isMobile: {},
       }),
+      sendIndicatorPlaceholder: {
+        width: 20,
+        height: 20,
+      },
       timestamp: Styles.platformStyles({
         isElectron: {
           flexShrink: 0,

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -591,9 +591,7 @@ const styles = Styles.styleSheetCreate(
         paddingRight: 4,
         position: 'relative',
       },
-      moreActionsTooltip: {
-        marginRight: -Styles.globalMargins.xxtiny,
-      },
+      moreActionsTooltip: {marginRight: -Styles.globalMargins.xxtiny},
       paddingLeftTiny: {paddingLeft: Styles.globalMargins.tiny},
       rightSide: Styles.platformStyles({
         common: {
@@ -609,7 +607,6 @@ const styles = Styles.styleSheetCreate(
           right: 16,
           top: 4,
         },
-        isMobile: {},
       }),
       rightSideItems: Styles.platformStyles({
         common: {
@@ -617,14 +614,11 @@ const styles = Styles.styleSheetCreate(
           minHeight: 20,
           paddingLeft: Styles.globalMargins.tiny,
         },
-        isElectron: {
-          minHeight: 14,
-        },
-        isMobile: {},
+        isElectron: {minHeight: 14},
       }),
       sendIndicatorPlaceholder: {
-        width: 20,
         height: 20,
+        width: 20,
       },
       timestamp: Styles.platformStyles({
         isElectron: {

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -394,12 +394,7 @@ type RProps = {
 const RightSide = React.memo(function RightSide(p: RProps) {
   const {showCenteredHighlight, toggleShowingPopup, showSendIndicator, showCoinsIcon} = p
   const {showExplodingCountdown, showRevoked, botname} = p
-  const hasShownSendIndicator = React.useRef(showSendIndicator)
-  const sendIndicator = showSendIndicator ? (
-    <SendIndicator />
-  ) : hasShownSendIndicator.current ? (
-    <Kb.Box2 direction="vertical" style={styles.sendIndicatorPlaceholder} />
-  ) : null
+  const sendIndicator = showSendIndicator ? <SendIndicator /> : null
 
   const explodingCountdown = showExplodingCountdown ? (
     <ExplodingMeta isParentHighlighted={showCenteredHighlight} onClick={toggleShowingPopup} />
@@ -419,7 +414,7 @@ const RightSide = React.memo(function RightSide(p: RProps) {
     </Kb.WithTooltip>
   ) : null
 
-  const hasVisibleItems = sendIndicator || explodingCountdown || revokedIcon || coinsIcon || bot
+  const hasVisibleItems = explodingCountdown || revokedIcon || coinsIcon || bot
 
   // On mobile there is no ... menu
   // On Desktop we float the menu on top, if there are no items
@@ -439,24 +434,26 @@ const RightSide = React.memo(function RightSide(p: RProps) {
     </Kb.WithTooltip>
   )
 
-  return hasVisibleItems || menu ? (
-    <Kb.Box2
-      direction="horizontal"
-      alignSelf="flex-start"
-      style={hasVisibleItems ? styles.rightSideItems : styles.rightSide}
-      gap="tiny"
-      className={Styles.classNames({
-        'hover-reverse-row': hasVisibleItems && menu,
-        'hover-visible': !hasVisibleItems && menu,
-      })}
-    >
-      {menu}
+  return hasVisibleItems || menu || sendIndicator ? (
+    <>
+      <Kb.Box2
+        direction="horizontal"
+        alignSelf="flex-start"
+        style={hasVisibleItems ? styles.rightSideItems : styles.rightSide}
+        gap="tiny"
+        className={Styles.classNames({
+          'hover-reverse-row': hasVisibleItems && menu,
+          'hover-visible': !hasVisibleItems && menu,
+        })}
+      >
+        {menu}
+        {explodingCountdown}
+        {revokedIcon}
+        {coinsIcon}
+        {bot}
+      </Kb.Box2>
       {sendIndicator}
-      {explodingCountdown}
-      {revokedIcon}
-      {coinsIcon}
-      {bot}
-    </Kb.Box2>
+    </>
   ) : null
 })
 


### PR DESCRIPTION
Having the send indicator take up space just causes a lot of layout thrash as it appears and disappears. I changed this earlier today to keep the space but it looks weird with unfurls (moves the close button over) so instead lets just float this thing always