### PR TITLE
Expose TLS pinning feature without requiring proxy to be enabled

### DIFF
--- a/shared/settings/proxy/index.tsx
+++ b/shared/settings/proxy/index.tsx
@@ -126,15 +126,15 @@ class ProxySettings extends React.Component<Props, State> {
               onChangeText={port => this.setState({port})}
               value={this.state.port}
             />
-            <Kb.Checkbox
-              checked={!this.certPinning()}
-              onCheck={this.toggleCertPinning}
-              label="Allow TLS Interception"
-              style={styles.proxySetting}
-            />
-            <Kb.Button onClick={this.saveProxySettings} label="Save Proxy Settings" />
           </>
         )}
+        <Kb.Checkbox
+          checked={!this.certPinning()}
+          onCheck={this.toggleCertPinning}
+          label="Allow TLS Interception"
+          style={styles.proxySetting}
+        />
+        <Kb.Button onClick={this.saveProxySettings} label="Save Proxy Settings" />
       </>
     )
   }


### PR DESCRIPTION
![image](https://github.com/keybase/client/assets/917230/4c31e40e-6b36-43a5-8711-340f493b11e4)
This was the least amount of work needed to make this work, I think the UI is still fine.