### PR TITLE
useCollapseStyle

### DIFF
--- a/shared/chat/conversation/messages/react-button/index.tsx
+++ b/shared/chat/conversation/messages/react-button/index.tsx
@@ -39,7 +39,7 @@ const ReactButton = React.memo(function ReactButton(p: Props) {
       className={Styles.classNames('react-button', className, {noShadow: active})}
       onLongPress={onLongPress}
       onClick={onClick}
-      style={Styles.collapseStyles([styles.borderBase, styles.buttonBox, active && styles.active, style])}
+      style={[styles.borderBase, styles.buttonBox, active && styles.active, style]}
     >
       <Box2 centerChildren={true} fullHeight={true} direction="horizontal" style={styles.container}>
         <Box2 direction="horizontal" style={styles.containerInner} gap="xtiny">
@@ -147,12 +147,12 @@ export class NewReactionButton extends React.Component<NewReactionButtonProps, N
         className={Styles.classNames('react-button', {border: this.props.showBorder})}
         onLongPress={this.props.onLongPress}
         onClick={this._onShowPicker}
-        style={Styles.collapseStyles([
+        style={[
           styles.borderBase,
           styles.newReactionButtonBox,
           this.props.showBorder && styles.buttonBox,
           this.props.style,
-        ])}
+        ]}
       >
         <Box2
           centerChildren={true}

--- a/shared/common-adapters/clickable-box.d.ts
+++ b/shared/common-adapters/clickable-box.d.ts
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import {StylesCrossPlatform} from '../styles'
+import * as Styles from '../styles'
 
 export type Props = {
   className?: string
   children?: any
-  style?: StylesCrossPlatform
+  style?: Styles.StylesCrossPlatform
   onClick?: (event: React.BaseSyntheticEvent) => void
   onDoubleClick?: (event: React.BaseSyntheticEvent) => void
   onPress?: void
@@ -35,7 +35,7 @@ export type Props2 = {
   onClick?: (event: React.BaseSyntheticEvent) => void
   children: React.ReactNode
   className?: string
-  style?: StylesCrossPlatform
+  style?: Styles.StylesCrossPlatform
 }
 export declare class ClickableBox2 extends React.Component<Props2> {}
 

--- a/shared/common-adapters/clickable-box.desktop.tsx
+++ b/shared/common-adapters/clickable-box.desktop.tsx
@@ -118,8 +118,9 @@ export default ClickableBox
 
 export const ClickableBox2 = (p: Props2) => {
   const {onClick, children, style, className} = p
+  const collapsed = Styles.useCollapseStyles(style, true)
   return (
-    <div onClick={onClick} style={style as any} className={Styles.classNames('clickable-box2', className)}>
+    <div onClick={onClick} style={collapsed} className={Styles.classNames('clickable-box2', className)}>
       {children}
     </div>
   )

--- a/shared/styles/css.d.ts
+++ b/shared/styles/css.d.ts
@@ -113,10 +113,14 @@ type _StylesDesktopFalsy = _StylesDesktop | undefined | null | false
 export type StylesDesktop = _StylesDesktopFalsy | ReadonlyArray<_StylesDesktopFalsy>
 
 type _StylesMobileOverride = {
-  textAlignVertical?: 'auto' | 'top' | 'bottom' | 'center'
+  textAlignVertical?: 'top' | 'bottom' | 'center'
+  textAlign?: 'left' | 'right' | 'center' | 'justify'
 }
 
-export type _StylesMobile = ViewStyle & TextStyle & ImageStyle & _StylesMobileOverride
+export type _StylesMobile = ViewStyle &
+  Omit<TextStyle, 'textAlignVertical' | 'textAlign'> &
+  ImageStyle &
+  _StylesMobileOverride
 type _StylesMobileFalsy = _StylesMobile | undefined | null | false
 export type StylesMobile = _StylesMobileFalsy | ReadonlyArray<_StylesMobileFalsy>
 

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -105,6 +105,12 @@ type CollapsibleStyle = CSS.StylesCrossPlatform | RemovedStyle
 // TODO better styles that aren't slow
 export declare function collapseStyles(styles: ReadonlyArray<CollapsibleStyle>): any
 
+// new style, used in the common-adapters, not the components, can memo for you
+export declare function useCollapseStyles<
+  IsMobile = false,
+  Ret = IsMobile extends false ? CSS._StylesCrossPlatform : CSS.StylesCrossPlatform
+>(styles: CSS.StylesCrossPlatform, memo?: boolean): undefined | Ret
+
 export declare const windowStyle: {
   minWidth: number
   minHeight: number

--- a/shared/styles/index.native.tsx
+++ b/shared/styles/index.native.tsx
@@ -6,6 +6,7 @@ import styleSheetCreateProxy from './style-sheet-proxy'
 import {StyleSheet, Dimensions} from 'react-native'
 import {isDarkMode} from './dark-mode'
 import {isIOS, isTablet} from '../constants/platform'
+import type {StylesCrossPlatform} from './css'
 
 type _Elem = Object | null | false | void
 // CollapsibleStyle is a generic version of ?StylesMobile and family,
@@ -99,6 +100,55 @@ export const styleSheetCreate = (obj: any) => styleSheetCreateProxy(obj, o => St
 //   })
 // }
 export {isDarkMode}
+
+// we don't need this at all on mobile
+export const useCollapseStyles = (
+  styles: StylesCrossPlatform,
+  _memo: boolean = false
+): undefined | StylesCrossPlatform => {
+  return styles
+  // const old = React.useRef<undefined | StylesCrossPlatform>(undefined)
+
+  // if (!isArray(styles)) {
+  //   const ret = styles || undefined
+  //   if (memo) {
+  //     if (shallowEqual(old.current, ret)) return old.current
+  //     old.current = ret
+  //   }
+  //   return ret
+  // }
+  // // if we have no / singular values we pass those on in the hopes they're consts
+  // const nonNull = styles.reduce<Array<_StylesCrossPlatform>>((arr, s) => {
+  //   // has a value?
+  //   if (s && !isEmpty(s)) {
+  //     arr.push(s)
+  //   }
+  //   return arr
+  // }, [])
+  // if (!nonNull.length) {
+  //   old.current = undefined
+  //   return undefined
+  // }
+  // if (nonNull.length === 1) {
+  //   const ret = nonNull[0]
+  //   if (memo) {
+  //     if (shallowEqual(old.current, ret)) return old.current
+  //     old.current = ret
+  //   }
+  //   return ret
+  // }
+
+  // // take advantage of memo by collapsing
+  // if (memo) {
+  //   const collapsed = Object.assign({}, ...nonNull) as _StylesCrossPlatform
+  //   const ret = Object.keys(collapsed).length ? collapsed : undefined
+  //   if (shallowEqual(old.current, ret)) return old.current
+  //   old.current = ret
+  //   return ret
+  // }
+  // // rn allows falsy values so let memoized values through
+  // return styles
+}
 export const collapseStyles = (
   styles: ReadonlyArray<CollapsibleStyle>
 ): ReadonlyArray<Object | null | false> => {


### PR DESCRIPTION
This is the beginning of fixing up the styling typing we have. 
The current pattern is:
1. Components call `style={Styles.collapseStyles([a,b,c])}` which is `any` typed
1. The common adapters the style plumbs down to eventually has to do `style={props.style as any}` as the style prop and what it has can't match

Instead the new pattern is
1. Components pass the raw array like RN `style={[a,b,]}` or `style={a}`
2. The common adapter uses a typed `useCollapse` like 
```
const collapsed = useCollapse(props.style, true)
return <Thing style={collapsed} />
```
on RN useCollapse is the identity, on desktop it'll flatten (with optional memo)

There are some side effects of this, before if you didn't actually need to flatten and ended up with something like 
`[a, false, false, false]` it'd pull out `a` and pass that, which could help you with memo issues, but frankly its better to memo the array in the component anyways. The `memo` param of `useCollapse` memoes the output, so it will do a shallowEqual then