### PR TITLE
fixes for auto complete / hud interactions

### DIFF
--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -69,6 +69,7 @@ export const useSyncInput = (p: UseSyncInputProps) => {
     setFilter('')
   }, [setActive, setFilter])
 
+  // TODO fix this function w/
   const getWordAtCursor = React.useCallback(() => {
     if (inputRef.current) {
       const useSpaces = active === 'commands'
@@ -79,7 +80,13 @@ export const useSyncInput = (p: UseSyncInputProps) => {
       if (!selection || selection.start === null) {
         return null
       }
-      const upToCursor = text.substring(0, selection.start)
+
+      // move selection to end of the selected word so replacements don't squish with text after
+      const startIdx = Math.min(selection.start, text.length)
+      const nextSpaceIndex = text.indexOf(' ', startIdx)
+      const toReplaceEnd = nextSpaceIndex !== -1 ? nextSpaceIndex : text.length
+
+      const upToCursor = text.substring(0, toReplaceEnd)
       let wordRegex: string | RegExp
 
       // If the datasource has data which contains spaces, we can't just split by a space character.
@@ -91,8 +98,20 @@ export const useSyncInput = (p: UseSyncInputProps) => {
         wordRegex = / |\n/
       }
       const words = upToCursor.split(wordRegex)
-      const word = words.at(-1)
-      const position = {end: selection.start, start: selection.start - word!.length}
+      const lastWordPrefix = words.at(-1)
+      const toReplaceStart = toReplaceEnd - (lastWordPrefix?.length ?? 0)
+      const position = {end: toReplaceEnd, start: toReplaceStart}
+
+      const word = text.substring(toReplaceStart, toReplaceEnd)
+      console.log('aaa getWordAtCursor', {
+        // orig: text.substring(selection.start),
+        startIdx,
+        nextSpaceIndex,
+        toReplaceEnd,
+        word,
+        position,
+      })
+
       return {position, word}
     }
     return null
@@ -163,6 +182,13 @@ export const useSyncInput = (p: UseSyncInputProps) => {
         {position: cursorInfo?.position ?? {end: null, start: null}, text: lastTextRef.current},
         !final
       )
+      // console.log('aaa triggerTransform', {
+      //   cursorInfo,
+      //   matchInfo,
+      //   transformedText,
+      //   lastTextRef: lastTextRef.current,
+      //   value,
+      // })
       lastTextRef.current = transformedText.text
       input.transformText(() => transformedText, final)
     },

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -103,15 +103,6 @@ export const useSyncInput = (p: UseSyncInputProps) => {
       const position = {end: toReplaceEnd, start: toReplaceStart}
 
       const word = text.substring(toReplaceStart, toReplaceEnd)
-      console.log('aaa getWordAtCursor', {
-        // orig: text.substring(selection.start),
-        startIdx,
-        nextSpaceIndex,
-        toReplaceEnd,
-        word,
-        position,
-      })
-
       return {position, word}
     }
     return null
@@ -182,13 +173,6 @@ export const useSyncInput = (p: UseSyncInputProps) => {
         {position: cursorInfo?.position ?? {end: null, start: null}, text: lastTextRef.current},
         !final
       )
-      // console.log('aaa triggerTransform', {
-      //   cursorInfo,
-      //   matchInfo,
-      //   transformedText,
-      //   lastTextRef: lastTextRef.current,
-      //   value,
-      // })
       lastTextRef.current = transformedText.text
       input.transformText(() => transformedText, final)
     },

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -69,7 +69,6 @@ export const useSyncInput = (p: UseSyncInputProps) => {
     setFilter('')
   }, [setActive, setFilter])
 
-  // TODO fix this function w/
   const getWordAtCursor = React.useCallback(() => {
     if (inputRef.current) {
       const useSpaces = active === 'commands'

--- a/shared/chat/conversation/normal/container.tsx
+++ b/shared/chat/conversation/normal/container.tsx
@@ -5,6 +5,8 @@ import Normal from '.'
 import {OrangeLineContext} from '../orange-line-context'
 import {FocusProvider, ScrollProvider} from './context'
 
+const DEBUG = __DEV__
+
 const noOrd = T.Chat.numberToOrdinal(-1)
 const caughtUpOrd = T.Chat.numberToOrdinal(0)
 // Orange line logic:
@@ -64,6 +66,16 @@ const useOrangeLine = () => {
     const ord = s.messageMap.get(T.Chat.numberToOrdinal(mord))?.ordinal
     return ord ?? noOrd
   })
+
+  DEBUG &&
+    console.log('[useOrangeLine debug] ', {
+      convoChanged,
+      maxMsgOrd,
+      noExisting,
+      orangeLineRef: orangeLineRef.current,
+      readMsgWentBackwards,
+      wentInactive,
+    })
 
   if (convoChanged || noExisting || readMsgWentBackwards) {
     orangeLineRef.current = storeOrangeLine

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -102,6 +102,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
       const newTextInfo = fn(textInfo)
       checkTextInfo(newTextInfo)
       n.value = newTextInfo.text
+      // if we change this immediately it can fail
       setTimeout(() => {
         n.selectionStart = newTextInfo.selection.start
         n.selectionEnd = newTextInfo.selection.end

--- a/shared/common-adapters/plain-input.desktop.tsx
+++ b/shared/common-adapters/plain-input.desktop.tsx
@@ -102,8 +102,10 @@ class PlainInput extends React.PureComponent<InternalProps> {
       const newTextInfo = fn(textInfo)
       checkTextInfo(newTextInfo)
       n.value = newTextInfo.text
-      n.selectionStart = newTextInfo.selection.start
-      n.selectionEnd = newTextInfo.selection.end
+      setTimeout(() => {
+        n.selectionStart = newTextInfo.selection.start
+        n.selectionEnd = newTextInfo.selection.end
+      }, 1)
 
       if (reflectChange && this._input.current) {
         this._onChange({target: this._input.current})

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -38,6 +38,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
   // Needed to support wrapping with e.g. a ClickableBox. See
   // https://facebook.github.io/react-native/docs/direct-manipulation.html .
   setNativeProps = (nativeProps: Object) => {
+    console.log('aaa setnative', nativeProps)
     this._input.current?.setNativeProps(nativeProps)
   }
 
@@ -59,20 +60,34 @@ class PlainInput extends React.PureComponent<InternalProps> {
     const newTextInfo = fn(currentTextInfo)
     const newCheckedSelection = this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text)
     checkTextInfo(newTextInfo)
+    console.log('aaa transform setnative', newTextInfo.text)
+
     this.setNativeProps({text: newTextInfo.text})
-    // selection is pretty flakey on RN, skip if its at the end?
-    if (
-      newCheckedSelection.start === newCheckedSelection.end &&
-      newCheckedSelection.start === newTextInfo.text.length
-    ) {
-    } else {
+    setTimeout(() => {
+      this.setNativeProps({text: newTextInfo.text})
       setTimeout(() => {
-        this._mounted && this.setNativeProps({selection: newCheckedSelection})
-      }, 100)
-    }
+        this.setNativeProps({selection: newCheckedSelection})
+        setTimeout(() => {
+          this.setNativeProps({selection: newCheckedSelection})
+        }, 10)
+      }, 10)
+    }, 10)
+
+    // this.setNativeProps({text: newTextInfo.text})
+    // selection is pretty flakey on RN, skip if its at the end?
+    // if (
+    //   newCheckedSelection.start === newCheckedSelection.end &&
+    //   newCheckedSelection.start === newTextInfo.text.length
+    // ) {
+    // } else {
+    //   setTimeout(() => {
+    //     this._mounted && this.setNativeProps({selection: newCheckedSelection})
+    //   }, 100)
+    // }
     this._lastNativeText = newTextInfo.text
     this._lastNativeSelection = newCheckedSelection
     if (reflectChange) {
+      console.log('aaa _onchange refelct', newTextInfo)
       this._onChangeText(newTextInfo.text)
     }
   }
@@ -104,6 +119,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
   }
 
   _onChangeText = (t: string) => {
+    console.log('aaa _onchange', t)
     if (this.props.maxBytes) {
       const {maxBytes} = this.props
       if (stringToUint8Array(t).byteLength > maxBytes) {
@@ -115,6 +131,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
   }
 
   _onSelectionChange = (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
+    console.log('aaa _onSelectionChange', event.nativeEvent.selection)
     const {start: _start, end: _end} = event.nativeEvent.selection
     // Work around Android bug which sometimes puts end before start:
     // https://github.com/facebook/react-native/issues/18579 .
@@ -224,7 +241,17 @@ class PlainInput extends React.PureComponent<InternalProps> {
       multiline: false,
       onBlur: this._onBlur,
       onChangeText: this._onChangeText,
-      onEndEditing: this.props.onEndEditing,
+
+      // TEMP
+      onChange: a => {
+        console.log('aaa onchange', a.nativeEvent)
+      },
+      onEndEditing: (...a) => {
+        console.log('aaa onendediting', a)
+        this.props.onEndEditing?.()
+      },
+      // TEMP end
+      // onEndEditing: this.props.onEndEditing,
       onFocus: this._onFocus,
       onImageChange: this.onImageChange,
       onKeyPress: this.props.onKeyPress,
@@ -236,7 +263,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
       returnKeyType: this.props.returnKeyType,
       secureTextEntry: this.props.type === 'password' || this.props.secureTextEntry,
       // currently broken on ios https://github.com/facebook/react-native/issues/30585
-      selectTextOnFocus: this.props.selectTextOnFocus,
+      selectTextOnFocus: false, //this.props.selectTextOnFocus,
       style: this._getStyle(),
       textContentType: this.props.textContentType,
       underlineColorAndroid: 'transparent',

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -61,12 +61,12 @@ class PlainInput extends React.PureComponent<InternalProps> {
     checkTextInfo(newTextInfo)
 
     // this is a very hacky workaround for internal bugs in RN TextInput
-    // write a stub with the same length
-    this.setNativeProps({text: new Array(newTextInfo.text.length).fill('A')})
+    // write a stub with different content
+    this.setNativeProps({text: null})
     // fix selection and text after a delay
     setTimeout(() => {
-      this.setNativeProps({selection: newCheckedSelection})
-      this.setNativeProps({text: newTextInfo.text})
+      this.setNativeProps({selection: newCheckedSelection, text: newTextInfo.text})
+      // if this is shorter it doesn't seem to register at all
     }, 100)
 
     if (reflectChange) {

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -51,11 +51,6 @@ class PlainInput extends React.PureComponent<InternalProps> {
   _toSettleSel = {}
   _toSettleTries = 0
   _transformSettle = () => {
-    --this._toSettleTries
-    if (this._toSettleTries < 0) {
-      console.log('aaa settle fail tries')
-      return
-    }
     if (
       shallowEqual(this._lastNativeSelection, this._toSettleSel) &&
       this._lastNativeText === this._toSettleText
@@ -75,6 +70,11 @@ class PlainInput extends React.PureComponent<InternalProps> {
     )
     this.setNativeProps({selection: this._toSettleSel, text: this._toSettleText})
     // sadly just doing this once doesn't work
+    --this._toSettleTries
+    if (this._toSettleTries < 0) {
+      console.log('aaa settle fail tries')
+      return
+    }
     setTimeout(() => {
       this._transformSettle()
     }, 100)

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -38,7 +38,6 @@ class PlainInput extends React.PureComponent<InternalProps> {
   // Needed to support wrapping with e.g. a ClickableBox. See
   // https://facebook.github.io/react-native/docs/direct-manipulation.html .
   setNativeProps = (nativeProps: Object) => {
-    console.log('aaa setnative', nativeProps)
     this._input.current?.setNativeProps(nativeProps)
   }
 
@@ -102,7 +101,6 @@ class PlainInput extends React.PureComponent<InternalProps> {
   }
 
   _onChangeText = (t: string) => {
-    console.log('aaa _onchange', t)
     if (this.props.maxBytes) {
       const {maxBytes} = this.props
       if (stringToUint8Array(t).byteLength > maxBytes) {
@@ -114,12 +112,7 @@ class PlainInput extends React.PureComponent<InternalProps> {
   }
 
   _onSelectionChange = (event: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
-    console.log('aaa _onSelectionChange', event.nativeEvent.selection)
     const {start, end} = event.nativeEvent.selection
-    // Work around Android bug which sometimes puts end before start:
-    // https://github.com/facebook/react-native/issues/18579 .
-    // const start = Math.min(_start || 0, _end || 0)
-    // const end = Math.max(_start || 0, _end || 0)
     this._lastNativeSelection = {end, start}
     this.props.onSelectionChange?.(this._lastNativeSelection)
   }

--- a/shared/common-adapters/plain-input.native.tsx
+++ b/shared/common-adapters/plain-input.native.tsx
@@ -43,7 +43,12 @@ class PlainInput extends React.PureComponent<InternalProps> {
     this._input.current?.setNativeProps(nativeProps)
   }
 
+  componentDidMount() {
+    console.log('aaaa mount >>>>>>>>>>>>>>')
+  }
+
   componentWillUnmount() {
+    console.log('aaaa unmount <<<<<<<<<<<<<<<')
     this._mounted = false
   }
 
@@ -102,14 +107,47 @@ class PlainInput extends React.PureComponent<InternalProps> {
     const newTextInfo = fn(currentTextInfo)
     const newCheckedSelection = this._sanityCheckSelection(newTextInfo.selection, newTextInfo.text)
     checkTextInfo(newTextInfo)
-    console.log('aaa transform setnative', newTextInfo.text)
+    console.log('aaa transformtxt ', newTextInfo.text)
 
-    this._toSettleText = newTextInfo.text
-    this._toSettleSel = newCheckedSelection
-    this._toSettleTries = this._toSettleTriesMax
-    // this._lastNativeText = newTextInfo.text
-    // this._lastNativeSelection = newCheckedSelection
-    this._transformSettle()
+    // write
+    this.setNativeProps({text: new Array(newTextInfo.text.length).fill('A')})
+    // fix selection
+    setTimeout(() => {
+      this.setNativeProps({selection: newCheckedSelection})
+      this.setNativeProps({text: newTextInfo.text})
+    }, 100)
+
+    // WORKS!
+    // move to end
+    // this.setNativeProps({selection: {end: newTextInfo.text.length, start: newTextInfo.text.length}})
+    // // write
+    // setTimeout(() => {
+    //   this.setNativeProps({text: new Array(newTextInfo.text.length).fill('A')})
+    //   // fix selection
+    //   setTimeout(() => {
+    //     this.setNativeProps({selection: newCheckedSelection})
+    //     this.setNativeProps({text: newTextInfo.text})
+    //   }, 100)
+    // }, 100)
+    // WORKS!
+    // this._toSettleText = newTextInfo.text
+    // this._toSettleSel = newCheckedSelection
+    // this._toSettleTries = this._toSettleTriesMax
+    // // this._lastNativeText = newTextInfo.text
+    // // this._lastNativeSelection = newCheckedSelection
+    // //this._transformSettle()
+    //
+    // this.setNativeProps({text: newTextInfo.text})
+    // // selection is pretty flakey on RN, skip if its at the end?
+    // if (
+    //   newCheckedSelection.start === newCheckedSelection.end &&
+    //   newCheckedSelection.start === newTextInfo.text.length
+    // ) {
+    // } else {
+    //   setTimeout(() => {
+    //     this._mounted && this.setNativeProps({selection: newCheckedSelection})
+    //   }, 100)
+    // }
 
     if (reflectChange) {
       console.log('aaa _onchange refelct', newTextInfo)

--- a/shared/todo.txt
+++ b/shared/todo.txt
@@ -1,5 +1,3 @@
 Some short term todos:
 swipeable2 slow
 remove F1 debug in chat
-
-cahnges in rn-tet input

--- a/shared/todo.txt
+++ b/shared/todo.txt
@@ -1,3 +1,5 @@
 Some short term todos:
 swipeable2 slow
 remove F1 debug in chat
+
+cahnges in rn-tet input


### PR DESCRIPTION
- [x] on ios when we get a predictive text prompt it renders the suggestions as grey text after our cursor, but we get onChangeText calls as if the user typed it and had the cursor not at the end. Aka '@z' with a suggestion 'zoom' gives us '@z*oom' where * is the cursor, with no way to differentiate the user doing this or being in this mode. Additionally when you click our suggestions (on either platform) it'd inject it in so you'd get stuff like '@z*oom' => '@zoombot oom'. Instead when we inject we kill any contiguous characters connected so the selected word
- [x] additionally we have issues since we're using `setNativeProps` on the `TextInput` which has always been buggy in RN. There are many open/closed issues. Setting the text and the selection does not work as you'd expect it to. The only workable workaround is to inject blank, then defer, then set the selection, then set the actual text. Variants of this do not work. Setting text and selection fails as we can't control the key order and even then its not clear it would work. If the selection races the text it'll bail as the lengths need to sync up. Setting the text and then setting it later will bail as there's 'no diff' etc. Even calling it multiple times for it to settle doesnt' work, we don't get correct callbacks on the selection changing.