### PR TITLE
try and fix audio stopping issue

### DIFF
--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -29,6 +29,7 @@ import {_getNavigator} from '../../constants/router2'
 import {getEngine} from '../../engine/require'
 import {isIOS, isAndroid} from '../../constants/platform'
 import {launchImageLibraryAsync} from '../../util/expo-image-picker.native'
+import {Audio, InterruptionModeIOS, InterruptionModeAndroid} from 'expo-av'
 import {
   getDefaultCountryCode,
   androidOpenSettings,
@@ -701,6 +702,20 @@ const notifyNativeOfDarkModeChange = (state: Container.TypedState) => {
   }
 }
 
+const setupAudioModes = () => {
+  Audio.setAudioModeAsync({
+    allowsRecordingIOS: true,
+    interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
+    interruptionModeIOS: InterruptionModeIOS.DoNotMix,
+    playThroughEarpieceAndroid: false,
+    playsInSilentModeIOS: true,
+    shouldDuckAndroid: false,
+    staysActiveInBackground: true,
+  })
+    .then(() => {})
+    .catch(() => {})
+}
+
 export const initPlatformListener = () => {
   Container.listenAction(ConfigGen.persistRoute, persistRoute)
   Container.listenAction(ConfigGen.mobileAppState, updateChangedFocus)
@@ -749,4 +764,5 @@ export const initPlatformListener = () => {
   Container.spawn(loadStartupDetails, 'loadStartupDetails')
   initPushListener()
   Container.spawn(setupNetInfoWatcher, 'setupNetInfoWatcher')
+  Container.spawn(setupAudioModes, 'setupAudioModes')
 }

--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -329,7 +329,7 @@ const makeRecorder = async (onRecordingStatusUpdate: (s: Audio.RecordingStatus) 
     playThroughEarpieceAndroid: false,
     playsInSilentModeIOS: true,
     shouldDuckAndroid: false,
-    staysActiveInBackground: false,
+    staysActiveInBackground: true,
   })
   const recording = new Audio.Recording()
   await recording.prepareToRecordAsync({

--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react-native-gesture-handler'
 import {View} from 'react-native'
 import {formatAudioRecordDuration} from '../../util/timestamp'
-import {Audio, InterruptionModeIOS, InterruptionModeAndroid} from 'expo-av'
+import {Audio} from 'expo-av'
 import logger from '../../logger'
 import * as Haptics from 'expo-haptics'
 import * as FileSystem from 'expo-file-system'
@@ -322,15 +322,6 @@ const vibrate = (short: boolean) => {
 const makeRecorder = async (onRecordingStatusUpdate: (s: Audio.RecordingStatus) => void) => {
   vibrate(true)
 
-  await Audio.setAudioModeAsync({
-    allowsRecordingIOS: true,
-    interruptionModeAndroid: InterruptionModeAndroid.DoNotMix,
-    interruptionModeIOS: InterruptionModeIOS.DoNotMix,
-    playThroughEarpieceAndroid: false,
-    playsInSilentModeIOS: true,
-    shouldDuckAndroid: false,
-    staysActiveInBackground: true,
-  })
   const recording = new Audio.Recording()
   await recording.prepareToRecordAsync({
     android: {


### PR DESCRIPTION
There are a couple of issues w/ how the audio mode setup works. This is specific to you listening to 3rd party audio in headphones outside of keybase first.

1. We only set our audio mode preferences when we actually click on the recording microphone. Once you do this then our prefs are set so how the app works before / after you record isn't the same. Instead we handle this on app init
2. Before this if you click to play an inline audio the audio stops or is mixed/ducked (depends on if you did the microphone in part 1). if you background and click to play your music then come back into the app and then immediately background your audio stops. With this fix that shouldn't interrupt your 3rd party audio anymore