### PR TITLE
emoji shortnames can conflict which causes a key clash

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -2371,12 +2371,12 @@ const markThreadAsRead = async (
   logger.info(`marking read messages ${conversationIDKey} ${readMsgID} for ${action.type}`)
   await RPCChatTypes.localMarkAsReadLocalRpcPromise({
     conversationID: Types.keyToConversationID(conversationIDKey),
-    msgID: readMsgID,
     forceUnread: false,
+    msgID: readMsgID,
   })
 }
 
-const markAsUnread = async (state: Container.TypedState, action: Chat2Gen.MarkAsUnreadPayload) => {
+const markAsUnread = (state: Container.TypedState, action: Chat2Gen.MarkAsUnreadPayload) => {
   if (!state.config.loggedIn) {
     logger.info('bail on not logged in')
     return
@@ -2401,8 +2401,8 @@ const markAsUnread = async (state: Container.TypedState, action: Chat2Gen.MarkAs
   logger.info(`marking unread messages ${conversationIDKey} ${readMsgID}`)
   RPCChatTypes.localMarkAsReadLocalRpcPromise({
     conversationID: Types.keyToConversationID(conversationIDKey),
-    msgID: message ? message.id : unreadLineID,
     forceUnread: true,
+    msgID: message ? message.id : unreadLineID,
   })
     .then(() => {})
     .catch(() => {})

--- a/shared/chat/conversation/input-area/suggestors/common.tsx
+++ b/shared/chat/conversation/input-area/suggestors/common.tsx
@@ -48,7 +48,7 @@ export type ItemRendererProps<T> = {selected: boolean; item: T; conversationIDKe
 export type ListProps<T> = {
   expanded: boolean
   items: Array<T>
-  keyExtractor: (item: T) => string
+  keyExtractor: (item: T, idx: number) => string
   suggestBotCommandsUpdateStatus?: RPCChatTypes.UIBotCommandsUpdateStatusTyp
   listStyle: Styles.StylesCrossPlatform
   spinnerStyle: Styles.StylesCrossPlatform
@@ -67,7 +67,7 @@ export function List<T>(p: ListProps<T>) {
 
   const renderItem = React.useCallback(
     (idx, item: T) => (
-      <Kb.ClickableBox key={keyExtractor(item)} onClick={() => onSelected(item, true)}>
+      <Kb.ClickableBox key={keyExtractor(item, idx)} onClick={() => onSelected(item, true)}>
         <ItemRenderer selected={idx === selectedIndex} item={item} conversationIDKey={conversationIDKey} />
       </Kb.ClickableBox>
     ),

--- a/shared/chat/conversation/input-area/suggestors/emoji.tsx
+++ b/shared/chat/conversation/input-area/suggestors/emoji.tsx
@@ -25,7 +25,7 @@ export const transformer = (
   return Common.standardTransformer(`${marker}${emoji.short_name}:`, tData, preview)
 }
 
-const keyExtractor = (item: EmojiData, idx: number) => String(idx) // emojis can have conflicts on the names
+const keyExtractor = (_item: EmojiData, idx: number) => String(idx) // emojis can have conflicts on the names
 
 const ItemRenderer = (p: Common.ItemRendererProps<EmojiData>) => {
   const {item, selected} = p

--- a/shared/chat/conversation/input-area/suggestors/emoji.tsx
+++ b/shared/chat/conversation/input-area/suggestors/emoji.tsx
@@ -25,7 +25,7 @@ export const transformer = (
   return Common.standardTransformer(`${marker}${emoji.short_name}:`, tData, preview)
 }
 
-const keyExtractor = (item: EmojiData) => item.short_name
+const keyExtractor = (item: EmojiData, idx: number) => String(idx) // emojis can have conflicts on the names
 
 const ItemRenderer = (p: Common.ItemRendererProps<EmojiData>) => {
   const {item, selected} = p

--- a/shared/chat/conversation/input-area/suggestors/suggestion-list.d.ts
+++ b/shared/chat/conversation/input-area/suggestors/suggestion-list.d.ts
@@ -4,7 +4,7 @@ import * as RPCChatTypes from '../../../../constants/types/rpc-chat-gen'
 
 export type Props = {
   items: Array<any>
-  keyExtractor?: (item: any) => string
+  keyExtractor?: (item: any, idx: number) => string
   renderItem: (index: number, item: any) => React.ReactElement
   selectedIndex: number
   style?: Styles.StylesCrossPlatform

--- a/shared/chat/conversation/messages/message-popup/attachment/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment/container.tsx
@@ -128,19 +128,19 @@ export default Container.connect(
           path: [{props: {members: [username], teamID}, selected: 'teamReallyRemoveMember'}],
         })
       ),
-    _onPinMessage: (message: Types.Message) => {
-      dispatch(
-        Chat2Gen.createPinMessage({
-          conversationIDKey: message.conversationIDKey,
-          messageID: message.id,
-        })
-      )
-    },
     _onMarkAsUnread: (message: Types.Message) => {
       dispatch(
         Chat2Gen.createMarkAsUnread({
           conversationIDKey: message.conversationIDKey,
           readMsgID: message.id,
+        })
+      )
+    },
+    _onPinMessage: (message: Types.Message) => {
+      dispatch(
+        Chat2Gen.createPinMessage({
+          conversationIDKey: message.conversationIDKey,
+          messageID: message.id,
         })
       )
     },
@@ -205,8 +205,8 @@ export default Container.connect(
       onHidden: () => ownProps.onHidden(),
       onInstallBot: stateProps._authorIsBot ? () => dispatchProps._onInstallBot(message) : undefined,
       onKick: () => dispatchProps._onKick(stateProps._teamID, message.author),
-      onPinMessage: stateProps._canPinMessage ? () => dispatchProps._onPinMessage(message) : undefined,
       onMarkAsUnread: () => dispatchProps._onMarkAsUnread(message),
+      onPinMessage: stateProps._canPinMessage ? () => dispatchProps._onPinMessage(message) : undefined,
       onReact: (emoji: string) => dispatchProps._onReact(message, emoji),
       onReply: () => dispatchProps._onReply(message),
       onSaveAttachment:

--- a/shared/chat/conversation/messages/message-popup/exploding/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding/container.tsx
@@ -147,19 +147,19 @@ export default Container.connect(
           path: [{props: {members: [username], teamID}, selected: 'teamReallyRemoveMember'}],
         })
       ),
-    _onPinMessage: (id: number) => {
-      dispatch(
-        Chat2Gen.createPinMessage({
-          conversationIDKey: ownProps.conversationIDKey,
-          messageID: id,
-        })
-      )
-    },
     _onMarkAsUnread: (id: number) => {
       dispatch(
         Chat2Gen.createMarkAsUnread({
           conversationIDKey: ownProps.conversationIDKey,
           readMsgID: id,
+        })
+      )
+    },
+    _onPinMessage: (id: number) => {
+      dispatch(
+        Chat2Gen.createPinMessage({
+          conversationIDKey: ownProps.conversationIDKey,
+          messageID: id,
         })
       )
     },

--- a/shared/chat/conversation/messages/message-popup/text/container.tsx
+++ b/shared/chat/conversation/messages/message-popup/text/container.tsx
@@ -137,19 +137,19 @@ export default Container.connect(
           path: [{props: {members: [username], teamID}, selected: 'teamReallyRemoveMember'}],
         })
       ),
-    _onPinMessage: (message: Types.Message) => {
-      dispatch(
-        Chat2Gen.createPinMessage({
-          conversationIDKey: message.conversationIDKey,
-          messageID: message.id,
-        })
-      )
-    },
     _onMarkAsUnread: (message: Types.Message) => {
       dispatch(
         Chat2Gen.createMarkAsUnread({
           conversationIDKey: message.conversationIDKey,
           readMsgID: message.id,
+        })
+      )
+    },
+    _onPinMessage: (message: Types.Message) => {
+      dispatch(
+        Chat2Gen.createPinMessage({
+          conversationIDKey: message.conversationIDKey,
+          messageID: message.id,
         })
       )
     },
@@ -237,8 +237,8 @@ export default Container.connect(
       onHidden: () => ownProps.onHidden(),
       onInstallBot: stateProps._authorIsBot ? () => dispatchProps._onInstallBot(message) : undefined,
       onKick: () => dispatchProps._onKick(stateProps._teamID, message.author),
-      onPinMessage: stateProps._canPinMessage ? () => dispatchProps._onPinMessage(message) : undefined,
       onMarkAsUnread: () => dispatchProps._onMarkAsUnread(message),
+      onPinMessage: stateProps._canPinMessage ? () => dispatchProps._onPinMessage(message) : undefined,
       onReact: (emoji: string) => dispatchProps._onReact(message, emoji),
       onReply: message.type === 'text' ? () => dispatchProps._onReply(message) : undefined,
       onReplyPrivately:

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -94,6 +94,7 @@ export const makeState = (): Types.State => ({
   infoPanelSelectedTab: undefined,
   infoPanelShowing: false,
   lastCoord: undefined,
+  markedAsUnreadMap: new Map(), // store a bit if we've marked this thread as unread so we don't mark as read when navgiating away
   maybeMentionMap: new Map(),
   messageCenterOrdinals: new Map(), // ordinals to center threads on,
   messageMap: new Map(), // messages in a thread,
@@ -104,7 +105,6 @@ export const makeState = (): Types.State => ({
   mutedMap: new Map(),
   mutualTeamMap: new Map(),
   orangeLineMap: new Map(), // last message we've seen,
-  markedAsUnreadMap: new Map(), // store a bit if we've marked this thread as unread so we don't mark as read when navgiating away
   participantMap: new Map(),
   paymentConfirmInfo: undefined,
   paymentStatusMap: new Map(),

--- a/shared/teams/join-team/index.tsx
+++ b/shared/teams/join-team/index.tsx
@@ -47,7 +47,7 @@ const JoinTeam = (props: Props) => {
     <Kb.Modal
       banners={[
         !!props.errorText && (
-          <Kb.Banner color="red">
+          <Kb.Banner key="red" color="red">
             <Kb.BannerParagraph bannerColor="red" content={props.errorText} />
           </Kb.Banner>
         ),


### PR DESCRIPTION
user emojis can have name conflicts w/ existing emojis or even between themselves, so they can't be used as raw keys