### PR TITLE
fix inbox losing state

### DIFF
--- a/shared/patches/react-virtualized-auto-sizer+1.0.21.patch
+++ b/shared/patches/react-virtualized-auto-sizer+1.0.21.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.cjs.js b/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.cjs.js
+index f68650c..2caedca 100644
+--- a/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.cjs.js
++++ b/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.cjs.js
+@@ -375,7 +375,7 @@ class AutoSizer extends react.Component {
+         ...style
+       },
+       ...rest
+-    }, !bailoutOnChildren && children(childParams));
++    }, /*!bailoutOnChildren && */children(childParams));
+   }
+ }
+ 
+diff --git a/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.esm.js b/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.esm.js
+index 6125a3c..8981a9d 100644
+--- a/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.esm.js
++++ b/node_modules/react-virtualized-auto-sizer/dist/react-virtualized-auto-sizer.esm.js
+@@ -371,7 +371,7 @@ class AutoSizer extends Component {
+         ...style
+       },
+       ...rest
+-    }, !bailoutOnChildren && children(childParams));
++    }, /*!bailoutOnChildren && */children(childParams));
+   }
+ }
+ 


### PR DESCRIPTION
inbox will lose state if you switch tabs due to the library we use opportunistically not rendering children if it think the parent div is 0x0, which it is cause its hidden