### PR TITLE
Better desktop image zoom / use for edit avatar

### DIFF
--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -219,6 +219,8 @@ dependencies {
     implementation project(':keybaselib')
     implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation "me.leolin:ShortcutBadger:1.1.22@aar"
+    implementation "androidx.lifecycle:lifecycle-common-java8:2.6.1"
+    implementation "androidx.lifecycle:lifecycle-process:2.6.1"
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/shared/android/build.gradle
+++ b/shared/android/build.gradle
@@ -21,3 +21,7 @@ buildscript {
         classpath("com.github.triplet.gradle:play-publisher:3.7.0") // To publish from gradle
     }
 }
+
+plugins {
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+}

--- a/shared/chat/conversation/attachment-fullscreen/index.native.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.native.tsx
@@ -19,6 +19,7 @@ const Fullscreen = (p: Props) => {
 
   let content: React.ReactNode = null
   let spinner: React.ReactNode = null
+
   if (path) {
     if (isVideo) {
       content = (
@@ -46,7 +47,7 @@ const Fullscreen = (p: Props) => {
         </Kb.Box2>
       )
     } else {
-      content = <Kb.ZoomableImage src={path} />
+      content = <Kb.ZoomableImage src={path} style={styles.zoomableBox} />
     }
   }
   if (!loaded && isVideo) {

--- a/shared/common-adapters/avatar.tsx
+++ b/shared/common-adapters/avatar.tsx
@@ -9,13 +9,12 @@ import type * as Types from '../constants/types/teams'
 import './avatar.css'
 
 // Desktop sizes also imported for edit-avatar
-export const AVATAR_CONTAINER_SIZE = 175
-export const AVATAR_BORDER_SIZE = 4
+const AVATAR_CONTAINER_SIZE = 175
+const AVATAR_BORDER_SIZE = 4
 export const AVATAR_SIZE = AVATAR_CONTAINER_SIZE - AVATAR_BORDER_SIZE * 2
-export const VIEWPORT_CENTER = AVATAR_SIZE / 2
 
 export const avatarSizes = [128, 96, 64, 48, 32, 24, 16] as const
-export type AvatarSize = typeof avatarSizes[number]
+export type AvatarSize = (typeof avatarSizes)[number]
 
 type URLType = string
 

--- a/shared/common-adapters/image2.desktop.tsx
+++ b/shared/common-adapters/image2.desktop.tsx
@@ -5,8 +5,7 @@ import type {Props} from './image2'
 import LoadingStateView from './loading-state-view'
 
 const onDragStart = e => e.preventDefault()
-// TODO only reason this is a ref is for edit profile, which shouldn't likely use it at all
-const Image2 = React.forwardRef<Props, any>(function Image2(p: Props, ref: any) {
+const Image2 = (p: Props) => {
   const {showLoadingStateUntilLoaded, src, onLoad, onError} = p
   const [loading, setLoading] = React.useState(true)
   const isMounted = Container.useIsMounted()
@@ -17,7 +16,7 @@ const Image2 = React.forwardRef<Props, any>(function Image2(p: Props, ref: any) 
     },
     [isMounted, onLoad]
   )
-  const style = {
+  const style: any = {
     ...p.style,
     ...(showLoadingStateUntilLoaded && loading ? styles.absolute : {}),
     opacity: showLoadingStateUntilLoaded && loading ? 0 : 1,
@@ -26,7 +25,6 @@ const Image2 = React.forwardRef<Props, any>(function Image2(p: Props, ref: any) 
   return (
     <>
       <img
-        ref={ref}
         src={
           // eslint-disable-next-line
           src as any
@@ -39,7 +37,7 @@ const Image2 = React.forwardRef<Props, any>(function Image2(p: Props, ref: any) 
       {showLoadingStateUntilLoaded ? <LoadingStateView loading={loading} /> : null}
     </>
   )
-})
+}
 
 const styles = Styles.styleSheetCreate(() => ({
   absolute: {

--- a/shared/common-adapters/image2.native.tsx
+++ b/shared/common-adapters/image2.native.tsx
@@ -4,15 +4,21 @@ import type {Props} from './image2'
 import {Image} from 'expo-image'
 
 const Image2 = (p: Props) => {
-  const {showLoadingStateUntilLoaded = true, src, onLoad, onError, style} = p
+  console.log('aaa image2', p)
+  const {showLoadingStateUntilLoaded = true, src, onLoad, /*onError, */ style} = p
   const [loading, setLoading] = React.useState(true)
   const _onLoad = React.useCallback(
     (e: any) => {
+      console.log('aaa onloaded', e)
       setLoading(false)
       onLoad?.(e)
     },
     [onLoad]
   )
+
+  const onError = e => {
+    console.log('aaa onerror', e)
+  }
 
   return (
     <>
@@ -21,9 +27,10 @@ const Image2 = (p: Props) => {
         style={
           // eslint-disable-next-line
           style as any
+          // {width: 200, height: 200, backgroundColor: 'red'}
         }
         onLoad={_onLoad}
-        cachePolicy="memory"
+        cachePolicy="none"
         contentFit="contain"
         onError={onError}
       />

--- a/shared/common-adapters/image2.native.tsx
+++ b/shared/common-adapters/image2.native.tsx
@@ -4,7 +4,7 @@ import type {Props} from './image2'
 import {Image} from 'expo-image'
 
 const Image2 = (p: Props) => {
-  const {showLoadingStateUntilLoaded = true, src, onLoad, /*onError, */ style} = p
+  const {showLoadingStateUntilLoaded, src, onLoad, onError, style} = p
   const [loading, setLoading] = React.useState(true)
   const _onLoad = React.useCallback(
     (e: any) => {
@@ -14,8 +14,10 @@ const Image2 = (p: Props) => {
     [onLoad]
   )
 
-  const onError = e => {
+  const _onError = (e: unknown) => {
+    setLoading(false)
     console.log('Image2 load error', e)
+    onError?.()
   }
 
   return (
@@ -28,7 +30,7 @@ const Image2 = (p: Props) => {
         }
         onLoad={_onLoad}
         contentFit="contain"
-        onError={onError}
+        onError={_onError}
       />
       {showLoadingStateUntilLoaded && loading ? <LoadingStateView loading={loading} /> : null}
     </>

--- a/shared/common-adapters/image2.native.tsx
+++ b/shared/common-adapters/image2.native.tsx
@@ -4,12 +4,10 @@ import type {Props} from './image2'
 import {Image} from 'expo-image'
 
 const Image2 = (p: Props) => {
-  console.log('aaa image2', p)
   const {showLoadingStateUntilLoaded = true, src, onLoad, /*onError, */ style} = p
   const [loading, setLoading] = React.useState(true)
   const _onLoad = React.useCallback(
     (e: any) => {
-      console.log('aaa onloaded', e)
       setLoading(false)
       onLoad?.(e)
     },
@@ -17,7 +15,7 @@ const Image2 = (p: Props) => {
   )
 
   const onError = e => {
-    console.log('aaa onerror', e)
+    console.log('Image2 load error', e)
   }
 
   return (
@@ -27,10 +25,8 @@ const Image2 = (p: Props) => {
         style={
           // eslint-disable-next-line
           style as any
-          // {width: 200, height: 200, backgroundColor: 'red'}
         }
         onLoad={_onLoad}
-        cachePolicy="none"
         contentFit="contain"
         onError={onError}
       />

--- a/shared/common-adapters/toast.desktop.tsx
+++ b/shared/common-adapters/toast.desktop.tsx
@@ -8,7 +8,12 @@ const Kb = {
 }
 
 const Toast = (props: Props) => (
-  <Kb.FloatingBox attachTo={props.attachTo} propagateOutsideClicks={true} position={props.position}>
+  <Kb.FloatingBox
+    attachTo={props.attachTo}
+    propagateOutsideClicks={true}
+    position={props.position}
+    containerStyle={styles.float}
+  >
     <div
       className={Styles.classNames({visible: props.visible}, props.className, 'fadeBox')}
       style={Styles.collapseStyles([styles.container, props.containerStyle])}
@@ -35,4 +40,5 @@ const styles = Styles.styleSheetCreate(() => ({
       pointerEvents: 'none',
     },
   }),
+  float: {pointerEvents: 'none'},
 }))

--- a/shared/common-adapters/toast.desktop.tsx
+++ b/shared/common-adapters/toast.desktop.tsx
@@ -40,5 +40,7 @@ const styles = Styles.styleSheetCreate(() => ({
       pointerEvents: 'none',
     },
   }),
-  float: {pointerEvents: 'none'},
+  float: Styles.platformStyles({
+    isElectron: {pointerEvents: 'none'},
+  }),
 }))

--- a/shared/common-adapters/zoomable-box.android.tsx
+++ b/shared/common-adapters/zoomable-box.android.tsx
@@ -208,7 +208,7 @@ export function ZoomableBox(props: Props) {
       const width = scale * viewWidth.value
       const x = width / 2 - px - containerWidth.value / 2
       const y = height / 2 - py - containerHeight.value / 2
-      onZoom?.({height, width, x, y})
+      onZoom?.({height, scale, width, x, y})
     },
     [onZoom, viewHeight, viewWidth, containerHeight, containerWidth]
   )

--- a/shared/common-adapters/zoomable-box.android.tsx
+++ b/shared/common-adapters/zoomable-box.android.tsx
@@ -194,13 +194,13 @@ export function ZoomableBox(props: Props) {
     translationY,
   ])
 
-  useDerivedValue(() => {
-    if (scale.value > 1 && !isZoomed.value) {
-      isZoomed.value = true
-    } else if (scale.value === 1 && isZoomed.value) {
-      isZoomed.value = false
-    }
-  }, [])
+  // useDerivedValue(() => {
+  //   if (scale.value > 1 && !isZoomed.value) {
+  //     isZoomed.value = true
+  //   } else if (scale.value === 1 && isZoomed.value) {
+  //     isZoomed.value = false
+  //   }
+  // }, [])
 
   const updateOnZoom = React.useCallback(
     (scale: number, px: number, py: number) => {
@@ -213,9 +213,9 @@ export function ZoomableBox(props: Props) {
     [onZoom, viewHeight, viewWidth, containerHeight, containerWidth]
   )
 
-  useDerivedValue(() => {
-    runOnJS(updateOnZoom)(scale.value, translationX.value, translationY.value)
-  }, [])
+  // useDerivedValue(() => {
+  //   runOnJS(updateOnZoom)(scale.value, translationX.value, translationY.value)
+  // }, [])
 
   const as = useAnimatedStyle(() => {
     return {

--- a/shared/common-adapters/zoomable-box.android.tsx
+++ b/shared/common-adapters/zoomable-box.android.tsx
@@ -194,13 +194,13 @@ export function ZoomableBox(props: Props) {
     translationY,
   ])
 
-  // useDerivedValue(() => {
-  //   if (scale.value > 1 && !isZoomed.value) {
-  //     isZoomed.value = true
-  //   } else if (scale.value === 1 && isZoomed.value) {
-  //     isZoomed.value = false
-  //   }
-  // }, [])
+  useDerivedValue(() => {
+    if (scale.value > 1 && !isZoomed.value) {
+      isZoomed.value = true
+    } else if (scale.value === 1 && isZoomed.value) {
+      isZoomed.value = false
+    }
+  }, [])
 
   const updateOnZoom = React.useCallback(
     (scale: number, px: number, py: number) => {
@@ -213,9 +213,9 @@ export function ZoomableBox(props: Props) {
     [onZoom, viewHeight, viewWidth, containerHeight, containerWidth]
   )
 
-  // useDerivedValue(() => {
-  //   runOnJS(updateOnZoom)(scale.value, translationX.value, translationY.value)
-  // }, [])
+  useDerivedValue(() => {
+    runOnJS(updateOnZoom)(scale.value, translationX.value, translationY.value)
+  }, [])
 
   const as = useAnimatedStyle(() => {
     return {

--- a/shared/common-adapters/zoomable-box.d.ts
+++ b/shared/common-adapters/zoomable-box.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react'
 export type Props = {
   maxZoom?: number
   minZoom?: number
-  onZoom?: ((arg0: {height: number; width: number; x: number; y: number}) => void) | null
+  onZoom?: ((e: {height: number; width: number; x: number; y: number; scale: number}) => void) | null
   style?: any
   bounces?: boolean
   children?: React.ReactNode

--- a/shared/common-adapters/zoomable-box.ios.tsx
+++ b/shared/common-adapters/zoomable-box.ios.tsx
@@ -20,6 +20,8 @@ export const ZoomableBox = (props: Props) => (
         // @ts-ignore misses rn types
         height: e.nativeEvent.contentSize.height,
         // @ts-ignore misses rn types
+        scale: e.nativeEvent.zoomScale,
+        // @ts-ignore misses rn types
         width: e.nativeEvent.contentSize.width,
         // @ts-ignore misses rn types
         x: e.nativeEvent.contentOffset.x,

--- a/shared/common-adapters/zoomable-image.d.ts
+++ b/shared/common-adapters/zoomable-image.d.ts
@@ -4,7 +4,10 @@ import * as Styles from '../styles'
 export type Props = {
   src: string
   style?: Styles.StylesCrossPlatform
+  zoomRatio?: number
+  onLoaded?: () => void
   onIsZoomed?: (z: boolean) => void // desktop only
+  dragPan?: boolean // desktop only, pan on drag only
   // mobile only but TODO desktop also
   onChanged?: (e: {height: number; width: number; x: number; y: number}) => void
 }

--- a/shared/common-adapters/zoomable-image.d.ts
+++ b/shared/common-adapters/zoomable-image.d.ts
@@ -8,8 +8,7 @@ export type Props = {
   onLoaded?: () => void
   onIsZoomed?: (z: boolean) => void // desktop only
   dragPan?: boolean // desktop only, pan on drag only
-  // mobile only but TODO desktop also
-  onChanged?: (e: {height: number; width: number; x: number; y: number}) => void
+  onChanged?: (e: {height: number; width: number; x: number; y: number; scale: number}) => void
 }
 
 export default class ZoomableImage extends React.Component<Props> {}

--- a/shared/common-adapters/zoomable-image.desktop.tsx
+++ b/shared/common-adapters/zoomable-image.desktop.tsx
@@ -1,239 +1,29 @@
 import * as React from 'react'
-import * as Styles from '../styles'
-import * as Container from '../util/container'
 import Toast from './toast.desktop'
 import Text from './text.desktop'
 import type {Props} from './zoomable-image'
-import clamp from 'lodash/clamp'
 
 const Kb = {
   Text,
   Toast,
 }
 
-// type PannerProps = {
-//   src: string
-//   onLoaded?: () => void
-//   onPanned: (x: number, y: number, width: number, height: number, scale: number) => void
-// }
-
-// const Panner: React.FC<PannerProps> = ({src, onPanned, onLoaded}) => {
-//   const containerRef = React.useRef<HTMLDivElement>(null)
-//   const imgRef = React.useRef<HTMLImageElement>(null)
-
-//   const [allowPan, setAllowPan] = React.useState(true)
-//   const scaleRef = React.useRef(1)
-
-//   const handleMouseMove = (e: React.MouseEvent) => {
-//     if (!containerRef.current || !imgRef.current) return
-
-//     if (!allowPan) return
-
-//     const containerRect = containerRef.current.getBoundingClientRect()
-//     const imgRect = imgRef.current.getBoundingClientRect()
-
-//     const xPercent = (e.clientX - containerRect.left) / containerRect.width
-//     const yPercent = (e.clientY - containerRect.top) / containerRect.height
-
-//     const x = Math.min(
-//       0,
-//       Math.max(
-//         -(imgRect.width - containerRect.width),
-//         containerRect.width * xPercent - imgRect.width * xPercent
-//       )
-//     )
-//     const y = Math.min(
-//       0,
-//       Math.max(
-//         -(imgRect.height - containerRect.height),
-//         containerRect.height * yPercent - imgRect.height * yPercent
-//       )
-//     )
-
-//     imgRef.current.style.transform = `translate(${x}px, ${y}px) scale(${scaleRef.current})`
-//     onPanned(-x, -y, imgRect.width, imgRect.height, scaleRef.current)
-//   }
-
-//   const handleWheel = (e: React.WheelEvent) => {
-//     e.preventDefault()
-//     if (!allowPan) return
-//     const delta = e.deltaY > 0 ? 1.1 : 0.9
-//     scaleRef.current = Math.max(1, scaleRef.current * delta)
-
-//     // Update image position after scaling
-//     handleMouseMove(e)
-//   }
-
-//   const handleClick = () => {
-//     setAllowPan(p => !p)
-//   }
-
-//   return (
-//     <div
-//       ref={containerRef}
-//       style={{
-//         cursor: allowPan ? 'move' : 'zoom-in',
-//         height: '100%',
-//         overflow: 'hidden',
-//         position: 'relative',
-//         width: '100%',
-//       }}
-//       onMouseMove={handleMouseMove}
-//       onWheel={handleWheel}
-//       onClick={handleClick}
-//     >
-//       <img
-//         onLoad={onLoaded}
-//         ref={imgRef}
-//         src={src}
-//         style={{position: 'absolute', transformOrigin: '0 0', opacity: src ? 1 : 0}}
-//       />
-//     </div>
-//   )
-// }
-
-// type CropperProps = {
-//   src: string
-//   onPanned: (x: number, y: number, width: number, height: number) => void
-// }
-// const Cropper: React.FC<CropperProps> = ({src, onPanned}) => {
-//   const [scale, setScale] = React.useState(1)
-//   const [position, setPosition] = React.useState({x: 0, y: 0})
-//   const imgRef = React.useRef<HTMLImageElement>(null)
-
-//   React.useEffect(() => {
-//     const handleMouseWheel = (e: WheelEvent) => {
-//       e.preventDefault()
-//       const newScale = scale + (e.deltaY > 0 ? -0.1 : 0.1)
-//       setScale(Math.max(1, newScale))
-//     }
-
-//     const handleMouseMove = (e: MouseEvent) => {
-//       e.preventDefault()
-//       console.log('aaa2', e.offsetX)
-//       // setPosition({x: position.x + e.movementX, y: position.y + e.movementY})
-//       setPosition({x: e.offsetX, y: e.offsetY})
-//     }
-
-//     const handleMouseUp = () => {
-//       document.removeEventListener('mousemove', handleMouseMove)
-//       document.removeEventListener('mouseup', handleMouseUp)
-//     }
-
-//     const handleMouseDown = () => {
-//       document.addEventListener('mousemove', handleMouseMove)
-//       document.addEventListener('mouseup', handleMouseUp)
-//     }
-
-//     if (imgRef.current) {
-//       imgRef.current.addEventListener('wheel', handleMouseWheel)
-//       imgRef.current.addEventListener('mousedown', handleMouseDown)
-//     }
-
-//     return () => {
-//       if (imgRef.current) {
-//         imgRef.current.removeEventListener('wheel', handleMouseWheel)
-//         imgRef.current.removeEventListener('mousedown', handleMouseDown)
-//       }
-//       document.removeEventListener('mousemove', handleMouseMove)
-//       document.removeEventListener('mouseup', handleMouseUp)
-//     }
-//   }, [])
-
-//   React.useEffect(() => {
-//     if (imgRef.current) {
-//       const {width, height} = imgRef.current.getBoundingClientRect()
-//       onPanned(position.x, position.y, width / scale, height / scale)
-//     }
-//   }, [position, scale, onPanned])
-
-//   return (
-//     <div
-//       ref={imgRef}
-//       style={{
-//         overflow: 'hidden',
-//         position: 'relative',
-//         width: '100%',
-//         height: '100%',
-//       }}
-//     >
-//       <img
-//         src={src}
-//         alt="cropper"
-//         style={{
-//           cursor: 'move',
-//           position: 'absolute',
-//           transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
-//           transformOrigin: 'top left',
-//           pointerEvents: 'none',
-//         }}
-//       />
-//     </div>
-//   )
-// }
-const onDragStart = (e: React.BaseSyntheticEvent) => e.preventDefault()
 const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
   const {src, onIsZoomed, onLoaded, dragPan, onChanged} = p
   const [isZoomed, setIsZoomed] = React.useState(false)
   const [allowPan, setAllowPan] = React.useState(true)
-  const [imgSize, setImgSize] = React.useState({height: 0, width: 0})
-  const isMounted = Container.useIsMounted()
-  const [lastSrc, setLastSrc] = React.useState('')
-  // const isDragging = React.useRef(false)
-
+  const [showToast, setShowToast] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement>(null)
   const imgRef = React.useRef<HTMLImageElement>(null)
-
-  // const [allowPan, setAllowPan] = React.useState(true)
   const scaleRef = React.useRef(1)
   const isZoomedRef = React.useRef(isZoomed)
-
-  if (lastSrc !== src) {
-    setLastSrc(src)
-    const img = new Image()
-    img.src = src
-    img.onload = () => {
-      isMounted() && setImgSize({height: img.naturalHeight, width: img.naturalWidth})
-    }
-  }
-
-  const onImageMouseLeave = React.useCallback(() => {
-    const target = document.getElementById('imgAttach')
-    if (!target) return
-    target.style.transform = ''
-  }, [])
-
-  const initialZoomRatio = 1.2
-  const [zoomRatio, setZoomRatio] = React.useState(p.zoomRatio ?? initialZoomRatio)
-  // const [lastIncomingZoom, setLastIncomingZoom] = React.useState(p.zoomRatio)
-  // if (lastIncomingZoom !== p.zoomRatio) {
-  //   setLastIncomingZoom(p.zoomRatio)
-  //   if (p.zoomRatio) {
-  //     setZoomRatio(p.zoomRatio)
-  //   }
-  // }
-
-  const toggleAllowPan = () => {
-    setAllowPan(s => !s)
-  }
 
   const toggleZoom = React.useCallback(() => {
     isZoomedRef.current = !isZoomed
     setIsZoomed(s => !s)
     onIsZoomed?.(!isZoomed)
-    setZoomRatio(initialZoomRatio)
   }, [isZoomed, onIsZoomed])
 
-  const [lastIsZoomed, setLastIsZoomed] = React.useState(isZoomed)
-  if (lastIsZoomed !== isZoomed) {
-    setLastIsZoomed(isZoomed)
-    if (!isZoomed) {
-      onImageMouseLeave()
-    }
-  }
-
-  // const toastAnchorRef = React.useRef(null)
-  const [showToast, setShowToast] = React.useState(false)
   React.useEffect(() => {
     if (isZoomed) {
       setShowToast(true)
@@ -247,137 +37,9 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     } else return undefined
   }, [isZoomed])
 
-  // const onImageWheel = React.useCallback(e => {
-  //   setZoomRatio(z => {
-  //     const diff = e.deltaY > 0 ? 0.07 : -0.07
-  //     const next = Math.max(0.1, Math.min(z + diff, 20))
-  //     return next
-  //   })
-  // }, [])
-
-  // const lastEvent = React.useRef<React.MouseEvent<HTMLDivElement> | undefined>()
-
-  // const adjustImageStyle = React.useCallback(() => {
-  //   const zoomRatio = 1.2 // TEMP
-  //   // const zoomRatio = 1 / 0.3669724770642202 // TEMP
-  //   const e = lastEvent.current
-  //   const parent = document.getElementById('scrollAttach')
-  //   const img = document.getElementById('imgAttach')
-  //   if (!parent || !img) {
-  //     return
-  //   }
-  //   if (!isZoomedRef.current && !dragPan) {
-  //     img.style.transform = ''
-  //     return
-  //   }
-
-  //   if (!e) return
-
-  //   const rect = parent.getBoundingClientRect()
-  //   // position in parent
-  //   const x = clamp(Math.round(e.clientX - rect.left), 0, rect.width - 1) //rect.width / 2
-  //   const y = clamp(Math.round(e.clientY - rect.top), 0, rect.height - 1) //rect.height / 2
-
-  //   console.log('bbb', x, e?.clientX, rect.left)
-
-  //   // ratio in parent
-  //   let xr = x / (rect.width - 1)
-  //   let yr = y / (rect.height - 1)
-
-  //   // xr = 1 // TEMP
-  //   // yr = 1 // TEMP
-
-  //   console.log('eee', xr, x, rect.width)
-
-  //   // image size
-  //   const iw = imgSize.width
-  //   const ih = imgSize.height
-
-  //   // offset to center ourselves in parent after scaling
-  //   const centerX = rect.width / 2 - (iw * zoomRatio) / 2
-  //   const centerY = rect.height / 2 - (ih * zoomRatio) / 2
-
-  //   // moving the mouse should translate you to the edges of the image
-  //   const mouseX = centerX + (1 - xr) * 2 * -centerX
-  //   const mouseY = centerY + (1 - yr) * 2 * -centerY
-
-  //   console.log('ddd', mouseX, mouseY)
-
-  //   const temp = [
-  //     // move to middle
-  //     `translate(${-0.5 * iw}px, ${-0.5 * ih}px)`,
-  //     // scale up
-  //     `scale(${zoomRatio})`,
-  //     // move to top left
-  //     `translate(${0.5 * iw * zoomRatio}px, ${0.5 * ih * zoomRatio}px)`,
-  //     // center in parent. you go half the parent rect (img top in center, then go back so your center is center)
-  //     `translate(${centerX}px, ${centerY}px)`,
-  //     // move based on mouse
-  //     `translate(${mouseX}px, ${mouseY}px)`,
-  //   ]
-  //     .reverse() // applied right to left
-  //     .join(' ')
-  //   img.style.transform = temp
-
-  //   if (onChanged) {
-  //     const width = iw * zoomRatio
-  //     const height = ih * zoomRatio
-  //     // const xr = 1 // TEMP
-  //     // const yr = 0 // TEMP
-  //     // const _x = xr * (iw * zoomRatio - rect.width * zoomRatio)
-  //     // const _y = yr * (ih * zoomRatio - rect.height * zoomRatio)
-  //     // const _x = xr * iw * zoomRatio - rect.width * zoomRatio
-  //     // const _y = yr * ih * zoomRatio - rect.height * zoomRatio
-  //     // x0pixels should be: 2400 (pixels) - 300 (zoomed pixels) = 2100
-  //     // x1pixels should be: 2100 (x0pixels) + 300 (zoomed pixels) = 2400
-
-  //     //zoom * imagew - rect.width/zoom
-  //     // const _x = xr * width - (xr * rect.width) / zoomRatio
-  //     // x1pixels = x0pixels +rect.width/zoom
-  //     // const _y = yr * height - (yr * rect.height) / zoomRatio
-
-  //     let _x = xr * (width - rect.width / zoomRatio)
-  //     let _y = yr * (height - rect.height / zoomRatio)
-
-  //     const temp = {height, scale: zoomRatio, width, x: _x, y: _y}
-  //     console.log('aaa2', {x: temp.x, x1: _x + rect.width / zoomRatio})
-  //     // onChanged(temp)
-  //   }
-  // }, [zoomRatio, imgSize, isZoomed, dragPan, onChanged])
-
-  // const [lastZoomRatio, setLastZoomRatio] = React.useState(0)
-  // if (lastZoomRatio !== zoomRatio || isZoomed !== lastIsZoomed) {
-  //   setLastZoomRatio(zoomRatio)
-  //   setLastIsZoomed(isZoomed)
-  //   adjustImageStyle()
-  // }
-
-  // const onImageMouseMove = React.useCallback(
-  //   (e: React.MouseEvent<HTMLDivElement>) => {
-  //     if (dragPan && !allowPan) {
-  //       return
-  //     }
-  //     lastEvent.current = e
-  //     adjustImageStyle()
-  //   },
-  //   [adjustImageStyle, dragPan, allowPan]
-  // )
-
   const attachTo = React.useCallback(() => {
     return containerRef.current
   }, [containerRef])
-
-  // const onMouseDown = React.useCallback(() => {
-  //   isDragging.current = true
-  // }, [])
-  // const onMouseUp = React.useCallback(() => {
-  //   isDragging.current = false
-  // }, [])
-  // const onPanned = (x: number, y: number, width: number, height: number, scale: number) => {
-  //   console.log('aaa', {x, y, width, height})
-  //   onChanged?.({x, y, width, height, scale})
-  // }
-  // return <Panner src={src} onPanned={onChanged} onLoaded={onLoaded} />
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!containerRef.current || !imgRef.current) return
@@ -390,7 +52,6 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
 
     const containerRect = containerRef.current.getBoundingClientRect()
     const imgRect = imgRef.current.getBoundingClientRect()
-
     const xPercent = (e.clientX - containerRect.left) / containerRect.width
     const yPercent = (e.clientY - containerRect.top) / containerRect.height
 
@@ -421,8 +82,6 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
 
     const delta = e.deltaY > 0 ? 1.1 : 0.9
     scaleRef.current = Math.max(1, scaleRef.current * delta)
-
-    // Update image position after scaling
     handleMouseMove(e)
   }
 
@@ -456,10 +115,6 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
   return (
     <div
       ref={containerRef}
-      // style={Styles.collapseStyles([
-      //   isZoomed ? styles.scrollAttachZoomed : (styles.scrollAttachOrig as any),
-      //   style,
-      // ])}
       style={style}
       onMouseMove={handleMouseMove}
       onWheel={handleWheel}
@@ -473,80 +128,6 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
       </Kb.Toast>
     </div>
   )
-
-  return (
-    <div
-      id="scrollAttach"
-      onClick={dragPan ? toggleAllowPan : toggleZoom}
-      // onMouseDown={dragPan ? onMouseDown : undefined}
-      // onMouseUp={dragPan ? onMouseUp : undefined}
-      ref={toastAnchorRef}
-      style={Styles.collapseStyles([
-        isZoomed ? styles.scrollAttachZoomed : (styles.scrollAttachOrig as any),
-        style,
-      ])}
-      onMouseMove={onImageMouseMove}
-      onMouseLeave={isZoomed ? onImageMouseLeave : undefined}
-      onWheel={isZoomed || dragPan ? onImageWheel : undefined}
-    >
-      <img
-        id="imgAttach"
-        src={src}
-        style={isZoomed || dragPan ? styles.imgZoomed : (styles.imgOrig as any)}
-        onLoad={onLoaded}
-        onDragStart={onDragStart}
-      />
-      <Kb.Toast visible={showToast} attachTo={attachTo}>
-        <Kb.Text type="Body" negative={true}>
-          Scroll to zoom. Move to pan
-        </Kb.Text>
-      </Kb.Toast>
-    </div>
-  )
 })
-
-const styles = Styles.styleSheetCreate(
-  () =>
-    ({
-      imgOrig: Styles.platformStyles({
-        isElectron: {
-          display: 'flex',
-          margin: 'auto',
-          maxHeight: '100%',
-          maxWidth: '100%',
-          transform: '',
-        },
-      }),
-      imgZoomed: Styles.platformStyles({
-        isElectron: {
-          left: 0,
-          position: 'absolute',
-          top: 0,
-          transformOrigin: 'top left',
-        },
-      }),
-      scrollAttachOrig: Styles.platformStyles({
-        isElectron: {
-          alignItems: 'center',
-          cursor: 'zoom-in',
-          display: 'flex',
-          height: '100%',
-          justifyContent: 'center',
-          overflow: 'hidden',
-          position: 'relative',
-          width: '100%',
-        },
-      }),
-      scrollAttachZoomed: Styles.platformStyles({
-        isElectron: {
-          cursor: 'zoom-out',
-          height: '100%',
-          overflow: 'hidden',
-          position: 'relative',
-          width: '100%',
-        },
-      }),
-    } as const)
-)
 
 export default ZoomableImage

--- a/shared/common-adapters/zoomable-image.desktop.tsx
+++ b/shared/common-adapters/zoomable-image.desktop.tsx
@@ -11,94 +11,86 @@ const Kb = {
   Toast,
 }
 
-type PannerProps = {
-  src: string
-  onLoaded?: () => void
-  onPanned: (x: number, y: number, width: number, height: number, scale: number) => void
-}
+// type PannerProps = {
+//   src: string
+//   onLoaded?: () => void
+//   onPanned: (x: number, y: number, width: number, height: number, scale: number) => void
+// }
 
-const Panner: React.FC<PannerProps> = ({src, onPanned, onLoaded}) => {
-  const containerRef = React.useRef<HTMLDivElement>(null)
-  const imgRef = React.useRef<HTMLImageElement>(null)
+// const Panner: React.FC<PannerProps> = ({src, onPanned, onLoaded}) => {
+//   const containerRef = React.useRef<HTMLDivElement>(null)
+//   const imgRef = React.useRef<HTMLImageElement>(null)
 
-  const [allowPan, setAllowPan] = React.useState(true)
-  // const [scale, setScale] = React.useState(1)
-  const scaleRef = React.useRef(1)
+//   const [allowPan, setAllowPan] = React.useState(true)
+//   const scaleRef = React.useRef(1)
 
-  const handleMouseMove = (e: React.MouseEvent) => {
-    if (!containerRef.current || !imgRef.current) return
+//   const handleMouseMove = (e: React.MouseEvent) => {
+//     if (!containerRef.current || !imgRef.current) return
 
-    if (!allowPan) return
+//     if (!allowPan) return
 
-    const containerRect = containerRef.current.getBoundingClientRect()
-    const imgRect = imgRef.current.getBoundingClientRect()
+//     const containerRect = containerRef.current.getBoundingClientRect()
+//     const imgRect = imgRef.current.getBoundingClientRect()
 
-    const xPercent = (e.clientX - containerRect.left) / containerRect.width
-    const yPercent = (e.clientY - containerRect.top) / containerRect.height
+//     const xPercent = (e.clientX - containerRect.left) / containerRect.width
+//     const yPercent = (e.clientY - containerRect.top) / containerRect.height
 
-    const x = Math.min(
-      0,
-      Math.max(
-        -(imgRect.width - containerRect.width),
-        containerRect.width * xPercent - imgRect.width * xPercent
-      )
-    )
-    const y = Math.min(
-      0,
-      Math.max(
-        -(imgRect.height - containerRect.height),
-        containerRect.height * yPercent - imgRect.height * yPercent
-      )
-    )
+//     const x = Math.min(
+//       0,
+//       Math.max(
+//         -(imgRect.width - containerRect.width),
+//         containerRect.width * xPercent - imgRect.width * xPercent
+//       )
+//     )
+//     const y = Math.min(
+//       0,
+//       Math.max(
+//         -(imgRect.height - containerRect.height),
+//         containerRect.height * yPercent - imgRect.height * yPercent
+//       )
+//     )
 
-    imgRef.current.style.transform = `translate(${x}px, ${y}px) scale(${scaleRef.current})`
-    onPanned(-x, -y, imgRect.width, imgRect.height, scaleRef.current)
-  }
+//     imgRef.current.style.transform = `translate(${x}px, ${y}px) scale(${scaleRef.current})`
+//     onPanned(-x, -y, imgRect.width, imgRect.height, scaleRef.current)
+//   }
 
-  const handleWheel = (e: React.WheelEvent) => {
-    e.preventDefault()
-    if (!allowPan) return
-    const delta = e.deltaY > 0 ? 1.1 : 0.9
-    scaleRef.current = Math.max(1, scaleRef.current * delta)
+//   const handleWheel = (e: React.WheelEvent) => {
+//     e.preventDefault()
+//     if (!allowPan) return
+//     const delta = e.deltaY > 0 ? 1.1 : 0.9
+//     scaleRef.current = Math.max(1, scaleRef.current * delta)
 
-    // setScale(newScale)
+//     // Update image position after scaling
+//     handleMouseMove(e)
+//   }
 
-    // Apply the new scale to the image
-    // if (imgRef.current) {
-    //   imgRef.current.style.transform = `translate(${imgRef.current.offsetLeft}px, ${imgRef.current.offsetTop}px) scale(${scaleRef.current})`
-    // }
+//   const handleClick = () => {
+//     setAllowPan(p => !p)
+//   }
 
-    // Update image position after scaling
-    handleMouseMove(e)
-  }
-
-  const handleClick = () => {
-    setAllowPan(p => !p)
-  }
-
-  return (
-    <div
-      ref={containerRef}
-      style={{
-        cursor: allowPan ? 'move' : 'zoom-in',
-        height: '100%',
-        overflow: 'hidden',
-        position: 'relative',
-        width: '100%',
-      }}
-      onMouseMove={handleMouseMove}
-      onWheel={handleWheel}
-      onClick={handleClick}
-    >
-      <img
-        onLoad={onLoaded}
-        ref={imgRef}
-        src={src}
-        style={{position: 'absolute', transformOrigin: '0 0', opacity: src ? 1 : 0}}
-      />
-    </div>
-  )
-}
+//   return (
+//     <div
+//       ref={containerRef}
+//       style={{
+//         cursor: allowPan ? 'move' : 'zoom-in',
+//         height: '100%',
+//         overflow: 'hidden',
+//         position: 'relative',
+//         width: '100%',
+//       }}
+//       onMouseMove={handleMouseMove}
+//       onWheel={handleWheel}
+//       onClick={handleClick}
+//     >
+//       <img
+//         onLoad={onLoaded}
+//         ref={imgRef}
+//         src={src}
+//         style={{position: 'absolute', transformOrigin: '0 0', opacity: src ? 1 : 0}}
+//       />
+//     </div>
+//   )
+// }
 
 // type CropperProps = {
 //   src: string
@@ -181,13 +173,20 @@ const Panner: React.FC<PannerProps> = ({src, onPanned, onLoaded}) => {
 // }
 const onDragStart = (e: React.BaseSyntheticEvent) => e.preventDefault()
 const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
-  const {src, onIsZoomed, style, onLoaded, dragPan, onChanged} = p
+  const {src, onIsZoomed, onLoaded, dragPan, onChanged} = p
   const [isZoomed, setIsZoomed] = React.useState(false)
   const [allowPan, setAllowPan] = React.useState(true)
   const [imgSize, setImgSize] = React.useState({height: 0, width: 0})
   const isMounted = Container.useIsMounted()
   const [lastSrc, setLastSrc] = React.useState('')
   // const isDragging = React.useRef(false)
+
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const imgRef = React.useRef<HTMLImageElement>(null)
+
+  // const [allowPan, setAllowPan] = React.useState(true)
+  const scaleRef = React.useRef(1)
+  const isZoomedRef = React.useRef(isZoomed)
 
   if (lastSrc !== src) {
     setLastSrc(src)
@@ -219,6 +218,7 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
   }
 
   const toggleZoom = React.useCallback(() => {
+    isZoomedRef.current = !isZoomed
     setIsZoomed(s => !s)
     onIsZoomed?.(!isZoomed)
     setZoomRatio(initialZoomRatio)
@@ -232,7 +232,7 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     }
   }
 
-  const toastAnchorRef = React.useRef(null)
+  // const toastAnchorRef = React.useRef(null)
   const [showToast, setShowToast] = React.useState(false)
   React.useEffect(() => {
     if (isZoomed) {
@@ -247,125 +247,125 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     } else return undefined
   }, [isZoomed])
 
-  const onImageWheel = React.useCallback(e => {
-    setZoomRatio(z => {
-      const diff = e.deltaY > 0 ? 0.07 : -0.07
-      const next = Math.max(0.1, Math.min(z + diff, 20))
-      return next
-    })
-  }, [])
+  // const onImageWheel = React.useCallback(e => {
+  //   setZoomRatio(z => {
+  //     const diff = e.deltaY > 0 ? 0.07 : -0.07
+  //     const next = Math.max(0.1, Math.min(z + diff, 20))
+  //     return next
+  //   })
+  // }, [])
 
-  const lastEvent = React.useRef<React.MouseEvent<HTMLDivElement> | undefined>()
+  // const lastEvent = React.useRef<React.MouseEvent<HTMLDivElement> | undefined>()
 
-  const adjustImageStyle = React.useCallback(() => {
-    const zoomRatio = 1.2 // TEMP
-    // const zoomRatio = 1 / 0.3669724770642202 // TEMP
-    const e = lastEvent.current
-    const parent = document.getElementById('scrollAttach')
-    const img = document.getElementById('imgAttach')
-    if (!parent || !img) {
-      return
-    }
-    if (!isZoomed && !dragPan) {
-      img.style.transform = ''
-      return
-    }
+  // const adjustImageStyle = React.useCallback(() => {
+  //   const zoomRatio = 1.2 // TEMP
+  //   // const zoomRatio = 1 / 0.3669724770642202 // TEMP
+  //   const e = lastEvent.current
+  //   const parent = document.getElementById('scrollAttach')
+  //   const img = document.getElementById('imgAttach')
+  //   if (!parent || !img) {
+  //     return
+  //   }
+  //   if (!isZoomedRef.current && !dragPan) {
+  //     img.style.transform = ''
+  //     return
+  //   }
 
-    if (!e) return
+  //   if (!e) return
 
-    const rect = parent.getBoundingClientRect()
-    // position in parent
-    const x = clamp(Math.round(e.clientX - rect.left), 0, rect.width - 1) //rect.width / 2
-    const y = clamp(Math.round(e.clientY - rect.top), 0, rect.height - 1) //rect.height / 2
+  //   const rect = parent.getBoundingClientRect()
+  //   // position in parent
+  //   const x = clamp(Math.round(e.clientX - rect.left), 0, rect.width - 1) //rect.width / 2
+  //   const y = clamp(Math.round(e.clientY - rect.top), 0, rect.height - 1) //rect.height / 2
 
-    console.log('bbb', x, e?.clientX, rect.left)
+  //   console.log('bbb', x, e?.clientX, rect.left)
 
-    // ratio in parent
-    let xr = x / (rect.width - 1)
-    let yr = y / (rect.height - 1)
+  //   // ratio in parent
+  //   let xr = x / (rect.width - 1)
+  //   let yr = y / (rect.height - 1)
 
-    // xr = 1 // TEMP
-    // yr = 1 // TEMP
+  //   // xr = 1 // TEMP
+  //   // yr = 1 // TEMP
 
-    console.log('eee', xr, x, rect.width)
+  //   console.log('eee', xr, x, rect.width)
 
-    // image size
-    const iw = imgSize.width
-    const ih = imgSize.height
+  //   // image size
+  //   const iw = imgSize.width
+  //   const ih = imgSize.height
 
-    // offset to center ourselves in parent after scaling
-    const centerX = rect.width / 2 - (iw * zoomRatio) / 2
-    const centerY = rect.height / 2 - (ih * zoomRatio) / 2
+  //   // offset to center ourselves in parent after scaling
+  //   const centerX = rect.width / 2 - (iw * zoomRatio) / 2
+  //   const centerY = rect.height / 2 - (ih * zoomRatio) / 2
 
-    // moving the mouse should translate you to the edges of the image
-    const mouseX = centerX + (1 - xr) * 2 * -centerX
-    const mouseY = centerY + (1 - yr) * 2 * -centerY
+  //   // moving the mouse should translate you to the edges of the image
+  //   const mouseX = centerX + (1 - xr) * 2 * -centerX
+  //   const mouseY = centerY + (1 - yr) * 2 * -centerY
 
-    console.log('ddd', mouseX, mouseY)
+  //   console.log('ddd', mouseX, mouseY)
 
-    const temp = [
-      // move to middle
-      `translate(${-0.5 * iw}px, ${-0.5 * ih}px)`,
-      // scale up
-      `scale(${zoomRatio})`,
-      // move to top left
-      `translate(${0.5 * iw * zoomRatio}px, ${0.5 * ih * zoomRatio}px)`,
-      // center in parent. you go half the parent rect (img top in center, then go back so your center is center)
-      `translate(${centerX}px, ${centerY}px)`,
-      // move based on mouse
-      `translate(${mouseX}px, ${mouseY}px)`,
-    ]
-      .reverse() // applied right to left
-      .join(' ')
-    img.style.transform = temp
+  //   const temp = [
+  //     // move to middle
+  //     `translate(${-0.5 * iw}px, ${-0.5 * ih}px)`,
+  //     // scale up
+  //     `scale(${zoomRatio})`,
+  //     // move to top left
+  //     `translate(${0.5 * iw * zoomRatio}px, ${0.5 * ih * zoomRatio}px)`,
+  //     // center in parent. you go half the parent rect (img top in center, then go back so your center is center)
+  //     `translate(${centerX}px, ${centerY}px)`,
+  //     // move based on mouse
+  //     `translate(${mouseX}px, ${mouseY}px)`,
+  //   ]
+  //     .reverse() // applied right to left
+  //     .join(' ')
+  //   img.style.transform = temp
 
-    if (onChanged) {
-      const width = iw * zoomRatio
-      const height = ih * zoomRatio
-      // const xr = 1 // TEMP
-      // const yr = 0 // TEMP
-      // const _x = xr * (iw * zoomRatio - rect.width * zoomRatio)
-      // const _y = yr * (ih * zoomRatio - rect.height * zoomRatio)
-      // const _x = xr * iw * zoomRatio - rect.width * zoomRatio
-      // const _y = yr * ih * zoomRatio - rect.height * zoomRatio
-      // x0pixels should be: 2400 (pixels) - 300 (zoomed pixels) = 2100
-      // x1pixels should be: 2100 (x0pixels) + 300 (zoomed pixels) = 2400
+  //   if (onChanged) {
+  //     const width = iw * zoomRatio
+  //     const height = ih * zoomRatio
+  //     // const xr = 1 // TEMP
+  //     // const yr = 0 // TEMP
+  //     // const _x = xr * (iw * zoomRatio - rect.width * zoomRatio)
+  //     // const _y = yr * (ih * zoomRatio - rect.height * zoomRatio)
+  //     // const _x = xr * iw * zoomRatio - rect.width * zoomRatio
+  //     // const _y = yr * ih * zoomRatio - rect.height * zoomRatio
+  //     // x0pixels should be: 2400 (pixels) - 300 (zoomed pixels) = 2100
+  //     // x1pixels should be: 2100 (x0pixels) + 300 (zoomed pixels) = 2400
 
-      //zoom * imagew - rect.width/zoom
-      // const _x = xr * width - (xr * rect.width) / zoomRatio
-      // x1pixels = x0pixels +rect.width/zoom
-      // const _y = yr * height - (yr * rect.height) / zoomRatio
+  //     //zoom * imagew - rect.width/zoom
+  //     // const _x = xr * width - (xr * rect.width) / zoomRatio
+  //     // x1pixels = x0pixels +rect.width/zoom
+  //     // const _y = yr * height - (yr * rect.height) / zoomRatio
 
-      let _x = xr * (width - rect.width / zoomRatio)
-      let _y = yr * (height - rect.height / zoomRatio)
+  //     let _x = xr * (width - rect.width / zoomRatio)
+  //     let _y = yr * (height - rect.height / zoomRatio)
 
-      const temp = {height, scale: zoomRatio, width, x: _x, y: _y}
-      console.log('aaa2', {x: temp.x, x1: _x + rect.width / zoomRatio})
-      // onChanged(temp)
-    }
-  }, [zoomRatio, imgSize, isZoomed, dragPan, onChanged])
+  //     const temp = {height, scale: zoomRatio, width, x: _x, y: _y}
+  //     console.log('aaa2', {x: temp.x, x1: _x + rect.width / zoomRatio})
+  //     // onChanged(temp)
+  //   }
+  // }, [zoomRatio, imgSize, isZoomed, dragPan, onChanged])
 
-  const [lastZoomRatio, setLastZoomRatio] = React.useState(0)
-  if (lastZoomRatio !== zoomRatio || isZoomed !== lastIsZoomed) {
-    setLastZoomRatio(zoomRatio)
-    setLastIsZoomed(isZoomed)
-    adjustImageStyle()
-  }
+  // const [lastZoomRatio, setLastZoomRatio] = React.useState(0)
+  // if (lastZoomRatio !== zoomRatio || isZoomed !== lastIsZoomed) {
+  //   setLastZoomRatio(zoomRatio)
+  //   setLastIsZoomed(isZoomed)
+  //   adjustImageStyle()
+  // }
 
-  const onImageMouseMove = React.useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (dragPan && !allowPan) {
-        return
-      }
-      lastEvent.current = e
-      adjustImageStyle()
-    },
-    [adjustImageStyle, dragPan, allowPan]
-  )
+  // const onImageMouseMove = React.useCallback(
+  //   (e: React.MouseEvent<HTMLDivElement>) => {
+  //     if (dragPan && !allowPan) {
+  //       return
+  //     }
+  //     lastEvent.current = e
+  //     adjustImageStyle()
+  //   },
+  //   [adjustImageStyle, dragPan, allowPan]
+  // )
 
   const attachTo = React.useCallback(() => {
-    return toastAnchorRef.current
-  }, [toastAnchorRef])
+    return containerRef.current
+  }, [containerRef])
 
   // const onMouseDown = React.useCallback(() => {
   //   isDragging.current = true
@@ -373,11 +373,106 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
   // const onMouseUp = React.useCallback(() => {
   //   isDragging.current = false
   // }, [])
-  const onPanned = (x: number, y: number, width: number, height: number, scale: number) => {
-    console.log('aaa', {x, y, width, height})
-    onChanged?.({x, y, width, height, scale})
+  // const onPanned = (x: number, y: number, width: number, height: number, scale: number) => {
+  //   console.log('aaa', {x, y, width, height})
+  //   onChanged?.({x, y, width, height, scale})
+  // }
+  // return <Panner src={src} onPanned={onChanged} onLoaded={onLoaded} />
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!containerRef.current || !imgRef.current) return
+
+    if (dragPan && !allowPan) return
+    if (!dragPan && !isZoomedRef.current) {
+      imgRef.current.style.transform = ''
+      return
+    }
+
+    const containerRect = containerRef.current.getBoundingClientRect()
+    const imgRect = imgRef.current.getBoundingClientRect()
+
+    const xPercent = (e.clientX - containerRect.left) / containerRect.width
+    const yPercent = (e.clientY - containerRect.top) / containerRect.height
+
+    const x = Math.min(
+      0,
+      Math.max(
+        -(imgRect.width - containerRect.width),
+        containerRect.width * xPercent - imgRect.width * xPercent
+      )
+    )
+    const y = Math.min(
+      0,
+      Math.max(
+        -(imgRect.height - containerRect.height),
+        containerRect.height * yPercent - imgRect.height * yPercent
+      )
+    )
+
+    imgRef.current.style.transform = `translate(${x}px, ${y}px) scale(${scaleRef.current})`
+    onChanged?.({x: -x, y: -y, width: imgRect.width, height: imgRect.height, scale: scaleRef.current})
   }
-  return <Panner src={src} onPanned={onPanned} onLoaded={onLoaded} />
+
+  const handleWheel = (e: React.WheelEvent) => {
+    e.preventDefault()
+
+    if (dragPan && !allowPan) return
+    if (!dragPan && !isZoomedRef.current) return
+
+    const delta = e.deltaY > 0 ? 1.1 : 0.9
+    scaleRef.current = Math.max(1, scaleRef.current * delta)
+
+    // Update image position after scaling
+    handleMouseMove(e)
+  }
+
+  const handleClick = e => {
+    if (dragPan) {
+      setAllowPan(p => !p)
+    } else {
+      toggleZoom()
+      handleMouseMove(e)
+    }
+  }
+
+  let style: any = {
+    height: '100%',
+    overflow: 'hidden',
+    position: 'relative',
+    width: '100%',
+  }
+  let imgStyle: any = {display: 'flex', position: 'absolute', transformOrigin: '0 0', opacity: src ? 1 : 0}
+  if (dragPan) {
+    style = {...style, cursor: allowPan ? 'move' : 'pointer'}
+  } else {
+    style = {
+      ...style,
+      cursor: isZoomed ? 'zoom-out' : 'zoom-in',
+      ...(isZoomed ? {} : {display: 'flex'}),
+    }
+    imgStyle = isZoomed ? undefined : {maxWidth: '100%', maxHeight: '100%', margin: 'auto'}
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      // style={Styles.collapseStyles([
+      //   isZoomed ? styles.scrollAttachZoomed : (styles.scrollAttachOrig as any),
+      //   style,
+      // ])}
+      style={style}
+      onMouseMove={handleMouseMove}
+      onWheel={handleWheel}
+      onClick={handleClick}
+    >
+      <img onLoad={onLoaded} ref={imgRef} src={src} style={imgStyle} />
+      <Kb.Toast visible={showToast} attachTo={attachTo}>
+        <Kb.Text type="Body" negative={true}>
+          Scroll to zoom. Move to pan
+        </Kb.Text>
+      </Kb.Toast>
+    </div>
+  )
 
   return (
     <div

--- a/shared/common-adapters/zoomable-image.desktop.tsx
+++ b/shared/common-adapters/zoomable-image.desktop.tsx
@@ -71,7 +71,7 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     )
 
     imgRef.current.style.transform = `translate(${x}px, ${y}px) scale(${scaleRef.current})`
-    onChanged?.({x: -x, y: -y, width: imgRect.width, height: imgRect.height, scale: scaleRef.current})
+    onChanged?.({height: imgRect.height, scale: scaleRef.current, width: imgRect.width, x: -x, y: -y})
   }
 
   const handleWheel = (e: React.WheelEvent) => {
@@ -85,7 +85,7 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     handleMouseMove(e)
   }
 
-  const handleClick = e => {
+  const handleClick = (e: React.MouseEvent) => {
     if (dragPan) {
       setAllowPan(p => !p)
     } else {
@@ -94,13 +94,18 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     }
   }
 
-  let style: any = {
+  let style: React.CSSProperties = {
     height: '100%',
     overflow: 'hidden',
     position: 'relative',
     width: '100%',
   }
-  let imgStyle: any = {display: 'flex', position: 'absolute', transformOrigin: '0 0', opacity: src ? 1 : 0}
+  let imgStyle: React.CSSProperties = {
+    display: 'flex',
+    opacity: src ? 1 : 0,
+    position: 'absolute',
+    transformOrigin: '0 0',
+  }
   if (dragPan) {
     style = {...style, cursor: allowPan ? 'move' : 'pointer'}
   } else {
@@ -109,7 +114,7 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
       cursor: isZoomed ? 'zoom-out' : 'zoom-in',
       ...(isZoomed ? {} : {display: 'flex'}),
     }
-    imgStyle = isZoomed ? undefined : {maxWidth: '100%', maxHeight: '100%', margin: 'auto'}
+    imgStyle = isZoomed ? {} : {margin: 'auto', maxHeight: '100%', maxWidth: '100%'}
   }
 
   return (

--- a/shared/common-adapters/zoomable-image.native.tsx
+++ b/shared/common-adapters/zoomable-image.native.tsx
@@ -2,10 +2,8 @@ import * as Styles from '../styles'
 import {ZoomableBox} from './zoomable-box'
 import Image2 from './image2.native'
 import type {Props} from './zoomable-image'
-import {Box2} from './box'
 
 const Kb = {
-  Box2,
   Image2,
   ZoomableBox,
 }

--- a/shared/common-adapters/zoomable-image.native.tsx
+++ b/shared/common-adapters/zoomable-image.native.tsx
@@ -9,10 +9,10 @@ const Kb = {
 }
 
 const ZoomableImage = (p: Props) => {
-  const {src, style, onChanged} = p
+  const {src, style, onChanged, onLoaded} = p
   return (
     <Kb.ZoomableBox style={style} contentContainerStyle={styles.zoomableBoxContainer} onZoom={onChanged}>
-      <Kb.Image2 src={src} style={styles.image} />
+      <Kb.Image2 src={src} style={styles.image} onLoaded={onLoaded} />
     </Kb.ZoomableBox>
   )
 }

--- a/shared/common-adapters/zoomable-image.native.tsx
+++ b/shared/common-adapters/zoomable-image.native.tsx
@@ -12,7 +12,7 @@ const ZoomableImage = (p: Props) => {
   const {src, style, onChanged, onLoaded} = p
   return (
     <Kb.ZoomableBox style={style} contentContainerStyle={styles.zoomableBoxContainer} onZoom={onChanged}>
-      <Kb.Image2 src={src} style={styles.image} onLoaded={onLoaded} />
+      <Kb.Image2 src={src} style={styles.image} onLoad={onLoaded} />
     </Kb.ZoomableBox>
   )
 }

--- a/shared/common-adapters/zoomable-image.native.tsx
+++ b/shared/common-adapters/zoomable-image.native.tsx
@@ -10,23 +10,12 @@ const Kb = {
   ZoomableBox,
 }
 
-// TODO
-// setState in convo somwhere
-// image2 not working on adnroid, path prefix?
 const ZoomableImage = (p: Props) => {
   const {src, style, onChanged, onLoaded} = p
 
-  console.log('aaa zoom render', style)
-
-  // TEMP
-  // return (
-  //   <Kb.Box2 dir="vertical" style={[style, {backgroundColor: 'red'}]}>
-  //     <Kb.Image2 src={src} style={styles.image} onLoad={onLoaded} />
-  //   </Kb.Box2>
-  // )
   return (
     <Kb.ZoomableBox style={style} contentContainerStyle={styles.zoomableBoxContainer} onZoom={onChanged}>
-      <Kb.Image2 src={src} style={styles.image} onLoad={onLoaded} />
+      <Kb.Image2 src={src} style={styles.image} onLoad={onLoaded} showLoadingStateUntilLoaded={true} />
     </Kb.ZoomableBox>
   )
 }

--- a/shared/common-adapters/zoomable-image.native.tsx
+++ b/shared/common-adapters/zoomable-image.native.tsx
@@ -2,14 +2,28 @@ import * as Styles from '../styles'
 import {ZoomableBox} from './zoomable-box'
 import Image2 from './image2.native'
 import type {Props} from './zoomable-image'
+import {Box2} from './box'
 
 const Kb = {
+  Box2,
   Image2,
   ZoomableBox,
 }
 
+// TODO
+// setState in convo somwhere
+// image2 not working on adnroid, path prefix?
 const ZoomableImage = (p: Props) => {
   const {src, style, onChanged, onLoaded} = p
+
+  console.log('aaa zoom render', style)
+
+  // TEMP
+  // return (
+  //   <Kb.Box2 dir="vertical" style={[style, {backgroundColor: 'red'}]}>
+  //     <Kb.Image2 src={src} style={styles.image} onLoad={onLoaded} />
+  //   </Kb.Box2>
+  // )
   return (
     <Kb.ZoomableBox style={style} contentContainerStyle={styles.zoomableBoxContainer} onZoom={onChanged}>
       <Kb.Image2 src={src} style={styles.image} onLoad={onLoaded} />

--- a/shared/ios/Podfile.lock
+++ b/shared/ios/Podfile.lock
@@ -810,7 +810,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: d8f53a7eee90a870a75656280e8d4b85726ea903
@@ -853,7 +853,7 @@ SPEC CHECKSUMS:
   lottie-ios: c55158d67d0629a260625cc2ded2052b829e3c3e
   lottie-react-native: f00d55936805d0155d5ec3ca7b3205b07728af44
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
+  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 5a4a30ac20c86eeadd6844a9328f78d4168cf9b2
   RCTTypeSafety: 279fc5861a89f0f37db3a585f27f971485b4b734
   React: 88307a9be3bd0e71a6822271cf28b84a587fb97f

--- a/shared/ios/Podfile.lock
+++ b/shared/ios/Podfile.lock
@@ -810,7 +810,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: d8f53a7eee90a870a75656280e8d4b85726ea903
@@ -853,7 +853,7 @@ SPEC CHECKSUMS:
   lottie-ios: c55158d67d0629a260625cc2ded2052b829e3c3e
   lottie-react-native: f00d55936805d0155d5ec3ca7b3205b07728af44
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: 5a4a30ac20c86eeadd6844a9328f78d4168cf9b2
   RCTTypeSafety: 279fc5861a89f0f37db3a585f27f971485b4b734
   React: 88307a9be3bd0e71a6822271cf28b84a587fb97f

--- a/shared/profile/edit-avatar/index.d.ts
+++ b/shared/profile/edit-avatar/index.d.ts
@@ -15,6 +15,8 @@ type TeamProps = {
 type ProfileProps = {
   createdTeam?: false
   onSkip?: undefined
+  teamname?: string
+  teamID?: Types.TeamID
   type: 'profile'
   showBack?: false
   wizard?: false

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -8,7 +8,7 @@ import {AVATAR_SIZE} from '../../common-adapters/avatar'
 import KB2 from '../../util/electron.desktop'
 import './edit-avatar.css'
 
-const AVATAR_CONTAINER_SIZE = 300
+const AVATAR_CONTAINER_SIZE = 167 // 300
 const AVATAR_BORDER_SIZE = 4
 const VIEWPORT_CENTER = AVATAR_CONTAINER_SIZE / 2
 

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -4,46 +4,17 @@ import * as Styles from '../../styles'
 import clamp from 'lodash/clamp'
 import type {Props} from '.'
 import {ModalTitle} from '../../teams/common'
-import {AVATAR_SIZE} from '../../common-adapters/avatar'
 import KB2 from '../../util/electron.desktop'
 import './edit-avatar.css'
-
-const AVATAR_CONTAINER_SIZE = 167 // 300
-const AVATAR_BORDER_SIZE = 4
-const VIEWPORT_CENTER = AVATAR_CONTAINER_SIZE / 2
-
 const {isDirectory} = KB2.functions
 
-// TODO use zoomableimage here instead
-
-type State = {
-  dragStartX: number
-  dragStartY: number
-  dragStopX: number
-  dragStopY: number
-  dragging: boolean
-  dropping: boolean
-  error: boolean
-  hasPreview: boolean
-  imageSource: string
-  loading: boolean
-  naturalImageWidth: number
-  offsetLeft: number
-  offsetTop: number
-  scale: number
-  scaledImageHeight: number
-  scaledImageWidth: number
-  startingImageHeight: number
-  startingImageWidth: number
-  viewingCenterX: number
-  viewingCenterY: number
-}
+const AVATAR_CONTAINER_SIZE = 300
 
 const validDrag = (e: React.DragEvent<any>) => {
   return Array.prototype.map.call(e.dataTransfer.types, t => t).includes('Files')
 }
 
-const getFile = async (fileList: {length?: number}): Promise<string> => {
+const getFile = async (fileList: {length?: number} | undefined): Promise<string> => {
   const paths: Array<string> = fileList?.length
     ? Array.prototype.map.call(fileList, f => f.path)
     : ([] as any)
@@ -75,21 +46,11 @@ const getCropCoordinates = (c: Crop) => {
   const windowScaled = Math.round(AVATAR_CONTAINER_SIZE / scale)
   let x0 = x / scale
   x0 = clamp(Math.round(x0), 0, maxX)
-  // const x1 = clamp(Math.round(x0 + AVATAR_CONTAINER_SIZE / scale), x0, maxX)
   const x1 = Math.min(x0 + windowScaled, maxX)
   let y0 = y / scale
   y0 = clamp(Math.round(y0), 0, maxY)
-  // const y1 = clamp(Math.round(y0 + AVATAR_CONTAINER_SIZE / scale), y0, maxY)
   const y1 = Math.min(y0 + windowScaled, maxY)
   return {x0, x1, y0, y1}
-
-  // x0pixels should be: 2400 (pixels) - 300 (zoomed pixels) = 2100
-  // x1pixels should be: 2100 (x0pixels) + 300 (zoomed pixels) = 2400
-
-  // x0: 2100 / 2(zoom) = 1050 (good)
-  // x1: 2400 / 2 (zoom) = 1200 (good)
-
-  // x1 - x0: 150 should be
 }
 
 type Loading = undefined | 'loading' | 'loaded'
@@ -104,12 +65,10 @@ const EditAvatar = (p: Props) => {
 
   const onSave = () => {
     const crop = getCropCoordinates(cropRef.current)
-    console.log('aaaa onsave', crop, cropRef.current)
     p.onSave(imageSource, crop)
   }
-  const cropRef = React.useRef({height: 0, unscaledHeight: 0, unscaledWidth: 0, width: 0, x: 0, y: 0})
+  const cropRef = React.useRef({height: 0, scale: 0, width: 0, x: 0, y: 0})
   const onChanged = (e: Crop) => {
-    console.log('aaa onchanged', e)
     cropRef.current = e
   }
 
@@ -134,7 +93,7 @@ const EditAvatar = (p: Props) => {
   const pickFile = async () => {
     setSerror(false)
     setLoading('loading')
-    const img = await getFile(fileRef.current?.files)
+    const img = await getFile(fileRef.current?.files ?? undefined)
     if (img) {
       setImageSource(img)
     }
@@ -239,447 +198,9 @@ const EditAvatar = (p: Props) => {
   )
 }
 
-// class EditAvatar2 extends React.Component<Props, State> {
-//   private file: HTMLInputElement | null = null
-//   private imageRef = React.createRef<Kb.Image2>()
-//   private timerID?: ReturnType<typeof setTimeout>
-
-//   constructor(props: Props) {
-//     super(props)
-//     this.state = {
-//       dragStartX: 0,
-//       dragStartY: 0,
-//       dragStopX: 0,
-//       dragStopY: 0,
-//       dragging: false,
-//       dropping: false,
-//       error: false,
-//       hasPreview: false,
-//       imageSource: '',
-//       loading: false,
-//       naturalImageWidth: 0,
-//       offsetLeft: 0,
-//       offsetTop: 0,
-//       scale: 1,
-//       scaledImageHeight: 1,
-//       scaledImageWidth: 1,
-//       startingImageHeight: 1,
-//       startingImageWidth: 1,
-//       viewingCenterX: 0,
-//       viewingCenterY: 0,
-//     }
-//   }
-
-//   componentWillUnmount() {
-//     this.timerID && clearTimeout(this.timerID)
-//   }
-
-//   private filePickerFiles = () => (this.file && this.file.files) || []
-
-//   private filePickerOpen = () => {
-//     this.file && this.file.click()
-//   }
-
-//   private filePickerSetRef = (r: HTMLInputElement | null) => {
-//     this.file = r
-//   }
-
-//   private filePickerSetValue = (value: string) => {
-//     if (this.file) this.file.value = value
-//   }
-
-//   private pickFile = () => {
-//     this.setState({error: false, loading: true})
-//     const fileList = this.filePickerFiles()
-//     const paths: Array<string> = fileList.length
-//       ? Array.prototype.map
-//           .call(fileList, (f: File) => {
-//             // We rely on path being here, even though it's not part of the File spec.
-//             const path: string = f.path
-//             return path
-//           })
-//           .filter(Boolean)
-//       : ([] as any)
-//     if (paths) {
-//       const img = paths.pop()
-//       img && this.paintImage(img)
-//     }
-//     this.filePickerSetValue('')
-//   }
-
-//   private onDragLeave = () => {
-//     this.setState({dropping: false})
-//   }
-
-//   private onDrop = async (e: React.DragEvent<any>) => {
-//     this.setState({dropping: false, error: false, loading: true})
-//     if (!this.validDrag(e)) {
-//       return
-//     }
-//     const fileList = e.dataTransfer.files
-//     const paths: Array<string> = fileList.length
-//       ? Array.prototype.map.call(fileList, f => f.path)
-//       : ([] as any)
-//     if (paths.length) {
-//       // TODO: Show an error when there's more than one path.
-//       for (const path of paths) {
-//         // Check if any file is a directory and bail out if not
-//         try {
-//           const isDir = await (isDirectory?.(path) ?? Promise.resolve(false))
-//           if (isDir) {
-//             // TODO: Show a red error banner on failure: https://zpl.io/2jlkMLm
-//             return
-//           }
-//         } catch (e) {
-//           // TODO: Show a red error banner on failure: https://zpl.io/2jlkMLm
-//         }
-//       }
-//       const img = paths.pop()
-//       img && this.paintImage(img)
-//     }
-//   }
-
-//   private validDrag = (e: React.DragEvent<any>) => {
-//     return Array.prototype.map.call(e.dataTransfer.types, t => t).includes('Files')
-//   }
-
-//   private onDragOver = (e: React.DragEvent<any>) => {
-//     this.setState({dropping: true})
-//     if (this.validDrag(e)) {
-//       e.dataTransfer.dropEffect = 'copy'
-//     } else {
-//       e.dataTransfer.dropEffect = 'none'
-//     }
-//   }
-
-//   private paintImage = (path: string) => {
-//     this.setState({imageSource: path})
-//   }
-
-//   private onImageError = () => {
-//     this.setState({error: true, hasPreview: false, loading: false})
-//   }
-
-//   private onImageLoad = (/*e: React.BaseSyntheticEvent*/) => {
-//     // TODO: Make RPC to check file size and warn them before they try submitting.
-
-//     // let height = AVATAR_SIZE
-//     // let width = (AVATAR_SIZE * e.currentTarget.naturalWidth) / e.currentTarget.naturalHeight
-
-//     // if (width < AVATAR_SIZE) {
-//     //   height = (AVATAR_SIZE * e.currentTarget.naturalHeight) / e.currentTarget.naturalWidth
-//     //   width = AVATAR_SIZE
-//     // }
-
-//     this.setState({
-//       // naturalImageWidth: e.currentTarget.naturalWidth,
-//       // offsetLeft: width / -2 + VIEWPORT_CENTER,
-//       // offsetTop: height / -2 + VIEWPORT_CENTER,
-//       // scaledImageHeight: height,
-//       // scaledImageWidth: width,
-//       // startingImageHeight: height,
-//       // startingImageWidth: width,
-//       // viewingCenterX: e.currentTarget.naturalWidth / 2,
-//       // viewingCenterY: e.currentTarget.naturalHeight / 2,
-//       hasPreview: true,
-//       loading: false,
-//     })
-
-//     // this.timerID = setTimeout(() => {
-//     //   this.setState({
-//     //     hasPreview: true,
-//     //     loading: false,
-//     //   })
-//     // }, 1500)
-//   }
-
-//   private onRangeChange = (e: React.FormEvent<any>) => {
-//     const scale = parseFloat(e.currentTarget.value)
-//     console.log('aaa range', scale)
-//     // likely unsafe to ref this.state but afraid to change this now
-//     // eslint-disable-next-line
-//     const scaledImageHeight = this.state.startingImageHeight * scale
-//     // eslint-disable-next-line
-//     const scaledImageWidth = this.state.startingImageWidth * scale
-
-//     const ratio = this.state.naturalImageWidth / scaledImageWidth
-//     const offsetLeft = clamp(
-//       // eslint-disable-next-line
-//       VIEWPORT_CENTER - this.state.viewingCenterX / ratio,
-//       AVATAR_SIZE - scaledImageWidth,
-//       0
-//     )
-//     const offsetTop = clamp(
-//       // eslint-disable-next-line
-//       VIEWPORT_CENTER - this.state.viewingCenterY / ratio,
-//       AVATAR_SIZE - scaledImageHeight,
-//       0
-//     )
-
-//     this.setState({
-//       offsetLeft,
-//       offsetTop,
-//       scale,
-//       scaledImageHeight,
-//       scaledImageWidth,
-//     })
-//   }
-
-//   private onMouseDown = (e: React.MouseEvent) => {
-//     if (!this.state.hasPreview || !this.imageRef) return
-
-//     // Grab the values now. The event object will be nullified by the time setState is called.
-//     const {pageX, pageY} = e
-
-//     const img = this.imageRef.current
-
-//     this.setState(s => ({
-//       dragStartX: pageX,
-//       dragStartY: pageY,
-//       // @ts-ignore codemode issue
-//       dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
-//       // @ts-ignore codemode issue
-//       dragStopY: img && img.style.top ? parseInt(img.style.top, 10) : s.dragStopY,
-//       dragging: true,
-//     }))
-//   }
-
-//   private onMouseUp = () => {
-//     if (!this.state.hasPreview || !this.imageRef) return
-
-//     const img = this.imageRef.current
-
-//     this.setState(s => ({
-//       // @ts-ignore codemode issue
-//       dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
-//       // @ts-ignore codemode issue
-//       dragStopY: img && img.style.top ? parseInt(img.style.top, 10) : s.dragStopY,
-//       dragging: false,
-//     }))
-//   }
-
-//   private onMouseMove = (e: React.MouseEvent) => {
-//     if (!this.state.dragging || this.props.submitting) return
-
-//     // Grab the values now. The event object will be nullified by the time setState is called.
-//     const {pageX, pageY} = e
-
-//     const offsetLeft = clamp(
-//       // eslint-disable-next-line
-//       this.state.dragStopX + pageX - this.state.dragStartX,
-//       // eslint-disable-next-line
-//       AVATAR_SIZE - this.state.scaledImageWidth,
-//       0
-//     )
-//     const offsetTop = clamp(
-//       // eslint-disable-next-line
-//       this.state.dragStopY + pageY - this.state.dragStartY,
-//       // eslint-disable-next-line
-//       AVATAR_SIZE - this.state.scaledImageHeight,
-//       0
-//     )
-
-//     const ratio = this.state.naturalImageWidth / this.state.scaledImageWidth
-//     // eslint-disable-next-line
-//     const viewingCenterX = (VIEWPORT_CENTER - this.state.offsetLeft) * ratio
-//     // eslint-disable-next-line
-//     const viewingCenterY = (VIEWPORT_CENTER - this.state.offsetTop) * ratio
-
-//     this.setState({
-//       offsetLeft,
-//       offsetTop,
-//       viewingCenterX,
-//       viewingCenterY,
-//     })
-//   }
-
-//   private onSave = () => {
-//     const x = this.state.offsetLeft * -1
-//     const y = this.state.offsetTop * -1
-//     const ratio =
-//       this.state.scaledImageWidth !== 0 ? this.state.naturalImageWidth / this.state.scaledImageWidth : 1
-//     const crop = {
-//       x0: Math.round(x * ratio),
-//       x1: Math.round((x + AVATAR_SIZE) * ratio),
-//       y0: Math.round(y * ratio),
-//       y1: Math.round((y + AVATAR_SIZE) * ratio),
-//     }
-
-//     if (this.props.wizard) {
-//       return this.props.onSave(
-//         this.state.imageSource,
-//         crop,
-//         this.state.scaledImageWidth,
-//         this.state.offsetLeft,
-//         this.state.offsetTop
-//       )
-//     }
-
-//     this.props.onSave(this.state.imageSource, crop)
-//   }
-
-//   private onChanged = e => {
-//     console.log('aaa on changed', e)
-//   }
-
-//   render() {
-//     console.log('aaa rendering', this.state.scale)
-//     return (
-//       <Kb.Modal
-//         mode="DefaultFullHeight"
-//         onClose={this.props.onClose}
-//         header={{
-//           leftButton:
-//             this.props.wizard || this.props.showBack ? (
-//               <Kb.Icon type="iconfont-arrow-left" onClick={this.props.onBack} />
-//             ) : null,
-//           rightButton: this.props.wizard ? (
-//             <Kb.Button
-//               label="Skip"
-//               mode="Secondary"
-//               onClick={this.props.onSkip}
-//               style={styles.skipButton}
-//               type="Default"
-//             />
-//           ) : null,
-//           title:
-//             this.props.type === 'team' ? (
-//               <ModalTitle teamID={this.props.teamID} title="Upload an avatar" />
-//             ) : (
-//               'Upload an avatar'
-//             ),
-//         }}
-//         allowOverflow={true}
-//         footer={{
-//           content: (
-//             <Kb.WaitingButton
-//               fullWidth={true}
-//               label={this.props.wizard ? 'Continue' : 'Save'}
-//               onClick={this.onSave}
-//               disabled={!this.state.hasPreview}
-//               waitingKey={null}
-//             />
-//           ),
-//         }}
-//         banners={
-//           <>
-//             {this.props.error ? (
-//               <Kb.Banner color="red" key="propsError">
-//                 {this.props.error}
-//               </Kb.Banner>
-//             ) : null}
-//             {this.state.error ? (
-//               <Kb.Banner color="red" key="stateError">
-//                 The image you uploaded could not be read. Try again with a valid PNG, JPG or GIF.
-//               </Kb.Banner>
-//             ) : null}
-//           </>
-//         }
-//       >
-//         <Kb.Box
-//           className={Styles.classNames({dropping: this.state.dropping})}
-//           onDragLeave={this.onDragLeave}
-//           onDragOver={this.onDragOver}
-//           onDrop={this.onDrop}
-//           style={Styles.collapseStyles([
-//             styles.container,
-//             this.props.createdTeam && styles.paddingTopForCreatedTeam,
-//           ])}
-//           onMouseUp={this.onMouseUp}
-//           onMouseDown={this.onMouseDown}
-//           onMouseMove={this.onMouseMove}
-//         >
-//           {this.props.type === 'team' && this.props.createdTeam && !this.props.wizard && (
-//             <Kb.Box style={styles.createdBanner}>
-//               <Kb.Text type="BodySmallSemibold" negative={true}>
-//                 Hoorah! Your team {this.props.teamname} was created.
-//               </Kb.Text>
-//             </Kb.Box>
-//           )}
-//           <Kb.Text center={true} type="Body" style={styles.instructions}>
-//             Drag and drop a {this.props.type} avatar or{' '}
-//             <Kb.Text type="BodyPrimaryLink" className="hover-underline" onClick={this.filePickerOpen}>
-//               browse your computer
-//             </Kb.Text>{' '}
-//             for one.
-//           </Kb.Text>
-//           <Kb.Box
-//             className={Styles.classNames('hoverbox', {filled: this.state.hasPreview})}
-//             onClick={this.state.hasPreview ? null : this.filePickerOpen}
-//             style={{
-//               borderRadius: this.props.type === 'team' ? 32 : AVATAR_CONTAINER_SIZE,
-//               ...hoverStyles.hoverContainer,
-//             }}
-//           >
-//             <input
-//               accept="image/gif,image/jpeg,image/png"
-//               multiple={false}
-//               onChange={this.pickFile}
-//               ref={this.filePickerSetRef}
-//               style={styles.hidden}
-//               type="file"
-//             />
-//             {this.state.loading && (
-//               <Kb.Box2 direction="vertical" fullHeight={true} style={styles.spinnerContainer}>
-//                 <Kb.ProgressIndicator type="Large" style={styles.spinner} />
-//               </Kb.Box2>
-//             )}
-//             <Kb.ZoomableImage
-//               zoomRatio={this.state.scale}
-//               dragPan={true}
-//               src={this.state.imageSource}
-//               onChanged={this.onChanged}
-//               onLoaded={this.onImageLoad}
-//             />
-//             {!this.state.loading && !this.state.hasPreview && (
-//               <Kb.Icon
-//                 className="icon"
-//                 color={Styles.globalColors.greyDark}
-//                 fontSize={48}
-//                 style={styles.icon}
-//                 type="iconfont-camera"
-//               />
-//             )}
-//           </Kb.Box>
-//           {this.state.hasPreview && (
-//             <input
-//               disabled={!this.state.hasPreview || this.props.submitting}
-//               min={1}
-//               max={10}
-//               onChange={this.onRangeChange}
-//               onMouseMove={e => e.stopPropagation()}
-//               step="any"
-//               type="range"
-//               value={this.state.scale}
-//             />
-//           )}
-//         </Kb.Box>
-//       </Kb.Modal>
-//     )
-//   }
-// }
-
 const hoverStyles = Styles.styleSheetCreate(
   () =>
     ({
-      dropping: {
-        backgroundColor: Styles.globalColors.blue_60,
-        borderColor: Styles.globalColors.blue_60,
-      },
-      droppingIcon: {color: Styles.globalColors.blue_60},
-      filled: Styles.platformStyles({
-        common: {
-          backgroundColor: Styles.globalColors.white,
-          borderColor: Styles.globalColors.grey,
-          borderStyle: 'solid',
-        },
-        isElectron: {cursor: '-webkit-grab'},
-      }),
-      filledHover: {
-        backgroundColor: Styles.globalColors.white,
-        borderColor: Styles.globalColors.grey,
-      },
-      hover: {borderColor: Styles.globalColors.black_50},
       hoverContainer: Styles.platformStyles({
         common: {
           alignItems: 'flex-start',
@@ -687,8 +208,8 @@ const hoverStyles = Styles.styleSheetCreate(
           marginBottom: Styles.globalMargins.small,
           marginTop: Styles.globalMargins.medium,
           outlineStyle: 'dotted',
-          outlineWidth: AVATAR_BORDER_SIZE,
-          // overflow: 'hidden',
+          outlineWidth: 4,
+          overflow: 'hidden',
           position: 'relative',
           width: AVATAR_CONTAINER_SIZE,
         },
@@ -696,7 +217,6 @@ const hoverStyles = Styles.styleSheetCreate(
           cursor: 'pointer',
         },
       }),
-      hoverIcon: {color: Styles.globalColors.black_50},
     } as const)
 )
 
@@ -728,11 +248,6 @@ const styles = Styles.styleSheetCreate(() => ({
   instructions: {maxWidth: 200},
   paddingTopForCreatedTeam: {paddingTop: Styles.globalMargins.xlarge},
   skipButton: {minWidth: 60},
-  spinner: {alignSelf: 'center'},
-  spinnerContainer: {
-    backgroundColor: Styles.globalColors.grey,
-    justifyContent: 'center',
-  },
 }))
 
 export default EditAvatar

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -40,7 +40,150 @@ type State = {
   viewingCenterY: number
 }
 
-class EditAvatar extends React.Component<Props, State> {
+const EditAvatar = (p: Props) => {
+  const {onClose, wizard, showBack, onBack, onSkip, type, error, teamID, createdTeam, teamname} = p
+
+  const [hasPreview, setHasPreview] = React.useState(false)
+  const [serror, setSerror] = React.useState('TODO')
+  const [dropping, setDropping] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const [scale, setScale] = React.useState(1)
+  const [imageSource, setImageSource] = React.useState('')
+
+  const filePickerSetRef = React.useRef(null)
+
+  const onSave = () => {}
+  const onChanged = () => {}
+  const onImageLoad = () => {}
+  const onRangeChange = () => {}
+  const onDrop = () => {}
+  const filePickerOpen = () => {}
+  const pickFile = () => {}
+
+  return (
+    <Kb.Modal
+      mode="DefaultFullHeight"
+      onClose={onClose}
+      header={{
+        leftButton: wizard || showBack ? <Kb.Icon type="iconfont-arrow-left" onClick={onBack} /> : null,
+        rightButton: wizard ? (
+          <Kb.Button
+            label="Skip"
+            mode="Secondary"
+            onClick={onSkip}
+            style={styles.skipButton}
+            type="Default"
+          />
+        ) : null,
+        title: type === 'team' ? <ModalTitle teamID={teamID} title="Upload an avatar" /> : 'Upload an avatar',
+      }}
+      allowOverflow={true}
+      footer={{
+        content: (
+          <Kb.WaitingButton
+            fullWidth={true}
+            label={wizard ? 'Continue' : 'Save'}
+            onClick={onSave}
+            disabled={!hasPreview}
+            waitingKey={null}
+          />
+        ),
+      }}
+      banners={
+        <>
+          {error ? (
+            <Kb.Banner color="red" key="propsError">
+              {error}
+            </Kb.Banner>
+          ) : null}
+          {serror ? (
+            <Kb.Banner color="red" key="stateError">
+              The image you uploaded could not be read. Try again with a valid PNG, JPG or GIF.
+            </Kb.Banner>
+          ) : null}
+        </>
+      }
+    >
+      <Kb.Box
+        className={Styles.classNames({dropping: dropping})}
+        // onDragLeave={this.onDragLeave}
+        // onDragOver={this.onDragOver}
+        onDrop={onDrop}
+        style={Styles.collapseStyles([styles.container, createdTeam && styles.paddingTopForCreatedTeam])}
+        // onMouseUp={this.onMouseUp}
+        // onMouseDown={this.onMouseDown}
+        // onMouseMove={this.onMouseMove}
+      >
+        {type === 'team' && createdTeam && !wizard && (
+          <Kb.Box style={styles.createdBanner}>
+            <Kb.Text type="BodySmallSemibold" negative={true}>
+              Hoorah! Your team {teamname} was created.
+            </Kb.Text>
+          </Kb.Box>
+        )}
+        <Kb.Text center={true} type="Body" style={styles.instructions}>
+          Drag and drop a {type} avatar or{' '}
+          <Kb.Text type="BodyPrimaryLink" className="hover-underline" onClick={filePickerOpen}>
+            browse your computer
+          </Kb.Text>{' '}
+          for one.
+        </Kb.Text>
+        <Kb.Box
+          className={Styles.classNames('hoverbox', {filled: hasPreview})}
+          onClick={hasPreview ? null : filePickerOpen}
+          style={{
+            borderRadius: type === 'team' ? 32 : AVATAR_CONTAINER_SIZE,
+            ...hoverStyles.hoverContainer,
+          }}
+        >
+          <input
+            accept="image/gif,image/jpeg,image/png"
+            multiple={false}
+            onChange={pickFile}
+            ref={filePickerSetRef}
+            style={styles.hidden}
+            type="file"
+          />
+          {loading && (
+            <Kb.Box2 direction="vertical" fullHeight={true} style={styles.spinnerContainer}>
+              <Kb.ProgressIndicator type="Large" style={styles.spinner} />
+            </Kb.Box2>
+          )}
+          <Kb.ZoomableImage
+            zoomRatio={scale}
+            dragPan={true}
+            src={imageSource}
+            onChanged={onChanged}
+            onLoaded={onImageLoad}
+          />
+          {!loading && !hasPreview && (
+            <Kb.Icon
+              className="icon"
+              color={Styles.globalColors.greyDark}
+              fontSize={48}
+              style={styles.icon}
+              type="iconfont-camera"
+            />
+          )}
+        </Kb.Box>
+        {hasPreview && (
+          <input
+            disabled={false /*!hasPreview || submitting*/}
+            min={1}
+            max={10}
+            onChange={onRangeChange}
+            // onMouseMove={e => e.stopPropagation()}
+            step="any"
+            type="range"
+            // value={this.state.scale}
+          />
+        )}
+      </Kb.Box>
+    </Kb.Modal>
+  )
+}
+
+class EditAvatar2 extends React.Component<Props, State> {
   private file: HTMLInputElement | null = null
   private imageRef = React.createRef<Kb.Image2>()
   private timerID?: ReturnType<typeof setTimeout>
@@ -161,39 +304,42 @@ class EditAvatar extends React.Component<Props, State> {
     this.setState({error: true, hasPreview: false, loading: false})
   }
 
-  private onImageLoad = (e: React.BaseSyntheticEvent) => {
+  private onImageLoad = (/*e: React.BaseSyntheticEvent*/) => {
     // TODO: Make RPC to check file size and warn them before they try submitting.
 
-    let height = AVATAR_SIZE
-    let width = (AVATAR_SIZE * e.currentTarget.naturalWidth) / e.currentTarget.naturalHeight
+    // let height = AVATAR_SIZE
+    // let width = (AVATAR_SIZE * e.currentTarget.naturalWidth) / e.currentTarget.naturalHeight
 
-    if (width < AVATAR_SIZE) {
-      height = (AVATAR_SIZE * e.currentTarget.naturalHeight) / e.currentTarget.naturalWidth
-      width = AVATAR_SIZE
-    }
+    // if (width < AVATAR_SIZE) {
+    //   height = (AVATAR_SIZE * e.currentTarget.naturalHeight) / e.currentTarget.naturalWidth
+    //   width = AVATAR_SIZE
+    // }
 
     this.setState({
-      naturalImageWidth: e.currentTarget.naturalWidth,
-      offsetLeft: width / -2 + VIEWPORT_CENTER,
-      offsetTop: height / -2 + VIEWPORT_CENTER,
-      scaledImageHeight: height,
-      scaledImageWidth: width,
-      startingImageHeight: height,
-      startingImageWidth: width,
-      viewingCenterX: e.currentTarget.naturalWidth / 2,
-      viewingCenterY: e.currentTarget.naturalHeight / 2,
+      // naturalImageWidth: e.currentTarget.naturalWidth,
+      // offsetLeft: width / -2 + VIEWPORT_CENTER,
+      // offsetTop: height / -2 + VIEWPORT_CENTER,
+      // scaledImageHeight: height,
+      // scaledImageWidth: width,
+      // startingImageHeight: height,
+      // startingImageWidth: width,
+      // viewingCenterX: e.currentTarget.naturalWidth / 2,
+      // viewingCenterY: e.currentTarget.naturalHeight / 2,
+      hasPreview: true,
+      loading: false,
     })
 
-    this.timerID = setTimeout(() => {
-      this.setState({
-        hasPreview: true,
-        loading: false,
-      })
-    }, 1500)
+    // this.timerID = setTimeout(() => {
+    //   this.setState({
+    //     hasPreview: true,
+    //     loading: false,
+    //   })
+    // }, 1500)
   }
 
   private onRangeChange = (e: React.FormEvent<any>) => {
     const scale = parseFloat(e.currentTarget.value)
+    console.log('aaa range', scale)
     // likely unsafe to ref this.state but afraid to change this now
     // eslint-disable-next-line
     const scaledImageHeight = this.state.startingImageHeight * scale
@@ -316,7 +462,12 @@ class EditAvatar extends React.Component<Props, State> {
     this.props.onSave(this.state.imageSource, crop)
   }
 
+  private onChanged = e => {
+    console.log('aaa', e)
+  }
+
   render() {
+    console.log('aaa rendering', this.state.scale)
     return (
       <Kb.Modal
         mode="DefaultFullHeight"
@@ -417,23 +568,12 @@ class EditAvatar extends React.Component<Props, State> {
                 <Kb.ProgressIndicator type="Large" style={styles.spinner} />
               </Kb.Box2>
             )}
-            <Kb.Image2
-              ref={this.imageRef}
+            <Kb.ZoomableImage
+              zoomRatio={this.state.scale}
+              dragPan={true}
               src={this.state.imageSource}
-              style={Styles.platformStyles({
-                isElectron: {
-                  height: this.state.scaledImageHeight,
-                  left: this.state.offsetLeft,
-                  opacity: this.state.loading ? 0 : 1,
-                  position: 'absolute',
-                  top: this.state.offsetTop,
-                  transition: 'opacity 0.25s ease-in',
-                  userSelect: 'none',
-                  width: this.state.scaledImageWidth,
-                },
-              } as const)}
-              onLoad={this.onImageLoad}
-              onError={this.onImageError}
+              onChanged={this.onChanged}
+              onLoaded={this.onImageLoad}
             />
             {!this.state.loading && !this.state.hasPreview && (
               <Kb.Icon

--- a/shared/profile/edit-avatar/index.desktop.tsx
+++ b/shared/profile/edit-avatar/index.desktop.tsx
@@ -4,14 +4,13 @@ import * as Styles from '../../styles'
 import clamp from 'lodash/clamp'
 import type {Props} from '.'
 import {ModalTitle} from '../../teams/common'
-import {
-  AVATAR_CONTAINER_SIZE,
-  AVATAR_BORDER_SIZE,
-  AVATAR_SIZE,
-  VIEWPORT_CENTER,
-} from '../../common-adapters/avatar'
+import {AVATAR_SIZE} from '../../common-adapters/avatar'
 import KB2 from '../../util/electron.desktop'
 import './edit-avatar.css'
+
+const AVATAR_CONTAINER_SIZE = 300
+const AVATAR_BORDER_SIZE = 4
+const VIEWPORT_CENTER = AVATAR_CONTAINER_SIZE / 2
 
 const {isDirectory} = KB2.functions
 
@@ -40,25 +39,109 @@ type State = {
   viewingCenterY: number
 }
 
+const validDrag = (e: React.DragEvent<any>) => {
+  return Array.prototype.map.call(e.dataTransfer.types, t => t).includes('Files')
+}
+
+const getFile = async (fileList: {length?: number}): Promise<string> => {
+  const paths: Array<string> = fileList?.length
+    ? Array.prototype.map.call(fileList, f => f.path)
+    : ([] as any)
+  if (!paths.length) {
+    return ''
+  }
+  for (const path of paths) {
+    try {
+      const isDir = await (isDirectory?.(path) ?? Promise.resolve(false))
+      if (isDir) {
+        return ''
+      }
+    } catch (e) {}
+  }
+  return paths.pop() ?? ''
+}
+
+type Crop = {
+  height: number
+  width: number
+  x: number
+  y: number
+  scale: number
+}
+const getCropCoordinates = (c: Crop) => {
+  const {x, y, scale, width, height} = c
+  const maxX = width / scale
+  const maxY = height / scale
+  const windowScaled = Math.round(AVATAR_CONTAINER_SIZE / scale)
+  let x0 = x / scale
+  x0 = clamp(Math.round(x0), 0, maxX)
+  // const x1 = clamp(Math.round(x0 + AVATAR_CONTAINER_SIZE / scale), x0, maxX)
+  const x1 = Math.min(x0 + windowScaled, maxX)
+  let y0 = y / scale
+  y0 = clamp(Math.round(y0), 0, maxY)
+  // const y1 = clamp(Math.round(y0 + AVATAR_CONTAINER_SIZE / scale), y0, maxY)
+  const y1 = Math.min(y0 + windowScaled, maxY)
+  return {x0, x1, y0, y1}
+
+  // x0pixels should be: 2400 (pixels) - 300 (zoomed pixels) = 2100
+  // x1pixels should be: 2100 (x0pixels) + 300 (zoomed pixels) = 2400
+
+  // x0: 2100 / 2(zoom) = 1050 (good)
+  // x1: 2400 / 2 (zoom) = 1200 (good)
+
+  // x1 - x0: 150 should be
+}
+
+type Loading = undefined | 'loading' | 'loaded'
 const EditAvatar = (p: Props) => {
   const {onClose, wizard, showBack, onBack, onSkip, type, error, teamID, createdTeam, teamname} = p
-
-  const [hasPreview, setHasPreview] = React.useState(false)
-  const [serror, setSerror] = React.useState('TODO')
+  const [serror, setSerror] = React.useState(false)
   const [dropping, setDropping] = React.useState(false)
-  const [loading, setLoading] = React.useState(false)
-  const [scale, setScale] = React.useState(1)
+  const [loading, setLoading] = React.useState<Loading>()
   const [imageSource, setImageSource] = React.useState('')
 
-  const filePickerSetRef = React.useRef(null)
+  const fileRef = React.useRef<HTMLInputElement>(null)
 
-  const onSave = () => {}
-  const onChanged = () => {}
-  const onImageLoad = () => {}
-  const onRangeChange = () => {}
-  const onDrop = () => {}
-  const filePickerOpen = () => {}
-  const pickFile = () => {}
+  const onSave = () => {
+    const crop = getCropCoordinates(cropRef.current)
+    console.log('aaaa onsave', crop, cropRef.current)
+    p.onSave(imageSource, crop)
+  }
+  const cropRef = React.useRef({height: 0, unscaledHeight: 0, unscaledWidth: 0, width: 0, x: 0, y: 0})
+  const onChanged = (e: Crop) => {
+    console.log('aaa onchanged', e)
+    cropRef.current = e
+  }
+
+  const onImageLoad = () => {
+    setLoading('loaded')
+  }
+  const onDrop = async (e: React.DragEvent<any>) => {
+    setDropping(false)
+    setSerror(false)
+    setLoading('loading')
+    if (!validDrag(e)) {
+      return
+    }
+    const img = await getFile(e.dataTransfer.files)
+    if (img) {
+      setImageSource(img)
+    }
+  }
+  const filePickerOpen = () => {
+    fileRef.current?.click()
+  }
+  const pickFile = async () => {
+    setSerror(false)
+    setLoading('loading')
+    const img = await getFile(fileRef.current?.files)
+    if (img) {
+      setImageSource(img)
+    }
+    if (fileRef.current) {
+      fileRef.current.value = ''
+    }
+  }
 
   return (
     <Kb.Modal
@@ -84,7 +167,7 @@ const EditAvatar = (p: Props) => {
             fullWidth={true}
             label={wizard ? 'Continue' : 'Save'}
             onClick={onSave}
-            disabled={!hasPreview}
+            disabled={loading !== 'loaded'}
             waitingKey={null}
           />
         ),
@@ -106,13 +189,8 @@ const EditAvatar = (p: Props) => {
     >
       <Kb.Box
         className={Styles.classNames({dropping: dropping})}
-        // onDragLeave={this.onDragLeave}
-        // onDragOver={this.onDragOver}
         onDrop={onDrop}
         style={Styles.collapseStyles([styles.container, createdTeam && styles.paddingTopForCreatedTeam])}
-        // onMouseUp={this.onMouseUp}
-        // onMouseDown={this.onMouseDown}
-        // onMouseMove={this.onMouseMove}
       >
         {type === 'team' && createdTeam && !wizard && (
           <Kb.Box style={styles.createdBanner}>
@@ -129,8 +207,8 @@ const EditAvatar = (p: Props) => {
           for one.
         </Kb.Text>
         <Kb.Box
-          className={Styles.classNames('hoverbox', {filled: hasPreview})}
-          onClick={hasPreview ? null : filePickerOpen}
+          className={Styles.classNames('hoverbox', {filled: loading !== 'loaded'})}
+          onClick={!loading ? filePickerOpen : undefined}
           style={{
             borderRadius: type === 'team' ? 32 : AVATAR_CONTAINER_SIZE,
             ...hoverStyles.hoverContainer,
@@ -140,23 +218,12 @@ const EditAvatar = (p: Props) => {
             accept="image/gif,image/jpeg,image/png"
             multiple={false}
             onChange={pickFile}
-            ref={filePickerSetRef}
+            ref={fileRef}
             style={styles.hidden}
             type="file"
           />
-          {loading && (
-            <Kb.Box2 direction="vertical" fullHeight={true} style={styles.spinnerContainer}>
-              <Kb.ProgressIndicator type="Large" style={styles.spinner} />
-            </Kb.Box2>
-          )}
-          <Kb.ZoomableImage
-            zoomRatio={scale}
-            dragPan={true}
-            src={imageSource}
-            onChanged={onChanged}
-            onLoaded={onImageLoad}
-          />
-          {!loading && !hasPreview && (
+          <Kb.ZoomableImage dragPan={true} src={imageSource} onChanged={onChanged} onLoaded={onImageLoad} />
+          {!loading && (
             <Kb.Icon
               className="icon"
               color={Styles.globalColors.greyDark}
@@ -166,442 +233,431 @@ const EditAvatar = (p: Props) => {
             />
           )}
         </Kb.Box>
-        {hasPreview && (
-          <input
-            disabled={false /*!hasPreview || submitting*/}
-            min={1}
-            max={10}
-            onChange={onRangeChange}
-            // onMouseMove={e => e.stopPropagation()}
-            step="any"
-            type="range"
-            // value={this.state.scale}
-          />
-        )}
+        {loading === 'loaded' ? <Kb.Text type="Body">Click to select. Scroll to zoom.</Kb.Text> : null}
       </Kb.Box>
     </Kb.Modal>
   )
 }
 
-class EditAvatar2 extends React.Component<Props, State> {
-  private file: HTMLInputElement | null = null
-  private imageRef = React.createRef<Kb.Image2>()
-  private timerID?: ReturnType<typeof setTimeout>
+// class EditAvatar2 extends React.Component<Props, State> {
+//   private file: HTMLInputElement | null = null
+//   private imageRef = React.createRef<Kb.Image2>()
+//   private timerID?: ReturnType<typeof setTimeout>
 
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      dragStartX: 0,
-      dragStartY: 0,
-      dragStopX: 0,
-      dragStopY: 0,
-      dragging: false,
-      dropping: false,
-      error: false,
-      hasPreview: false,
-      imageSource: '',
-      loading: false,
-      naturalImageWidth: 0,
-      offsetLeft: 0,
-      offsetTop: 0,
-      scale: 1,
-      scaledImageHeight: 1,
-      scaledImageWidth: 1,
-      startingImageHeight: 1,
-      startingImageWidth: 1,
-      viewingCenterX: 0,
-      viewingCenterY: 0,
-    }
-  }
+//   constructor(props: Props) {
+//     super(props)
+//     this.state = {
+//       dragStartX: 0,
+//       dragStartY: 0,
+//       dragStopX: 0,
+//       dragStopY: 0,
+//       dragging: false,
+//       dropping: false,
+//       error: false,
+//       hasPreview: false,
+//       imageSource: '',
+//       loading: false,
+//       naturalImageWidth: 0,
+//       offsetLeft: 0,
+//       offsetTop: 0,
+//       scale: 1,
+//       scaledImageHeight: 1,
+//       scaledImageWidth: 1,
+//       startingImageHeight: 1,
+//       startingImageWidth: 1,
+//       viewingCenterX: 0,
+//       viewingCenterY: 0,
+//     }
+//   }
 
-  componentWillUnmount() {
-    this.timerID && clearTimeout(this.timerID)
-  }
+//   componentWillUnmount() {
+//     this.timerID && clearTimeout(this.timerID)
+//   }
 
-  private filePickerFiles = () => (this.file && this.file.files) || []
+//   private filePickerFiles = () => (this.file && this.file.files) || []
 
-  private filePickerOpen = () => {
-    this.file && this.file.click()
-  }
+//   private filePickerOpen = () => {
+//     this.file && this.file.click()
+//   }
 
-  private filePickerSetRef = (r: HTMLInputElement | null) => {
-    this.file = r
-  }
+//   private filePickerSetRef = (r: HTMLInputElement | null) => {
+//     this.file = r
+//   }
 
-  private filePickerSetValue = (value: string) => {
-    if (this.file) this.file.value = value
-  }
+//   private filePickerSetValue = (value: string) => {
+//     if (this.file) this.file.value = value
+//   }
 
-  private pickFile = () => {
-    this.setState({error: false, loading: true})
-    const fileList = this.filePickerFiles()
-    const paths: Array<string> = fileList.length
-      ? Array.prototype.map
-          .call(fileList, (f: File) => {
-            // We rely on path being here, even though it's not part of the File spec.
-            const path: string = f.path
-            return path
-          })
-          .filter(Boolean)
-      : ([] as any)
-    if (paths) {
-      const img = paths.pop()
-      img && this.paintImage(img)
-    }
-    this.filePickerSetValue('')
-  }
+//   private pickFile = () => {
+//     this.setState({error: false, loading: true})
+//     const fileList = this.filePickerFiles()
+//     const paths: Array<string> = fileList.length
+//       ? Array.prototype.map
+//           .call(fileList, (f: File) => {
+//             // We rely on path being here, even though it's not part of the File spec.
+//             const path: string = f.path
+//             return path
+//           })
+//           .filter(Boolean)
+//       : ([] as any)
+//     if (paths) {
+//       const img = paths.pop()
+//       img && this.paintImage(img)
+//     }
+//     this.filePickerSetValue('')
+//   }
 
-  private onDragLeave = () => {
-    this.setState({dropping: false})
-  }
+//   private onDragLeave = () => {
+//     this.setState({dropping: false})
+//   }
 
-  private onDrop = async (e: React.DragEvent<any>) => {
-    this.setState({dropping: false, error: false, loading: true})
-    if (!this.validDrag(e)) {
-      return
-    }
-    const fileList = e.dataTransfer.files
-    const paths: Array<string> = fileList.length
-      ? Array.prototype.map.call(fileList, f => f.path)
-      : ([] as any)
-    if (paths.length) {
-      // TODO: Show an error when there's more than one path.
-      for (const path of paths) {
-        // Check if any file is a directory and bail out if not
-        try {
-          const isDir = await (isDirectory?.(path) ?? Promise.resolve(false))
-          if (isDir) {
-            // TODO: Show a red error banner on failure: https://zpl.io/2jlkMLm
-            return
-          }
-        } catch (e) {
-          // TODO: Show a red error banner on failure: https://zpl.io/2jlkMLm
-        }
-      }
-      const img = paths.pop()
-      img && this.paintImage(img)
-    }
-  }
+//   private onDrop = async (e: React.DragEvent<any>) => {
+//     this.setState({dropping: false, error: false, loading: true})
+//     if (!this.validDrag(e)) {
+//       return
+//     }
+//     const fileList = e.dataTransfer.files
+//     const paths: Array<string> = fileList.length
+//       ? Array.prototype.map.call(fileList, f => f.path)
+//       : ([] as any)
+//     if (paths.length) {
+//       // TODO: Show an error when there's more than one path.
+//       for (const path of paths) {
+//         // Check if any file is a directory and bail out if not
+//         try {
+//           const isDir = await (isDirectory?.(path) ?? Promise.resolve(false))
+//           if (isDir) {
+//             // TODO: Show a red error banner on failure: https://zpl.io/2jlkMLm
+//             return
+//           }
+//         } catch (e) {
+//           // TODO: Show a red error banner on failure: https://zpl.io/2jlkMLm
+//         }
+//       }
+//       const img = paths.pop()
+//       img && this.paintImage(img)
+//     }
+//   }
 
-  private validDrag = (e: React.DragEvent<any>) => {
-    return Array.prototype.map.call(e.dataTransfer.types, t => t).includes('Files')
-  }
+//   private validDrag = (e: React.DragEvent<any>) => {
+//     return Array.prototype.map.call(e.dataTransfer.types, t => t).includes('Files')
+//   }
 
-  private onDragOver = (e: React.DragEvent<any>) => {
-    this.setState({dropping: true})
-    if (this.validDrag(e)) {
-      e.dataTransfer.dropEffect = 'copy'
-    } else {
-      e.dataTransfer.dropEffect = 'none'
-    }
-  }
+//   private onDragOver = (e: React.DragEvent<any>) => {
+//     this.setState({dropping: true})
+//     if (this.validDrag(e)) {
+//       e.dataTransfer.dropEffect = 'copy'
+//     } else {
+//       e.dataTransfer.dropEffect = 'none'
+//     }
+//   }
 
-  private paintImage = (path: string) => {
-    this.setState({imageSource: path})
-  }
+//   private paintImage = (path: string) => {
+//     this.setState({imageSource: path})
+//   }
 
-  private onImageError = () => {
-    this.setState({error: true, hasPreview: false, loading: false})
-  }
+//   private onImageError = () => {
+//     this.setState({error: true, hasPreview: false, loading: false})
+//   }
 
-  private onImageLoad = (/*e: React.BaseSyntheticEvent*/) => {
-    // TODO: Make RPC to check file size and warn them before they try submitting.
+//   private onImageLoad = (/*e: React.BaseSyntheticEvent*/) => {
+//     // TODO: Make RPC to check file size and warn them before they try submitting.
 
-    // let height = AVATAR_SIZE
-    // let width = (AVATAR_SIZE * e.currentTarget.naturalWidth) / e.currentTarget.naturalHeight
+//     // let height = AVATAR_SIZE
+//     // let width = (AVATAR_SIZE * e.currentTarget.naturalWidth) / e.currentTarget.naturalHeight
 
-    // if (width < AVATAR_SIZE) {
-    //   height = (AVATAR_SIZE * e.currentTarget.naturalHeight) / e.currentTarget.naturalWidth
-    //   width = AVATAR_SIZE
-    // }
+//     // if (width < AVATAR_SIZE) {
+//     //   height = (AVATAR_SIZE * e.currentTarget.naturalHeight) / e.currentTarget.naturalWidth
+//     //   width = AVATAR_SIZE
+//     // }
 
-    this.setState({
-      // naturalImageWidth: e.currentTarget.naturalWidth,
-      // offsetLeft: width / -2 + VIEWPORT_CENTER,
-      // offsetTop: height / -2 + VIEWPORT_CENTER,
-      // scaledImageHeight: height,
-      // scaledImageWidth: width,
-      // startingImageHeight: height,
-      // startingImageWidth: width,
-      // viewingCenterX: e.currentTarget.naturalWidth / 2,
-      // viewingCenterY: e.currentTarget.naturalHeight / 2,
-      hasPreview: true,
-      loading: false,
-    })
+//     this.setState({
+//       // naturalImageWidth: e.currentTarget.naturalWidth,
+//       // offsetLeft: width / -2 + VIEWPORT_CENTER,
+//       // offsetTop: height / -2 + VIEWPORT_CENTER,
+//       // scaledImageHeight: height,
+//       // scaledImageWidth: width,
+//       // startingImageHeight: height,
+//       // startingImageWidth: width,
+//       // viewingCenterX: e.currentTarget.naturalWidth / 2,
+//       // viewingCenterY: e.currentTarget.naturalHeight / 2,
+//       hasPreview: true,
+//       loading: false,
+//     })
 
-    // this.timerID = setTimeout(() => {
-    //   this.setState({
-    //     hasPreview: true,
-    //     loading: false,
-    //   })
-    // }, 1500)
-  }
+//     // this.timerID = setTimeout(() => {
+//     //   this.setState({
+//     //     hasPreview: true,
+//     //     loading: false,
+//     //   })
+//     // }, 1500)
+//   }
 
-  private onRangeChange = (e: React.FormEvent<any>) => {
-    const scale = parseFloat(e.currentTarget.value)
-    console.log('aaa range', scale)
-    // likely unsafe to ref this.state but afraid to change this now
-    // eslint-disable-next-line
-    const scaledImageHeight = this.state.startingImageHeight * scale
-    // eslint-disable-next-line
-    const scaledImageWidth = this.state.startingImageWidth * scale
+//   private onRangeChange = (e: React.FormEvent<any>) => {
+//     const scale = parseFloat(e.currentTarget.value)
+//     console.log('aaa range', scale)
+//     // likely unsafe to ref this.state but afraid to change this now
+//     // eslint-disable-next-line
+//     const scaledImageHeight = this.state.startingImageHeight * scale
+//     // eslint-disable-next-line
+//     const scaledImageWidth = this.state.startingImageWidth * scale
 
-    const ratio = this.state.naturalImageWidth / scaledImageWidth
-    const offsetLeft = clamp(
-      // eslint-disable-next-line
-      VIEWPORT_CENTER - this.state.viewingCenterX / ratio,
-      AVATAR_SIZE - scaledImageWidth,
-      0
-    )
-    const offsetTop = clamp(
-      // eslint-disable-next-line
-      VIEWPORT_CENTER - this.state.viewingCenterY / ratio,
-      AVATAR_SIZE - scaledImageHeight,
-      0
-    )
+//     const ratio = this.state.naturalImageWidth / scaledImageWidth
+//     const offsetLeft = clamp(
+//       // eslint-disable-next-line
+//       VIEWPORT_CENTER - this.state.viewingCenterX / ratio,
+//       AVATAR_SIZE - scaledImageWidth,
+//       0
+//     )
+//     const offsetTop = clamp(
+//       // eslint-disable-next-line
+//       VIEWPORT_CENTER - this.state.viewingCenterY / ratio,
+//       AVATAR_SIZE - scaledImageHeight,
+//       0
+//     )
 
-    this.setState({
-      offsetLeft,
-      offsetTop,
-      scale,
-      scaledImageHeight,
-      scaledImageWidth,
-    })
-  }
+//     this.setState({
+//       offsetLeft,
+//       offsetTop,
+//       scale,
+//       scaledImageHeight,
+//       scaledImageWidth,
+//     })
+//   }
 
-  private onMouseDown = (e: React.MouseEvent) => {
-    if (!this.state.hasPreview || !this.imageRef) return
+//   private onMouseDown = (e: React.MouseEvent) => {
+//     if (!this.state.hasPreview || !this.imageRef) return
 
-    // Grab the values now. The event object will be nullified by the time setState is called.
-    const {pageX, pageY} = e
+//     // Grab the values now. The event object will be nullified by the time setState is called.
+//     const {pageX, pageY} = e
 
-    const img = this.imageRef.current
+//     const img = this.imageRef.current
 
-    this.setState(s => ({
-      dragStartX: pageX,
-      dragStartY: pageY,
-      // @ts-ignore codemode issue
-      dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
-      // @ts-ignore codemode issue
-      dragStopY: img && img.style.top ? parseInt(img.style.top, 10) : s.dragStopY,
-      dragging: true,
-    }))
-  }
+//     this.setState(s => ({
+//       dragStartX: pageX,
+//       dragStartY: pageY,
+//       // @ts-ignore codemode issue
+//       dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
+//       // @ts-ignore codemode issue
+//       dragStopY: img && img.style.top ? parseInt(img.style.top, 10) : s.dragStopY,
+//       dragging: true,
+//     }))
+//   }
 
-  private onMouseUp = () => {
-    if (!this.state.hasPreview || !this.imageRef) return
+//   private onMouseUp = () => {
+//     if (!this.state.hasPreview || !this.imageRef) return
 
-    const img = this.imageRef.current
+//     const img = this.imageRef.current
 
-    this.setState(s => ({
-      // @ts-ignore codemode issue
-      dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
-      // @ts-ignore codemode issue
-      dragStopY: img && img.style.top ? parseInt(img.style.top, 10) : s.dragStopY,
-      dragging: false,
-    }))
-  }
+//     this.setState(s => ({
+//       // @ts-ignore codemode issue
+//       dragStopX: img && img.style.left ? parseInt(img.style.left, 10) : s.dragStopX,
+//       // @ts-ignore codemode issue
+//       dragStopY: img && img.style.top ? parseInt(img.style.top, 10) : s.dragStopY,
+//       dragging: false,
+//     }))
+//   }
 
-  private onMouseMove = (e: React.MouseEvent) => {
-    if (!this.state.dragging || this.props.submitting) return
+//   private onMouseMove = (e: React.MouseEvent) => {
+//     if (!this.state.dragging || this.props.submitting) return
 
-    // Grab the values now. The event object will be nullified by the time setState is called.
-    const {pageX, pageY} = e
+//     // Grab the values now. The event object will be nullified by the time setState is called.
+//     const {pageX, pageY} = e
 
-    const offsetLeft = clamp(
-      // eslint-disable-next-line
-      this.state.dragStopX + pageX - this.state.dragStartX,
-      // eslint-disable-next-line
-      AVATAR_SIZE - this.state.scaledImageWidth,
-      0
-    )
-    const offsetTop = clamp(
-      // eslint-disable-next-line
-      this.state.dragStopY + pageY - this.state.dragStartY,
-      // eslint-disable-next-line
-      AVATAR_SIZE - this.state.scaledImageHeight,
-      0
-    )
+//     const offsetLeft = clamp(
+//       // eslint-disable-next-line
+//       this.state.dragStopX + pageX - this.state.dragStartX,
+//       // eslint-disable-next-line
+//       AVATAR_SIZE - this.state.scaledImageWidth,
+//       0
+//     )
+//     const offsetTop = clamp(
+//       // eslint-disable-next-line
+//       this.state.dragStopY + pageY - this.state.dragStartY,
+//       // eslint-disable-next-line
+//       AVATAR_SIZE - this.state.scaledImageHeight,
+//       0
+//     )
 
-    const ratio = this.state.naturalImageWidth / this.state.scaledImageWidth
-    // eslint-disable-next-line
-    const viewingCenterX = (VIEWPORT_CENTER - this.state.offsetLeft) * ratio
-    // eslint-disable-next-line
-    const viewingCenterY = (VIEWPORT_CENTER - this.state.offsetTop) * ratio
+//     const ratio = this.state.naturalImageWidth / this.state.scaledImageWidth
+//     // eslint-disable-next-line
+//     const viewingCenterX = (VIEWPORT_CENTER - this.state.offsetLeft) * ratio
+//     // eslint-disable-next-line
+//     const viewingCenterY = (VIEWPORT_CENTER - this.state.offsetTop) * ratio
 
-    this.setState({
-      offsetLeft,
-      offsetTop,
-      viewingCenterX,
-      viewingCenterY,
-    })
-  }
+//     this.setState({
+//       offsetLeft,
+//       offsetTop,
+//       viewingCenterX,
+//       viewingCenterY,
+//     })
+//   }
 
-  private onSave = () => {
-    const x = this.state.offsetLeft * -1
-    const y = this.state.offsetTop * -1
-    const ratio =
-      this.state.scaledImageWidth !== 0 ? this.state.naturalImageWidth / this.state.scaledImageWidth : 1
-    const crop = {
-      x0: Math.round(x * ratio),
-      x1: Math.round((x + AVATAR_SIZE) * ratio),
-      y0: Math.round(y * ratio),
-      y1: Math.round((y + AVATAR_SIZE) * ratio),
-    }
+//   private onSave = () => {
+//     const x = this.state.offsetLeft * -1
+//     const y = this.state.offsetTop * -1
+//     const ratio =
+//       this.state.scaledImageWidth !== 0 ? this.state.naturalImageWidth / this.state.scaledImageWidth : 1
+//     const crop = {
+//       x0: Math.round(x * ratio),
+//       x1: Math.round((x + AVATAR_SIZE) * ratio),
+//       y0: Math.round(y * ratio),
+//       y1: Math.round((y + AVATAR_SIZE) * ratio),
+//     }
 
-    if (this.props.wizard) {
-      return this.props.onSave(
-        this.state.imageSource,
-        crop,
-        this.state.scaledImageWidth,
-        this.state.offsetLeft,
-        this.state.offsetTop
-      )
-    }
+//     if (this.props.wizard) {
+//       return this.props.onSave(
+//         this.state.imageSource,
+//         crop,
+//         this.state.scaledImageWidth,
+//         this.state.offsetLeft,
+//         this.state.offsetTop
+//       )
+//     }
 
-    this.props.onSave(this.state.imageSource, crop)
-  }
+//     this.props.onSave(this.state.imageSource, crop)
+//   }
 
-  private onChanged = e => {
-    console.log('aaa', e)
-  }
+//   private onChanged = e => {
+//     console.log('aaa on changed', e)
+//   }
 
-  render() {
-    console.log('aaa rendering', this.state.scale)
-    return (
-      <Kb.Modal
-        mode="DefaultFullHeight"
-        onClose={this.props.onClose}
-        header={{
-          leftButton:
-            this.props.wizard || this.props.showBack ? (
-              <Kb.Icon type="iconfont-arrow-left" onClick={this.props.onBack} />
-            ) : null,
-          rightButton: this.props.wizard ? (
-            <Kb.Button
-              label="Skip"
-              mode="Secondary"
-              onClick={this.props.onSkip}
-              style={styles.skipButton}
-              type="Default"
-            />
-          ) : null,
-          title:
-            this.props.type === 'team' ? (
-              <ModalTitle teamID={this.props.teamID} title="Upload an avatar" />
-            ) : (
-              'Upload an avatar'
-            ),
-        }}
-        allowOverflow={true}
-        footer={{
-          content: (
-            <Kb.WaitingButton
-              fullWidth={true}
-              label={this.props.wizard ? 'Continue' : 'Save'}
-              onClick={this.onSave}
-              disabled={!this.state.hasPreview}
-              waitingKey={null}
-            />
-          ),
-        }}
-        banners={
-          <>
-            {this.props.error ? (
-              <Kb.Banner color="red" key="propsError">
-                {this.props.error}
-              </Kb.Banner>
-            ) : null}
-            {this.state.error ? (
-              <Kb.Banner color="red" key="stateError">
-                The image you uploaded could not be read. Try again with a valid PNG, JPG or GIF.
-              </Kb.Banner>
-            ) : null}
-          </>
-        }
-      >
-        <Kb.Box
-          className={Styles.classNames({dropping: this.state.dropping})}
-          onDragLeave={this.onDragLeave}
-          onDragOver={this.onDragOver}
-          onDrop={this.onDrop}
-          style={Styles.collapseStyles([
-            styles.container,
-            this.props.createdTeam && styles.paddingTopForCreatedTeam,
-          ])}
-          onMouseUp={this.onMouseUp}
-          onMouseDown={this.onMouseDown}
-          onMouseMove={this.onMouseMove}
-        >
-          {this.props.type === 'team' && this.props.createdTeam && !this.props.wizard && (
-            <Kb.Box style={styles.createdBanner}>
-              <Kb.Text type="BodySmallSemibold" negative={true}>
-                Hoorah! Your team {this.props.teamname} was created.
-              </Kb.Text>
-            </Kb.Box>
-          )}
-          <Kb.Text center={true} type="Body" style={styles.instructions}>
-            Drag and drop a {this.props.type} avatar or{' '}
-            <Kb.Text type="BodyPrimaryLink" className="hover-underline" onClick={this.filePickerOpen}>
-              browse your computer
-            </Kb.Text>{' '}
-            for one.
-          </Kb.Text>
-          <Kb.Box
-            className={Styles.classNames('hoverbox', {filled: this.state.hasPreview})}
-            onClick={this.state.hasPreview ? null : this.filePickerOpen}
-            style={{
-              borderRadius: this.props.type === 'team' ? 32 : AVATAR_CONTAINER_SIZE,
-              ...hoverStyles.hoverContainer,
-            }}
-          >
-            <input
-              accept="image/gif,image/jpeg,image/png"
-              multiple={false}
-              onChange={this.pickFile}
-              ref={this.filePickerSetRef}
-              style={styles.hidden}
-              type="file"
-            />
-            {this.state.loading && (
-              <Kb.Box2 direction="vertical" fullHeight={true} style={styles.spinnerContainer}>
-                <Kb.ProgressIndicator type="Large" style={styles.spinner} />
-              </Kb.Box2>
-            )}
-            <Kb.ZoomableImage
-              zoomRatio={this.state.scale}
-              dragPan={true}
-              src={this.state.imageSource}
-              onChanged={this.onChanged}
-              onLoaded={this.onImageLoad}
-            />
-            {!this.state.loading && !this.state.hasPreview && (
-              <Kb.Icon
-                className="icon"
-                color={Styles.globalColors.greyDark}
-                fontSize={48}
-                style={styles.icon}
-                type="iconfont-camera"
-              />
-            )}
-          </Kb.Box>
-          {this.state.hasPreview && (
-            <input
-              disabled={!this.state.hasPreview || this.props.submitting}
-              min={1}
-              max={10}
-              onChange={this.onRangeChange}
-              onMouseMove={e => e.stopPropagation()}
-              step="any"
-              type="range"
-              value={this.state.scale}
-            />
-          )}
-        </Kb.Box>
-      </Kb.Modal>
-    )
-  }
-}
+//   render() {
+//     console.log('aaa rendering', this.state.scale)
+//     return (
+//       <Kb.Modal
+//         mode="DefaultFullHeight"
+//         onClose={this.props.onClose}
+//         header={{
+//           leftButton:
+//             this.props.wizard || this.props.showBack ? (
+//               <Kb.Icon type="iconfont-arrow-left" onClick={this.props.onBack} />
+//             ) : null,
+//           rightButton: this.props.wizard ? (
+//             <Kb.Button
+//               label="Skip"
+//               mode="Secondary"
+//               onClick={this.props.onSkip}
+//               style={styles.skipButton}
+//               type="Default"
+//             />
+//           ) : null,
+//           title:
+//             this.props.type === 'team' ? (
+//               <ModalTitle teamID={this.props.teamID} title="Upload an avatar" />
+//             ) : (
+//               'Upload an avatar'
+//             ),
+//         }}
+//         allowOverflow={true}
+//         footer={{
+//           content: (
+//             <Kb.WaitingButton
+//               fullWidth={true}
+//               label={this.props.wizard ? 'Continue' : 'Save'}
+//               onClick={this.onSave}
+//               disabled={!this.state.hasPreview}
+//               waitingKey={null}
+//             />
+//           ),
+//         }}
+//         banners={
+//           <>
+//             {this.props.error ? (
+//               <Kb.Banner color="red" key="propsError">
+//                 {this.props.error}
+//               </Kb.Banner>
+//             ) : null}
+//             {this.state.error ? (
+//               <Kb.Banner color="red" key="stateError">
+//                 The image you uploaded could not be read. Try again with a valid PNG, JPG or GIF.
+//               </Kb.Banner>
+//             ) : null}
+//           </>
+//         }
+//       >
+//         <Kb.Box
+//           className={Styles.classNames({dropping: this.state.dropping})}
+//           onDragLeave={this.onDragLeave}
+//           onDragOver={this.onDragOver}
+//           onDrop={this.onDrop}
+//           style={Styles.collapseStyles([
+//             styles.container,
+//             this.props.createdTeam && styles.paddingTopForCreatedTeam,
+//           ])}
+//           onMouseUp={this.onMouseUp}
+//           onMouseDown={this.onMouseDown}
+//           onMouseMove={this.onMouseMove}
+//         >
+//           {this.props.type === 'team' && this.props.createdTeam && !this.props.wizard && (
+//             <Kb.Box style={styles.createdBanner}>
+//               <Kb.Text type="BodySmallSemibold" negative={true}>
+//                 Hoorah! Your team {this.props.teamname} was created.
+//               </Kb.Text>
+//             </Kb.Box>
+//           )}
+//           <Kb.Text center={true} type="Body" style={styles.instructions}>
+//             Drag and drop a {this.props.type} avatar or{' '}
+//             <Kb.Text type="BodyPrimaryLink" className="hover-underline" onClick={this.filePickerOpen}>
+//               browse your computer
+//             </Kb.Text>{' '}
+//             for one.
+//           </Kb.Text>
+//           <Kb.Box
+//             className={Styles.classNames('hoverbox', {filled: this.state.hasPreview})}
+//             onClick={this.state.hasPreview ? null : this.filePickerOpen}
+//             style={{
+//               borderRadius: this.props.type === 'team' ? 32 : AVATAR_CONTAINER_SIZE,
+//               ...hoverStyles.hoverContainer,
+//             }}
+//           >
+//             <input
+//               accept="image/gif,image/jpeg,image/png"
+//               multiple={false}
+//               onChange={this.pickFile}
+//               ref={this.filePickerSetRef}
+//               style={styles.hidden}
+//               type="file"
+//             />
+//             {this.state.loading && (
+//               <Kb.Box2 direction="vertical" fullHeight={true} style={styles.spinnerContainer}>
+//                 <Kb.ProgressIndicator type="Large" style={styles.spinner} />
+//               </Kb.Box2>
+//             )}
+//             <Kb.ZoomableImage
+//               zoomRatio={this.state.scale}
+//               dragPan={true}
+//               src={this.state.imageSource}
+//               onChanged={this.onChanged}
+//               onLoaded={this.onImageLoad}
+//             />
+//             {!this.state.loading && !this.state.hasPreview && (
+//               <Kb.Icon
+//                 className="icon"
+//                 color={Styles.globalColors.greyDark}
+//                 fontSize={48}
+//                 style={styles.icon}
+//                 type="iconfont-camera"
+//               />
+//             )}
+//           </Kb.Box>
+//           {this.state.hasPreview && (
+//             <input
+//               disabled={!this.state.hasPreview || this.props.submitting}
+//               min={1}
+//               max={10}
+//               onChange={this.onRangeChange}
+//               onMouseMove={e => e.stopPropagation()}
+//               step="any"
+//               type="range"
+//               value={this.state.scale}
+//             />
+//           )}
+//         </Kb.Box>
+//       </Kb.Modal>
+//     )
+//   }
+// }
 
 const hoverStyles = Styles.styleSheetCreate(
   () =>
@@ -626,12 +682,13 @@ const hoverStyles = Styles.styleSheetCreate(
       hover: {borderColor: Styles.globalColors.black_50},
       hoverContainer: Styles.platformStyles({
         common: {
-          borderStyle: 'dotted',
-          borderWidth: AVATAR_BORDER_SIZE,
+          alignItems: 'flex-start',
           height: AVATAR_CONTAINER_SIZE,
           marginBottom: Styles.globalMargins.small,
           marginTop: Styles.globalMargins.medium,
-          overflow: 'hidden',
+          outlineStyle: 'dotted',
+          outlineWidth: AVATAR_BORDER_SIZE,
+          // overflow: 'hidden',
           position: 'relative',
           width: AVATAR_CONTAINER_SIZE,
         },
@@ -646,8 +703,9 @@ const hoverStyles = Styles.styleSheetCreate(
 const styles = Styles.styleSheetCreate(() => ({
   container: {
     ...Styles.globalStyles.flexBoxColumn,
-    ...Styles.padding(Styles.globalMargins.xlarge, 0),
     alignItems: 'center',
+    flexGrow: 1,
+    paddingTop: Styles.globalMargins.small,
   },
   createdBanner: {
     backgroundColor: Styles.globalColors.green,

--- a/shared/profile/edit-avatar/index.native.tsx
+++ b/shared/profile/edit-avatar/index.native.tsx
@@ -98,16 +98,6 @@ class AvatarUpload extends React.Component<Props & WrappedProps> {
     const rW = this._w !== 0 && width ? width / this._w : 1
     const x0 = rW * x
     const y0 = rH * y
-    // console.log('aaaa', {
-    //   width,
-    //   height,
-    //   x,
-    //   y,
-    //   rH,
-    //   rW,
-    //   x0,
-    //   y0,
-    // })
     return {
       x0: Math.round(x0),
       x1: Math.round((x + this.avatar_size()) * rW),

--- a/shared/profile/edit-avatar/index.native.tsx
+++ b/shared/profile/edit-avatar/index.native.tsx
@@ -98,6 +98,16 @@ class AvatarUpload extends React.Component<Props & WrappedProps> {
     const rW = this._w !== 0 && width ? width / this._w : 1
     const x0 = rW * x
     const y0 = rH * y
+    // console.log('aaaa', {
+    //   width,
+    //   height,
+    //   x,
+    //   y,
+    //   rH,
+    //   rW,
+    //   x0,
+    //   y0,
+    // })
     return {
       x0: Math.round(x0),
       x1: Math.round((x + this.avatar_size()) * rW),
@@ -112,6 +122,7 @@ class AvatarUpload extends React.Component<Props & WrappedProps> {
     this._x = x
     this._y = y
     this._z = true
+    console.log('aaa on zoomnative', {height, width, x, y})
   }
 
   _imageDimensions = () => {

--- a/shared/profile/edit-avatar/index.native.tsx
+++ b/shared/profile/edit-avatar/index.native.tsx
@@ -154,7 +154,7 @@ class AvatarUpload extends React.Component<Props & WrappedProps> {
       <Kb.ZoomableImage
         src={uri}
         onChanged={this._onZoom}
-        style={isIOS ? Styles.collapseStyles([styles.zoomContainer, this.getImageStyle()]) : null}
+        style={Styles.collapseStyles([styles.zoomContainer, this.getImageStyle()])}
       />
     ) : null
   }

--- a/shared/profile/edit-avatar/index.native.tsx
+++ b/shared/profile/edit-avatar/index.native.tsx
@@ -112,7 +112,6 @@ class AvatarUpload extends React.Component<Props & WrappedProps> {
     this._x = x
     this._y = y
     this._z = true
-    console.log('aaa on zoomnative', {height, width, x, y})
   }
 
   _imageDimensions = () => {


### PR DESCRIPTION
This leverages the zoomable-image component for the edit avatar flow so it matches what mobile does.
I also made the view bigger so its easier to use
This also simplifies the zoomable image while adding the concept of a click and drag 'mode' and handles the transforms way simpler