### PR TITLE
rollback rcttext text2 native impl

### DIFF
--- a/shared/chat/inbox/row/big-team-channel.tsx
+++ b/shared/chat/inbox/row/big-team-channel.tsx
@@ -85,9 +85,9 @@ const BigTeamChannel = React.memo(function BigTeamChannel(props: Props) {
       style={Kb.Styles.collapseStyles([styles.channelHash, selected && styles.channelHashSelected])}
     >
       #{' '}
-      <Kb.Text type={selected ? 'BodySemibold' : 'Body'} fixOverdraw={Kb.Styles.isPhone} style={nameStyle}>
+      <Kb.Text2 type={selected ? 'BodySemibold' : 'Body'} style={nameStyle}>
         {channelname}
-      </Kb.Text>
+      </Kb.Text2>
     </Kb.Text2>
   )
 

--- a/shared/common-adapters/text2.native.tsx
+++ b/shared/common-adapters/text2.native.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as Styles from '@/styles'
 import {fontSizeToSizeStyle, metaData} from './text.meta.native'
 import type {Props} from './text2'
-import type {Text as RNText} from 'react-native'
+import {Text as RNText} from 'react-native'
 import type {TextType} from './text.shared'
 import {debugWarning} from '@/util/debug-warning'
 
@@ -12,12 +12,13 @@ const TEMP_SWITCH = __DEV__ && (false as boolean)
 if (TEMP_MARK_V2 || TEMP_SWITCH) {
   debugWarning('Text2 flags on')
 }
-
-type RNTextProps = React.ComponentProps<typeof RNText>
-const RCTText = (props: RNTextProps) => {
-  const {onLongPress, onPress, onPressIn, onPressOut, ...p} = props
-  return React.createElement('RCTText', p)
-}
+// this is supposed to be faster with some tradeoffs but it doesn't work on text that updates
+// the value doesn't show up on the native side
+// type RNTextProps = React.ComponentProps<typeof RNText>
+// const RCTText = (props: RNTextProps) => {
+//   const {onLongPress, onPress, onPressIn, onPressOut, ...p} = props
+//   return React.createElement('RCTText', p)
+// }
 
 const styles = Styles.styleSheetCreate(() =>
   Object.keys(metaData()).reduce<{[key: string]: Styles._StylesCrossPlatform}>((map, type) => {
@@ -40,8 +41,10 @@ export const Text2 = TEMP_SWITCH
       const style = React.useMemo(() => {
         const baseStyle: Styles.StylesCrossPlatform = styles[type]
         const overdrawStyle = canFixOverdraw ? {backgroundColor: Styles.globalColors.fastBlank} : undefined
-        return Styles.collapseStyles([baseStyle, _style, overdrawStyle])
+        return Styles.collapseStyles([baseStyle, overdrawStyle, _style])
       }, [type, _style, canFixOverdraw])
+
+      // const style = Styles.collapseStyles([baseStyle, overdrawStyle, _style])
 
       const clampProps = React.useMemo(() => {
         return lineClamp ? {ellipsizeMode, numberOfLines: lineClamp} : undefined
@@ -53,9 +56,10 @@ export const Text2 = TEMP_SWITCH
           children = ['⚠', children]
         }
       }
+
       return (
-        <RCTText style={style} numberOfLines={lineClamp} selectable={selectable} {...clampProps}>
+        <RNText style={style} numberOfLines={lineClamp} selectable={selectable} {...clampProps}>
           {children}
-        </RCTText>
+        </RNText>
       )
     })

--- a/shared/common-adapters/text2.native.tsx
+++ b/shared/common-adapters/text2.native.tsx
@@ -44,8 +44,6 @@ export const Text2 = TEMP_SWITCH
         return Styles.collapseStyles([baseStyle, overdrawStyle, _style])
       }, [type, _style, canFixOverdraw])
 
-      // const style = Styles.collapseStyles([baseStyle, overdrawStyle, _style])
-
       const clampProps = React.useMemo(() => {
         return lineClamp ? {ellipsizeMode, numberOfLines: lineClamp} : undefined
       }, [ellipsizeMode, lineClamp])

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -1487,6 +1487,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
 
         // else just write it
         logger.info(`marking read messages ${conversationIDKey} ${readMsgID}`)
+
         await T.RPCChat.localMarkAsReadLocalRpcPromise({
           conversationID: get().getConvID(),
           forceUnread: false,


### PR DESCRIPTION
So you can avoid some overhead by using a `RCTText` directly and things seemed ok at first but then i noticed updates weren't flowing correctly. Turns out there's some issue where even though style (or even child) updates it doesn't render for some reason. I spent a little time looking at it but its scary enough that I had to roll back to using the exposed `Text` class