### PR TITLE
zus config 3 dark mode

### DIFF
--- a/shared/actions/config-gen.tsx
+++ b/shared/actions/config-gen.tsx
@@ -17,6 +17,7 @@ export const checkForUpdate = 'config:checkForUpdate'
 export const copyToClipboard = 'config:copyToClipboard'
 export const daemonHandshake = 'config:daemonHandshake'
 export const daemonHandshakeDone = 'config:daemonHandshakeDone'
+export const darkModePreferenceChanged = 'config:darkModePreferenceChanged'
 export const dumpLogs = 'config:dumpLogs'
 export const filePickerError = 'config:filePickerError'
 export const followerInfoUpdated = 'config:followerInfoUpdated'
@@ -42,7 +43,6 @@ export const pushLoaded = 'config:pushLoaded'
 export const remoteWindowWantsProps = 'config:remoteWindowWantsProps'
 export const restartHandshake = 'config:restartHandshake'
 export const revoked = 'config:revoked'
-export const setDarkModePreference = 'config:setDarkModePreference'
 export const setDeletedSelf = 'config:setDeletedSelf'
 export const setIncomingShareUseOriginal = 'config:setIncomingShareUseOriginal'
 export const setNavigator = 'config:setNavigator'
@@ -259,6 +259,10 @@ export const createCopyToClipboard = (payload: {readonly text: string}) => ({
   payload,
   type: copyToClipboard as typeof copyToClipboard,
 })
+export const createDarkModePreferenceChanged = (payload?: undefined) => ({
+  payload,
+  type: darkModePreferenceChanged as typeof darkModePreferenceChanged,
+})
 export const createDumpLogs = (payload: {readonly reason: 'quitting through menu'}) => ({
   payload,
   type: dumpLogs as typeof dumpLogs,
@@ -302,9 +306,6 @@ export const createRevoked = (payload: {
   readonly wasCurrentDevice: boolean
   readonly deviceName: string
 }) => ({payload, type: revoked as typeof revoked})
-export const createSetDarkModePreference = (payload: {
-  readonly preference: 'system' | 'alwaysDark' | 'alwaysLight'
-}) => ({payload, type: setDarkModePreference as typeof setDarkModePreference})
 export const createSetDeletedSelf = (payload: {readonly deletedUsername: string}) => ({
   payload,
   type: setDeletedSelf as typeof setDeletedSelf,
@@ -379,6 +380,7 @@ export type CheckForUpdatePayload = ReturnType<typeof createCheckForUpdate>
 export type CopyToClipboardPayload = ReturnType<typeof createCopyToClipboard>
 export type DaemonHandshakeDonePayload = ReturnType<typeof createDaemonHandshakeDone>
 export type DaemonHandshakePayload = ReturnType<typeof createDaemonHandshake>
+export type DarkModePreferenceChangedPayload = ReturnType<typeof createDarkModePreferenceChanged>
 export type DumpLogsPayload = ReturnType<typeof createDumpLogs>
 export type FilePickerErrorPayload = ReturnType<typeof createFilePickerError>
 export type FollowerInfoUpdatedPayload = ReturnType<typeof createFollowerInfoUpdated>
@@ -404,7 +406,6 @@ export type PushLoadedPayload = ReturnType<typeof createPushLoaded>
 export type RemoteWindowWantsPropsPayload = ReturnType<typeof createRemoteWindowWantsProps>
 export type RestartHandshakePayload = ReturnType<typeof createRestartHandshake>
 export type RevokedPayload = ReturnType<typeof createRevoked>
-export type SetDarkModePreferencePayload = ReturnType<typeof createSetDarkModePreference>
 export type SetDeletedSelfPayload = ReturnType<typeof createSetDeletedSelf>
 export type SetIncomingShareUseOriginalPayload = ReturnType<typeof createSetIncomingShareUseOriginal>
 export type SetNavigatorPayload = ReturnType<typeof createSetNavigator>
@@ -439,6 +440,7 @@ export type Actions =
   | CopyToClipboardPayload
   | DaemonHandshakeDonePayload
   | DaemonHandshakePayload
+  | DarkModePreferenceChangedPayload
   | DumpLogsPayload
   | FilePickerErrorPayload
   | FollowerInfoUpdatedPayload
@@ -464,7 +466,6 @@ export type Actions =
   | RemoteWindowWantsPropsPayload
   | RestartHandshakePayload
   | RevokedPayload
-  | SetDarkModePreferencePayload
   | SetDeletedSelfPayload
   | SetIncomingShareUseOriginalPayload
   | SetNavigatorPayload

--- a/shared/actions/config/index.tsx
+++ b/shared/actions/config/index.tsx
@@ -13,6 +13,7 @@ import * as Router2 from '../../constants/router2'
 import * as SettingsConstants from '../../constants/settings'
 import * as SettingsGen from '../settings-gen'
 import * as Tabs from '../../constants/tabs'
+import * as DarkMode from '../../constants/darkmode'
 import {useAvatarState} from '../../common-adapters/avatar-zus'
 import logger from '../../logger'
 import {initPlatformListener} from '../platform-specific'
@@ -476,7 +477,7 @@ const onPowerMonitorEvent = async (_s: unknown, action: ConfigGen.PowerMonitorEv
 
 const initConfig = () => {
   Container.listenAction(ConfigGen.daemonHandshake, () => {
-    Constants.useConfigState.getState().dispatch.loadDarkPrefs()
+    DarkMode.useDarkModeState.getState().dispatch.loadDarkPrefs()
   })
   // Re-get info about our account if you log in/we're done handshaking/became reachable
   Container.listenAction(
@@ -587,8 +588,11 @@ const initConfig = () => {
   })
 
   Container.listenAction(ConfigGen.setSystemDarkMode, (_, action) => {
-    const {setSystemDarkMode} = Constants.useConfigState.getState().dispatch
-    setSystemDarkMode(action.payload.dark)
+    // only to bridge electron bridge, todo remove this
+    if (!Container.isMobile) {
+      const {setSystemDarkMode} = DarkMode.useDarkModeState.getState().dispatch
+      setSystemDarkMode(action.payload.dark)
+    }
   })
 }
 

--- a/shared/actions/json/config.json
+++ b/shared/actions/json/config.json
@@ -117,9 +117,7 @@
       "type": "Types.ConnectionType",
       "isInit?": "boolean"
     },
-    "setDarkModePreference": {
-      "preference": ["'system'", "'alwaysDark'", "'alwaysLight'"]
-    },
+    "darkModePreferenceChanged": {},
     "setSystemDarkMode": {"dark": "boolean"},
     "updateHTTPSrvInfo": {
       "address": "string",

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -1,8 +1,10 @@
 import * as Chat2Gen from '../chat2-gen'
 import * as Clipboard from 'expo-clipboard'
+import * as ConfigConstants from '../../constants/config'
 import * as ConfigGen from '../config-gen'
 import * as Contacts from 'expo-contacts'
 import * as Container from '../../util/container'
+import * as DarkMode from '../../constants/darkmode'
 import * as EngineGen from '../engine-gen-gen'
 import * as ExpoLocation from 'expo-location'
 import * as ExpoTaskManager from 'expo-task-manager'
@@ -14,7 +16,6 @@ import * as RPCTypes from '../../constants/types/rpc-gen'
 import * as RouteTreeGen from '../route-tree-gen'
 import * as RouterConstants from '../../constants/router2'
 import * as SettingsConstants from '../../constants/settings'
-import * as ConfigConstants from '../../constants/config'
 import * as SettingsGen from '../settings-gen'
 import * as Tabs from '../../constants/tabs'
 import * as Types from '../../constants/types/chat2'
@@ -787,7 +788,7 @@ export const initPlatformListener = () => {
   Container.listenAction(ConfigGen.daemonHandshake, checkNav)
   Container.listenAction(ConfigGen.darkModePreferenceChanged, () => {
     if (isAndroid) {
-      const {darkModePreference} = ConfigConstants.useConfigState.getState()
+      const {darkModePreference} = DarkMode.useDarkModeState.getState()
       androidAppColorSchemeChanged?.(darkModePreference ?? '')
     }
   })

--- a/shared/actions/platform-specific/index.native.tsx
+++ b/shared/actions/platform-specific/index.native.tsx
@@ -741,12 +741,6 @@ const checkNav = async (
   }
 }
 
-const notifyNativeOfDarkModeChange = (state: Container.TypedState) => {
-  if (isAndroid) {
-    androidAppColorSchemeChanged?.(state.config.darkModePreference ?? '')
-  }
-}
-
 const initAudioModes = () => {
   setupAudioMode(false)
     .then(() => {})
@@ -791,7 +785,12 @@ export const initPlatformListener = () => {
   }
 
   Container.listenAction(ConfigGen.daemonHandshake, checkNav)
-  Container.listenAction(ConfigGen.setDarkModePreference, notifyNativeOfDarkModeChange)
+  Container.listenAction(ConfigGen.darkModePreferenceChanged, () => {
+    if (isAndroid) {
+      const {darkModePreference} = ConfigConstants.useConfigState.getState()
+      androidAppColorSchemeChanged?.(darkModePreference ?? '')
+    }
+  })
 
   Container.listenAction(RouteTreeGen.onNavChanged, onPersistRoute)
 

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -1,15 +1,24 @@
-import uniq from 'lodash/uniq'
-import type * as RPCTypes from './types/rpc-gen'
-import type * as Types from './types/config'
-import {noConversationIDKey} from './types/chat2/common'
 import * as ConfigGen from '../actions/config-gen'
 import HiddenString from '../util/hidden-string'
+import * as RPCTypes from './types/rpc-gen'
+import type * as Types from './types/config'
+import uniq from 'lodash/uniq'
 import {defaultUseNativeFrame, runMode} from './platform'
-import {isDarkMode as _isDarkMode} from '../styles/dark-mode'
+import {
+  type DarkModePreference,
+  _setSystemIsDarkMode,
+  _setDarkModePreference,
+  isDarkMode as _isDarkMode,
+} from '../styles/dark-mode'
+import {noConversationIDKey} from './types/chat2/common'
 // normally util.container but it re-exports from us so break the cycle
 import {create as createZustand} from 'zustand'
 import {immer as immerZustand} from 'zustand/middleware/immer'
 import {getReduxDispatch} from '../util/zustand'
+
+const ignorePromise = (f: Promise<void>) => {
+  f.then(() => {}).catch(() => {})
+}
 
 export const loginAsOtherUserWaitingKey = 'config:loginAsOther'
 export const createOtherAccountWaitingKey = 'config:createOther'
@@ -27,7 +36,6 @@ export const publicFolderWithUsers = (users: Array<string>) =>
 export const teamFolder = (team: string) => `${defaultKBFSPath}${defaultTeamPrefix}${team}`
 
 export const initialState: Types.State = {
-  darkModePreference: 'system',
   deviceID: '',
   deviceName: '',
   followers: new Set(),
@@ -55,7 +63,6 @@ export const initialState: Types.State = {
   startupLink: '',
   startupPushPayload: undefined,
   startupWasFromPush: false,
-  systemDarkMode: false,
   uid: '',
   useNativeFrame: defaultUseNativeFrame,
   userActive: true,
@@ -75,7 +82,7 @@ export const initialState: Types.State = {
 }
 
 // we proxy the style helper to keep the logic in one place but act like a selector
-export const isDarkMode = (_: Types.State) => _isDarkMode()
+export const isDarkMode = () => _isDarkMode()
 
 export type ZStore = {
   allowAnimatedEmojis: boolean
@@ -91,13 +98,17 @@ export type ZStore = {
   appFocused: boolean
   configuredAccounts: Array<Types.ConfiguredAccount>
   defaultUsername: string
+  darkModePreference: DarkModePreference
+  systemDarkMode: boolean
 }
 
 const initialZState: ZStore = {
   allowAnimatedEmojis: true,
   appFocused: true,
   configuredAccounts: [],
+  darkModePreference: 'system',
   defaultUsername: '',
+  systemDarkMode: false,
 }
 
 type ZState = ZStore & {
@@ -108,6 +119,9 @@ type ZState = ZStore & {
     changedFocus: (f: boolean) => void
     setAccounts: (a: ZStore['configuredAccounts']) => void
     setDefaultUsername: (u: string) => void
+    loadDarkPrefs: () => void
+    setDarkModePreference: (p: DarkModePreference) => void
+    setSystemDarkMode: (dark: boolean) => void
   }
 }
 
@@ -122,11 +136,30 @@ export const useConfigState = createZustand(
         })
         reduxDispatch(ConfigGen.createChangedFocus({appFocused: f}))
       },
+      loadDarkPrefs: () => {
+        const f = async () => {
+          const v = await RPCTypes.configGuiGetValueRpcPromise({path: 'ui.darkMode'})
+          const preference = v.s
+          switch (preference) {
+            case 'system':
+            case 'alwaysDark': // fallthrough
+            case 'alwaysLight': // fallthrough
+              _setDarkModePreference(preference)
+              set(s => {
+                s.darkModePreference = preference
+              })
+              break
+            default:
+          }
+        }
+        ignorePromise(f())
+      },
       reset: () => {
         set(s => ({
           ...initialState,
           appFocused: s.appFocused,
           configuredAccounts: s.configuredAccounts,
+          darkModePreference: s.darkModePreference,
           defaultUsername: s.defaultUsername,
         }))
       },
@@ -145,9 +178,28 @@ export const useConfigState = createZustand(
           s.androidShare = share
         })
       },
+      setDarkModePreference: (p: DarkModePreference) => {
+        _setDarkModePreference(p)
+        set(s => {
+          s.darkModePreference = p
+        })
+        const f = async () => {
+          await RPCTypes.configGuiSetValueRpcPromise({
+            path: 'ui.darkMode',
+            value: {isNull: false, s: p},
+          })
+        }
+        ignorePromise(f())
+      },
       setDefaultUsername: (u: string) => {
         set(s => {
           s.defaultUsername = u
+        })
+      },
+      setSystemDarkMode: (dark: boolean) => {
+        _setSystemIsDarkMode(dark)
+        set(s => {
+          s.systemDarkMode = dark
         })
       },
     }

--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -1,24 +1,14 @@
 import * as ConfigGen from '../actions/config-gen'
 import HiddenString from '../util/hidden-string'
-import * as RPCTypes from './types/rpc-gen'
+import type * as RPCTypes from './types/rpc-gen'
 import type * as Types from './types/config'
 import uniq from 'lodash/uniq'
 import {defaultUseNativeFrame, runMode} from './platform'
-import {
-  type DarkModePreference,
-  _setSystemIsDarkMode,
-  _setDarkModePreference,
-  isDarkMode as _isDarkMode,
-} from '../styles/dark-mode'
 import {noConversationIDKey} from './types/chat2/common'
 // normally util.container but it re-exports from us so break the cycle
 import {create as createZustand} from 'zustand'
 import {immer as immerZustand} from 'zustand/middleware/immer'
 import {getReduxDispatch} from '../util/zustand'
-
-const ignorePromise = (f: Promise<void>) => {
-  f.then(() => {}).catch(() => {})
-}
 
 export const loginAsOtherUserWaitingKey = 'config:loginAsOther'
 export const createOtherAccountWaitingKey = 'config:createOther'
@@ -81,9 +71,6 @@ export const initialState: Types.State = {
   },
 }
 
-// we proxy the style helper to keep the logic in one place but act like a selector
-export const isDarkMode = () => _isDarkMode()
-
 export type ZStore = {
   allowAnimatedEmojis: boolean
   androidShare?:
@@ -98,17 +85,13 @@ export type ZStore = {
   appFocused: boolean
   configuredAccounts: Array<Types.ConfiguredAccount>
   defaultUsername: string
-  darkModePreference: DarkModePreference
-  systemDarkMode: boolean
 }
 
 const initialZState: ZStore = {
   allowAnimatedEmojis: true,
   appFocused: true,
   configuredAccounts: [],
-  darkModePreference: 'system',
   defaultUsername: '',
-  systemDarkMode: false,
 }
 
 type ZState = ZStore & {
@@ -119,9 +102,6 @@ type ZState = ZStore & {
     changedFocus: (f: boolean) => void
     setAccounts: (a: ZStore['configuredAccounts']) => void
     setDefaultUsername: (u: string) => void
-    loadDarkPrefs: () => void
-    setDarkModePreference: (p: DarkModePreference) => void
-    setSystemDarkMode: (dark: boolean) => void
   }
 }
 
@@ -136,30 +116,11 @@ export const useConfigState = createZustand(
         })
         reduxDispatch(ConfigGen.createChangedFocus({appFocused: f}))
       },
-      loadDarkPrefs: () => {
-        const f = async () => {
-          const v = await RPCTypes.configGuiGetValueRpcPromise({path: 'ui.darkMode'})
-          const preference = v.s
-          switch (preference) {
-            case 'system':
-            case 'alwaysDark': // fallthrough
-            case 'alwaysLight': // fallthrough
-              _setDarkModePreference(preference)
-              set(s => {
-                s.darkModePreference = preference
-              })
-              break
-            default:
-          }
-        }
-        ignorePromise(f())
-      },
       reset: () => {
         set(s => ({
-          ...initialState,
+          ...initialZState,
           appFocused: s.appFocused,
           configuredAccounts: s.configuredAccounts,
-          darkModePreference: s.darkModePreference,
           defaultUsername: s.defaultUsername,
         }))
       },
@@ -178,28 +139,9 @@ export const useConfigState = createZustand(
           s.androidShare = share
         })
       },
-      setDarkModePreference: (p: DarkModePreference) => {
-        _setDarkModePreference(p)
-        set(s => {
-          s.darkModePreference = p
-        })
-        const f = async () => {
-          await RPCTypes.configGuiSetValueRpcPromise({
-            path: 'ui.darkMode',
-            value: {isNull: false, s: p},
-          })
-        }
-        ignorePromise(f())
-      },
       setDefaultUsername: (u: string) => {
         set(s => {
           s.defaultUsername = u
-        })
-      },
-      setSystemDarkMode: (dark: boolean) => {
-        _setSystemIsDarkMode(dark)
-        set(s => {
-          s.systemDarkMode = dark
         })
       },
     }

--- a/shared/constants/darkmode.tsx
+++ b/shared/constants/darkmode.tsx
@@ -1,0 +1,99 @@
+// normally util.container but it re-exports from us so break the cycle
+import * as RPCTypes from './types/rpc-gen'
+import {create as createZustand} from 'zustand'
+import {immer as immerZustand} from 'zustand/middleware/immer'
+
+export type DarkModePreference = 'system' | 'alwaysDark' | 'alwaysLight'
+
+export type ZStore = {
+  darkModePreference: DarkModePreference
+  systemDarkMode: boolean
+  supported: boolean
+}
+
+const initialState: ZStore = {
+  darkModePreference: 'system',
+  supported: false,
+  systemDarkMode: false,
+}
+
+type ZState = ZStore & {
+  isDarkMode: () => boolean
+  dispatch: {
+    loadDarkPrefs: () => void
+    setDarkModePreference: (p: DarkModePreference) => void
+    setSystemDarkMode: (dark: boolean) => void
+    setSystemSupported: (s: boolean) => void
+  }
+}
+
+const ignorePromise = (f: Promise<void>) => {
+  f.then(() => {}).catch(() => {})
+}
+
+export const useDarkModeState = createZustand(
+  immerZustand<ZState>((set, get) => {
+    const dispatch = {
+      loadDarkPrefs: () => {
+        const f = async () => {
+          const v = await RPCTypes.configGuiGetValueRpcPromise({path: 'ui.darkMode'})
+          const preference = v.s
+          switch (preference) {
+            case 'system':
+            case 'alwaysDark': // fallthrough
+            case 'alwaysLight': // fallthrough
+              set(s => {
+                s.darkModePreference = preference
+              })
+              break
+            default:
+          }
+        }
+        ignorePromise(f())
+      },
+      reset: () => {
+        set(s => ({
+          ...initialState,
+          darkModePreference: s.darkModePreference,
+        }))
+      },
+      setDarkModePreference: (p: DarkModePreference) => {
+        set(s => {
+          s.darkModePreference = p
+        })
+        const f = async () => {
+          await RPCTypes.configGuiSetValueRpcPromise({
+            path: 'ui.darkMode',
+            value: {isNull: false, s: p},
+          })
+        }
+        ignorePromise(f())
+      },
+      setSystemDarkMode: (dark: boolean) => {
+        set(s => {
+          s.systemDarkMode = dark
+        })
+      },
+      setSystemSupported: (sup: boolean) => {
+        set(s => {
+          s.supported = sup
+        })
+      },
+    }
+
+    return {
+      ...initialState,
+      dispatch,
+      isDarkMode: () => {
+        switch (get().darkModePreference) {
+          case 'system':
+            return get().systemDarkMode
+          case 'alwaysDark':
+            return true
+          case 'alwaysLight':
+            return false
+        }
+      },
+    }
+  })
+)

--- a/shared/constants/types/config.tsx
+++ b/shared/constants/types/config.tsx
@@ -2,7 +2,6 @@ import type * as NetInfo from '@react-native-community/netinfo'
 import type * as RPCTypes from './rpc-gen'
 import type HiddenString from '../../util/hidden-string'
 import type {ConversationIDKey} from './chat2'
-import type {DarkModePreference} from '../../styles/dark-mode'
 import type {RPCError} from '../../util/errors'
 import type {Tab} from '../tabs'
 
@@ -31,7 +30,6 @@ export type WindowState = {
 }
 
 export type State = {
-  darkModePreference: DarkModePreference
   deviceID: RPCTypes.DeviceID
   deviceName?: string
   followers: Set<string>
@@ -62,7 +60,6 @@ export type State = {
   startupFollowUser: string
   startupLink: string
   startupTab?: Tab
-  systemDarkMode: boolean
   windowShownCount: Map<string, number>
   windowState: WindowState
   uid: string

--- a/shared/desktop/app/main-window.desktop.tsx
+++ b/shared/desktop/app/main-window.desktop.tsx
@@ -278,7 +278,7 @@ const MainWindow = () => {
   loadWindowState()
 
   // pass to main window
-  htmlFile = htmlFile + `?darkModePreference=${darkModePreference || ''}`
+  htmlFile = htmlFile + `?darkModePreference=${darkModePreference || ''}&isDarkMode=${isDarkMode ? 1 : 0}`
   const win = new Electron.BrowserWindow({
     backgroundColor: isDarkMode ? '#191919' : '#ffffff',
     frame: useNativeFrame,

--- a/shared/desktop/renderer/container.desktop.tsx
+++ b/shared/desktop/renderer/container.desktop.tsx
@@ -1,18 +1,22 @@
 import * as React from 'react'
 import {Provider} from 'react-redux'
 import {GlobalKeyEventHandler} from '../../util/key-event-handler.desktop'
-import {CanFixOverdrawContext} from '../../styles'
+import {CanFixOverdrawContext, DarkModeContext} from '../../styles'
 import * as Container from '../../util/container'
+import * as DarkMode from '../../constants/darkmode'
 import './style.css'
 
 // if we want to load the read profiler before the app is loaded
 const deferLoadingApp = __DEV__ && false
 
 const Root = ({store, children}: any) => {
+  const darkMode = DarkMode.useDarkModeState(s => s.isDarkMode())
   return (
     <GlobalKeyEventHandler>
       <CanFixOverdrawContext.Provider value={true}>
-        <Provider store={store}>{children}</Provider>
+        <DarkModeContext.Provider value={darkMode}>
+          <Provider store={store}>{children}</Provider>
+        </DarkModeContext.Provider>
       </CanFixOverdrawContext.Provider>
     </GlobalKeyEventHandler>
   )

--- a/shared/desktop/renderer/main.desktop.tsx
+++ b/shared/desktop/renderer/main.desktop.tsx
@@ -1,14 +1,15 @@
 // Entry point to the chrome part of the app: ORDER IS IMPORTANT
 import './globals.desktop'
-import {_setSystemIsDarkMode, _setSystemSupported} from '../../styles/dark-mode'
 import {isDarwin, isWindows} from '../../constants/platform'
 import {enableMapSet} from 'immer'
 import '../../why-did-you-render'
 import KB2, {waitOnKB2Loaded} from '../../util/electron.desktop'
+import * as DarkMode from '../../constants/darkmode'
 
 enableMapSet()
 waitOnKB2Loaded(() => {
-  _setSystemIsDarkMode(KB2.constants.startDarkMode)
-  _setSystemSupported(isDarwin || isWindows)
+  const {setSystemSupported, setSystemDarkMode} = DarkMode.useDarkModeState.getState().dispatch
+  setSystemDarkMode(KB2.constants.startDarkMode)
+  setSystemSupported(isDarwin || isWindows)
   require('./main2.desktop')
 })

--- a/shared/desktop/renderer/main2.desktop.tsx
+++ b/shared/desktop/renderer/main2.desktop.tsx
@@ -1,9 +1,9 @@
 // Entry point to the chrome part of the app
 import Main from '../../app/main.desktop'
 // order of the above 2 must NOT change. needed for patching / hot loading to be correct
-import {useSelector} from '../../util/container'
 import * as NotificationsGen from '../../actions/notifications-gen'
 import * as WaitingConstants from '../../constants/waiting'
+import * as DarkMode from '../../constants/darkmode'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import RemoteProxies from '../remote/proxies.desktop'
@@ -14,9 +14,7 @@ import {disableDragDrop} from '../../util/drag-drop.desktop'
 import flags from '../../util/feature-flags'
 import {dumpLogs} from '../../actions/platform-specific/index.desktop'
 import {initDesktopStyles} from '../../styles/index.desktop'
-import {_setDarkModePreference} from '../../styles/dark-mode'
 import {isWindows} from '../../constants/platform'
-import {isDarkMode} from '../../constants/config'
 import type {TypedActions} from '../../actions/typed-actions-gen'
 import KB2 from '../../util/electron.desktop'
 
@@ -25,13 +23,15 @@ const {ipcRendererOn, requestWindowsStartService, appStartedUp} = KB2.functions
 // node side plumbs through initial pref so we avoid flashes
 const darkModeFromNode = window.location.search.match(/darkModePreference=(alwaysLight|alwaysDark|system)/)
 
+const {setDarkModePreference} = DarkMode.useDarkModeState.getState().dispatch
+
 if (darkModeFromNode) {
   const dm = darkModeFromNode[1]
   switch (dm) {
     case 'alwaysLight':
     case 'alwaysDark':
     case 'system':
-      _setDarkModePreference(dm)
+      setDarkModePreference(dm)
   }
 }
 
@@ -118,7 +118,7 @@ const FontLoader = () => (
 let store
 
 const DarkCSSInjector = () => {
-  const isDark = useSelector(() => isDarkMode())
+  const isDark = DarkMode.useDarkModeState(s => s.isDarkMode())
   const [lastIsDark, setLastIsDark] = React.useState<boolean | undefined>()
   if (lastIsDark !== isDark) {
     setLastIsDark(isDark)

--- a/shared/desktop/renderer/main2.desktop.tsx
+++ b/shared/desktop/renderer/main2.desktop.tsx
@@ -118,7 +118,7 @@ const FontLoader = () => (
 let store
 
 const DarkCSSInjector = () => {
-  const isDark = useSelector(state => isDarkMode(state.config))
+  const isDark = useSelector(() => isDarkMode())
   const [lastIsDark, setLastIsDark] = React.useState<boolean | undefined>()
   if (lastIsDark !== isDark) {
     setLastIsDark(isDark)

--- a/shared/desktop/renderer/main2.desktop.tsx
+++ b/shared/desktop/renderer/main2.desktop.tsx
@@ -22,8 +22,9 @@ const {ipcRendererOn, requestWindowsStartService, appStartedUp} = KB2.functions
 
 // node side plumbs through initial pref so we avoid flashes
 const darkModeFromNode = window.location.search.match(/darkModePreference=(alwaysLight|alwaysDark|system)/)
+const isDarkFromNode = window.location.search.match(/isDarkMode=(0|1)/)
 
-const {setDarkModePreference} = DarkMode.useDarkModeState.getState().dispatch
+const {setDarkModePreference, setSystemDarkMode} = DarkMode.useDarkModeState.getState().dispatch
 
 if (darkModeFromNode) {
   const dm = darkModeFromNode[1]
@@ -33,6 +34,10 @@ if (darkModeFromNode) {
     case 'system':
       setDarkModePreference(dm)
   }
+}
+
+if (isDarkFromNode) {
+  setSystemDarkMode(isDarkFromNode[1] === '1')
 }
 
 // Top level HMR accept

--- a/shared/desktop/webpack.config.babel.js
+++ b/shared/desktop/webpack.config.babel.js
@@ -253,7 +253,7 @@ const config = (_, {mode}) => {
     </head>
     <body>
         <div id="root">
-            <div title="loading..." style="flex: 1;background-color: #f5f5f5"></div>
+            <div title="loading..." style="flex: 1"></div>
         </div>
         <div id="modal-root"></div>
         ${htmlWebpackPlugin.files.js.map(js => `<script src="${js}"></script>`).join('\n')} </body>

--- a/shared/index.android.js
+++ b/shared/index.android.js
@@ -5,7 +5,7 @@ import './why-did-you-render'
 import './app/globals.native'
 import {Appearance} from 'react-native'
 import {darkModeSupported, guiConfig} from 'react-native-kb'
-import {_setSystemIsDarkMode, _setSystemSupported, _setDarkModePreference} from './styles/dark-mode'
+import * as DarkMode from './constants/darkmode'
 import {enableES5, enableMapSet} from 'immer'
 enableES5()
 enableMapSet()
@@ -13,20 +13,19 @@ enableMapSet()
 // Add scaleY back to work around its removal in React Native 0.70. needed for list perf issues, see list-area.native
 ViewReactNativeStyleAttributes.scaleY = true
 
-_setSystemIsDarkMode(Appearance.getColorScheme() === 'dark')
-
-_setSystemSupported(darkModeSupported === '1')
+const {setSystemSupported, setSystemDarkMode, setDarkModePreference} =
+  DarkMode.useDarkModeState.getState().dispatch
+setSystemDarkMode(Appearance.getColorScheme() === 'dark')
+setSystemSupported(darkModeSupported === '1')
 try {
   const obj = JSON.parse(guiConfig)
-  if (obj && obj.ui) {
-    const dm = obj.ui.darkMode
-    switch (dm) {
-      case 'system': // fallthrough
-      case 'alwaysDark': // fallthrough
-      case 'alwaysLight':
-        _setDarkModePreference(dm)
-        break
-    }
+  const dm = obj?.ui?.darkMode
+  switch (dm) {
+    case 'system': // fallthrough
+    case 'alwaysDark': // fallthrough
+    case 'alwaysLight':
+      setDarkModePreference(dm)
+      break
   }
 } catch (_) {}
 

--- a/shared/index.ios.js
+++ b/shared/index.ios.js
@@ -5,14 +5,15 @@ import 'react-native-gesture-handler' // MUST BE FIRST https://github.com/softwa
 import './app/globals.native'
 import {Appearance} from 'react-native'
 import {darkModeSupported, guiConfig} from 'react-native-kb'
-import {_setSystemIsDarkMode, _setSystemSupported, _setDarkModePreference} from './styles/dark-mode'
+import * as DarkMode from './constants/darkmode'
 import {enableES5, enableMapSet} from 'immer'
 enableES5()
 enableMapSet()
 
-_setSystemIsDarkMode(Appearance.getColorScheme() === 'dark')
-
-_setSystemSupported(darkModeSupported === '1')
+const {setSystemSupported, setSystemDarkMode, setDarkModePreference} =
+  DarkMode.useDarkModeState.getState().dispatch
+setSystemDarkMode(Appearance.getColorScheme() === 'dark')
+setSystemSupported(darkModeSupported === '1')
 try {
   const obj = JSON.parse(guiConfig)
   const dm = obj?.ui?.darkMode
@@ -20,7 +21,7 @@ try {
     case 'system': // fallthrough
     case 'alwaysDark': // fallthrough
     case 'alwaysLight':
-      _setDarkModePreference(dm)
+      setDarkModePreference(dm)
       break
   }
 } catch (_) {}

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -1,26 +1,26 @@
 // A mirror of the remote menubar windows.
-import * as FSConstants from '../constants/fs'
 import * as ConfigConstants from '../constants/config'
-import type * as NotificationTypes from '../constants/types/notifications'
-import * as FSTypes from '../constants/types/fs'
 import * as Container from '../util/container'
+import * as DarkMode from '../constants/darkmode'
+import * as FSConstants from '../constants/fs'
+import * as FSTypes from '../constants/types/fs'
 import * as React from 'react'
 import * as Styles from '../styles'
-import {useAvatarState} from '../common-adapters/avatar-zus'
-import {intersect} from '../util/set'
+import KB2 from '../util/electron.desktop'
+import _getIcons from './icons'
+import shallowEqual from 'shallowequal'
+import type * as NotificationTypes from '../constants/types/notifications'
 import useSerializeProps from '../desktop/remote/use-serialize-props.desktop'
-import {serialize, type ProxyProps, type RemoteTlfUpdates} from './remote-serializer.desktop'
-import {isSystemDarkMode} from '../styles/dark-mode'
+import {intersect} from '../util/set'
 import {mapFilterByKey} from '../util/map'
 import {memoize} from '../util/memoize'
-import shallowEqual from 'shallowequal'
-import _getIcons from './icons'
-import KB2 from '../util/electron.desktop'
+import {serialize, type ProxyProps, type RemoteTlfUpdates} from './remote-serializer.desktop'
+import {useAvatarState} from '../common-adapters/avatar-zus'
 
 const {showTray} = KB2.functions
 
 const getIcons = (iconType: NotificationTypes.BadgeType, isBadged: boolean) => {
-  return _getIcons(iconType, isBadged, isSystemDarkMode())
+  return _getIcons(iconType, isBadged, DarkMode.useDarkModeState.getState().systemDarkMode)
 }
 
 type WidgetProps = {
@@ -30,7 +30,7 @@ type WidgetProps = {
 
 function useWidgetBrowserWindow(p: WidgetProps) {
   const {widgetBadge, desktopAppBadgeCount} = p
-  const systemDarkMode = ConfigConstants.useConfigState(s => s.systemDarkMode)
+  const systemDarkMode = DarkMode.useDarkModeState(s => s.systemDarkMode)
   React.useEffect(() => {
     const icon = getIcons(widgetBadge, desktopAppBadgeCount > 0)
     showTray?.(desktopAppBadgeCount, icon)

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -30,9 +30,7 @@ type WidgetProps = {
 
 function useWidgetBrowserWindow(p: WidgetProps) {
   const {widgetBadge, desktopAppBadgeCount} = p
-
-  const systemDarkMode = Container.useSelector(state => state.config.systemDarkMode)
-
+  const systemDarkMode = ConfigConstants.useConfigState(s => s.systemDarkMode)
   React.useEffect(() => {
     const icon = getIcons(widgetBadge, desktopAppBadgeCount > 0)
     showTray?.(desktopAppBadgeCount, icon)

--- a/shared/pinentry/index.desktop.tsx
+++ b/shared/pinentry/index.desktop.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react'
+import * as DarkMode from '../constants/darkmode'
 import * as Kb from '../common-adapters'
-import DragHeader from '../desktop/remote/drag-header.desktop'
-import * as Styles from '../styles'
-import {_setDarkModePreference} from '../styles/dark-mode'
 import * as RPCTypes from '../constants/types/rpc-gen'
+import * as React from 'react'
+import * as Styles from '../styles'
+import DragHeader from '../desktop/remote/drag-header.desktop'
 
 export type Props = {
   darkMode: boolean
@@ -39,6 +39,12 @@ class Pinentry extends React.Component<Props, State> {
     }
   }
 
+  componentDidMount() {
+    DarkMode.useDarkModeState
+      .getState()
+      .dispatch.setDarkModePreference(this.props.darkMode ? 'alwaysDark' : 'alwaysLight')
+  }
+
   componentDidUpdate(prevProps: Props) {
     if (prevProps.showTyping !== this.props.showTyping) {
       this.setState({showTyping: this.props.showTyping?.defaultValue ?? false})
@@ -55,7 +61,6 @@ class Pinentry extends React.Component<Props, State> {
   }
 
   render() {
-    _setDarkModePreference(this.props.darkMode ? 'alwaysDark' : 'alwaysLight')
     const isPaperKey = this.props.type === RPCTypes.PassphraseType.paperKey
     return (
       <Kb.Box

--- a/shared/pinentry/remote-proxy.desktop.tsx
+++ b/shared/pinentry/remote-proxy.desktop.tsx
@@ -2,7 +2,7 @@
 import * as Container from '../util/container'
 import * as RPCTypes from '../constants/types/rpc-gen'
 import * as React from 'react'
-import * as Styles from '../styles'
+import * as DarkMode from '../constants/darkmode'
 import useBrowserWindow from '../desktop/remote/use-browser-window.desktop'
 import useSerializeProps from '../desktop/remote/use-serialize-props.desktop'
 import {serialize, type ProxyProps} from './remote-serializer.desktop'
@@ -30,12 +30,13 @@ const PinentryProxy = () => {
   const pinentry = Container.useSelector(s => s.pinentry)
   const {showTyping, type} = pinentry
   const show = type !== RPCTypes.PassphraseType.none && !!showTyping
+  const darkMode = DarkMode.useDarkModeState(s => s.isDarkMode())
   if (show) {
     const {cancelLabel, prompt, retryLabel, submitLabel, windowTitle} = pinentry
     return (
       <PinentryMemo
         cancelLabel={cancelLabel}
-        darkMode={Styles.isDarkMode()}
+        darkMode={darkMode}
         prompt={prompt}
         retryLabel={retryLabel}
         showTyping={showTyping}

--- a/shared/reducers/config.tsx
+++ b/shared/reducers/config.tsx
@@ -11,7 +11,6 @@ import type * as Types from '../constants/types/config'
 import type * as Tracker2Gen from '../actions/tracker2-gen'
 import {isEOFError, isErrorTransient} from '../util/errors'
 import {isMobile} from '../constants/platform'
-import {_setSystemIsDarkMode, _setDarkModePreference} from '../styles/dark-mode'
 import isEqual from 'lodash/isEqual'
 
 type Actions =
@@ -36,7 +35,6 @@ export default Container.makeReducer<Actions, Types.State>(Constants.initialStat
   },
   [ConfigGen.resetStore]: draftState => ({
     ...Constants.initialState,
-    darkModePreference: draftState.darkModePreference,
     logoutHandshakeVersion: draftState.logoutHandshakeVersion,
     logoutHandshakeWaiters: draftState.logoutHandshakeWaiters,
     pushLoaded: draftState.pushLoaded,
@@ -198,14 +196,6 @@ export default Container.makeReducer<Actions, Types.State>(Constants.initialStat
   },
   [ConfigGen.osNetworkStatusChanged]: (draftState, action) => {
     draftState.osNetworkOnline = action.payload.online
-  },
-  [ConfigGen.setDarkModePreference]: (draftState, action) => {
-    _setDarkModePreference(action.payload.preference)
-    draftState.darkModePreference = action.payload.preference
-  },
-  [ConfigGen.setSystemDarkMode]: (draftState, action) => {
-    _setSystemIsDarkMode(action.payload.dark)
-    draftState.systemDarkMode = action.payload.dark
   },
   [ConfigGen.remoteWindowWantsProps]: (draftState, action) => {
     const {component, param} = action.payload

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -144,8 +144,6 @@ const ElectronApp = () => {
   const {loggedInLoaded, loggedIn, appState, onStateChange, navKey, initialState} = Shared.useShared()
   Shared.useSharedAfter(appState)
 
-  console.log('aaa electorn app render nav key', navKey)
-
   return (
     <NavigationContainer
       ref={Constants.navigationRef_ as any}

--- a/shared/router-v2/router.desktop.tsx
+++ b/shared/router-v2/router.desktop.tsx
@@ -144,6 +144,8 @@ const ElectronApp = () => {
   const {loggedInLoaded, loggedIn, appState, onStateChange, navKey, initialState} = Shared.useShared()
   Shared.useSharedAfter(appState)
 
+  console.log('aaa electorn app render nav key', navKey)
+
   return (
     <NavigationContainer
       ref={Constants.navigationRef_ as any}

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -1,4 +1,5 @@
 import * as Constants from '../constants/router2'
+import * as DarkMode from '../constants/darkmode'
 import * as Kb from '../common-adapters'
 import * as React from 'react'
 import * as Shared from './router.shared'
@@ -9,7 +10,6 @@ import * as Container from '../util/container'
 import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as RouterLinking from './router-linking.native'
 import * as Common from './common.native'
-import * as ConfigConstants from '../constants/config'
 import {StatusBar, View} from 'react-native'
 import {HeaderLeftCancel2} from '../common-adapters/header-hoc'
 import {NavigationContainer, getFocusedRouteNameFromRoute} from '@react-navigation/native'
@@ -303,8 +303,8 @@ const RootStack = createNativeStackNavigator()
 const ModalScreens = makeNavScreens(Shim.shim(modalRoutes, true, false), RootStack.Screen, true)
 
 const useBarStyle = () => {
-  const isDarkMode = Container.useSelector(() => ConfigConstants.isDarkMode())
-  const darkModePreference = ConfigConstants.useConfigState(s => s.darkModePreference)
+  const darkModePreference = DarkMode.useDarkModeState(s => s.darkModePreference)
+  const isDarkMode = DarkMode.useDarkModeState(s => s.isDarkMode())
 
   if (!darkModePreference || darkModePreference === 'system') {
     return 'default'

--- a/shared/router-v2/router.native.tsx
+++ b/shared/router-v2/router.native.tsx
@@ -303,8 +303,8 @@ const RootStack = createNativeStackNavigator()
 const ModalScreens = makeNavScreens(Shim.shim(modalRoutes, true, false), RootStack.Screen, true)
 
 const useBarStyle = () => {
-  const isDarkMode = Container.useSelector(state => ConfigConstants.isDarkMode(state.config))
-  const darkModePreference = Container.useSelector(state => state.config.darkModePreference)
+  const isDarkMode = Container.useSelector(() => ConfigConstants.isDarkMode())
+  const darkModePreference = ConfigConstants.useConfigState(s => s.darkModePreference)
 
   if (!darkModePreference || darkModePreference === 'system') {
     return 'default'

--- a/shared/router-v2/router.shared.tsx
+++ b/shared/router-v2/router.shared.tsx
@@ -1,18 +1,18 @@
-import * as Kbfs from '../fs/common'
-import * as FsConstants from '../constants/fs'
-import * as Styles from '../styles'
 import * as ConfigConstants from '../constants/config'
 import * as ConfigGen from '../actions/config-gen'
-import * as RouteTreeGen from '../actions/route-tree-gen'
 import * as Constants from '../constants/router2'
 import * as Container from '../util/container'
-import * as React from 'react'
+import * as DarkMode from '../constants/darkmode'
+import * as FsConstants from '../constants/fs'
 import * as Kb from '../common-adapters'
+import * as Kbfs from '../fs/common'
+import * as React from 'react'
+import * as RouteTreeGen from '../actions/route-tree-gen'
+import * as Styles from '../styles'
 import Loading from '../login/loading'
-import type {Theme} from '@react-navigation/native'
-import {isDarkMode} from '../styles/dark-mode'
-import {colors, darkColors, themed} from '../styles/colors'
 import type {NavState} from '../constants/types/route-tree'
+import type {Theme} from '@react-navigation/native'
+import {colors, darkColors, themed} from '../styles/colors'
 
 export enum AppState {
   UNINIT, // haven't rendered the nav yet
@@ -43,9 +43,9 @@ const useConnectNavToRedux = () => {
 // if dark mode changes we should redraw
 // on ios if dark mode changes and we're on system, ignore as it will thrash and we don't want that
 const useDarkNeedsRedraw = () => {
-  const isDarkMode = Container.useSelector(() => ConfigConstants.isDarkMode())
+  const isDarkMode = DarkMode.useDarkModeState(s => s.isDarkMode())
   const darkChanged = Container.usePrevious(isDarkMode) !== isDarkMode
-  const darkModePreference = ConfigConstants.useConfigState(s => s.darkModePreference)
+  const darkModePreference = DarkMode.useDarkModeState(s => s.darkModePreference)
   const darkModePreferenceChanged = Container.usePrevious(darkModePreference) !== darkModePreference
 
   if (Styles.isIOS) {
@@ -68,7 +68,7 @@ const useNavKey = (appState: AppState, key: React.MutableRefObject<number>) => {
 }
 
 const useIsDarkChanged = () => {
-  const isDarkMode = Container.useSelector(() => ConfigConstants.isDarkMode())
+  const isDarkMode = DarkMode.useDarkModeState(s => s.isDarkMode())
   const darkChanged = Container.usePrevious(isDarkMode) !== isDarkMode
   return darkChanged
 }
@@ -168,13 +168,15 @@ export const theme: Theme = {
   colors: {
     get background() {
       // return themed.fastBlank as string
-      return (isDarkMode() ? darkColors.white : colors.white) as string
+      return (DarkMode.useDarkModeState.getState().isDarkMode() ? darkColors.white : colors.white) as string
     },
     get border() {
       return themed.black_10 as string
     },
     get card() {
-      return (isDarkMode() ? darkColors.fastBlank : colors.fastBlank) as string
+      return (
+        DarkMode.useDarkModeState.getState().isDarkMode() ? darkColors.fastBlank : colors.fastBlank
+      ) as string
     },
     get notification() {
       return themed.black as string
@@ -183,7 +185,7 @@ export const theme: Theme = {
       return themed.black as string
     },
     get text() {
-      return (isDarkMode() ? darkColors.black : colors.black) as string
+      return (DarkMode.useDarkModeState.getState().isDarkMode() ? darkColors.black : colors.black) as string
     },
   },
   dark: false,

--- a/shared/router-v2/router.shared.tsx
+++ b/shared/router-v2/router.shared.tsx
@@ -43,9 +43,9 @@ const useConnectNavToRedux = () => {
 // if dark mode changes we should redraw
 // on ios if dark mode changes and we're on system, ignore as it will thrash and we don't want that
 const useDarkNeedsRedraw = () => {
-  const isDarkMode = Container.useSelector(state => ConfigConstants.isDarkMode(state.config))
+  const isDarkMode = Container.useSelector(() => ConfigConstants.isDarkMode())
   const darkChanged = Container.usePrevious(isDarkMode) !== isDarkMode
-  const darkModePreference = Container.useSelector(state => state.config.darkModePreference)
+  const darkModePreference = ConfigConstants.useConfigState(s => s.darkModePreference)
   const darkModePreferenceChanged = Container.usePrevious(darkModePreference) !== darkModePreference
 
   if (Styles.isIOS) {
@@ -68,7 +68,7 @@ const useNavKey = (appState: AppState, key: React.MutableRefObject<number>) => {
 }
 
 const useIsDarkChanged = () => {
-  const isDarkMode = Container.useSelector(state => ConfigConstants.isDarkMode(state.config))
+  const isDarkMode = Container.useSelector(() => ConfigConstants.isDarkMode())
   const darkChanged = Container.usePrevious(isDarkMode) !== isDarkMode
   return darkChanged
 }

--- a/shared/settings/display.tsx
+++ b/shared/settings/display.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react'
 import * as ConfigConstants from '../constants/config'
+import * as DarkMode from '../constants/darkmode'
 import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import * as Container from '../util/container'
 import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
-import {isDarkModeSystemSupported} from '../styles/dark-mode'
 import logger from '../logger'
 
 const Display = () => {
   const allowAnimatedEmojis = ConfigConstants.useConfigState(s => s.allowAnimatedEmojis)
-  const darkModePreference = ConfigConstants.useConfigState(s => s.darkModePreference)
+  const darkModePreference = DarkMode.useDarkModeState(s => s.darkModePreference)
   const toggleAnimatedEmoji = Container.useRPC(RPCChatTypes.localToggleEmojiAnimationsRpcPromise)
-  const onSetDarkModePreference = ConfigConstants.useConfigState(s => s.dispatch.setDarkModePreference)
+  const supported = DarkMode.useDarkModeState(s => s.supported)
+  const onSetDarkModePreference = DarkMode.useDarkModeState(s => s.dispatch.setDarkModePreference)
   const doToggleAnimatedEmoji = (enabled: boolean) => {
     toggleAnimatedEmoji(
       [{enabled}],
@@ -27,7 +28,7 @@ const Display = () => {
         <Kb.Box2 direction="vertical" fullWidth={true} gap="medium">
           <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny">
             <Kb.Text type="Header">Appearance</Kb.Text>
-            {isDarkModeSystemSupported() && (
+            {supported && (
               <Kb.RadioButton
                 label="Respect system settings"
                 selected={darkModePreference === 'system' || darkModePreference === undefined}

--- a/shared/settings/display.tsx
+++ b/shared/settings/display.tsx
@@ -1,22 +1,17 @@
 import * as React from 'react'
-import * as ConfigGen from '../actions/config-gen'
-import * as SettingsConstants from '../constants/config'
+import * as ConfigConstants from '../constants/config'
 import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
 import * as Container from '../util/container'
 import * as RPCChatTypes from '../constants/types/rpc-chat-gen'
-import {isDarkModeSystemSupported, type DarkModePreference} from '../styles/dark-mode'
+import {isDarkModeSystemSupported} from '../styles/dark-mode'
 import logger from '../logger'
 
 const Display = () => {
-  const allowAnimatedEmojis = SettingsConstants.useConfigState(s => s.allowAnimatedEmojis)
-  const darkModePreference = Container.useSelector(state => state.config.darkModePreference)
+  const allowAnimatedEmojis = ConfigConstants.useConfigState(s => s.allowAnimatedEmojis)
+  const darkModePreference = ConfigConstants.useConfigState(s => s.darkModePreference)
   const toggleAnimatedEmoji = Container.useRPC(RPCChatTypes.localToggleEmojiAnimationsRpcPromise)
-  const dispatch = Container.useDispatch()
-  const onSetDarkModePreference = React.useCallback(
-    (preference: DarkModePreference) => dispatch(ConfigGen.createSetDarkModePreference({preference})),
-    [dispatch]
-  )
+  const onSetDarkModePreference = ConfigConstants.useConfigState(s => s.dispatch.setDarkModePreference)
   const doToggleAnimatedEmoji = (enabled: boolean) => {
     toggleAnimatedEmoji(
       [{enabled}],

--- a/shared/styles/colors.tsx
+++ b/shared/styles/colors.tsx
@@ -1,5 +1,5 @@
 // the _on_white are precomputed colors so we can do less blending on mobile
-import {isDarkMode, isDarkModePreference} from './dark-mode'
+import * as DarkMode from '../constants/darkmode'
 import {partyMode} from '../local-debug'
 import {isIOS, isNewArch} from '../constants/platform'
 
@@ -513,14 +513,16 @@ if (isIOS && !isNewArch /* not working? */) {
 }
 
 export const themed: {[P in keyof typeof colors]: (typeof colors)[P]} = names.reduce<Color>((obj, name) => {
+  const {isDarkMode} = DarkMode.useDarkModeState.getState()
   if (isIOS) {
     // ios actually handles this nicely natively
     return Object.defineProperty(obj, name, {
       configurable: false,
       enumerable: true,
       get() {
+        const {darkModePreference} = DarkMode.useDarkModeState.getState()
         // if we're in auto mode, use ios native dynamic colors
-        if (isDarkModePreference() === 'system') {
+        if (darkModePreference === 'system') {
           return iosDynamicColors[name]
         }
         return isDarkMode() ? darkColors[name] : colors[name]

--- a/shared/styles/dark-mode.tsx
+++ b/shared/styles/dark-mode.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react'
-// The current darkMode story is complex and could be cleaned up.
-// Current state: In app/index.native we register for the system events which tell us if the mode changes.
-// You can also manually configure to override this. We also inject it on startup in the root index.ios.js files
-// This then dispatches to redux so it can be in there so we can drive the settings screens. We recently
-// added context which should likely be used instead of isDarkMode (see below)
-//
+import * as DarkMode from '../constants/darkmode'
+
 // Individual components can then call Styles.isDarkMode() to get the value. Problem is they need to know that
 // that value has changed.
 // To solve this at the router level we increment the navKey to cause an entire redraw. This is very
@@ -22,40 +18,6 @@ import * as React from 'react'
 // One additional note. The animation system does not work with the magic colors so that code will use
 // the explicit colors/darkColors and not this magic wrapper
 //
-// Future work:
-// Likely move this all out of redux and into context
-export type DarkModePreference = 'system' | 'alwaysDark' | 'alwaysLight'
 
-let darkModePreference: DarkModePreference = 'system'
-let systemDarkMode = false
-// supports system level changes
-let systemSupported = false
-
-// called ONLY from config sagas / mobile boot / remote windows
-export const _setDarkModePreference = (pref: DarkModePreference) => {
-  darkModePreference = pref
-}
-// ONLY from system hooks, never call this directly
-export const _setSystemIsDarkMode = (dm: boolean) => {
-  systemDarkMode = dm
-}
-export const _setSystemSupported = (supported: boolean) => {
-  systemSupported = supported
-}
-
-export const isDarkMode = () => {
-  switch (darkModePreference) {
-    case 'system':
-      return systemDarkMode
-    case 'alwaysDark':
-      return true
-    case 'alwaysLight':
-      return false
-  }
-}
-
-export const isDarkModeSystemSupported = () => systemSupported
-export const isSystemDarkMode = () => systemDarkMode
-export const isDarkModePreference = () => darkModePreference
-
+export const isDarkMode = () => DarkMode.useDarkModeState.getState().isDarkMode()
 export const DarkModeContext = React.createContext(isDarkMode())

--- a/shared/styles/style-sheet-proxy.tsx
+++ b/shared/styles/style-sheet-proxy.tsx
@@ -1,4 +1,4 @@
-import {isDarkMode, isDarkModePreference} from './dark-mode'
+import * as DarkMode from '../constants/darkmode'
 import type {StylesCrossPlatform} from '.'
 
 // Support a closure to enable simple dark mode.
@@ -12,7 +12,7 @@ const styleSheetCreate = (f: () => MapToStyles, transform: Transform) => {
   let lightCached: MapToStyles | undefined
   let darkCached: MapToStyles | undefined
 
-  let darkModePrefCached = isDarkModePreference()
+  let darkModePrefCached = DarkMode.useDarkModeState.getState().darkModePreference
 
   const keys = Object.keys(f())
   const sheet = {}
@@ -23,14 +23,14 @@ const styleSheetCreate = (f: () => MapToStyles, transform: Transform) => {
       enumerable: true,
       get() {
         // if this changes we should kill our caches
-        const darkModePref = isDarkModePreference()
+        const darkModePref = DarkMode.useDarkModeState.getState().darkModePreference
         if (darkModePrefCached !== darkModePref) {
           darkModePrefCached = darkModePref
           darkCached = undefined
           lightCached = undefined
         }
 
-        if (isDarkMode()) {
+        if (DarkMode.useDarkModeState.getState().isDarkMode()) {
           darkCached = darkCached || transform(f())
           return darkCached[key]
         } else {

--- a/shared/tracker2/index.desktop.tsx
+++ b/shared/tracker2/index.desktop.tsx
@@ -1,10 +1,11 @@
-import * as Kb from '../common-adapters'
+import * as React from 'react'
 import * as Constants from '../constants/tracker2'
-import type * as Types from '../constants/types/tracker2'
+import * as DarkMode from '../constants/darkmode'
+import * as Kb from '../common-adapters'
 import * as Styles from '../styles'
-import {_setDarkModePreference} from '../styles/dark-mode'
 import Assertion from './assertion/container'
 import Bio from './bio/container'
+import type * as Types from '../constants/types/tracker2'
 
 type Props = {
   assertionKeys?: ReadonlyArray<string>
@@ -110,7 +111,14 @@ const TeamShowcase = ({name}) => (
 )
 
 const Tracker = (props: Props) => {
-  _setDarkModePreference(props.darkMode ? 'alwaysDark' : 'alwaysLight')
+  const [lastDM, setLastDM] = React.useState(props.darkMode)
+  if (props.darkMode !== lastDM) {
+    setLastDM(props.darkMode)
+    DarkMode.useDarkModeState
+      .getState()
+      .dispatch.setDarkModePreference(props.darkMode ? 'alwaysDark' : 'alwaysLight')
+  }
+
   let assertions
   if (props.assertionKeys) {
     const unsorted = [...props.assertionKeys]

--- a/shared/tracker2/remote-proxy.desktop.tsx
+++ b/shared/tracker2/remote-proxy.desktop.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import * as Container from '../util/container'
 import * as Constants from '../constants/tracker2'
 import * as WaitConstants from '../constants/waiting'
-import * as Styles from '../styles'
+import * as DarkMode from '../constants/darkmode'
 import useSerializeProps from '../desktop/remote/use-serialize-props.desktop'
 import useBrowserWindow from '../desktop/remote/use-browser-window.desktop'
 import {serialize, type ProxyProps} from './remote-serializer.desktop'
@@ -38,6 +38,8 @@ const RemoteTracker = (props: {trackerUsername: string}) => {
     return new Map([[trackerUsername, avatarCount]])
   }, [trackerUsername, avatarCount])
 
+  const darkMode = DarkMode.useDarkModeState(s => s.isDarkMode())
+
   const p: ProxyProps = {
     assertions,
     avatarRefreshCounter,
@@ -45,7 +47,7 @@ const RemoteTracker = (props: {trackerUsername: string}) => {
     blockMap: mapFilterByKey(blockMap, trackerUsernames),
     blocked,
     counts,
-    darkMode: Styles.isDarkMode(),
+    darkMode,
     errors,
     followers: intersect(followers, trackerUsernames),
     followersCount,

--- a/shared/unlock-folders/index.desktop.tsx
+++ b/shared/unlock-folders/index.desktop.tsx
@@ -1,8 +1,8 @@
+import * as DarkMode from '../constants/darkmode'
 import * as React from 'react'
 import * as Styles from '../styles'
-import DragHeader from '../desktop/remote/drag-header.desktop'
-import {_setDarkModePreference} from '../styles/dark-mode'
 import DeviceList from './device-list.desktop'
+import DragHeader from '../desktop/remote/drag-header.desktop'
 import PaperKeyInput from './paper-key-input.desktop'
 import Success from './success.desktop'
 import type {State, Device} from '../constants/types/unlock-folders'
@@ -21,7 +21,12 @@ export type Props = {
 }
 
 const UnlockFolders = (props: Props) => {
-  _setDarkModePreference(props.darkMode ? 'alwaysDark' : 'alwaysLight')
+  const {darkMode} = props
+  React.useEffect(() => {
+    DarkMode.useDarkModeState
+      .getState()
+      .dispatch.setDarkModePreference(darkMode ? 'alwaysDark' : 'alwaysLight')
+  }, [darkMode])
 
   let innerComponent: React.ReactNode
 


### PR DESCRIPTION
Cleanup on how we handle dark mode. Switching to zustand allows us to cleanly deal with our store in all the weird ways we need to setup the values (on init, through node, etc). Also fixes the longstanding bug where you get a white flash on darkmode startup on desktop