### PR TITLE
Only 8 characters are available for signature revocation

### DIFF
--- a/go/client/cmd_sigs_revoke.go
+++ b/go/client/cmd_sigs_revoke.go
@@ -28,7 +28,7 @@ func (c *CmdSigsRevoke) ParseArgv(ctx *cli.Context) error {
 
 	for _, arg := range ctx.Args() {
 		if len(arg) < keybase1.SigIDQueryMin {
-			return fmt.Errorf("sig id %q is too short; must be at least 16 characters long", arg)
+			return fmt.Errorf("sig id %q is too short; must be at least 8 characters long", arg)
 		}
 		c.queries = append(c.queries, strings.TrimSuffix(arg, "..."))
 	}


### PR DESCRIPTION
`keybase sigs list` only shows 8 characters of the signature, not 16. Updating the error help text to reflect that.