### PR TITLE
Smooth scaling delta and cap zoom in

### DIFF
--- a/shared/common-adapters/zoomable-image.desktop.tsx
+++ b/shared/common-adapters/zoomable-image.desktop.tsx
@@ -80,8 +80,8 @@ const ZoomableImage = React.memo(function ZoomableImage(p: Props) {
     if (dragPan && !allowPan) return
     if (!dragPan && !isZoomedRef.current) return
 
-    const delta = e.deltaY > 0 ? 1.1 : 0.9
-    scaleRef.current = Math.max(1, scaleRef.current * delta)
+    const delta = e.deltaY > 0 ? 1.02 : 0.92
+    scaleRef.current = Math.min(2.5, Math.max(0.5, scaleRef.current * delta))
     handleMouseMove(e)
   }
 


### PR DESCRIPTION
Some parts prior to 6a3aef2fca382aa12f392005ef1ae98c0e7c5ae8 seemed to work better, i.e. taking into account the mouse position post scale so you don't have a sharp jump after zooming and then moving the mouse