### PR TITLE
fix keyboard race

### DIFF
--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -6,13 +6,14 @@ import * as Container from '../util/container'
 import {chatDebugEnabled} from '../constants/chat2/debug'
 import Main from './main.native'
 import makeStore from '../store/configure-store'
-import {AppRegistry, AppState, Appearance, Linking} from 'react-native'
+import {AppRegistry, AppState, Appearance, Linking, Keyboard} from 'react-native'
 import {PortalProvider} from '../common-adapters/portal.native'
 import {Provider, useDispatch} from 'react-redux'
 import {SafeAreaProvider, initialWindowMetrics} from 'react-native-safe-area-context'
 import {makeEngine} from '../engine'
 import {GestureHandlerRootView} from 'react-native-gesture-handler'
 import {enableFreeze} from 'react-native-screens'
+import {setKeyboardUp} from '../styles/keyboard-state'
 enableFreeze(true)
 
 type ConfigureStore = ReturnType<typeof makeStore>
@@ -56,10 +57,27 @@ const ReduxHelper = (p: {children: React.ReactNode}) => {
       dispatch(DeeplinksGen.createLink({link: url}))
     })
 
+    const kbSubWS = Keyboard.addListener('keyboardWillShow', () => {
+      setKeyboardUp(true)
+    })
+    const kbSubDS = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardUp(true)
+    })
+    const kbSubWH = Keyboard.addListener('keyboardWillHide', () => {
+      setKeyboardUp(false)
+    })
+    const kbSubDH = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardUp(false)
+    })
+
     return () => {
       appStateChangeSub.remove()
       darkSub.remove()
       linkingSub.remove()
+      kbSubWS.remove()
+      kbSubDS.remove()
+      kbSubWH.remove()
+      kbSubDH.remove()
     }
   }, [dispatch])
 

--- a/shared/common-adapters/keyboard-avoiding-view.native.tsx
+++ b/shared/common-adapters/keyboard-avoiding-view.native.tsx
@@ -16,6 +16,7 @@ import {
 import {useHeaderHeight} from '@react-navigation/elements'
 import type {Props as KAVProps} from './keyboard-avoiding-view'
 import * as React from 'react'
+import {getKeyboardUp} from '../styles/keyboard-state'
 
 type Props = React.ComponentProps<typeof OldKeyboardAvoidingViewType> & {extraPadding?: number}
 
@@ -125,8 +126,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       this._bottom = 0
       this.setState({bottom: 0})
 
-      // @ts-ignore actually exists but not in the api until 71
-      if (Keyboard.isVisible()) {
+      if (getKeyboardUp()) {
         // @ts-ignore actually exists but not in the api until 71
         const h = Keyboard.metrics()?.height ?? 0
         this._bottom = h

--- a/shared/styles/keyboard-state.tsx
+++ b/shared/styles/keyboard-state.tsx
@@ -1,0 +1,8 @@
+// Keep track of keyboard state, ran by the ReduxHelper in main app
+// Keyboard.isVisible() internal bookkeeping is actually racy and can't be trusted
+let _up = false
+
+export const setKeyboardUp = (up: boolean) => {
+  _up = up
+}
+export const getKeyboardUp = () => _up


### PR DESCRIPTION
if you hit back while backgrounding on ios you can get the `Keyboard.isVisible()` to miss the keyboard dismissal message. So instead we track this at the app level and stash it into a new module var