### PR TITLE
better bot logic

### DIFF
--- a/shared/chat/conversation/messages/separator.tsx
+++ b/shared/chat/conversation/messages/separator.tsx
@@ -197,12 +197,17 @@ const useReduxFast = (
 const useRedux = (conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ordinal) => {
   return Container.useSelector(state => {
     const m = Constants.getMessage(state, conversationIDKey, ordinal) ?? missingMessage
-    const {author, timestamp, botUsername} = m
+    const {author, timestamp} = m
     const meta = Constants.getMeta(state, conversationIDKey)
     const {teamID, botAliases} = meta
     const authorRoleInTeam = state.teams.teamIDToMembers.get(teamID ?? '')?.get(author)?.type
     const botAlias = botAliases[author] ?? ''
-    const authorIsBot = botUsername === author
+    const participantInfoNames = Constants.getParticipantInfo(state, conversationIDKey).name
+    const authorIsBot = meta.teamname
+      ? authorRoleInTeam === 'restrictedbot' || authorRoleInTeam === 'bot'
+      : meta.teamType === 'adhoc' && participantInfoNames.length > 0 // teams without info may have type adhoc with an empty participant name list
+      ? !participantInfoNames.includes(author) // if adhoc, check if author in participants
+      : false
     return {
       authorIsBot,
       authorRoleInTeam,

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -87,14 +87,6 @@ type WMProps = {
 } & Props
 
 const useRedux = (conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ordinal) => {
-  const getBotname = (message: Types.Message) => {
-    const {botUsername, author} = message
-    const keyedBot = botUsername
-    if (!keyedBot) return ''
-    const authorIsBot = author === botUsername
-    return !authorIsBot ? keyedBot : ''
-  }
-
   const getReactionsPopupPosition = (
     hasReactions: boolean,
     message: Types.Message,
@@ -142,7 +134,7 @@ const useRedux = (conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ord
   return Container.useSelector(state => {
     const you = state.config.username
     const m = Constants.getMessage(state, conversationIDKey, ordinal) ?? missingMessage
-    const {exploded, submitState, author, id} = m
+    const {exploded, submitState, author, id, botUsername} = m
     const exploding = !!m.exploding
     const isPendingPayment = Constants.isPendingPaymentMessage(state, m)
     const decorate = !exploded && !m.errorReason
@@ -154,7 +146,8 @@ const useRedux = (conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ord
     const showExplodingCountdown = !!exploding && !exploded && submitState !== 'failed'
     const showCoinsIcon = Constants.hasSuccessfulInlinePayments(state, m)
     const hasReactions = (m.reactions?.size ?? 0) > 0
-    const botname = getBotname(m)
+    // hide if the bot is writing to itself
+    const botname = botUsername === author ? '' : botUsername ?? ''
     const reactionsPopupPosition = getReactionsPopupPosition(hasReactions, m, state)
     const ecrType = getEcrType(m, you)
     return {
@@ -379,7 +372,7 @@ type RProps = {
   showExplodingCountdown: boolean
   showRevoked: boolean
   showCoinsIcon: boolean
-  botname?: string
+  botname: string
 }
 const RightSide = React.memo(function RightSide(p: RProps) {
   const {showCenteredHighlight, toggleShowingPopup, showSendIndicator, showCoinsIcon} = p


### PR DESCRIPTION
- [x] Small icon by name shows bot if we're in a team as a bot role or the old ad hoc logic
- [x] Big icon on side if we're using `botUsername` unless it matches the `author` (a bot writing to itself)