### PR TITLE
Revert "disable the KBFS merkle gap check"

### DIFF
--- a/go/kbfs/libkbfs/md_ops.go
+++ b/go/kbfs/libkbfs/md_ops.go
@@ -26,11 +26,14 @@ import (
 )
 
 const (
-	// Update 2024-02-16: we decided to disable the merkle gap check (by
-	// increasing the allowed gap to a very high number) since mdmerkle is slow
-	// and this gap check is doing more harm than good.
-	maxAllowedMerkleGapServer = 200 * (time.Hour * 24 * 365)
-	maxAllowedMerkleGap       = maxAllowedMerkleGapServer + 15*time.Minute
+	maxAllowedMerkleGapServer = 13 * time.Hour
+	// Our contract with the server states that it won't accept KBFS
+	// writes if more than 13 hours have passed since the last Merkle
+	// roots (both global and KBFS) were published.  Add some padding
+	// to that, and if we see any gaps larger than this, we will know
+	// we shouldn't be trusting the server.  TODO: reduce this once
+	// merkle computation is faster.
+	maxAllowedMerkleGap = maxAllowedMerkleGapServer + 15*time.Minute
 
 	// merkleGapEnforcementStartString indicates when the mdserver
 	// started rejecting new writes based on the lack of recent merkle


### PR DESCRIPTION
Reverts keybase/client#26251

turns out mdmerkle is much faster now

@strib @maxtaco @jzila 