### PR TITLE
fixes 5

### DIFF
--- a/shared/chat/conversation/info-panel/menu/index.tsx
+++ b/shared/chat/conversation/info-panel/menu/index.tsx
@@ -94,22 +94,22 @@ const TeamHeader = (props: TeamHeaderProps) => {
         isHovered={false}
         size={32}
       />
-      <Kb.Box2 direction="horizontal" style={styles.teamText}>
-        <Kb.Text type="BodySemibold" style={styles.maybeLongText} onClick={props.onViewTeam}>
-          {props.teamname}
-        </Kb.Text>
-        {teamHumanCount ? (
-          <Kb.Meta
-            backgroundColor={Kb.Styles.globalColors.blueGrey}
-            color={Kb.Styles.globalColors.black_50}
-            icon="iconfont-people-solid"
-            iconColor={Kb.Styles.globalColors.black_20}
-            title={teamHumanCount}
-          />
-        ) : (
-          <Kb.ProgressIndicator type="Small" />
-        )}
-      </Kb.Box2>
+      <Kb.Text type="BodySemibold" style={styles.maybeLongText} onClick={props.onViewTeam}>
+        {props.teamname}
+      </Kb.Text>
+      <Kb.BoxGrow2 />
+      {teamHumanCount ? (
+        <Kb.Meta
+          style={{alignSelf: 'center'}}
+          backgroundColor={Kb.Styles.globalColors.blueGrey}
+          color={Kb.Styles.globalColors.black_50}
+          icon="iconfont-people-solid"
+          iconColor={Kb.Styles.globalColors.black_20}
+          title={teamHumanCount}
+        />
+      ) : (
+        <Kb.ProgressIndicator type="Small" />
+      )}
     </Kb.Box2>
   )
 }
@@ -122,16 +122,16 @@ const InfoPanelMenu = (p: Props) => {
   const {onLeaveTeam, onLeaveChannel, onMarkAsRead, onMarkAsUnread, canAddPeople} = p
   const isGeneralChannel = !!(channelname && channelname === 'general')
   const hasChannelSection = !isSmallTeam && !hasHeader
-  const addPeopleItems: Kb.MenuItems = [
+  const addPeopleItems = [
     {
       icon: 'iconfont-new',
       iconIsVisible: false,
       onClick: onAddPeople,
       title: hasChannelSection ? 'Add/Invite people to team' : 'Add/invite people',
     },
-  ]
+  ] as const
 
-  const channelHeader: Kb.MenuItem = {
+  const channelHeader = {
     title: 'channelHeader',
     unWrapped: true,
     view: (
@@ -147,23 +147,23 @@ const InfoPanelMenu = (p: Props) => {
         </Kb.Text>
       </Kb.Box2>
     ),
-  }
-  const channelItem: Kb.MenuItem = isSmallTeam
-    ? {
+  } as const
+  const channelItem = isSmallTeam
+    ? ({
         icon: 'iconfont-hash',
         iconIsVisible: false,
         onClick: onManageChannels,
         subTitle: manageChannelsSubtitle,
         title: manageChannelsTitle,
-      }
-    : {
+      } as const)
+    : ({
         icon: 'iconfont-hash',
         iconIsVisible: false,
         isBadged: badgeSubscribe,
         onClick: onManageChannels,
         title: manageChannelsTitle,
-      }
-  const teamHeader: Kb.MenuItem = {
+      } as const)
+  const teamHeader = {
     title: 'teamHeader',
     unWrapped: true,
     view: (
@@ -180,7 +180,7 @@ const InfoPanelMenu = (p: Props) => {
         </Kb.Box2>
       </Kb.Box2>
     ),
-  }
+  } as const
 
   const conversationIDKey = C.useChatContext(s => s.id)
   const hideItem = (() => {
@@ -195,7 +195,7 @@ const InfoPanelMenu = (p: Props) => {
           onClick: onUnhideConv,
           style: {borderTopWidth: 0},
           title: 'Unhide conversation',
-        }
+        } as const
       } else {
         return {
           icon: 'iconfont-hide',
@@ -203,7 +203,7 @@ const InfoPanelMenu = (p: Props) => {
           onClick: onHideConv,
           style: {borderTopWidth: 0},
           title: 'Hide until next message',
-        }
+        } as const
       }
     } else {
       return null
@@ -220,7 +220,7 @@ const InfoPanelMenu = (p: Props) => {
       iconIsVisible: false,
       onClick: () => onMuteConv(!isMuted),
       title,
-    }
+    } as const
   })()
   const markAsUnread = (() => {
     if (!conversationIDKey) {
@@ -231,20 +231,20 @@ const InfoPanelMenu = (p: Props) => {
       iconIsVisible: false,
       onClick: onMarkAsUnread,
       title: 'Mark as unread',
-    }
+    } as const
   })()
 
   const isAdhoc = (isSmallTeam && !conversationIDKey) || !!(teamType === 'adhoc')
   const items: Kb.MenuItems = []
   if (isAdhoc) {
     if (markAsUnread) {
-      items.push(markAsUnread as Kb.MenuItem)
+      items.push(markAsUnread)
     }
     if (muteItem) {
-      items.push(muteItem as Kb.MenuItem)
+      items.push(muteItem)
     }
     if (hideItem) {
-      items.push(hideItem as Kb.MenuItem)
+      items.push(hideItem)
     }
     items.push({
       danger: true,
@@ -252,19 +252,19 @@ const InfoPanelMenu = (p: Props) => {
       iconIsVisible: false,
       onClick: onBlockConv,
       title: 'Block',
-    })
+    } as const)
   } else {
     if (hasChannelSection) {
       items.push(channelHeader)
     }
     if (markAsUnread) {
-      items.push(markAsUnread as Kb.MenuItem)
+      items.push(markAsUnread)
     }
     if (muteItem) {
-      items.push(muteItem as Kb.MenuItem)
+      items.push(muteItem)
     }
     if (hideItem) {
-      items.push(hideItem as Kb.MenuItem)
+      items.push(hideItem)
     }
     if (!isSmallTeam && !isInChannel && !isGeneralChannel && !hasHeader) {
       items.push({
@@ -272,7 +272,7 @@ const InfoPanelMenu = (p: Props) => {
         iconIsVisible: false,
         onClick: onJoinChannel,
         title: 'Join channel',
-      })
+      } as const)
     }
     if (!isSmallTeam && isInChannel && !isGeneralChannel && !hasHeader) {
       items.push({
@@ -280,7 +280,7 @@ const InfoPanelMenu = (p: Props) => {
         iconIsVisible: false,
         onClick: onLeaveChannel,
         title: 'Leave channel',
-      })
+      } as const)
     }
     if (hasChannelSection) {
       items.push(teamHeader)
@@ -292,14 +292,14 @@ const InfoPanelMenu = (p: Props) => {
         iconIsVisible: false,
         onClick: onMarkAsRead,
         title: 'Mark all as read',
-      })
+      } as const)
     }
     items.push(channelItem, {
       icon: 'iconfont-info',
       iconIsVisible: false,
       onClick: onViewTeam,
       title: 'Team info',
-    })
+    } as const)
     if (canAddPeople) {
       addPeopleItems.forEach(item => items.push(item))
     }
@@ -308,7 +308,7 @@ const InfoPanelMenu = (p: Props) => {
       iconIsVisible: false,
       onClick: onLeaveTeam,
       title: 'Leave team',
-    })
+    } as const)
   }
 
   const header = hasHeader ? (

--- a/shared/chat/conversation/info-panel/menu/index.tsx
+++ b/shared/chat/conversation/info-panel/menu/index.tsx
@@ -371,6 +371,11 @@ const styles = Kb.Styles.styleSheetCreate(
         isElectron: {wordBreak: 'break-all'},
       }),
       headerContainer: Kb.Styles.platformStyles({
+        common: {
+          borderBottomColor: Kb.Styles.globalColors.black_10,
+          borderBottomWidth: 1,
+          borderStyle: 'solid',
+        },
         isElectron: {
           ...Kb.Styles.padding(
             Kb.Styles.globalMargins.small,

--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -173,7 +173,7 @@ const ConnectedPlatformInput = React.memo(function ConnectedPlatformInput(
 
       injectText('')
 
-      const containsLatestMessage = cs.containsLatestMessage
+      const containsLatestMessage = cs.isCaughtUp()
       if (containsLatestMessage) {
         onRequestScrollToBottom()
       } else {

--- a/shared/chat/conversation/list-area/hooks.tsx
+++ b/shared/chat/conversation/list-area/hooks.tsx
@@ -19,7 +19,7 @@ export const useActions = (p: {conversationIDKey: T.Chat.ConversationIDKey}) => 
 }
 
 export const useJumpToRecent = (scrollToBottom: () => void, numOrdinals: number) => {
-  const containsLatestMessage = C.useChatContext(s => s.containsLatestMessage)
+  const containsLatestMessage = C.useChatContext(s => s.isCaughtUp())
   const toggleThreadSearch = C.useChatContext(s => s.dispatch.toggleThreadSearch)
   const jumpToRecent = C.useChatContext(s => s.dispatch.jumpToRecent)
 

--- a/shared/chat/conversation/list-area/index.desktop.tsx
+++ b/shared/chat/conversation/list-area/index.desktop.tsx
@@ -522,7 +522,7 @@ const ThreadWrapper = React.memo(function ThreadWrapper(p: Props) {
   const {requestScrollDownRef, requestScrollToBottomRef, requestScrollUpRef} = p
   const editingOrdinal = C.useChatContext(s => s.editing)
   const centeredOrdinal = C.useChatContext(s => s.messageCenterOrdinal)?.ordinal
-  const containsLatestMessage = C.useChatContext(s => s.containsLatestMessage) ?? false
+  const containsLatestMessage = C.useChatContext(s => s.isCaughtUp())
   const messageTypeMap = C.useChatContext(s => s.messageTypeMap)
   const messageOrdinals = C.useChatContext(s => s.messageOrdinals) ?? []
   const copyToClipboard = C.useConfigState(s => s.dispatch.dynamic.copyToClipboard)

--- a/shared/chat/inbox/row/big-team-header.tsx
+++ b/shared/chat/inbox/row/big-team-header.tsx
@@ -93,8 +93,8 @@ const styles = Kb.Styles.styleSheetCreate(
           ...Kb.Styles.globalStyles.flexBoxRow,
         },
         isElectron: {
+          alignSelf: 'center',
           position: 'relative',
-          top: Kb.Styles.globalMargins.xxtiny,
         },
         isMobile: {
           marginRight: -6,

--- a/shared/chat/inbox/row/small-team/small-team.css
+++ b/shared/chat/inbox/row/small-team/small-team.css
@@ -1,24 +1,24 @@
 .small-row {
   background-color: var(--color-blueGrey);
+  .conversation-gear {
+    display: none;
+  }
+  .conversation-timestamp {
+    display: flex;
+  }
 
   &:hover {
     background-color: var(--color-blueGreyDark);
 
-    .conversation-gear,
-    .conversation-timestamp {
+    .conversation-gear {
       display: flex;
+    }
+    .conversation-timestamp {
+      display: none;
     }
   }
 
   &.selected {
     background-color: var(--color-blue);
-  }
-
-  .conversation-gear {
-    display: none;
-  }
-
-  .conversation-timestamp {
-    display: none;
   }
 }

--- a/shared/chat/inbox/row/small-team/top-line.tsx
+++ b/shared/chat/inbox/row/small-team/top-line.tsx
@@ -139,12 +139,7 @@ const SimpleTopLineImpl = React.memo(function SimpleTopLineImpl(p: IProps) {
           <Names isSelected={isSelected} showBold={showBold} isInWidget={isInWidget} />
         </Kb.Box>
       </Kb.Box>
-      <Kb.Text
-        key="timestamp"
-        type="BodyTiny"
-        className={Kb.Styles.classNames({'conversation-timestamp': showGear})}
-        style={timestampStyle}
-      >
+      <Kb.Text key="timestamp" type="BodyTiny" className="conversation-timestamp" style={timestampStyle}>
         <Timestamp />
       </Kb.Text>
       {!Kb.Styles.isMobile && showGear && (

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -87,7 +87,6 @@ type ConvoStore = {
   giphyResult?: T.RPCChat.GiphySearchResults
   giphyWindow: boolean
   markedAsUnread: boolean // store a bit if we've marked this thread as unread so we don't mark as read when navgiating away
-  // TODO update this!
   maxMsgIDSeen: number // max id weve seen so far, we do delete things
   messageCenterOrdinal?: T.Chat.CenterOrdinal // ordinals to center threads on,
   messageTypeMap: Map<T.Chat.Ordinal, T.Chat.RenderMessageType> // messages T.Chat to help the thread, text is never used
@@ -2583,9 +2582,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
         }
       })
     }, 1000),
-    setupSubscriptions: () => {
-      // TODO
-    },
+    setupSubscriptions: () => {},
     showInfoPanel: (show, tab) => {
       C.useChatState.getState().dispatch.updateInfoPanel(show, tab)
       const conversationIDKey = get().id

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -80,7 +80,6 @@ type ConvoStore = {
   botTeamRoleMap: Map<string, T.Teams.TeamRoleType | undefined>
   commandMarkdown?: T.RPCChat.UICommandMarkdown
   commandStatus?: T.Chat.CommandStatusInfo
-  containsLatestMessage?: boolean
   dismissedInviteBanners: boolean
   editing: T.Chat.Ordinal // current message being edited,
   explodingMode: number // seconds to exploding message expiration,
@@ -88,6 +87,8 @@ type ConvoStore = {
   giphyResult?: T.RPCChat.GiphySearchResults
   giphyWindow: boolean
   markedAsUnread: boolean // store a bit if we've marked this thread as unread so we don't mark as read when navgiating away
+  // TODO update this!
+  maxMsgIDSeen: number // max id weve seen so far, we do delete things
   messageCenterOrdinal?: T.Chat.CenterOrdinal // ordinals to center threads on,
   messageTypeMap: Map<T.Chat.Ordinal, T.Chat.RenderMessageType> // messages T.Chat to help the thread, text is never used
   messageOrdinals?: Array<T.Chat.Ordinal> // ordered ordinals in a thread,
@@ -116,7 +117,6 @@ const initialConvoStore: ConvoStore = {
   botTeamRoleMap: new Map(),
   commandMarkdown: undefined,
   commandStatus: undefined,
-  containsLatestMessage: undefined,
   dismissedInviteBanners: false,
   editing: 0,
   explodingMode: 0,
@@ -125,6 +125,7 @@ const initialConvoStore: ConvoStore = {
   giphyWindow: false,
   id: noConversationIDKey,
   markedAsUnread: false,
+  maxMsgIDSeen: -1,
   messageCenterOrdinal: undefined,
   messageMap: new Map(),
   messageOrdinals: undefined,
@@ -239,7 +240,6 @@ export type ConvoState = ConvoStore & {
     refreshBotSettings: (username: string) => void
     refreshMutualTeamsInConv: () => void
     removeBotMember: (username: string) => void
-    replaceMessageMap: (mm: ConvoStore['messageMap']) => void
     replyJump: (messageID: T.Chat.MessageID) => void
     requestInfoReceived: (messageID: T.RPCChat.MessageID, requestInfo: T.Chat.ChatRequestInfo) => void
     resetChatWithoutThem: () => void
@@ -252,7 +252,6 @@ export type ConvoState = ConvoStore & {
     sendTyping: (typing: boolean) => void
     setCommandMarkdown: (md?: T.RPCChat.UICommandMarkdown) => void
     setCommandStatusInfo: (info?: T.Chat.CommandStatusInfo) => void
-    setContainsLatestMessage: (c: boolean) => void
     setConvRetentionPolicy: (policy: T.Retention.RetentionPolicy) => void
     setEditing: (ordinal: T.Chat.Ordinal | boolean) => void // true is last, false is clear
     setExplodingMode: (seconds: number, incoming?: boolean) => void
@@ -291,7 +290,6 @@ export type ConvoState = ConvoStore & {
     ) => void
     unfurlRemove: (messageID: T.Chat.MessageID) => void
     updateDraft: (text: string) => void
-    updateContainsLatestMessage: (force: boolean) => void
     updateFromUIInboxLayout: (l: {isMuted: boolean; draft?: string | null}) => void
     unfurlTogglePrompt: (messageID: T.Chat.MessageID, domain: string, show: boolean) => void
     unreadUpdated: (unread: number) => void
@@ -308,6 +306,7 @@ export type ConvoState = ConvoStore & {
   }
   getExplodingMode: () => number
   isMetaGood: () => boolean
+  isCaughtUp: () => boolean
 }
 
 // don't bug the users with black bars for network errors. chat isn't going to work in general
@@ -438,8 +437,14 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
     return clientPrev || 0
   }
 
-  const syncOrdinals = (s: ConvoState) => {
-    s.messageOrdinals = [...s.messageMap.keys()].sort((a, b) => a - b)
+  // things that depend on messageMap, like the ordinals and the maxMsgIDSeen
+  const syncMessageDerived = (s: ConvoState) => {
+    const mo = [...s.messageMap.keys()].sort((a, b) => a - b)
+    s.messageOrdinals = mo
+    const last = mo.at(-1)
+    if (last && last > s.maxMsgIDSeen) {
+      s.maxMsgIDSeen = last
+    }
   }
 
   const dispatch: ConvoState['dispatch'] = {
@@ -835,7 +840,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
                     info.messages.forEach(m => {
                       s.messageMap.set(m.id, m)
                     })
-                    syncOrdinals(s)
+                    syncMessageDerived(s)
                   })
                 }
               },
@@ -888,7 +893,6 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
         messageIDControl,
         knownRemotes,
         forceClear = false,
-        forceContainsLatestCalc = false,
         centeredMessageID,
         scrollDirection: sd = 'none',
         numberOfMessagesToLoad = numMessagesOnInitialLoad,
@@ -966,13 +970,6 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
               dispatch.messagesClear()
             }
             dispatch.messagesAdd(messages)
-            if (forceContainsLatestCalc) {
-              dispatch.updateContainsLatestMessage(forceContainsLatestCalc)
-            } else {
-              if (forceClear && sd === 'none') {
-                dispatch.updateContainsLatestMessage(true)
-              }
-            }
             if (centeredMessageID) {
               const ordinal = T.Chat.numberToOrdinal(T.Chat.messageIDToNumber(centeredMessageID.messageID))
               dispatch.setMessageCenterOrdinal({
@@ -1091,7 +1088,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
         }
         // Check to see if we do not have the latest message, and don't mark anything as read in that case
         // If we have no information at all, then just mark as read
-        if (!get().containsLatestMessage) {
+        if (!get().isCaughtUp()) {
           logger.info('bail on not containing latest message')
           return
         }
@@ -1460,6 +1457,11 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
     messagesAdd: messages => {
       set(s => {
         for (const m of messages) {
+          // we capture the highest one, cause sometimes we'll not track it in the map
+          // aka for deleted or placeholders
+          if (m.id > s.maxMsgIDSeen) {
+            s.maxMsgIDSeen = m.id
+          }
           if (m.type === 'deleted') {
             s.messageMap.delete(m.ordinal)
             s.messageTypeMap.delete(m.ordinal)
@@ -1488,7 +1490,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
             }
           }
         }
-        syncOrdinals(s)
+        syncMessageDerived(s)
       })
       get().dispatch.markThreadAsRead()
     },
@@ -1496,7 +1498,8 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
       set(s => {
         s.pendingOutboxToOrdinal.clear()
         s.messageMap.clear()
-        syncOrdinals(s)
+        s.maxMsgIDSeen = -1
+        syncMessageDerived(s)
         s.messageTypeMap.clear()
       })
     },
@@ -1555,7 +1558,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
         allOrdinals.forEach(ordinal => {
           s.messageMap.delete(ordinal)
         })
-        syncOrdinals(s)
+        syncMessageDerived(s)
       })
     },
     metaReceivedError: (error, username) => {
@@ -1909,7 +1912,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
 
       const {modifiedMessage, displayDesktopNotification, desktopNotificationSnippet} = incoming
       const conversationIDKey = get().id
-      const shouldAddMessage = get().containsLatestMessage ?? false
+      const shouldAddMessage = get().isCaughtUp() ?? false
       const devicename = C.useCurrentUserState.getState().deviceName
       const getLastOrdinal = () => get().messageOrdinals?.at(-1) ?? 0
       const message = Message.uiMessageToMessage(
@@ -2141,12 +2144,6 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
       }
       Z.ignorePromise(f())
     },
-    replaceMessageMap: mm => {
-      set(s => {
-        s.messageMap = mm
-        syncOrdinals(s)
-      })
-    },
     replyJump: messageID => {
       get().dispatch.setMessageCenterOrdinal()
       get().dispatch.loadMessagesCentered(messageID, 'flash')
@@ -2228,7 +2225,6 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
       C.useChatState.getState().dispatch.unboxRows([conversationIDKey], force)
       get().dispatch.setThreadLoadStatus(T.RPCChat.UIChatThreadStatusTyp.none)
       get().dispatch.setMessageCenterOrdinal()
-      get().dispatch.setContainsLatestMessage(true)
       fetchConversationBio()
       C.useChatState.getState().dispatch.resetConversationErrored()
     },
@@ -2290,11 +2286,6 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
     setCommandStatusInfo: info => {
       set(s => {
         s.commandStatus = info
-      })
-    },
-    setContainsLatestMessage: c => {
-      set(s => {
-        s.containsLatestMessage = c
       })
     },
     setConvRetentionPolicy: _policy => {
@@ -2908,15 +2899,6 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
         }
       })
     },
-    updateContainsLatestMessage: force => {
-      // already good
-      if (!force && get().containsLatestMessage) return
-      if (!get().isMetaGood()) return
-      const {meta, messageMap, messageOrdinals} = get()
-      const lastOrdinalWithID = findLast(messageOrdinals ?? [], o => (messageMap.get(o)?.id ?? 0) > 0)
-      const maxMsgID = lastOrdinalWithID ? messageMap.get(lastOrdinalWithID)?.id ?? 0 : 0
-      dispatch.setContainsLatestMessage(maxMsgID >= meta.maxVisibleMsgID)
-    },
     updateDraft: throttle(text => {
       const f = async () => {
         const meta = get().meta
@@ -3025,6 +3007,9 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
       const meta = get().meta
       const convRetention = Meta.getEffectiveRetentionPolicy(meta)
       return convRetention.type === 'explode' ? Math.min(mode || Infinity, convRetention.seconds) : mode
+    },
+    isCaughtUp: () => {
+      return get().maxMsgIDSeen >= get().meta.maxVisibleMsgID
     },
     isMetaGood: () => {
       // fake meta doesn't have our actual id in it

--- a/shared/constants/chat2/index.tsx
+++ b/shared/constants/chat2/index.tsx
@@ -572,7 +572,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
         }
         if (clearExistingMessages) {
           for (const [, cs] of C.chatStores) {
-            cs.getState().dispatch.replaceMessageMap(new Map())
+            cs.getState().dispatch.messagesClear()
           }
         }
       }
@@ -1039,9 +1039,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
           )
           get().dispatch.unboxRows(conversationIDKeys, true)
           if (T.RPCChat.StaleUpdateType[key] === T.RPCChat.StaleUpdateType.clear) {
-            conversationIDKeys.forEach(convID =>
-              C.getConvoState(convID).dispatch.replaceMessageMap(new Map())
-            )
+            conversationIDKeys.forEach(convID => C.getConvoState(convID).dispatch.messagesClear())
           }
         }
       })
@@ -1432,7 +1430,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
         // same? ignore
         if (wasChat && isChat && wasID === isID) {
           // if we've never loaded anything, keep going so we load it
-          if (!isID || C.getConvoState(isID).containsLatestMessage !== undefined) {
+          if (!isID || C.getConvoState(isID).maxMsgIDSeen !== -1) {
             return
           }
         }

--- a/shared/todo.txt
+++ b/shared/todo.txt
@@ -1,3 +1,2 @@
 Some short term todos:
-unify message popups
 


### PR DESCRIPTION
- [x] fix inbox time - gear hover logic
- [x] fix alignment of gear on big team header
- [x] fix alignment of member count in big team header
- [x] change how containsLatestVisible works. Instead of a bool we keep a max of the ids we've seen. We need this as we'll see but then toss some items (deleted, hidden placeholders). So we mark as being aware of them and use that to compare to the `meta.maxVisibleID`. A repro was to preview a channel you're not in which has placeholders