### PR TITLE
Allow inbox to load when behind a convo

### DIFF
--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -11,6 +11,8 @@ import {Provider, useDispatch} from 'react-redux'
 import {SafeAreaProvider, initialWindowMetrics} from 'react-native-safe-area-context'
 import {makeEngine} from '../engine'
 import {GestureHandlerRootView} from 'react-native-gesture-handler'
+import {enableFreeze} from 'react-native-screens'
+enableFreeze(true)
 
 type ConfigureStore = ReturnType<typeof makeStore>
 let _store: ConfigureStore | undefined

--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -73,7 +73,6 @@ type WrapperProps = Pick<
 >
 
 const InboxWrapper = React.memo(function InboxWrapper(props: WrapperProps) {
-  console.log('aaa inboxwrapper rneder >>>>>>>>>>>>>>>>>>>>>.', Math.random())
   const dispatch = Container.useDispatch()
   const inboxHasLoaded = Container.useSelector(state => state.chat2.inboxHasLoaded)
   const isFocused = useIsFocused()
@@ -148,6 +147,7 @@ const InboxWrapper = React.memo(function InboxWrapper(props: WrapperProps) {
 
 const buttonWidth = 132
 export const getOptions = () => ({
+  freezeOnBlur: false, // let it render even if not visible
   headerLeft: () => <Kb.HeaderLeftBlank />,
   headerLeftContainerStyle: {
     ...Common.defaultNavigationOptions.headerLeftContainerStyle,
@@ -241,7 +241,6 @@ const Connected = Container.connect(
         }
       }
     }
-
     return {
       isSearching: stateProps.isSearching,
       navKey,

--- a/shared/chat/inbox/container.tsx
+++ b/shared/chat/inbox/container.tsx
@@ -73,6 +73,7 @@ type WrapperProps = Pick<
 >
 
 const InboxWrapper = React.memo(function InboxWrapper(props: WrapperProps) {
+  console.log('aaa inboxwrapper rneder >>>>>>>>>>>>>>>>>>>>>.', Math.random())
   const dispatch = Container.useDispatch()
   const inboxHasLoaded = Container.useSelector(state => state.chat2.inboxHasLoaded)
   const isFocused = useIsFocused()

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -16,10 +16,7 @@ import {HeaderLeftCancel2} from '../common-adapters/header-hoc'
 import {NavigationContainer, getFocusedRouteNameFromRoute} from '@react-navigation/native'
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs'
 import {modalRoutes, routes, loggedOutRoutes, tabRoots} from './routes'
-import {enableFreeze} from 'react-native-screens'
 import {createNativeStackNavigator} from '@react-navigation/native-stack'
-
-enableFreeze()
 
 if (module.hot) {
   module.hot.accept('', () => {


### PR DESCRIPTION
For whatever reason screen freezing didn't seem to be working but it actually does now, but instead of rendering the top 2 as it advertises it doesn't render the inbox, so instead we force it to render no matter what