### PR TITLE
Fix incomplete locking in JSONConfigFile

### DIFF
--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func forceOpenDBs(tc libkb.TestContext) {
@@ -442,4 +443,102 @@ func testDeprovisionLastDevice(t *testing.T, upgradePerUserKey bool) {
 		revokePaperKey: true,
 	})
 	assertNumDevicesAndKeys(tc, fu, 0, 0)
+}
+
+func TestConcurrentDeprovision(t *testing.T) {
+	tc := SetupEngineTest(t, "deprovision-concurrent")
+	defer tc.Cleanup()
+	if tc.G.SecretStore() == nil {
+		t.Fatal("Need a secret store for this test")
+	}
+
+	// Sign up a new user and have it store its secret in the
+	// secret store (if possible).
+	fu := NewFakeUserOrBust(tc.T, "dpr")
+	arg := MakeTestSignupEngineRunArg(fu)
+	arg.SkipPaper = false
+	arg.StoreSecret = tc.G.SecretStore() != nil
+	uis := libkb.UIs{
+		LogUI:    tc.G.UI.GetLogUI(),
+		GPGUI:    &gpgtestui{},
+		SecretUI: fu.NewSecretUI(),
+		LoginUI:  &libkb.TestLoginUI{Username: fu.Username},
+	}
+	s := NewSignupEngine(tc.G, &arg)
+	err := RunEngine2(NewMetaContextForTest(tc).WithUIs(uis), s)
+	if err != nil {
+		tc.T.Fatal(err)
+	}
+
+	m := NewMetaContextForTest(tc)
+	if tc.G.SecretStore() != nil {
+		secretStore := libkb.NewSecretStore(m, fu.NormalizedUsername())
+		_, err := secretStore.RetrieveSecret(m)
+		if err != nil {
+			tc.T.Fatal(err)
+		}
+	}
+
+	forceOpenDBs(tc)
+	dbPath := tc.G.Env.GetDbFilename()
+	chatDBPath := tc.G.Env.GetChatDbFilename()
+	secretKeysPath := tc.G.SKBFilenameForUser(fu.NormalizedUsername())
+	numKeys := getNumKeys(tc, *fu)
+	expectedNumKeys := numKeys
+
+	assertFileExists(tc.T, dbPath)
+	assertFileExists(tc.T, chatDBPath)
+	assertFileExists(tc.T, secretKeysPath)
+	if !isUserInConfigFile(tc, *fu) {
+		tc.T.Fatalf("User %s is not in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
+	}
+	if !isUserConfigInMemory(tc) {
+		tc.T.Fatal("user config is not in memory")
+	}
+
+	if !LoggedIn(tc) {
+		tc.T.Fatal("Unexpectedly logged out")
+	}
+
+	g := new(errgroup.Group)
+	for i := 0; i < 5; i++ {
+		i := i
+		g.Go(func() error {
+			e := NewDeprovisionEngine(tc.G, fu.Username, i == 0 /* doRevoke */, libkb.LogoutOptions{})
+			uis = libkb.UIs{
+				LogUI:    tc.G.UI.GetLogUI(),
+				SecretUI: fu.NewSecretUI(),
+			}
+			m = m.WithUIs(uis)
+			return RunEngine2(m, e)
+		})
+	}
+	require.NoError(t, g.Wait())
+	expectedNumKeys -= 2
+
+	if LoggedIn(tc) {
+		tc.T.Error("Unexpectedly still logged in")
+	}
+
+	if tc.G.SecretStore() != nil {
+		secretStore := libkb.NewSecretStore(m, fu.NormalizedUsername())
+		secret, err := secretStore.RetrieveSecret(m)
+		if err == nil {
+			tc.T.Errorf("Unexpectedly got secret %v", secret)
+		}
+	}
+
+	assertFileDoesNotExist(tc.T, dbPath)
+	assertFileDoesNotExist(tc.T, chatDBPath)
+	assertFileDoesNotExist(tc.T, secretKeysPath)
+
+	if isUserInConfigFile(tc, *fu) {
+		tc.T.Fatalf("User %s is still in the config file %s", fu.Username, tc.G.Env.GetConfigFilename())
+	}
+	if isUserConfigInMemory(tc) {
+		tc.T.Fatal("user config is still in memory")
+	}
+
+	newKeys := getNumKeys(tc, *fu)
+	require.Equal(tc.T, expectedNumKeys, newKeys, "unexpected number of keys (failed to revoke device keys)")
 }

--- a/go/engine/deprovision_test.go
+++ b/go/engine/deprovision_test.go
@@ -502,9 +502,8 @@ func TestConcurrentDeprovision(t *testing.T) {
 
 	g := new(errgroup.Group)
 	for i := 0; i < 5; i++ {
-		i := i
 		g.Go(func() error {
-			e := NewDeprovisionEngine(tc.G, fu.Username, i == 0 /* doRevoke */, libkb.LogoutOptions{})
+			e := NewDeprovisionEngine(tc.G, fu.Username, false, libkb.LogoutOptions{})
 			uis = libkb.UIs{
 				LogUI:    tc.G.UI.GetLogUI(),
 				SecretUI: fu.NewSecretUI(),
@@ -514,11 +513,6 @@ func TestConcurrentDeprovision(t *testing.T) {
 		})
 	}
 	require.NoError(t, g.Wait())
-	expectedNumKeys -= 2
-
-	if LoggedIn(tc) {
-		tc.T.Error("Unexpectedly still logged in")
-	}
 
 	if tc.G.SecretStore() != nil {
 		secretStore := libkb.NewSecretStore(m, fu.NormalizedUsername())


### PR DESCRIPTION
Add locking whenever we read/write values from the `JSONFile` in `JSONConfigFile`. Add more complete use of `userConfigWrapper`'s lock. Many calls were previously accessing `jsonw.Wrapper` directly and sometimes not holding the `userConfigWrapper` lock either.

Uncovered during concurrent calls to `Deprovision`, the app could crash with concurrent read/writes of jsonw's internal map. 

```
▶ INFO Deleting cnojimagpg's secret keys file... [tags:LOIR=TEEB2PdEPEJK,GRGIBM=CjP0r_crraNL]
▶ INFO Deleting cnojimagpg's ephemeralKeys... [tags:GRGIBM=CjP0r_crraNL,LOIR=TEEB2PdEPEJK]
▶ INFO Deleting cnojimagpg from config.json... [tags:GRGIBM=CjP0r_crraNL,LOIR=TEEB2PdEPEJK]
fatal error: concurrent map read and map write
```

The test in this patch replicates the behavior. 

I'm surprised races were not hit earlier, much of this code has been untouched for over 8 years..

cc @chrisnojima 