### PR TITLE
cache heights in shim

### DIFF
--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -61,6 +61,7 @@ const Conversation = (p: SwitchProps) => {
 // @ts-ignore
 Conversation.navigationOptions = ({route}) => ({
   ...headerNavigationOptions(route),
+  heightFix: true,
   needsKeyboard: true,
   needsSafe: true,
   presentation: undefined,

--- a/shared/router-v2/shim.native.tsx
+++ b/shared/router-v2/shim.native.tsx
@@ -5,7 +5,7 @@ import * as Shared from './shim.shared'
 import * as Container from '../util/container'
 import {SafeAreaProvider, initialWindowMetrics} from 'react-native-safe-area-context'
 import {useHeaderHeight} from '@react-navigation/elements'
-import {View} from 'react-native'
+import {View, type LayoutChangeEvent} from 'react-native'
 
 export const shim = (routes: any, isModal: boolean, isLoggedOut: boolean) =>
   Shared.shim(routes, shimNewRoute, isModal, isLoggedOut)
@@ -23,6 +23,31 @@ const shimNewRoute = (Original: any, isModal: boolean, isLoggedOut: boolean, get
     let wrap = <Original {...props} />
 
     const wrapInSafe = navigationOptions?.needsSafe || isModal || isLoggedOut
+    // either they want it, or its a modal/loggedout and they haven't explicitly opted out
+    const wrapInKeyboard =
+      navigationOptions?.needsKeyboard ||
+      (isModal && (navigationOptions?.needsKeyboard ?? true)) ||
+      (isLoggedOut && (navigationOptions?.needsKeyboard ?? true))
+
+    // making this explicit opt in so we don't cut off screens by accident
+    const needsHeightFix = navigationOptions?.heightFix ?? false
+    if (needsHeightFix) {
+      let heightThrashType = 'normal'
+      if (isModal) {
+        heightThrashType += ':modal'
+      }
+      if (wrapInSafe) {
+        heightThrashType += ':safe'
+      }
+      if (wrapInKeyboard) {
+        heightThrashType += ':kb'
+      }
+
+      // needed to stop getting lots of heights
+      // https://github.com/software-mansion/react-native-screens/issues/1504
+      wrap = <HeightThrashWrapper type={heightThrashType}>{wrap}</HeightThrashWrapper>
+    }
+
     if (wrapInSafe) {
       wrap = (
         <SafeAreaProvider initialMetrics={initialWindowMetrics}>
@@ -32,12 +57,6 @@ const shimNewRoute = (Original: any, isModal: boolean, isLoggedOut: boolean, get
         </SafeAreaProvider>
       )
     }
-
-    // either they want it, or its a modal/loggedout and they haven't explicitly opted out
-    const wrapInKeyboard =
-      navigationOptions?.needsKeyboard ||
-      (isModal && (navigationOptions?.needsKeyboard ?? true)) ||
-      (isLoggedOut && (navigationOptions?.needsKeyboard ?? true))
 
     if (wrapInKeyboard) {
       wrap = <Kb.KeyboardAvoidingView2 extraOffset={40}>{wrap}</Kb.KeyboardAvoidingView2>
@@ -50,6 +69,41 @@ const shimNewRoute = (Original: any, isModal: boolean, isLoggedOut: boolean, get
   })
   Container.hoistNonReactStatic(ShimmedNew, Original)
   return ShimmedNew
+}
+
+const heightCache = new Map<string, number>()
+
+// there is an issue where we get a lot of sizing when we layout, so we cache it per type and use that
+const HeightThrashWrapper = (p: {children: React.ReactNode; type: string}) => {
+  const {children, type} = p
+
+  const iAmSettingCache = React.useRef(heightCache.get(type) === undefined)
+
+  // take it so no one else does
+  if (iAmSettingCache.current) {
+    heightCache.set(type, -1)
+  }
+
+  const onLayout = React.useCallback(
+    (e: LayoutChangeEvent) => {
+      if (iAmSettingCache.current) {
+        heightCache.set(type, e.nativeEvent.layout.height)
+      }
+    },
+    [type]
+  )
+
+  const style = React.useMemo(() => {
+    const height = heightCache.get(type)
+    if ((height ?? -1) === -1) return styles.keyboard
+    return [styles.keyboard, {height, maxHeight: height}]
+  }, [type])
+
+  return (
+    <View style={style} onLayout={iAmSettingCache.current ? onLayout : undefined}>
+      {children}
+    </View>
+  )
 }
 
 const useSafeHeaderHeight = () => {


### PR DESCRIPTION
We suffer from a bug where the RNScreen will lay us out several times (seemingly not taking into account the header, even if its height is known, https://github.com/software-mansion/react-native-screens/issues/1504 ) so to mitigate this we actually cache on first layout(s) a component of a 'type' based on the flags passed in `navigationOptions`. This is opt-in so we don't have issues w/ things getting cut off. Hopefully there's a good native fix but this is simpler for now and solves the problem