### PR TITLE
Try seteuid in redirector again

### DIFF
--- a/go/kbfs/redirector/main.go
+++ b/go/kbfs/redirector/main.go
@@ -293,7 +293,7 @@ func unmount(currUID, mountAsUID uint64, dir string) {
 	if currUID != mountAsUID {
 		// Unmounting requires escalating the effective user to the
 		// mounting user.  But we leave the real user ID the same.
-		err := syscall.Setreuid(int(currUID), int(mountAsUID))
+		err := syscall.Seteuid(int(mountAsUID))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can't setuid: %+v\n", err)
 			os.Exit(1)
@@ -307,7 +307,7 @@ func unmount(currUID, mountAsUID uint64, dir string) {
 
 	// Set it back.
 	if currUID != mountAsUID {
-		err := syscall.Setreuid(int(currUID), int(currUID))
+		err := syscall.Seteuid(int(currUID))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can't setuid: %+v\n", err)
 			os.Exit(1)
@@ -389,9 +389,9 @@ func main() {
 		// Escalate privileges of the effective user to the mounting
 		// user briefly, just for the `Mount` call.  Keep the real
 		// user the same throughout.
-		err := syscall.Setreuid(int(currUID), int(mountAsUID))
+		err := syscall.Seteuid(int(mountAsUID))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Can't setreuid: %+v\n", err)
+			fmt.Fprintf(os.Stderr, "Can't seteuid: %+v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -404,9 +404,9 @@ func main() {
 
 	if currUser.Uid != u.Uid {
 		runtime.LockOSThread()
-		err := syscall.Setreuid(int(currUID), int(currUID))
+		err := syscall.Seteuid(int(currUID))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Can't setreuid: %+v\n", err)
+			fmt.Fprintf(os.Stderr, "Can't seteuid: %+v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -141,6 +141,7 @@ build_one_architecture() {
     yarn run package -- --platform linux --arch "$electron_arch" --appVersion "$version" --network-concurrency 8
     rsync -a "desktop/release/linux-${electron_arch}/Keybase-linux-${electron_arch}/" \
       "$layout_dir/opt/keybase"
+    chmod 755 /opt/keybase
     chmod 4755 "$layout_dir/opt/keybase/chrome-sandbox"
   )
 

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -141,7 +141,7 @@ build_one_architecture() {
     yarn run package -- --platform linux --arch "$electron_arch" --appVersion "$version" --network-concurrency 8
     rsync -a "desktop/release/linux-${electron_arch}/Keybase-linux-${electron_arch}/" \
       "$layout_dir/opt/keybase"
-    chmod 755 /opt/keybase
+    chmod 755 "$layout_dir/opt/keybase"
     chmod 4755 "$layout_dir/opt/keybase/chrome-sandbox"
   )
 


### PR DESCRIPTION
We've tried this before and it caused some rare issues on debian... maybe time to try again so we can upgrade Go version. 