### PR TITLE
fix upload bar on video and fix preview

### DIFF
--- a/shared/chat/conversation/messages/attachment/image2/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image2/index.tsx
@@ -13,7 +13,6 @@ const Image2 = React.memo(function Image2(p: Props) {
   const {isHighlighted, toggleMessageMenu} = p
   const {fileName, isCollapsed, isEditing, showTitle, openFullscreen} = useAttachmentRedux()
   const containerStyle = isHighlighted || isEditing ? styles.containerHighlighted : styles.container
-
   const collapseIcon = useCollapseIcon(false)
 
   const filename = React.useMemo(() => {

--- a/shared/chat/conversation/messages/attachment/shared.tsx
+++ b/shared/chat/conversation/messages/attachment/shared.tsx
@@ -145,20 +145,30 @@ export const useAttachmentRedux = () => {
     dispatch(Chat2Gen.createAttachmentPreviewSelect({conversationIDKey, ordinal}))
   }, [dispatch, getIds])
 
-  const {fileName, isCollapsed, isEditing, showTitle} = Container.useSelector(state => {
-    const m = Constants.getMessage(state, conversationIDKey, ordinal)
-    const message = m?.type === 'attachment' ? m : missingMessage
-    const {isCollapsed, title, fileName: fileNameRaw, deviceType, inlineVideoPlayable} = message
-    const editInfo = Constants.getEditInfo(state, conversationIDKey)
-    const isEditing = !!(editInfo && editInfo.ordinal === ordinal)
-    const showTitle = !!title
-    const fileName =
-      deviceType === 'desktop' ? fileNameRaw : `${inlineVideoPlayable ? 'Video' : 'Image'} from mobile`
+  const {fileName, isCollapsed, isEditing, showTitle, transferProgress, transferState} =
+    Container.useSelector(state => {
+      const m = Constants.getMessage(state, conversationIDKey, ordinal)
+      const message = m?.type === 'attachment' ? m : missingMessage
+      const {isCollapsed, title, fileName: fileNameRaw, transferProgress} = message
+      const {deviceType, inlineVideoPlayable, transferState} = message
+      const editInfo = Constants.getEditInfo(state, conversationIDKey)
+      const isEditing = !!(editInfo && editInfo.ordinal === ordinal)
+      const showTitle = !!title
+      const fileName =
+        deviceType === 'desktop' ? fileNameRaw : `${inlineVideoPlayable ? 'Video' : 'Image'} from mobile`
 
-    return {fileName, isCollapsed, isEditing, showTitle}
-  }, shallowEqual)
+      return {fileName, isCollapsed, isEditing, showTitle, transferProgress, transferState}
+    }, shallowEqual)
 
-  return {fileName, isCollapsed, isEditing, openFullscreen, showTitle}
+  return {
+    fileName,
+    isCollapsed,
+    isEditing,
+    openFullscreen,
+    showTitle,
+    transferProgress,
+    transferState,
+  }
 }
 
 export const Collapsed = () => {

--- a/shared/chat/conversation/messages/attachment/video/index.tsx
+++ b/shared/chat/conversation/messages/attachment/video/index.tsx
@@ -9,11 +9,31 @@ type Props = {
   isHighlighted?: boolean
 }
 
+const Transferring = (p: {ratio: number}) => {
+  const {ratio} = p
+  return (
+    <Kb.Box2
+      direction="horizontal"
+      style={styles.transferring}
+      alignItems="center"
+      gap="xtiny"
+      gapEnd={true}
+      gapStart={true}
+    >
+      <Kb.Text type="BodySmall" negative={true}>
+        Uploading
+      </Kb.Text>
+      <Kb.ProgressBar ratio={ratio} />
+    </Kb.Box2>
+  )
+}
+
 const Video = React.memo(function Video(p: Props) {
   const {isHighlighted, toggleMessageMenu} = p
-  const {fileName, isCollapsed, showTitle, openFullscreen} = useAttachmentRedux()
+  const {fileName, isCollapsed, showTitle, openFullscreen, transferState, transferProgress} =
+    useAttachmentRedux()
   const containerStyle = isHighlighted ? styles.containerHighlighted : styles.container
-
+  const isUploading = transferState === 'uploading'
   const collapseIcon = useCollapseIcon(false)
 
   const filename = React.useMemo(() => {
@@ -36,12 +56,17 @@ const Video = React.memo(function Video(p: Props) {
           alignItems="flex-start"
           gap="xxtiny"
         >
-          <VideoImpl openFullscreen={openFullscreen} toggleMessageMenu={toggleMessageMenu} />
+          <VideoImpl
+            openFullscreen={openFullscreen}
+            toggleMessageMenu={toggleMessageMenu}
+            allowPlay={transferState !== 'uploading'}
+          />
           {showTitle ? <Title /> : null}
+          {isUploading ? <Transferring ratio={transferProgress} /> : null}
         </Kb.Box2>
       </>
     )
-  }, [openFullscreen, toggleMessageMenu, showTitle, filename])
+  }, [openFullscreen, toggleMessageMenu, showTitle, filename, isUploading, transferProgress])
 
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} style={containerStyle} alignItems="flex-start">
@@ -53,7 +78,7 @@ const Video = React.memo(function Video(p: Props) {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      container: {alignSelf: 'center', paddingRight: Styles.globalMargins.tiny},
+      container: {alignSelf: 'center', paddingRight: Styles.globalMargins.tiny, position: 'relative'},
       containerHighlighted: {
         alignSelf: 'center',
         backgroundColor: Styles.globalColors.yellowLight,
@@ -65,6 +90,14 @@ const styles = Styles.styleSheetCreate(
         maxWidth: Styles.isMobile ? '100%' : 330,
         padding: 3,
         position: 'relative',
+      },
+      transferring: {
+        backgroundColor: Styles.globalColors.black_50,
+        borderRadius: 2,
+        left: Styles.globalMargins.tiny,
+        overflow: 'hidden',
+        position: 'absolute',
+        top: Styles.globalMargins.tiny,
       },
     } as const)
 )

--- a/shared/chat/conversation/messages/attachment/video/index.tsx
+++ b/shared/chat/conversation/messages/attachment/video/index.tsx
@@ -66,7 +66,7 @@ const Video = React.memo(function Video(p: Props) {
         </Kb.Box2>
       </>
     )
-  }, [openFullscreen, toggleMessageMenu, showTitle, filename, isUploading, transferProgress])
+  }, [openFullscreen, toggleMessageMenu, showTitle, filename, isUploading, transferProgress, transferState])
 
   return (
     <Kb.Box2 direction="vertical" fullWidth={true} style={containerStyle} alignItems="flex-start">

--- a/shared/chat/conversation/messages/attachment/video/videoimpl.d.ts
+++ b/shared/chat/conversation/messages/attachment/video/videoimpl.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 export type Props = {
   openFullscreen: () => void
   toggleMessageMenu: () => void
+  allowPlay: boolean
 }
 declare class VideoImpl extends React.Component<Props> {}
 export default VideoImpl

--- a/shared/chat/conversation/messages/attachment/video/videoimpl.desktop.tsx
+++ b/shared/chat/conversation/messages/attachment/video/videoimpl.desktop.tsx
@@ -6,9 +6,8 @@ import {useRedux} from './use-redux'
 
 // its important we use explicit height/width so we never CLS while loading
 const VideoImpl = (p: Props) => {
-  const {openFullscreen} = p
+  const {openFullscreen, allowPlay} = p
   const {previewURL, height, width, url, videoDuration} = useRedux()
-
   const [showPoster, setShowPoster] = React.useState(true)
 
   React.useEffect(() => {
@@ -29,7 +28,7 @@ const VideoImpl = (p: Props) => {
   return showPoster ? (
     <div onClick={onPress} style={styles.posterContainer}>
       <Kb.Image src={previewURL} style={{height, width}} />
-      <Kb.Icon type="icon-play-64" style={styles.playButton} />
+      {allowPlay ? <Kb.Icon type="icon-play-64" style={styles.playButton} /> : null}
       <Kb.Box2 direction="vertical" style={styles.durationContainer}>
         <Kb.Text type="BodyTinyBold" style={styles.durationText}>
           {videoDuration}
@@ -39,6 +38,7 @@ const VideoImpl = (p: Props) => {
   ) : (
     <video
       ref={ref}
+      autoPlay={true}
       onDoubleClick={onDoubleClick}
       height={height}
       width={width}
@@ -57,18 +57,6 @@ const VideoImpl = (p: Props) => {
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      actionContainer: {
-        alignSelf: 'flex-end',
-        backgroundColor: Styles.globalColors.black_50,
-        borderRadius: 2,
-        overflow: 'hidden',
-        padding: 1,
-        paddingLeft: 4,
-        paddingRight: 4,
-        position: 'absolute',
-        right: Styles.globalMargins.tiny,
-        top: Styles.globalMargins.tiny,
-      },
       downloadIcon: Styles.platformStyles({
         isElectron: {
           display: 'inline-flex',

--- a/shared/chat/conversation/messages/attachment/video/videoimpl.native.tsx
+++ b/shared/chat/conversation/messages/attachment/video/videoimpl.native.tsx
@@ -7,7 +7,8 @@ import {Video, ResizeMode, type AVPlaybackStatus} from 'expo-av'
 import {Pressable} from 'react-native'
 import type {Props} from './videoimpl'
 
-const VideoImpl = (_p: Props) => {
+const VideoImpl = (p: Props) => {
+  const {allowPlay} = p
   const {previewURL, height, width, url, transferState, videoDuration} = useRedux()
   const source = React.useMemo(() => ({uri: `${url}&contentforce=true`}), [url])
 
@@ -47,7 +48,7 @@ const VideoImpl = (_p: Props) => {
               source={fiSrc}
               style={Styles.collapseStyles([styles.poster, {height, width}])}
             />
-            <Kb.Icon type="icon-play-64" style={styles.playButton} />
+            {allowPlay ? <Kb.Icon type="icon-play-64" style={styles.playButton} /> : null}
             <Kb.Box2 direction="vertical" style={styles.durationContainer}>
               <Kb.Text type="BodyTinyBold" style={styles.durationText}>
                 {videoDuration}

--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -1141,7 +1141,7 @@ const outboxUIMessagetoMessage = (
       const title = o.title
       const fileName = o.filename
       let previewURL = ''
-      let pre = previewSpecs(null, null)
+      let pre
       if (o.preview) {
         previewURL =
           o.preview.location && o.preview.location.ltyp === RPCChatTypes.PreviewLocationTyp.url
@@ -1150,6 +1150,8 @@ const outboxUIMessagetoMessage = (
         const md = (o.preview && o.preview.metadata) || null
         const baseMd = (o.preview && o.preview.baseMetadata) || null
         pre = previewSpecs(md, baseMd)
+      } else {
+        pre = previewSpecs(null, null)
       }
       return makePendingAttachmentMessage(
         conversationIDKey,
@@ -1351,6 +1353,7 @@ export const makePendingAttachmentMessage = (
     exploding,
     fileName: fileName,
     id: Types.numberToMessageID(0),
+    inlineVideoPlayable: previewSpec.showPlayButton,
     isCollapsed: false,
     ordinal: ordinal,
     outboxID: outboxID,


### PR DESCRIPTION
Bigger than I expected. Its not just the plumbing for the progress that needed plumbing, the preview wasn't setting the inline playable flag so we'd render the `image` attachment type and then swap it for the video one later, now we start with the video correctly