### PR TITLE
Explicitly skip CheckHiddenMerklePathResponseAndAddRatchets in case libkb.MerkleHiddenResponseTypeFLAGOFF

### DIFF
--- a/go/teams/hidden/loader.go
+++ b/go/teams/hidden/loader.go
@@ -534,6 +534,7 @@ func (l *LoaderPackage) CheckHiddenMerklePathResponseAndAddRatchets(mctx libkb.M
 		return false, NewLoaderError("Logic error in CheckHiddenMerklePathResponseAndAddRatchets: should not call this function with a NONE response.")
 	case libkb.MerkleHiddenResponseTypeFLAGOFF:
 		mctx.Debug("Skipping CheckHiddenMerklePathResponseAndAddRatchets as feature flag is off")
+		return true, nil
 	case libkb.MerkleHiddenResponseTypeOK:
 		newCommittedHiddenTail := hiddenResp.CommittedHiddenTail
 		newCommittedHiddenTailSeqno := newCommittedHiddenTail.Seqno

--- a/go/teams/loader.go
+++ b/go/teams/loader.go
@@ -550,18 +550,14 @@ func (l *TeamLoader) checkHiddenResponse(mctx libkb.MetaContext, hiddenPackage *
 
 	switch hiddenResp.RespType {
 	case libkb.MerkleHiddenResponseTypeNONE:
-		hiddenIsFresh = true
 		mctx.Debug("Skipping CheckHiddenMerklePathResponseAndAddRatchets as no hidden data was received. If the server had to show us the hidden chain and didn't, we will error out later (once we can establish our role in the team).")
+		return true, nil
 	case libkb.MerkleHiddenResponseTypeFLAGOFF:
-		hiddenIsFresh = true
 		mctx.Debug("Skipping CheckHiddenMerklePathResponseAndAddRatchets as the hidden flag is off.")
+		return true, nil
 	default:
-		hiddenIsFresh, err = hiddenPackage.CheckHiddenMerklePathResponseAndAddRatchets(mctx, hiddenResp)
-		if err != nil {
-			return false, err
-		}
+		return hiddenPackage.CheckHiddenMerklePathResponseAndAddRatchets(mctx, hiddenResp)
 	}
-	return hiddenIsFresh, nil
 }
 
 func (l *TeamLoader) load2InnerLockedRetry(ctx context.Context, arg load2ArgT) (*load2ResT, error) {


### PR DESCRIPTION
A previous time we had to skip this check locally https://github.com/keybase/client/commit/6b4525e654100a0c4f491f7fb89523505ce77818 was put in. It seems like `LoaderPackge.CheckHiddenMerklePathResponseAndAddRatchets` may have had a bug where it logged that it was skipping but didn't actually short circuit. `TeamLoader.checkHiddenResponse` was cleaned up for readability 

@mmaxim @heronhaye @AMarcedone 