### PR TITLE
simplify multi join/leave and move around

### DIFF
--- a/shared/chat/conversation/messages/separator.tsx
+++ b/shared/chat/conversation/messages/separator.tsx
@@ -19,28 +19,25 @@ const authorIsCollapsible = (type?: Types.MessageType) =>
 
 const getUsernameToShow = (message: Types.Message, pMessage: Types.Message | undefined, you: string) => {
   switch (message.type) {
-    case 'journeycard':
+    case 'journeycard': // fallthrough
+    case 'systemJoined':
       return ''
     case 'systemAddedToTeam':
       return message.adder
     case 'systemInviteAccepted':
       return message.invitee === you ? '' : message.invitee
-    case 'setDescription':
-    case 'pin':
+    case 'setDescription': // fallthrough
+    case 'pin': // fallthrough
     case 'systemUsersAddedToConversation':
       return message.author
-    case 'systemJoined': {
-      const joinLeaveLength = (message?.joiners?.length ?? 0) + (message?.leavers?.length ?? 0)
-      return joinLeaveLength > 1 ? '' : message.author
-    }
     case 'systemSBSResolved':
       return message.prover
     case 'setChannelname':
       // suppress this message for the #general channel, it is redundant.
       return message.newChannelname !== 'general' ? message.author : ''
-    case 'attachment':
-    case 'requestPayment':
-    case 'sendPayment':
+    case 'attachment': // fallthrough
+    case 'requestPayment': // fallthrough
+    case 'sendPayment': // fallthrough
     case 'text':
       break
     default:

--- a/shared/chat/conversation/messages/system-joined/index.tsx
+++ b/shared/chat/conversation/messages/system-joined/index.tsx
@@ -18,64 +18,26 @@ type Props = {
   timestamp: number
 }
 
-const textType = 'BodySmallSemiboldPrimaryLink'
-
-const Joined = (props: Props) => {
-  if (props.joiners.length + props.leavers.length == 1) {
-    return <JoinedUserNotice {...props} />
-  }
-
-  const joinMsg =
-    props.joiners.length == 1 ? (
-      <Kb.Box2 direction="vertical" fullWidth={true} alignSelf="flex-start" style={styles.singleEvent}>
-        <AuthorAndAvatar {...props} username={props.joiners[0]} />
-        <Kb.Box2
-          direction="vertical"
-          alignSelf="flex-start"
-          style={Styles.collapseStyles([
-            styles.contentUnderAuthorContainer,
-            props.leavers.length > 0 && styles.joinerPadding,
-          ])}
-        >
-          <JoinedUserNotice {...props} joiners={props.joiners} leavers={[]} />
-        </Kb.Box2>
-      </Kb.Box2>
-    ) : props.joiners.length > 1 ? (
-      <MultiUserJoinedNotice {...props} joiners={props.joiners} leavers={[]} />
-    ) : null
-  const leaveMsg =
-    props.leavers.length == 1 ? (
-      <Kb.Box2 direction="vertical" fullWidth={true} alignSelf="flex-start" style={styles.singleEvent}>
-        <AuthorAndAvatar {...props} username={props.leavers[0]} />
-        <Kb.Box2 direction="vertical" alignSelf="flex-start" style={styles.contentUnderAuthorContainer}>
-          <JoinedUserNotice {...props} joiners={[]} leavers={props.leavers} />
-        </Kb.Box2>
-      </Kb.Box2>
-    ) : props.leavers.length > 1 ? (
-      <MultiUserJoinedNotice {...props} joiners={[]} leavers={props.leavers} />
-    ) : null
-
-  return (
-    <Kb.Box2 direction="vertical" style={styles.container} fullWidth={true} alignSelf="flex-start">
-      {joinMsg}
-      {leaveMsg}
-    </Kb.Box2>
-  )
-}
+const Joined = (props: Props) => (
+  <Kb.Box2 direction="vertical" style={styles.container} fullWidth={true} alignSelf="flex-start">
+    {props.joiners.length ? <MultiUserJoinedNotice {...props} joiners={props.joiners} leavers={[]} /> : null}
+    {props.leavers.length ? <MultiUserJoinedNotice {...props} joiners={[]} leavers={props.leavers} /> : null}
+  </Kb.Box2>
+)
 
 const MultiUserJoinedNotice = (props: Props) => (
   <Kb.Box2 direction="vertical" fullWidth={true} alignSelf="flex-start">
     <UserNotice>
-      {!!props.timestamp && (
-        <Kb.Text type="BodyTiny" style={styles.timestamp}>
-          {formatTimeForChat(props.timestamp)}
-        </Kb.Text>
-      )}
-      <Kb.Text type="BodySmall" style={{paddingBottom: Styles.globalMargins.xxtiny}}>
+      <Kb.Text type="BodySmall" style={{paddingBottom: Styles.globalMargins.xxtiny}} lineClamp={1}>
         {props.joiners.length > 0 ? getAddedUsernames(props.joiners) : getAddedUsernames(props.leavers)}
         {` ${props.leavers.length > props.joiners.length ? 'left' : 'joined'} ${
           props.isBigTeam ? `#${props.channelname}.` : `${props.teamname}.`
         }`}
+        {props.timestamp ? (
+          <Kb.Text type="BodyTiny" style={styles.timestamp}>
+            {' ' + formatTimeForChat(props.timestamp)}
+          </Kb.Text>
+        ) : null}
       </Kb.Text>
       <Kb.Box2 direction="horizontal" alignSelf="flex-start" style={styles.avatarLine}>
         <Kb.AvatarLine
@@ -90,136 +52,15 @@ const MultiUserJoinedNotice = (props: Props) => (
   </Kb.Box2>
 )
 
-const JoinedUserNotice = (props: Props) => (
-  <UserNotice>
-    <Kb.Text type="BodySmall">
-      {props.authorIsYou ? 'You ' : ''}
-      {props.leavers.length > props.joiners.length ? 'left' : 'joined'}{' '}
-      {props.isBigTeam ? `#${props.channelname}` : props.isAdHoc ? 'the conversation' : 'the team'}.
-    </Kb.Text>
-    {props.authorIsYou && props.isBigTeam && (
-      <Kb.Text type="BodySmall">
-        <Kb.Text onClick={props.onManageNotifications} type={textType}>
-          Manage your notifications
-        </Kb.Text>
-        {` or `}
-        <Kb.Text onClick={props.onManageChannels} type={textType}>
-          browse other channels
-        </Kb.Text>
-        .
-      </Kb.Text>
-    )}
-  </UserNotice>
-)
-
-const AuthorAndAvatar = (props: {
-  username: string
-  timestamp: number
-  authorIsYou: boolean
-  onAuthorClick: (username: string) => void
-}) => (
-  <Kb.Box2 key="author" direction="horizontal" style={styles.authorContainer} gap="tiny" fullWidth={true}>
-    <Kb.Avatar
-      size={32}
-      username={props.username}
-      skipBackground={true}
-      onClick={() => props.onAuthorClick(props.username)}
-      style={styles.avatar}
-    />
-    <Kb.Box2 direction="horizontal" gap="xtiny" fullWidth={true} style={styles.usernameCrown}>
-      <Kb.ConnectedUsernames
-        colorBroken={true}
-        colorFollowing={true}
-        colorYou={true}
-        onUsernameClicked="profile"
-        style={Styles.collapseStyles([props.authorIsYou && styles.usernameHighlighted])}
-        type="BodySmallBold"
-        usernames={props.username}
-      />
-      <Kb.Text type="BodyTiny" style={styles.timestamp}>
-        {formatTimeForChat(props.timestamp)}
-      </Kb.Text>
-    </Kb.Box2>
-  </Kb.Box2>
-)
-
 const styles = Styles.styleSheetCreate(
   () =>
     ({
-      authorContainer: Styles.platformStyles({
-        common: {
-          alignItems: 'flex-start',
-          alignSelf: 'flex-start',
-          height: Styles.globalMargins.mediumLarge,
-        },
-        isMobile: {marginTop: 8},
-      }),
-      avatar: Styles.platformStyles({
-        isElectron: {
-          marginLeft: Styles.globalMargins.small,
-        },
-        isMobile: {marginLeft: Styles.globalMargins.tiny},
-      }),
       avatarLine: Styles.platformStyles({
-        isElectron: {
-          marginLeft: -2,
-        },
-        isMobile: {
-          marginLeft: -Styles.globalMargins.xsmall,
-        },
+        isElectron: {marginLeft: -2},
+        isMobile: {marginLeft: -Styles.globalMargins.xsmall},
       }),
-      container: Styles.platformStyles({
-        isElectron: {
-          paddingTop: Styles.globalMargins.xtiny,
-        },
-      }),
-      contentUnderAuthorContainer: Styles.platformStyles({
-        isElectron: {
-          marginTop: -16,
-          paddingLeft:
-            // Space for below the avatar
-            Styles.globalMargins.tiny + // right margin
-            Styles.globalMargins.small + // left margin
-            Styles.globalMargins.mediumLarge, // avatar
-        },
-        isMobile: {
-          marginTop: -12,
-          paddingBottom: 3,
-          paddingLeft:
-            // Space for below the avatar
-            Styles.globalMargins.small + Styles.globalMargins.mediumLarge, // left margin // avatar,
-          paddingRight: Styles.globalMargins.tiny,
-        },
-      }),
-      joinerPadding: Styles.platformStyles({
-        isElectron: {
-          paddingBottom: Styles.globalMargins.xsmall,
-        },
-        isMobile: {
-          paddingBottom: Styles.globalMargins.xtiny,
-        },
-      }),
-      singleEvent: Styles.platformStyles({
-        isMobile: {
-          marginLeft: -(
-            (Styles.globalMargins.small + Styles.globalMargins.mediumLarge) // left margin
-          ), // avatar
-        },
-      }),
-      timestamp: Styles.platformStyles({
-        isElectron: {lineHeight: 19},
-      }),
-      usernameCrown: Styles.platformStyles({
-        isElectron: {
-          alignItems: 'baseline',
-          position: 'relative',
-          top: -2,
-        },
-        isMobile: {alignItems: 'center'},
-      }),
-      usernameHighlighted: {
-        color: Styles.globalColors.blackOrBlack,
-      },
+      container: {marginLeft: -40, paddingBottom: 4},
+      timestamp: Styles.platformStyles({isElectron: {lineHeight: 19}}),
     } as const)
 )
 


### PR DESCRIPTION
This moves the join / leave messages back to the left. This also unifies and removes the 'singleEvent' concept and hoists the timestamp up so its more consistent

old:

<img width="384" alt="old" src="https://user-images.githubusercontent.com/516435/217637207-78545856-3847-4daf-a02e-fa0c82453c16.png">

new:

<img width="462" alt="new" src="https://user-images.githubusercontent.com/516435/217637224-85d29590-b7d0-4e04-9f63-c25f9fee374c.png">
