### PR TITLE
Remove libgconf-2-4 dependency

### DIFF
--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -35,7 +35,7 @@ elif [ "$mode" = "prerelease" ] ; then
   # lsof used in post_install.sh
   # systemd-container provides machinectl, which is used in post_install.sh
   # 'libasound2, libnss3, libxss1, libxtst6' is required by the GUI (issue #9872 and #17365)
-  dependencies="Depends: libappindicator1 | libayatana-appindicator1, fuse, libgconf-2-4, psmisc, lsof, procps, libasound2, libnss3, libxss1, libxtst6, libgtk-3-0"
+  dependencies="Depends: libappindicator1 | libayatana-appindicator1, fuse, psmisc, lsof, procps, libasound2, libnss3, libxss1, libxtst6, libgtk-3-0"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean repo


### PR DESCRIPTION
gconf has not been required by electron since electron v3: https://github.com/electron-userland/electron-installer-common/blob/1ef24cbba0db0fa392574595eaa00985a7587e7e/src/dependencies.js#L27-L32

The libgconf-2-4 package is unavailable in Debian trixie and Ubuntu mantic, resulting in installation errors on those platforms

I was able to force installation of keybase on Ubuntu 23.10 (mantic), despite the nonexistent dependency, keybase has been working fine for several weeks.

Fixes https://github.com/keybase/client/issues/26082, fixes https://github.com/keybase/client/issues/25984