### PR TITLE
only allow one item provider for pasteboarding

### DIFF
--- a/shared/patches/@mattermost+react-native-paste-input+0.5.1.patch
+++ b/shared/patches/@mattermost+react-native-paste-input+0.5.1.patch
@@ -45,7 +45,7 @@ index 93d0feb..3b491f4 100644
  
  NS_ASSUME_NONNULL_END
 diff --git a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputTextView.m b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputTextView.m
-index 73ed099..8140253 100644
+index 73ed099..1df0117 100644
 --- a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputTextView.m
 +++ b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputTextView.m
 @@ -8,9 +8,72 @@
@@ -121,7 +121,7 @@ index 73ed099..8140253 100644
  #pragma mark - Overrides
  
  - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
-@@ -35,34 +98,30 @@
+@@ -35,34 +98,34 @@
  }
  
  -(void)paste:(id)sender {
@@ -158,6 +158,10 @@ index 73ed099..8140253 100644
      
 -    // Dismiss contextual menu
 -    [self resignFirstResponder];
++    // Only one at a time due to threading issues
++    NSItemProvider * itemP = itemProviders.firstObject;
++    itemProviders = @[itemP];
++    
 +    __weak typeof(self) weakSelf = self;
 +    self.iph = [[ItemProviderHelper alloc]
 +             initForShare:false


### PR DESCRIPTION
Sometimes we get 2 items (a url and text) which i think isn't what we want. Our existing logic tries multiple times but i think in certain operations the timing is critical (aka the values are in some temp location then go away). So, in order for this to be more bullet proof my theory is we need some matrix of the values they encode for and what we can decode and we basically do one set of decodes immediately. This is a larger change than i want to attempt now so this is a simple fix. Its unlikely you're pasting multiple images into the chat input