### PR TITLE
fix issue w/ release mode ios not switching password input type

### DIFF
--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -209,6 +209,8 @@ class PlainInput extends React.PureComponent<InternalProps> {
       autoFocus: this.props.autoFocus,
       children: this.props.children,
       editable: !this.props.disabled,
+      // needed to workaround changing this not doing the right thing
+      key: this.props.type,
       keyboardAppearance: isIOS ? (Styles.isDarkMode() ? 'dark' : 'light') : undefined,
       keyboardType: this.props.keyboardType,
       multiline: false,


### PR DESCRIPTION
aka 'Show typing' checkbox in change password doesn't actually show the password. so we change the key to remount and its fine