### PR TITLE
Fix attachment view and plumb errors better

### DIFF
--- a/shared/chat/conversation/attachment-fullscreen/hooks.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/hooks.tsx
@@ -101,6 +101,11 @@ export const usePreviewFallback = (
   const [previewState, setPreviewState] = React.useState<PreviewState>(
     path && previewPath && !isVideo ? 'loadingPreview' : 'cantDoFallback'
   )
+  const lastPathsRef = React.useRef({path, previewPath})
+  if (lastPathsRef.current.path !== path || lastPathsRef.current.previewPath !== previewPath) {
+    lastPathsRef.current = {path, previewPath}
+    setPreviewState(path && previewPath && !isVideo ? 'loadingPreview' : 'cantDoFallback')
+  }
 
   const onLoadError = React.useCallback(() => {
     setPreviewState('cantDoFallback')

--- a/shared/chat/conversation/attachment-fullscreen/hooks.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/hooks.tsx
@@ -9,7 +9,10 @@ export const useData = (initialOrdinal: T.Chat.Ordinal) => {
   const [ordinal, setOrdinal] = React.useState(initialOrdinal)
 
   const message: T.Chat.MessageAttachment = C.useChatContext(s => {
-    const m = s.messageMap.get(ordinal)
+    let m = s.messageMap.get(ordinal)
+    if (!m) {
+      m = s.messageMapAttachments.get(ordinal)
+    }
     return m?.type === 'attachment' ? m : blankMessage
   })
 

--- a/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
@@ -33,6 +33,7 @@ const Arrow = (props: ArrowProps) => {
 
 const Fullscreen = React.memo(function Fullscreen(p: Props) {
   const data = useData(p.ordinal)
+  console.log('aaaa full loading ', p.ordinal, data)
   const {message, ordinal, path, title, progress, previewPath} = data
   const {progressLabel, onNextAttachment, onPreviousAttachment, onClose} = data
   const {onDownloadAttachment, onShowInFinder, isVideo} = data
@@ -51,6 +52,7 @@ const Fullscreen = React.memo(function Fullscreen(p: Props) {
   }, [])
 
   const {onLoaded, onLoadError, imgSrc} = usePreviewFallback(path, previewPath, isVideo, preload)
+
   const forceDims = React.useMemo(() => {
     if (!previewWidth) return undefined
     return imgSrc === previewPath

--- a/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
@@ -33,7 +33,6 @@ const Arrow = (props: ArrowProps) => {
 
 const Fullscreen = React.memo(function Fullscreen(p: Props) {
   const data = useData(p.ordinal)
-  console.log('aaaa full loading ', p.ordinal, data)
   const {message, ordinal, path, title, progress, previewPath} = data
   const {progressLabel, onNextAttachment, onPreviousAttachment, onClose} = data
   const {onDownloadAttachment, onShowInFinder, isVideo} = data

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -538,7 +538,9 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
             }
           }
 
-          m.ordinal = mapOrdinal
+          if (m.ordinal !== mapOrdinal) {
+            m.ordinal = mapOrdinal
+          }
           s.messageMap.set(mapOrdinal, T.castDraft(m))
           if (m.outboxID && T.Chat.messageIDToNumber(m.id) !== T.Chat.ordinalToNumber(m.ordinal)) {
             s.pendingOutboxToOrdinal.set(m.outboxID, mapOrdinal)
@@ -552,6 +554,8 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
       }
       syncMessageDerived(s)
     })
+
+    console.log('aaaa message add aftersync size', get().messageMap.size)
 
     if (markAsRead) {
       get().dispatch.markThreadAsRead()
@@ -1119,7 +1123,14 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
                     }
                   })
                   // inject them into the message map
-                  messagesAdd([message], 'gallery inject', false)
+                  messagesAdd(
+                    [
+                      // copy as its frozen by being injected
+                      {...message},
+                    ],
+                    'gallery inject',
+                    false
+                  )
                 }
               },
             },
@@ -1818,6 +1829,7 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
     messagesClear: () => {
       set(s => {
         s.pendingOutboxToOrdinal.clear()
+        console.log('aaaa messagemapclear')
         s.messageMap.clear()
         s.maxMsgIDSeen = T.Chat.numberToMessageID(-1)
         syncMessageDerived(s)

--- a/shared/constants/daemon.tsx
+++ b/shared/constants/daemon.tsx
@@ -222,7 +222,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
           }
         }
       }
-      await f()
+      return await f()
     },
     onRestartHandshakeNative: _onRestartHandshakeNative,
     refreshAccounts: async () => {

--- a/shared/constants/daemon.tsx
+++ b/shared/constants/daemon.tsx
@@ -111,7 +111,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
         wait(name, version, true)
         logger.info('Waiting on nav')
         C.useConfigState.setState(s => {
-          s.dispatch.dynamic.setNavigatorExistsNative = () => {
+          s.dispatch.dynamic.setNavigatorExistsNative = C.wrapErrors(() => {
             if (C.Router2._getNavigator()) {
               C.useConfigState.setState(s => {
                 s.dispatch.dynamic.setNavigatorExistsNative = undefined
@@ -120,7 +120,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
             } else {
               logger.info('Waiting on nav, got setNavigator but nothing in constants?')
             }
-          }
+          })
         })
       }
       checkNav(version)

--- a/shared/constants/daemon.tsx
+++ b/shared/constants/daemon.tsx
@@ -222,8 +222,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
           }
         }
       }
-
-      return await f()
+      await f()
     },
     onRestartHandshakeNative: _onRestartHandshakeNative,
     refreshAccounts: async () => {

--- a/shared/constants/fs/common.native.tsx
+++ b/shared/constants/fs/common.native.tsx
@@ -8,56 +8,60 @@ import {saveAttachmentToCameraRoll, showShareActionSheet} from '../platform-spec
 
 export default function initNative() {
   C.useFSState.setState(s => {
-    s.dispatch.dynamic.pickAndUploadMobile = (type, parentPath) => {
-      const f = async () => {
-        try {
-          const result = await launchImageLibraryAsync(type, true, true)
-          if (result.canceled) return
-          result.assets.map(r =>
-            C.useFSState.getState().dispatch.upload(parentPath, Styles.unnormalizePath(r.uri))
-          )
-        } catch (e) {
-          Constants.errorToActionOrThrow(e)
-        }
-      }
-      C.ignorePromise(f())
-    }
-
-    s.dispatch.dynamic.finishedDownloadWithIntentMobile = (downloadID, downloadIntent, mimeType) => {
-      const f = async () => {
-        const {downloads, dispatch} = C.useFSState.getState()
-        const downloadState = downloads.state.get(downloadID) || Constants.emptyDownloadState
-        if (downloadState === Constants.emptyDownloadState) {
-          logger.warn('missing download', downloadID)
-          return
-        }
-        const dismissDownload = dispatch.dismissDownload
-        if (downloadState.error) {
-          dispatch.redbar(downloadState.error)
-          dismissDownload(downloadID)
-          return
-        }
-        const {localPath} = downloadState
-        try {
-          switch (downloadIntent) {
-            case T.FS.DownloadIntent.CameraRoll:
-              await saveAttachmentToCameraRoll(localPath, mimeType)
-              dismissDownload(downloadID)
-              return
-            case T.FS.DownloadIntent.Share:
-              await showShareActionSheet({filePath: localPath, mimeType})
-              dismissDownload(downloadID)
-              return
-            case T.FS.DownloadIntent.None:
-              return
-            default:
-              return
+    s.dispatch.dynamic.pickAndUploadMobile = C.wrapErrors(
+      (type: T.FS.MobilePickType, parentPath: T.FS.Path) => {
+        const f = async () => {
+          try {
+            const result = await launchImageLibraryAsync(type, true, true)
+            if (result.canceled) return
+            result.assets.map(r =>
+              C.useFSState.getState().dispatch.upload(parentPath, Styles.unnormalizePath(r.uri))
+            )
+          } catch (e) {
+            Constants.errorToActionOrThrow(e)
           }
-        } catch (err) {
-          Constants.errorToActionOrThrow(err)
         }
+        C.ignorePromise(f())
       }
-      C.ignorePromise(f())
-    }
+    )
+
+    s.dispatch.dynamic.finishedDownloadWithIntentMobile = C.wrapErrors(
+      (downloadID: string, downloadIntent: T.FS.DownloadIntent, mimeType: string) => {
+        const f = async () => {
+          const {downloads, dispatch} = C.useFSState.getState()
+          const downloadState = downloads.state.get(downloadID) || Constants.emptyDownloadState
+          if (downloadState === Constants.emptyDownloadState) {
+            logger.warn('missing download', downloadID)
+            return
+          }
+          const dismissDownload = dispatch.dismissDownload
+          if (downloadState.error) {
+            dispatch.redbar(downloadState.error)
+            dismissDownload(downloadID)
+            return
+          }
+          const {localPath} = downloadState
+          try {
+            switch (downloadIntent) {
+              case T.FS.DownloadIntent.CameraRoll:
+                await saveAttachmentToCameraRoll(localPath, mimeType)
+                dismissDownload(downloadID)
+                return
+              case T.FS.DownloadIntent.Share:
+                await showShareActionSheet({filePath: localPath, mimeType})
+                dismissDownload(downloadID)
+                return
+              case T.FS.DownloadIntent.None:
+                return
+              default:
+                return
+            }
+          } catch (err) {
+            Constants.errorToActionOrThrow(err)
+          }
+        }
+        C.ignorePromise(f())
+      }
+    )
   })
 }

--- a/shared/constants/index.tsx
+++ b/shared/constants/index.tsx
@@ -1,5 +1,6 @@
 // Used to avoid circular dependencies, keep orders
 export * from './platform'
+export {wrapErrors} from '@/util/debug'
 export {_useState as useDarkModeState} from './darkmode'
 export {_useState as useRouterState} from './router2'
 export * as Router2 from './router2'

--- a/shared/constants/pinentry.tsx
+++ b/shared/constants/pinentry.tsx
@@ -89,20 +89,20 @@ export const _useState = Z.createZustand<State>((set, get) => {
         s.submitLabel = submitLabel
         s.type = type
         s.windowTitle = windowTitle
-        s.dispatch.dynamic.onSubmit = (password: string) => {
+        s.dispatch.dynamic.onSubmit = C.wrapErrors((password: string) => {
           set(s => {
             s.dispatch.dynamic.onSubmit = undefined
           })
           response.result({passphrase: password, storeSecret: false})
           get().dispatch.resetState()
-        }
-        s.dispatch.dynamic.onCancel = () => {
+        })
+        s.dispatch.dynamic.onCancel = C.wrapErrors(() => {
           set(s => {
             s.dispatch.dynamic.onCancel = undefined
           })
           response.error({code: T.RPCGen.StatusCode.scinputcanceled, desc: 'Input canceled'})
           get().dispatch.resetState()
-        }
+        })
       })
     },
   }

--- a/shared/constants/platform-specific/index.desktop.tsx
+++ b/shared/constants/platform-specific/index.desktop.tsx
@@ -65,17 +65,17 @@ export const dumpLogs = async (reason?: string) => {
 export const initPlatformListener = () => {
   C.useConfigState.setState(s => {
     s.dispatch.dynamic.dumpLogsNative = dumpLogs
-    s.dispatch.dynamic.showMainNative = () => showMainWindow?.()
-    s.dispatch.dynamic.copyToClipboard = s => copyToClipboard?.(s)
-    s.dispatch.dynamic.onEngineConnectedDesktop = () => {
+    s.dispatch.dynamic.showMainNative = C.wrapErrors(() => showMainWindow?.())
+    s.dispatch.dynamic.copyToClipboard = C.wrapErrors((s: string) => copyToClipboard?.(s))
+    s.dispatch.dynamic.onEngineConnectedDesktop = C.wrapErrors(() => {
       // Introduce ourselves to the service
       const f = async () => {
         await T.RPCGen.configHelloIAmRpcPromise({details: KB2.constants.helloDetails})
       }
       C.ignorePromise(f())
-    }
+    })
 
-    s.dispatch.dynamic.onEngineIncomingDesktop = action => {
+    s.dispatch.dynamic.onEngineIncomingDesktop = C.wrapErrors((action: EngineGen.Actions) => {
       switch (action.type) {
         case EngineGen.keybase1LogsendPrepareLogsend: {
           const f = async () => {
@@ -139,7 +139,7 @@ export const initPlatformListener = () => {
         }
         default:
       }
-    }
+    })
   })
 
   C.useConfigState.subscribe((s, old) => {

--- a/shared/constants/platform-specific/index.native.tsx
+++ b/shared/constants/platform-specific/index.native.tsx
@@ -354,7 +354,7 @@ let afterStartupDetails = (_done: boolean) => {}
 export const initPlatformListener = () => {
   let _lastPersist = ''
   C.useConfigState.setState(s => {
-    s.dispatch.dynamic.persistRoute = (path?: ReadonlyArray<any>) => {
+    s.dispatch.dynamic.persistRoute = C.wrapErrors((path?: ReadonlyArray<any>) => {
       const f = async () => {
         let param = {}
         let routeName = Tabs.peopleTab
@@ -385,13 +385,13 @@ export const initPlatformListener = () => {
         })
       }
       C.ignorePromise(f())
-    }
+    })
 
-    s.dispatch.dynamic.onEngineIncomingNative = action => {
+    s.dispatch.dynamic.onEngineIncomingNative = C.wrapErrors((action: EngineGen.Actions) => {
       switch (action.type) {
         default:
       }
-    }
+    })
   })
 
   C.useConfigState.subscribe((s, old) => {
@@ -421,11 +421,11 @@ export const initPlatformListener = () => {
   })
 
   C.useConfigState.setState(s => {
-    s.dispatch.dynamic.copyToClipboard = s => {
+    s.dispatch.dynamic.copyToClipboard = C.wrapErrors((s: string) => {
       Clipboard.setStringAsync(s)
         .then(() => {})
         .catch(() => {})
-    }
+    })
   })
 
   C.useDaemonState.subscribe((s, old) => {
@@ -458,16 +458,16 @@ export const initPlatformListener = () => {
   })
 
   C.useConfigState.setState(s => {
-    s.dispatch.dynamic.onFilePickerError = error => {
+    s.dispatch.dynamic.onFilePickerError = C.wrapErrors((error: Error) => {
       Alert.alert('Error', String(error))
-    }
-    s.dispatch.dynamic.openAppStore = () => {
+    })
+    s.dispatch.dynamic.openAppStore = C.wrapErrors(() => {
       Linking.openURL(
         isAndroid
           ? 'http://play.google.com/store/apps/details?id=io.keybase.ossifrage'
           : 'https://itunes.apple.com/us/app/keybase-crypto-for-everyone/id1044461770?mt=8'
       ).catch(() => {})
-    }
+    })
   })
 
   C.useProfileState.setState(s => {
@@ -514,12 +514,14 @@ export const initPlatformListener = () => {
   })
 
   C.useConfigState.setState(s => {
-    s.dispatch.dynamic.showShareActionSheet = (filePath: string, message: string, mimeType: string) => {
-      const f = async () => {
-        await showShareActionSheet({filePath, message, mimeType})
+    s.dispatch.dynamic.showShareActionSheet = C.wrapErrors(
+      (filePath: string, message: string, mimeType: string) => {
+        const f = async () => {
+          await showShareActionSheet({filePath, message, mimeType})
+        }
+        C.ignorePromise(f())
       }
-      C.ignorePromise(f())
-    }
+    )
   })
 
   C.useConfigState.subscribe((s, old) => {
@@ -565,7 +567,7 @@ export const initPlatformListener = () => {
   initAudioModes()
 
   C.useConfigState.setState(s => {
-    s.dispatch.dynamic.openAppSettings = () => {
+    s.dispatch.dynamic.openAppSettings = C.wrapErrors(() => {
       const f = async () => {
         if (isAndroid) {
           androidOpenSettings()
@@ -580,9 +582,9 @@ export const initPlatformListener = () => {
         }
       }
       C.ignorePromise(f())
-    }
+    })
 
-    s.dispatch.dynamic.onEngineIncomingNative = action => {
+    s.dispatch.dynamic.onEngineIncomingNative = C.wrapErrors((action: EngineGen.Actions) => {
       switch (action.type) {
         case EngineGen.chat1ChatUiTriggerContactSync:
           C.useSettingsContactsState.getState().dispatch.manageContactsCache()
@@ -604,11 +606,11 @@ export const initPlatformListener = () => {
           break
         default:
       }
-    }
+    })
   })
 
   C.useRouterState.setState(s => {
-    s.dispatch.dynamic.tabLongPress = tab => {
+    s.dispatch.dynamic.tabLongPress = C.wrapErrors((tab: string) => {
       if (tab !== Tabs.peopleTab) return
       const accountRows = C.useConfigState.getState().configuredAccounts
       const current = C.useCurrentUserState.getState().username
@@ -617,6 +619,6 @@ export const initPlatformListener = () => {
         C.useConfigState.getState().dispatch.setUserSwitching(true)
         C.useConfigState.getState().dispatch.login(row.username, '')
       }
-    }
+    })
   })
 }

--- a/shared/constants/profile.tsx
+++ b/shared/constants/profile.tsx
@@ -296,20 +296,20 @@ export const _useState = Z.createZustand<State>((set, get) => {
                   return
                 }
                 set(s => {
-                  s.dispatch.dynamic.afterCheckProof = () => {
+                  s.dispatch.dynamic.afterCheckProof = C.wrapErrors(() => {
                     set(s => {
                       s.dispatch.dynamic.afterCheckProof = undefined
                     })
                     response.result()
-                  }
-                  s.dispatch.dynamic.cancelAddProof = () => {
+                  })
+                  s.dispatch.dynamic.cancelAddProof = C.wrapErrors(() => {
                     set(s => {
                       s.dispatch.dynamic.cancelAddProof = _cancelAddProof
                     })
                     _cancelAddProof()
                     canceled = true
                     response.error(inputCancelError)
-                  }
+                  })
                 })
                 if (service) {
                   set(s => {
@@ -339,7 +339,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
                   })
                 }
                 set(s => {
-                  s.dispatch.dynamic.cancelAddProof = () => {
+                  s.dispatch.dynamic.cancelAddProof = C.wrapErrors(() => {
                     clear()
                     set(s => {
                       s.dispatch.dynamic.cancelAddProof = _cancelAddProof
@@ -347,15 +347,15 @@ export const _useState = Z.createZustand<State>((set, get) => {
                     _cancelAddProof()
                     canceled = true
                     response.error(inputCancelError)
-                  }
-                  s.dispatch.dynamic.submitUsername = () => {
+                  })
+                  s.dispatch.dynamic.submitUsername = C.wrapErrors(() => {
                     clear()
                     set(s => {
                       updateUsername(s)
                       s.dispatch.dynamic.submitUsername = undefined
                     })
                     response.result(get().username)
-                  }
+                  })
                 })
                 if (prevError) {
                   set(s => {
@@ -524,9 +524,9 @@ export const _useState = Z.createZustand<State>((set, get) => {
         C.useRouterState.getState().dispatch.navigateAppend('profileGenerate')
         // We allow the UI to cancel this call. Just stash this intention and nav away and response with an error to the rpc
         set(s => {
-          s.dispatch.dynamic.cancelPgpGen = () => {
+          s.dispatch.dynamic.cancelPgpGen = C.wrapErrors(() => {
             canceled = true
-          }
+          })
         })
 
         try {

--- a/shared/constants/provision.tsx
+++ b/shared/constants/provision.tsx
@@ -5,6 +5,7 @@ import {RPCError} from '@/util/errors'
 import {isMobile} from './platform'
 import {type CommonResponseHandler} from '../engine/types'
 import isEqual from 'lodash/isEqual'
+import {wrapFunctionLogError} from '@/util/debug'
 
 export type Device = {
   deviceNumberOfType: number
@@ -217,13 +218,13 @@ export const _useState = Z.createZustand<State>((set, get) => {
       let cancelled = false
       const setupCancel = (response: CommonResponseHandler) => {
         set(s => {
-          s.dispatch.dynamic.cancel = () => {
+          s.dispatch.dynamic.cancel = wrapFunctionLogError(() => {
             set(s => {
               s.dispatch.dynamic.cancel = _cancel
             })
             cancelled = true
             cancelOnCallback(undefined, response)
-          }
+          })
         })
       }
       const isCanceled = (response: CommonResponseHandler) => {

--- a/shared/constants/recover-password.tsx
+++ b/shared/constants/recover-password.tsx
@@ -89,14 +89,14 @@ export const _useState = Z.createZustand<State>((set, get) => {
                       s.dispatch.dynamic.submitDeviceSelect = undefined
                     })
                   }
-                  const cancel = () => {
+                  const cancel = C.wrapErrors(() => {
                     clear()
                     response.error({code: T.RPCGen.StatusCode.scinputcanceled, desc: 'Input canceled'})
                     C.useRouterState.getState().dispatch.navigateUp()
-                  }
+                  })
                   s.devices = devices
                   s.dispatch.dynamic.cancel = cancel
-                  s.dispatch.dynamic.submitDeviceSelect = (name: string) => {
+                  s.dispatch.dynamic.submitDeviceSelect = C.wrapErrors((name: string) => {
                     clear()
                     const d = get().devices.find(d => d.name === name)
                     if (d) {
@@ -104,7 +104,7 @@ export const _useState = Z.createZustand<State>((set, get) => {
                     } else {
                       cancel()
                     }
-                  }
+                  })
                 })
                 C.useRouterState
                   .getState()
@@ -122,19 +122,21 @@ export const _useState = Z.createZustand<State>((set, get) => {
                     })
                   }
                   set(s => {
-                    s.dispatch.dynamic.submitResetPassword = action => {
-                      clear()
-                      response.result(action)
-                      set(s => {
-                        s.resetEmailSent = true
-                      })
-                      C.useRouterState.getState().dispatch.navigateUp()
-                    }
-                    s.dispatch.dynamic.cancel = () => {
+                    s.dispatch.dynamic.submitResetPassword = C.wrapErrors(
+                      (action: T.RPCGen.ResetPromptResponse) => {
+                        clear()
+                        response.result(action)
+                        set(s => {
+                          s.resetEmailSent = true
+                        })
+                        C.useRouterState.getState().dispatch.navigateUp()
+                      }
+                    )
+                    s.dispatch.dynamic.cancel = C.wrapErrors(() => {
                       clear()
                       response.result(T.RPCGen.ResetPromptResponse.nothing)
                       C.useRouterState.getState().dispatch.navigateUp()
-                    }
+                    })
                   })
                 } else {
                   const {startAccountReset} = C.useAutoResetState.getState().dispatch
@@ -152,18 +154,18 @@ export const _useState = Z.createZustand<State>((set, get) => {
                   }
                   set(s => {
                     s.paperKeyError = params.pinentry.retryLabel
-                    s.dispatch.dynamic.cancel = () => {
+                    s.dispatch.dynamic.cancel = C.wrapErrors(() => {
                       clear()
                       response.error({code: T.RPCGen.StatusCode.scinputcanceled, desc: 'Input canceled'})
                       get().dispatch.startRecoverPassword({
                         replaceRoute: true,
                         username: get().username,
                       })
-                    }
-                    s.dispatch.dynamic.submitPaperKey = passphrase => {
+                    })
+                    s.dispatch.dynamic.submitPaperKey = C.wrapErrors((passphrase: string) => {
                       clear()
                       response.result({passphrase, storeSecret: false})
-                    }
+                    })
                   })
                   C.useRouterState.getState().dispatch.navigateAppend('recoverPasswordPaperKey', true)
                 } else {
@@ -175,17 +177,17 @@ export const _useState = Z.createZustand<State>((set, get) => {
                   }
                   set(s => {
                     s.passwordError = params.pinentry.retryLabel
-                    s.dispatch.dynamic.cancel = () => {
+                    s.dispatch.dynamic.cancel = C.wrapErrors(() => {
                       clear()
                       response.error({code: T.RPCGen.StatusCode.scinputcanceled, desc: 'Input canceled'})
-                    }
+                    })
                   })
                   if (!params.pinentry.retryLabel) {
                     set(s => {
-                      s.dispatch.dynamic.submitPassword = (passphrase: string) => {
+                      s.dispatch.dynamic.submitPassword = C.wrapErrors((passphrase: string) => {
                         clear()
                         response.result({passphrase, storeSecret: true})
-                      }
+                      })
                     })
                     // TODO maybe wait for loggedIn, for now the service promises to send this after login.
                     C.useRouterState.getState().dispatch.navigateAppend('recoverPasswordSetPassword')

--- a/shared/constants/teams.tsx
+++ b/shared/constants/teams.tsx
@@ -2106,12 +2106,12 @@ export const _useState = Z.createZustand<State>((set, get) => {
                   C.useRouterState.getState().dispatch.navigateAppend('teamInviteLinkJoin', true)
                 }
                 set(s => {
-                  s.dispatch.dynamic.respondToInviteLink = accept => {
+                  s.dispatch.dynamic.respondToInviteLink = C.wrapErrors((accept: boolean) => {
                     set(s => {
                       s.dispatch.dynamic.respondToInviteLink = undefined
                     })
                     response.result(accept)
-                  }
+                  })
                 })
               },
             },

--- a/shared/engine/listener.tsx
+++ b/shared/engine/listener.tsx
@@ -3,7 +3,7 @@ import {getEngine} from './require'
 import {RPCError} from '@/util/errors'
 import {printOutstandingRPCs} from '@/local-debug'
 import type {CommonResponseHandler} from './types'
-import {wrapFunctionLogError} from '@/util/debug'
+import {wrapErrors} from '@/util/debug'
 
 type WaitingKey = string | Array<string>
 
@@ -89,7 +89,7 @@ async function listener(p: {
 
         // defer to process network first
         setTimeout(() => {
-          const invokeAndDispatch = wrapFunctionLogError(async () => {
+          const invokeAndDispatch = wrapErrors(async () => {
             if (response) {
               const cb = customResponseIncomingCallMap[method]
               await cb?.(params, response)

--- a/shared/engine/listener.tsx
+++ b/shared/engine/listener.tsx
@@ -104,6 +104,7 @@ async function listener(p: {
             .catch(e => {
               if (__DEV__) {
                 logger.error('Error in incomingcallmap', method, e)
+                // eslint-disable-next-line no-debugger
                 debugger
               } else {
                 logger.error('Error in incomingcallmap', method)

--- a/shared/engine/listener.tsx
+++ b/shared/engine/listener.tsx
@@ -3,6 +3,7 @@ import {getEngine} from './require'
 import {RPCError} from '@/util/errors'
 import {printOutstandingRPCs} from '@/local-debug'
 import type {CommonResponseHandler} from './types'
+import logger from '@/logger'
 
 type WaitingKey = string | Array<string>
 
@@ -100,7 +101,14 @@ async function listener(p: {
 
           invokeAndDispatch()
             .then(() => {})
-            .catch(() => {})
+            .catch(e => {
+              if (__DEV__) {
+                logger.error('Error in incomingcallmap', method, e)
+                debugger
+              } else {
+                logger.error('Error in incomingcallmap', method)
+              }
+            })
         }, 5)
       }
       return map

--- a/shared/logger/index.tsx
+++ b/shared/logger/index.tsx
@@ -1,7 +1,7 @@
 import * as T from '@/constants/types'
 import Logger from './ring-logger'
 import noop from 'lodash/noop'
-import {hasEngine} from '../engine/require'
+import type {hasEngine as HasEngineType} from '../engine/require'
 import {isMobile} from '@/constants/platform'
 import {requestIdleCallback} from '@/util/idle-callback'
 
@@ -111,6 +111,7 @@ class AggregateLoggerImpl {
     if (!isMobile) {
       // don't want main node thread making these calls
       try {
+        const {hasEngine} = require('../engine/require') as {hasEngine: typeof HasEngineType}
         if (!hasEngine()) {
           return Promise.resolve()
         }

--- a/shared/util/debug.tsx
+++ b/shared/util/debug.tsx
@@ -1,4 +1,7 @@
+import type Logger from '@/logger'
 export const ENABLE_F5_REMOUNTS = __DEV__ && (false as boolean)
+
+const debuggerOnWrapError = false as boolean
 
 const debugClearCBs = new Array<() => void>()
 const debugUnClearCBs = new Array<() => void>()
@@ -65,4 +68,41 @@ export function createLoggingProxy<T extends {[key: string]: unknown}>(
   )
 
   return proxy as T
+}
+
+const maybeDebugger = () => {
+  if (debuggerOnWrapError) {
+    // eslint-disable-next-line no-debugger
+    debugger
+  }
+}
+
+export function wrapFunctionLogError<T extends (...args: Array<any>) => any>(f: T, logExtra: string = ''): T {
+  return ((...p: Parameters<T>): ReturnType<T> => {
+    try {
+      const result = f(...p)
+      if (result instanceof Promise) {
+        return result.catch(e => {
+          const {default: logger} = require('@/logger') as {default: typeof Logger}
+          if (__DEV__) {
+            logger.error('Error in wrapped call', logExtra, e)
+            maybeDebugger()
+          } else {
+            logger.error('Error in wrapped call', logExtra)
+          }
+          throw e
+        }) as ReturnType<T>
+      }
+      return result
+    } catch (e) {
+      const {default: logger} = require('@/logger') as {default: typeof Logger}
+      if (__DEV__) {
+        logger.error('Error in wrapped call', logExtra, e)
+        maybeDebugger()
+      } else {
+        logger.error('Error in wrapped call', logExtra)
+      }
+      throw e
+    }
+  }) as T
 }

--- a/shared/util/debug.tsx
+++ b/shared/util/debug.tsx
@@ -77,7 +77,7 @@ const maybeDebugger = () => {
   }
 }
 
-export function wrapFunctionLogError<T extends (...args: Array<any>) => any>(f: T, logExtra: string = ''): T {
+export function wrapErrors<T extends (...args: Array<any>) => any>(f: T, logExtra: string = ''): T {
   return ((...p: Parameters<T>): ReturnType<T> => {
     try {
       const result = f(...p)

--- a/shared/util/zustand.tsx
+++ b/shared/util/zustand.tsx
@@ -4,7 +4,7 @@ import isEqual from 'lodash/isEqual'
 import {type StateCreator} from 'zustand'
 import {create} from 'zustand'
 import {immer as immerZustand} from 'zustand/middleware/immer'
-import {registerDebugUnClear, registerDebugClear, wrapFunctionLogError} from '@/util/debug'
+import {registerDebugUnClear, registerDebugClear, wrapErrors} from '@/util/debug'
 
 // needed for tsc
 export type {WritableDraft} from 'immer'
@@ -37,7 +37,7 @@ export const createZustand = <T extends HasReset>(
   for (const d of dispatches) {
     const orig = unsafeISD[d] as any
     if (typeof orig === 'function') {
-      unsafeISD[d] = wrapFunctionLogError(orig, d)
+      unsafeISD[d] = wrapErrors(orig, d)
       // copy over things like .cancel etc
       Object.assign(unsafeISD[d], orig)
     }

--- a/shared/util/zustand.tsx
+++ b/shared/util/zustand.tsx
@@ -33,22 +33,26 @@ export const createZustand = <T extends HasReset>(
   // wrap so we log all exceptions
 
   const dispatches = Object.keys(initialState.dispatch)
-  const unsafeID = (initialState as any).dispatch as any
+  const unsafeISD = (initialState as any).dispatch as any
   for (const d of dispatches) {
-    const orig = unsafeID[d] as any
-    unsafeID[d] = (...p: Array<any>) => {
-      try {
-        return orig(...p)
-      } catch (e) {
-        if (__DEV__) {
-          logger.error('Error in dispatch', d, e)
-          // eslint-disable-next-line no-debugger
-          debugger
-        } else {
-          logger.error('Error in dispatch', d)
+    const orig = unsafeISD[d] as any
+    if (typeof orig === 'function') {
+      unsafeISD[d] = (...p: Array<any>) => {
+        try {
+          return orig(...p)
+        } catch (e) {
+          if (__DEV__) {
+            logger.error('Error in dispatch', d, e)
+            // eslint-disable-next-line no-debugger
+            debugger
+          } else {
+            logger.error('Error in dispatch', d)
+          }
+          throw e
         }
-        throw e
       }
+      // copy over things like .cancel etc
+      Object.assign(unsafeISD[d], orig)
     }
   }
 

--- a/shared/util/zustand.tsx
+++ b/shared/util/zustand.tsx
@@ -42,6 +42,7 @@ export const createZustand = <T extends HasReset>(
       } catch (e) {
         if (__DEV__) {
           logger.error('Error in dispatch', d, e)
+          // eslint-disable-next-line no-debugger
           debugger
         } else {
           logger.error('Error in dispatch', d)


### PR DESCRIPTION
This PR fixes an issue where you open the chat info panel and look at image attachments and click a not-loaded item. The initial issue is we took a message and placed it into a data structure which then frozen it, then in some side code we edited that message (often unnecessarily) and we'd throw and silently fail adding it to the store.
This lead to the following changes

1. Wrap all dispatch calls in a new function which logs exceptions before rethrowing
2. Wrap engine incoming calls (original issue) with the same logging
3. Wrap dynamic dispatch calls as well
4. Before we'd load the image gallery and inject the messages into our messageMap. This was convenient as other views could just load it up and not differentiate it from a regular message in the thread, but, the downside is i'm afraid this leads to other complexity where we have messages that aren't from a regular load and now we have holes in our threads. This mixing with maxUnread and pagination makes it not worth the tradeoff. So instead messageMap is just messages we load normally and we stash gallery stuff into messageMapAttachments and fallback when loading in the full screen loader (etc)

- [x] dynamic
- [x] coverage
- [x] holistic check