### PR TITLE
Revert "Bump to go 1.21.5"

### DIFF
--- a/go/kbfs/appveyor.yml
+++ b/go/kbfs/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     GOARCH: amd64
     CC: c:\msys64\mingw64\bin\gcc
     CPATH: C:\msys64\include;C:\msys64\include\ddk
-    GOVERSION: 1.21.5
+    GOVERSION: 1.19.4
 
 install:
   - systeminfo | findstr /C:"OS"

--- a/packaging/linux/Dockerfile
+++ b/packaging/linux/Dockerfile
@@ -30,9 +30,9 @@ RUN apt-get install -y nodejs yarn
 # When updating the version, remember to bump keybase_packaging_v# in docker_build.sh.
 # Copy over the new hash when upgrading version. But if not upgrading version,
 # the check should not ever fail.
-ENV GOLANG_VERSION 1.21.5
+ENV GOLANG_VERSION 1.19.4
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e
+ENV GOLANG_DOWNLOAD_SHA256 c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
 RUN wget "$GOLANG_DOWNLOAD_URL" -O /root/go.tar.gz
 RUN echo "$GOLANG_DOWNLOAD_SHA256 /root/go.tar.gz" | sha256sum --check --status --strict -
 RUN tar -C /usr/local -xzf /root/go.tar.gz

--- a/packaging/linux/docker/alpine-slim/Dockerfile
+++ b/packaging/linux/docker/alpine-slim/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=keybaseio/client:alpine
 
 FROM $BASE_IMAGE AS base
 
-FROM alpine:3.19
+FROM alpine:3.16
 LABEL maintainer="Keybase <admin@keybase.io>"
 
 RUN apk add --update --no-cache gnupg procps ca-certificates bash

--- a/packaging/linux/docker/alpine/Dockerfile
+++ b/packaging/linux/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-alpine3.19 AS builder
+FROM golang:1.19.4-alpine3.16 AS builder
 
 RUN apk add --update --no-cache gnupg bash build-base
 
@@ -23,7 +23,7 @@ RUN chmod +x /binaries/amd64/usr/bin/keybase \
     && chmod +x /binaries/amd64/usr/bin/kbfsfuse \
     && chmod +x /binaries/amd64/usr/bin/git-remote-keybase
 
-FROM alpine:3.19
+FROM alpine:3.16
 LABEL maintainer="Keybase <admin@keybase.io>"
 
 RUN apk add --update --no-cache gnupg procps ca-certificates bash

--- a/packaging/linux/docker/standard/Dockerfile
+++ b/packaging/linux/docker/standard/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-bookworm AS builder
+FROM golang:1.19.4-buster AS builder
 
 ARG SOURCE_COMMIT=unknown
 
@@ -21,7 +21,7 @@ RUN chmod +x /binaries/amd64/usr/bin/keybase \
     && chmod +x /binaries/amd64/usr/bin/kbfsfuse \
     && chmod +x /binaries/amd64/usr/bin/git-remote-keybase
 
-FROM debian:bookworm
+FROM debian:buster
 LABEL maintainer="Keybase <admin@keybase.io>"
 
 RUN apt-get update \

--- a/packaging/linux/docker_build.sh
+++ b/packaging/linux/docker_build.sh
@@ -58,7 +58,7 @@ gpg_tempfile="$gpg_tempdir/code_signing_key"
 gpg --export-secret-key --armor "$code_signing_fingerprint" > "$gpg_tempfile"
 
 # Make sure the Docker image is built.
-image=keybase_packaging_v49
+image=keybase_packaging_v48
 if [ -z "$(sudo docker images -q "$image")" ] ; then
   echo "Docker image '$image' not yet built. Building..."
   sudo docker build -t "$image" "$clientdir/packaging/linux"

--- a/packaging/linux/tuxbot/provision_tuxbot_root
+++ b/packaging/linux/tuxbot/provision_tuxbot_root
@@ -6,9 +6,9 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get --allow-releaseinfo-change update
 apt-get install -yq git curl vim python3-pip jq
 
-GOLANG_VERSION=1.21.5
+GOLANG_VERSION=1.19.4
 GOLANG_DOWNLOAD_URL=https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e
+GOLANG_DOWNLOAD_SHA256=c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
 wget "$GOLANG_DOWNLOAD_URL" -O /root/go.tar.gz
 echo "$GOLANG_DOWNLOAD_SHA256 /root/go.tar.gz" | sha256sum --check --status --strict -
 tar -C /usr/local -xzf /root/go.tar.gz


### PR DESCRIPTION
Reverts keybase/client#26075

temporarily revert to get a docker release with the new CA
cc @heronhaye @mmaxim 