### PR TITLE
center tooltips

### DIFF
--- a/shared/chat/inbox-and-conversation-header.tsx
+++ b/shared/chat/inbox-and-conversation-header.tsx
@@ -87,7 +87,11 @@ const Header2 = (props: Props) => {
   }
   if (isTeam && desc && canEditDesc) {
     description = (
-      <Kb.WithTooltip position="bottom left" tooltip="Set the description using the /headline command.">
+      <Kb.WithTooltip
+        position="bottom left"
+        tooltip="Set the description using the /headline command."
+        containerStyle={styles.descriptionTooltip}
+      >
         {description}
       </Kb.WithTooltip>
     )
@@ -248,6 +252,7 @@ const styles = Kb.Styles.styleSheetCreate(
         isElectron: {alignItems: 'baseline'},
         isTablet: {alignItems: 'baseline'},
       }),
+      descriptionTooltip: {alignItems: 'flex-start'},
       headerTitle: Kb.Styles.platformStyles({
         common: {
           flexGrow: 1,

--- a/shared/common-adapters/with-tooltip.desktop.tsx
+++ b/shared/common-adapters/with-tooltip.desktop.tsx
@@ -32,7 +32,7 @@ const WithTooltip = React.memo(function WithTooltip(p: Props) {
       <Kb.Box2Measure
         direction="vertical"
         alignSelf="stretch"
-        alignItems="flex-start"
+        alignItems="center"
         style={containerStyle}
         ref={popupAnchor}
         onMouseOver={IGNORE_FOR_PROFILING ? undefined : onMouseEnter}

--- a/shared/fs/common/path-status-icon.tsx
+++ b/shared/fs/common/path-status-icon.tsx
@@ -102,6 +102,7 @@ const PathStatusIcon = (props: Props) =>
 
 const styles = Kb.Styles.styleSheetCreate(() => ({
   iconFont: {
+    alignSelf: 'center',
     paddingLeft: Kb.Styles.globalMargins.xtiny,
     paddingRight: Kb.Styles.globalMargins.xtiny,
   },


### PR DESCRIPTION
undo previous change to flex-start it and just override the header instead