### PR TITLE
attachments view jumping

### DIFF
--- a/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
@@ -50,9 +50,7 @@ const Fullscreen = React.memo(function Fullscreen(p: Props) {
   }
   const isDownloadError = !!message.transferErrMsg
 
-  const {showPopup, popup, popupAnchor} = useMessagePopup({
-    ordinal,
-  })
+  const {showPopup, popup, popupAnchor} = useMessagePopup({ordinal})
 
   const titleOverride = React.useMemo(
     () => ({

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -407,24 +407,32 @@ export const useAttachmentSections = (
   const [lastSAV, setLastSAV] = React.useState(selectedAttachmentView)
   const loadAttachmentView = C.useChatContext(s => s.dispatch.loadAttachmentView)
   const loadMoreMessages = C.useChatContext(s => s.dispatch.loadMoreMessages)
+  const clearModals = C.useRouterState(s => s.dispatch.clearModals)
 
   const jumpToAttachment = React.useCallback(
     (messageID: T.Chat.MessageID) => {
+      if (C.isMobile) {
+        clearModals()
+      }
       loadMoreMessages({
         centeredMessageID: {conversationIDKey, highlightMode: 'always', messageID},
         reason: 'jumpAttachment',
       })
     },
-    [conversationIDKey, loadMoreMessages]
+    [conversationIDKey, loadMoreMessages, clearModals]
   )
 
   C.useOnMountOnce(() => {
-    loadAttachmentView(selectedAttachmentView)
+    setTimeout(() => {
+      loadAttachmentView(selectedAttachmentView)
+    }, 1)
   })
   if (cidChanged || lastSAV !== selectedAttachmentView) {
     setLastSAV(selectedAttachmentView)
     if (loadImmediately) {
-      loadAttachmentView(selectedAttachmentView)
+      setTimeout(() => {
+        loadAttachmentView(selectedAttachmentView)
+      }, 1)
     }
   }
 

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -52,6 +52,7 @@ type Doc = {
   progress: number
   onDownload?: () => void
   onShowInFinder?: () => void
+  onClick: () => void
 }
 
 type Link = {
@@ -60,6 +61,7 @@ type Link = {
   snippet: string
   title?: string
   url?: string
+  id: T.Chat.MessageID
 }
 type InfoPanelSection = Section<
   any,
@@ -176,7 +178,7 @@ const DocViewRow = (props: DocViewRowProps) => {
   })
   return (
     <Kb.Box2 direction="vertical" fullWidth={true}>
-      <Kb.ClickableBox onClick={item.onDownload} onLongPress={showPopup}>
+      <Kb.ClickableBox onClick={item.onClick} onLongPress={showPopup}>
         <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.docRowContainer} gap="xtiny">
           <Kb.Icon type="icon-file-32" style={styles.docIcon} />
           <Kb.Box2 direction="vertical" fullWidth={true} style={styles.docRowTitle}>
@@ -404,6 +406,17 @@ export const useAttachmentSections = (
   const cidChanged = C.Chat.useCIDChanged(conversationIDKey)
   const [lastSAV, setLastSAV] = React.useState(selectedAttachmentView)
   const loadAttachmentView = C.useChatContext(s => s.dispatch.loadAttachmentView)
+  const loadMoreMessages = C.useChatContext(s => s.dispatch.loadMoreMessages)
+
+  const jumpToAttachment = React.useCallback(
+    (messageID: T.Chat.MessageID) => {
+      loadMoreMessages({
+        centeredMessageID: {conversationIDKey, highlightMode: 'always', messageID},
+        reason: 'jumpAttachment',
+      })
+    },
+    [conversationIDKey, loadMoreMessages]
+  )
 
   C.useOnMountOnce(() => {
     loadAttachmentView(selectedAttachmentView)
@@ -520,6 +533,7 @@ export const useAttachmentSections = (
                   audioDuration: m.audioDuration,
                   ctime: m.timestamp,
                   height: m.previewHeight,
+                  id: m.id,
                   key: `media-${m.ordinal}-${m.timestamp}-${m.previewURL}`,
                   onClick: () => onMediaClick(m),
                   previewURL: m.previewURL,
@@ -575,6 +589,9 @@ export const useAttachmentSections = (
             key: `doc-${m.ordinal}-${m.author}-${m.timestamp}-${m.fileName}`,
             message: m,
             name: m.title || m.fileName,
+            onClick: () => {
+              jumpToAttachment(m.id)
+            },
             onDownload: () => onDocDownload(m),
             onShowInFinder: !C.isMobile && m.downloadPath ? () => onShowInFinder(m) : undefined,
             progress: m.transferProgress,
@@ -599,6 +616,7 @@ export const useAttachmentSections = (
               snippet: string
               title?: string
               url?: string
+              id: T.Chat.MessageID
             }>
           >((l, m) => {
             if (m.type !== 'text') {
@@ -608,6 +626,7 @@ export const useAttachmentSections = (
               l.push({
                 author: m.author,
                 ctime: m.timestamp,
+                id: m.id,
                 key: `unfurl-empty-${m.ordinal}-${m.author}-${m.timestamp}`,
                 snippet: m.decoratedText?.stringValue() ?? '',
               })
@@ -617,6 +636,7 @@ export const useAttachmentSections = (
                   l.push({
                     author: m.author,
                     ctime: m.timestamp,
+                    id: m.id,
                     key: `unfurl-${m.ordinal}-${i}-${m.author}-${m.timestamp}-${u.unfurl.generic.url}`,
                     snippet: m.decoratedText?.stringValue() ?? '',
                     title: u.unfurl.generic.title,
@@ -633,41 +653,50 @@ export const useAttachmentSections = (
             key: month.key,
             renderItem: ({item}: {item: Link}) => {
               return (
-                <Kb.Box2 direction="vertical" fullWidth={true} style={styles.linkContainer} gap="tiny">
-                  <Kb.Box2 direction="vertical" fullWidth={true} gap="xxtiny">
-                    <Kb.Box2 direction="horizontal" fullWidth={true} gap="tiny">
-                      <Kb.NameWithIcon
-                        avatarSize={32}
-                        avatarStyle={styles.avatar}
-                        colorFollowing={true}
-                        username={item.author}
-                        horizontal={true}
-                      />
-                      <Kb.Text type="BodyTiny" style={styles.linkTime}>
-                        {formatTimeForMessages(item.ctime)}
-                      </Kb.Text>
+                <Kb.ClickableBox2
+                  onClick={() => {
+                    jumpToAttachment(item.id)
+                  }}
+                >
+                  <Kb.Box2 direction="vertical" fullWidth={true} style={styles.linkContainer} gap="tiny">
+                    <Kb.Box2 direction="vertical" fullWidth={true} gap="xxtiny">
+                      <Kb.Box2 direction="horizontal" fullWidth={true} gap="tiny">
+                        <Kb.NameWithIcon
+                          avatarSize={32}
+                          avatarStyle={styles.avatar}
+                          colorFollowing={true}
+                          username={item.author}
+                          horizontal={true}
+                        />
+                        <Kb.Text type="BodyTiny" style={styles.linkTime}>
+                          {formatTimeForMessages(item.ctime)}
+                        </Kb.Text>
+                      </Kb.Box2>
+                      <Kb.Markdown
+                        serviceOnly={true}
+                        smallStandaloneEmoji={true}
+                        selectable={true}
+                        styleOverride={linkStyleOverride}
+                        style={styles.linkStyle}
+                      >
+                        {item.snippet}
+                      </Kb.Markdown>
                     </Kb.Box2>
-                    <Kb.Markdown
-                      serviceOnly={true}
-                      smallStandaloneEmoji={true}
-                      selectable={true}
-                      styleOverride={linkStyleOverride}
-                      style={styles.linkStyle}
-                    >
-                      {item.snippet}
-                    </Kb.Markdown>
+                    {!!item.title && (
+                      <Kb.Text
+                        type="BodySmallPrimaryLink"
+                        onClickURL={item.url}
+                        style={Styles.collapseStyles([
+                          styles.linkStyle,
+                          {color: Styles.globalColors.blueDark},
+                        ])}
+                      >
+                        {item.title}
+                      </Kb.Text>
+                    )}
+                    <Kb.Divider />
                   </Kb.Box2>
-                  {!!item.title && (
-                    <Kb.Text
-                      type="BodySmallPrimaryLink"
-                      onClickURL={item.url}
-                      style={Styles.collapseStyles([styles.linkStyle, {color: Styles.globalColors.blueDark}])}
-                    >
-                      {item.title}
-                    </Kb.Text>
-                  )}
-                  <Kb.Divider />
-                </Kb.Box2>
+                </Kb.ClickableBox2>
               )
             },
             renderSectionHeader: () => <Kb.SectionDivider label={`${month.month} ${month.year}`} />,

--- a/shared/chat/conversation/messages/message-popup/attachment.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment.tsx
@@ -24,6 +24,19 @@ const PopAttach = (ownProps: OwnProps) => {
   const pending = !!message.transferState
   const clearModals = C.useRouterState(s => s.dispatch.clearModals)
   const showInfoPanel = C.useChatContext(s => s.dispatch.showInfoPanel)
+
+  const loadMoreMessages = C.useChatContext(s => s.dispatch.loadMoreMessages)
+
+  const onJump = React.useCallback(() => {
+    m &&
+      loadMoreMessages({
+        centeredMessageID: {conversationIDKey: m.conversationIDKey, highlightMode: 'always', messageID: m.id},
+        reason: 'jumpAttachment',
+      })
+    showInfoPanel(false, 'attachments')
+    clearModals()
+  }, [m, loadMoreMessages, showInfoPanel, clearModals])
+
   const onAllMedia = () => {
     clearModals()
     showInfoPanel(true, 'attachments')
@@ -79,6 +92,8 @@ const PopAttach = (ownProps: OwnProps) => {
     : []
   const itemMedia = [{icon: 'iconfont-camera', onClick: onAllMedia, title: 'All media'}] as const
 
+  const itemJump = [{icon: 'iconfont-camera', onClick: onJump, title: 'Jump to message'}] as const
+
   const topSection = [...itemSave, ...itemShare, ...itemDelete, ...itemExplode]
 
   const items = [
@@ -91,6 +106,7 @@ const PopAttach = (ownProps: OwnProps) => {
     ...itemForward,
     ...itemEdit,
     ...itemDownload,
+    ...itemJump,
     ...itemUnread,
     ...itemFinder,
     ...itemBot,

--- a/shared/chat/conversation/messages/message-popup/attachment.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment.tsx
@@ -92,7 +92,7 @@ const PopAttach = (ownProps: OwnProps) => {
     : []
   const itemMedia = [{icon: 'iconfont-camera', onClick: onAllMedia, title: 'All media'}] as const
 
-  const itemJump = [{icon: 'iconfont-camera', onClick: onJump, title: 'Jump to message'}] as const
+  const itemJump = [{icon: 'iconfont-search', onClick: onJump, title: 'Jump to message'}] as const
 
   const topSection = [...itemSave, ...itemShare, ...itemDelete, ...itemExplode]
 

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -227,7 +227,7 @@ export type ConvoState = ConvoStore & {
     messageReplyPrivately: (ordinal: T.Chat.Ordinal) => void
     messageRetry: (outboxID: T.Chat.OutboxID) => void
     messageSend: (text: string, replyTo?: T.Chat.MessageID, waitingKey?: string) => void
-    messagesAdd: (messages: Array<T.Chat.Message>) => void
+    messagesAdd: (messages: Array<T.Chat.Message>, markAsRead?: boolean) => void
     messagesClear: () => void
     messagesExploded: (messageIDs: Array<T.Chat.MessageID>, explodedBy?: string) => void
     messagesWereDeleted: (p: {
@@ -864,7 +864,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
                     }
                   })
                   // inject them into the message map
-                  get().dispatch.messagesAdd([message])
+                  get().dispatch.messagesAdd([message], false)
                 }
               },
             },
@@ -1503,7 +1503,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
       }
       C.ignorePromise(f())
     },
-    messagesAdd: messages => {
+    messagesAdd: (messages, markAsRead = true) => {
       set(s => {
         for (const m of messages) {
           // we capture the highest one, cause sometimes we'll not track it in the map
@@ -1546,7 +1546,9 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
         }
         syncMessageDerived(s)
       })
-      get().dispatch.markThreadAsRead()
+      if (markAsRead) {
+        get().dispatch.markThreadAsRead()
+      }
     },
     messagesClear: () => {
       set(s => {

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -66,6 +66,7 @@ type NavReason =
   | 'teamMention' // from team mention
 
 type LoadMoreReason =
+  | 'jumpAttachment'
   | 'foregrounding'
   | 'got stale'
   | 'jump to recent'


### PR DESCRIPTION
In the side panel allow better jumping to the context of the attachment

- [x] clicking the area around links will jump to the message
- [x] clicking a doc will send you to the message, you download there now
- [x] clicking media will show the modal and there is a new ... menu option to jump to the message there