### PR TITLE
never allow a validated rollback in the thread status

### DIFF
--- a/shared/actions/chat2/index.tsx
+++ b/shared/actions/chat2/index.tsx
@@ -1182,13 +1182,21 @@ const loadMoreMessages = async (
 
   const pagination = messageIDControl ? null : scrollDirectionToPagination(sd, numberOfMessagesToLoad)
   try {
+    let validated = false
     const results = await RPCChatTypes.localGetThreadNonblockRpcListener(
       {
         incomingCallMap: {
           'chat.1.chatUi.chatThreadCached': p => p && onGotThread(p.thread || ''),
           'chat.1.chatUi.chatThreadFull': p => p && onGotThread(p.thread || ''),
-          'chat.1.chatUi.chatThreadStatus': p =>
-            !!p && Chat2Gen.createSetThreadLoadStatus({conversationIDKey, status: p.status}),
+          'chat.1.chatUi.chatThreadStatus': p => {
+            // if we're validated, never undo that
+            if (p.status.typ === RPCChatTypes.UIChatThreadStatusTyp.validated) {
+              validated = true
+            } else if (validated) {
+              return false
+            }
+            return !!p && Chat2Gen.createSetThreadLoadStatus({conversationIDKey, status: p.status})
+          },
         },
         params: {
           cbMode: RPCChatTypes.GetThreadNonblockCbMode.incremental,


### PR DESCRIPTION
Its hard to repro but sometimes it seems like we can get the thread status updates out of order. Maybe related to multiple loads of the convo. Either way if we (during a single load call) ever see a validated state we just retain that and ignore other updates so we never go `unknown -> validated -> validating`