### PR TITLE
video fixes

### DIFF
--- a/shared/chat/conversation/fwd-msg/team-picker.tsx
+++ b/shared/chat/conversation/fwd-msg/team-picker.tsx
@@ -63,7 +63,7 @@ const TeamPicker = (props: Props) => {
         {
           if (message.inlineVideoPlayable) {
             const url = `${message.fileURL}&contentforce=true`
-            preview = url ? <Kb.Video allowFile={true} url={url} /> : null
+            preview = url ? <Kb.Video allowFile={true} url={url} muted={true} /> : null
           } else {
             const src = message.fileURL ?? message.previewURL
             preview = src ? <Kb.ZoomableImage src={src} style={styles.image} /> : null

--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -10,7 +10,7 @@ import SpecialBottomMessage from '../messages/special-bottom-message'
 import SpecialTopMessage from '../messages/special-top-message'
 import type * as Types from '../../../constants/types/chat2'
 import type {ItemType} from '.'
-import {Animated, FlatList} from 'react-native'
+import {FlatList} from 'react-native'
 import {ConvoIDContext, SeparatorMapContext} from '../messages/ids-context'
 import {FlashList, type ListRenderItemInfo} from '@shopify/flash-list'
 import {getMessageRender} from '../messages/wrapper'
@@ -22,97 +22,6 @@ import {useChatDebugDump} from '../../../constants/chat2/debug'
 import {usingFlashList} from './flashlist-config'
 
 const List = usingFlashList ? FlashList : FlatList
-
-// Bookkeep whats animating so it finishes and isn't replaced, if we've animated it we keep the key and use null
-const animatingMap = new Map<string, null | React.ReactElement>()
-
-type AnimatedChildProps = {
-  animatingKey: string
-  children: React.ReactNode
-}
-const AnimatedChild = React.memo(function AnimatedChild({children, animatingKey}: AnimatedChildProps) {
-  const translateY = new Animated.Value(999)
-  const opacity = new Animated.Value(0)
-  React.useEffect(() => {
-    // on unmount, mark it null
-    return () => {
-      animatingMap.set(animatingKey, null)
-    }
-  }, [animatingKey])
-
-  // only animate up once
-  const onceRef = React.useRef(false)
-
-  React.useEffect(() => {
-    onceRef.current = false
-  }, [animatingKey])
-
-  return (
-    <Animated.View
-      style={{opacity, overflow: 'hidden', transform: [{translateY}], width: '100%'}}
-      onLayout={(e: any) => {
-        const {height} = e.nativeEvent.layout
-        if (onceRef.current) {
-          return
-        }
-        onceRef.current = true
-        translateY.setValue(height + 10)
-        Animated.parallel([
-          Animated.timing(opacity, {
-            duration: 200,
-            toValue: 1,
-            useNativeDriver: true,
-          }),
-          Animated.timing(translateY, {
-            duration: 200,
-            toValue: 0,
-            useNativeDriver: true,
-          }),
-        ]).start(() => {
-          animatingMap.set(animatingKey, null)
-        })
-      }}
-    >
-      {children}
-    </Animated.View>
-  )
-})
-
-type SentProps = {
-  children?: React.ReactElement
-  ordinal: Types.Ordinal
-}
-const Sent = React.memo(function Sent({ordinal}: SentProps) {
-  const conversationIDKey = React.useContext(ConvoIDContext)
-  const {subType, youSent} = Container.useSelector(state => {
-    const you = state.config.username
-    const message = state.chat2.messageMap.get(conversationIDKey)?.get(ordinal)
-    const youSent = message && message.author === you && message.ordinal !== message.id
-    const subType = message ? Constants.getMessageRenderType(message) : undefined
-    return {subType, youSent}
-  }, shallowEqual)
-  const key = `${conversationIDKey}:${ordinal}`
-  const state = animatingMap.get(key)
-
-  if (!subType) return null
-
-  // if its animating always show it
-  if (state) {
-    return state
-  }
-
-  const Clazz = getMessageRender(subType)
-  if (!Clazz) return null
-  const children = <Clazz ordinal={ordinal} />
-  // if state is null we already animated it
-  if (youSent && state === undefined) {
-    const c = <AnimatedChild animatingKey={key}>{children}</AnimatedChild>
-    animatingMap.set(key, c)
-    return c
-  } else {
-    return children || null
-  }
-})
 
 // We load the first thread automatically so in order to mark it read
 // we send an action on the first mount once
@@ -238,11 +147,6 @@ const ConversationList = React.memo(function ConversationList(p: {
       if (!ordinal) {
         return null
       }
-
-      if (!index) {
-        return <Sent ordinal={ordinal} />
-      }
-
       const type = messageTypeMap?.get(ordinal) ?? 'text'
       if (!type) return null
       const Clazz = getMessageRender(type)

--- a/shared/chat/conversation/messages/wrapper/sent.tsx
+++ b/shared/chat/conversation/messages/wrapper/sent.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import {Animated} from 'react-native'
+// Bookkeep whats animating so it finishes and isn't replaced, if we've animated it we keep the key and use null
+const animatingMap = new Map<string, null | React.ReactElement>()
+
+type AnimatedChildProps = {
+  animatingKey: string
+  children: React.ReactNode
+}
+const AnimatedChild = React.memo(function AnimatedChild({children, animatingKey}: AnimatedChildProps) {
+  const [done, setDone] = React.useState(false)
+  const translateY = React.useRef(new Animated.Value(999)).current
+  const opacity = React.useRef(new Animated.Value(0)).current
+  React.useEffect(() => {
+    // on unmount, mark it null
+    return () => {
+      animatingMap.set(animatingKey, null)
+    }
+  }, [animatingKey])
+
+  // only animate up once
+  const onceRef = React.useRef(false)
+
+  React.useEffect(() => {
+    onceRef.current = false
+  }, [animatingKey])
+
+  console.log('aaa animating view', animatingKey, !done)
+  return done ? (
+    <>{children}</>
+  ) : (
+    <Animated.View
+      style={{opacity, overflow: 'hidden', transform: [{translateY}], width: '100%'}}
+      onLayout={(e: any) => {
+        if (onceRef.current) {
+          return
+        }
+        const {height} = e.nativeEvent.layout
+        onceRef.current = true
+        translateY.setValue(height + 10)
+        Animated.parallel([
+          Animated.timing(opacity, {
+            duration: 200,
+            toValue: 1,
+            useNativeDriver: true,
+          }),
+          Animated.timing(translateY, {
+            duration: 200,
+            toValue: 0,
+            useNativeDriver: true,
+          }),
+        ]).start(() => {
+          animatingMap.set(animatingKey, null)
+          setDone(true)
+        })
+      }}
+    >
+      {children}
+    </Animated.View>
+  )
+})
+
+type SentProps = {
+  children: React.ReactNode
+  sentKey: string
+}
+export const Sent = function Sent(p: SentProps) {
+  const {children, sentKey} = p
+  const state = animatingMap.get(sentKey)
+
+  console.log('aaa', animatingMap, sentKey, state)
+
+  // if its animating always show it
+  if (state) {
+    return state
+  }
+
+  // if state is null we already animated it
+  if (state === undefined) {
+    const c = <AnimatedChild animatingKey={sentKey}>{children}</AnimatedChild>
+    animatingMap.set(sentKey, c)
+    return c
+  } else {
+    return <>{children}</>
+  }
+}

--- a/shared/chat/conversation/messages/wrapper/sent.tsx
+++ b/shared/chat/conversation/messages/wrapper/sent.tsx
@@ -25,7 +25,6 @@ const AnimatedChild = React.memo(function AnimatedChild({children, animatingKey}
     onceRef.current = false
   }, [animatingKey])
 
-  console.log('aaa animating view', animatingKey, !done)
   return done ? (
     <>{children}</>
   ) : (
@@ -67,8 +66,6 @@ type SentProps = {
 export const Sent = function Sent(p: SentProps) {
   const {children, sentKey} = p
   const state = animatingMap.get(sentKey)
-
-  console.log('aaa', animatingMap, sentKey, state)
 
   // if its animating always show it
   if (state) {

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -18,6 +18,7 @@ import SendIndicator from './send-indicator'
 import type * as Types from '../../../../constants/types/chat2'
 import capitalize from 'lodash/capitalize'
 import {useEdited} from './edited'
+import {Sent} from './sent'
 // import {useDebugLayout} from '../../../../util/debug'
 
 export type Props = {
@@ -128,6 +129,7 @@ const useRedux = (conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ord
     const you = state.config.username
     const m = Constants.getMessage(state, conversationIDKey, ordinal) ?? missingMessage
     const {exploded, submitState, author, id, botUsername} = m
+    const youSent = m.author === you && m.ordinal !== m.id
     const exploding = !!m.exploding
     const isPendingPayment = Constants.isPendingPaymentMessage(state, m)
     const decorate = !exploded && !m.errorReason
@@ -159,6 +161,7 @@ const useRedux = (conversationIDKey: Types.ConversationIDKey, ordinal: Types.Ord
       showSendIndicator,
       type,
       you,
+      youSent,
     }
   }, shallowEqual)
 }
@@ -483,14 +486,21 @@ export const WrapperMessage = React.memo(function WrapperMessage(p: WMProps) {
 
   const {isPendingPayment, decorate, type, hasReactions, isEditing} = mdata
   const {ecrType, showSendIndicator, showRevoked, showExplodingCountdown, exploding} = mdata
-  const {reactionsPopupPosition, showCoinsIcon, botname, you} = mdata
+  const {reactionsPopupPosition, showCoinsIcon, botname, you, youSent} = mdata
 
   const canFixOverdraw = !isPendingPayment && !showCenteredHighlight && !isEditing
+
+  const maybeSentChildren =
+    Container.isMobile && youSent ? (
+      <Sent sentKey={`${conversationIDKey}:${ordinal}`}>{children}</Sent>
+    ) : (
+      children
+    )
 
   const tsprops = {
     botname,
     bottomChildren,
-    children,
+    children: maybeSentChildren,
     decorate,
     ecrType,
     exploding,


### PR DESCRIPTION
- [x] mute on forward
- [x] video pause on incoming

A longstanding issue. We special case animating in message that you send on mobile. This was wrapped at the outermost level when rendering it in the list. This means that when an item transitions from being at the very bottom to be second from the bottom it'll entirely remount at the very top, which means all state is lost (which includes actually playing).
Instead we keep the `<Wrapper><Item/></Wrapper>` hierarchy but inject `<Sent>` around `Item` which allows us to retain state. `Sent` itself will remount the components after they're done animating so we don't have to pay for the overhead of having the components inbetween after animating. We could just keep it it and have less thrash but i think its fine for now. This does have the side effect that after the video animates up its just in a `Sent` without any animated wrapper so it'll stay static while still onscreen. Theoretically if you click play while its animating up you'll also lose state , but now this state could be correctly held in the outer wrapper, but this won't practically ever happen