### PR TITLE
another placholder fix

### DIFF
--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -1514,6 +1514,11 @@ export const upgradeMessage = (old: Types.Message, m: Types.Message): Types.Mess
     }
   }
 
+  // we never want to convert a non placeholder into a placeholder
+  if (m.type === 'placeholder' && old.type !== 'placeholder') {
+    return old
+  }
+
   return m
 }
 


### PR DESCRIPTION
This is another attempt at my previous fix which broken the offline streaming. If we have a type mismatch in the upgrade path we accept the new item, this is likely normally fine but we probably never want to stomp a value with a placeholder ever, so we skip that. This does fix the placeholders i can repro case