### PR TITLE
fix http token on reconnect

### DIFF
--- a/shared/constants/daemon.tsx
+++ b/shared/constants/daemon.tsx
@@ -190,11 +190,6 @@ export const _useState = Z.createZustand<State>((set, get) => {
       const version = get().handshakeVersion
       const {wait} = get().dispatch
 
-      if (C.useCurrentUserState.getState().username) {
-        // ready loaded, can bail
-        return
-      }
-
       const f = async () => {
         const {setBootstrap} = C.useCurrentUserState.getState().dispatch
         const {setDefaultUsername} = C.useConfigState.getState().dispatch


### PR DESCRIPTION
We bailed too eagerly so we didn't go through the whole flow when reconnecting to the service which could lead to using a stale token