### PR TITLE
Fix scraping for giphy.com URLs

### DIFF
--- a/go/chat/unfurl/scraper.go
+++ b/go/chat/unfurl/scraper.go
@@ -16,8 +16,7 @@ const userAgent = "Mozilla/5.0 (compatible; KeybaseBot; +https://keybase.io)"
 type Scraper struct {
 	globals.Contextified
 	utils.DebugLabeler
-	cache      *unfurlCache
-	giphyProxy bool
+	cache *unfurlCache
 }
 
 func NewScraper(g *globals.Context) *Scraper {
@@ -25,7 +24,6 @@ func NewScraper(g *globals.Context) *Scraper {
 		Contextified: globals.NewContextified(g),
 		DebugLabeler: utils.NewDebugLabeler(g.ExternalG(), "Scraper", false),
 		cache:        newUnfurlCache(),
-		giphyProxy:   true,
 	}
 }
 

--- a/go/chat/unfurl/scraper_test.go
+++ b/go/chat/unfurl/scraper_test.go
@@ -344,7 +344,7 @@ func TestGiphySearchScrape(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, chat1.UnfurlType_GIPHY, typ)
 	require.NotNil(t, res.Giphy().ImageUrl)
-	require.Nil(t, res.Giphy().Video)
+	require.NotNil(t, res.Giphy().Video)
 }
 
 func TestMapScraper(t *testing.T) {

--- a/go/chat/unfurl/scraper_test.go
+++ b/go/chat/unfurl/scraper_test.go
@@ -99,7 +99,6 @@ func TestScraper(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	scraper.cache.setClock(clock)
-	scraper.giphyProxy = false
 
 	srv := createTestCaseHTTPSrv(t)
 	addr := srv.Start()
@@ -315,7 +314,6 @@ func TestGiphySearchScrape(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 	scraper.cache.setClock(clock)
-	scraper.giphyProxy = false
 
 	url := "https://media0.giphy.com/media/iJDLBX5GY8niCpZYkR/giphy.mp4#height=360&width=640&isvideo=true"
 	res, err := scraper.Scrape(context.TODO(), url, nil)
@@ -338,6 +336,15 @@ func TestGiphySearchScrape(t *testing.T) {
 	require.NotNil(t, res.Giphy().ImageUrl)
 	require.Nil(t, res.Giphy().Video)
 	require.Equal(t, *res.Giphy().ImageUrl, url)
+
+	url = "https://giphy.com/gifs/culture--think-hmm-d3mlE7uhX8KFgEmY"
+	res, err = scraper.Scrape(context.TODO(), url, nil)
+	require.NoError(t, err)
+	typ, err = res.UnfurlType()
+	require.NoError(t, err)
+	require.Equal(t, chat1.UnfurlType_GIPHY, typ)
+	require.NotNil(t, res.Giphy().ImageUrl)
+	require.Nil(t, res.Giphy().Video)
 }
 
 func TestMapScraper(t *testing.T) {

--- a/go/chat/unfurl/utils.go
+++ b/go/chat/unfurl/utils.go
@@ -68,10 +68,3 @@ func ClassifyDomain(domain string) chat1.UnfurlType {
 		return chat1.UnfurlType_GENERIC
 	}
 }
-
-func ClassifyDomainFromURI(uri string) (typ chat1.UnfurlType, domain string, err error) {
-	if domain, err = GetDomain(uri); err != nil {
-		return typ, domain, err
-	}
-	return ClassifyDomain(domain), domain, nil
-}

--- a/shared/chat/conversation/messages/text/unfurl/unfurl-list/giphy.tsx
+++ b/shared/chat/conversation/messages/text/unfurl/unfurl-list/giphy.tsx
@@ -17,13 +17,14 @@ const UnfurlGiphy = React.memo(function UnfurlGiphy(p: {idx: number}) {
         return null
       }
       const {giphy} = unfurl
-      const {favicon, video} = giphy
-      const {height, url, width} = video || {height: 0, url: '', width: 0}
+      const {favicon, image, video} = giphy
+      const {height, isVideo, url, width} = video || image || {height: 0, isVideo: false, url: '', width: 0}
 
       return {
         favicon: favicon?.url,
         height,
         isCollapsed,
+        isVideo,
         unfurlMessageID,
         url,
         width,
@@ -40,7 +41,7 @@ const UnfurlGiphy = React.memo(function UnfurlGiphy(p: {idx: number}) {
 
   if (data === null) return null
 
-  const {favicon, isCollapsed, url, width, height} = data
+  const {favicon, isCollapsed, isVideo, url, width, height} = data
 
   return (
     <Kb.Box2 style={styles.container} gap="tiny" direction="horizontal">
@@ -72,7 +73,7 @@ const UnfurlGiphy = React.memo(function UnfurlGiphy(p: {idx: number}) {
           ) : null}
         </Kb.Box2>
         {isCollapsed ? null : (
-          <UnfurlImage url={url} height={height} width={width} isVideo={true} autoplayVideo={true} />
+          <UnfurlImage url={url} height={height} width={width} isVideo={isVideo} autoplayVideo={isVideo} />
         )}
       </Kb.Box2>
     </Kb.Box2>


### PR DESCRIPTION
- scrape new properties to get video url
- fallback to image if no video is present


cc @mmaxim @chrisnojima 