### PR TITLE
Fixing Debian dependencies for Trixie (Debian 13)

### DIFF
--- a/packaging/linux/deb/package_binaries.sh
+++ b/packaging/linux/deb/package_binaries.sh
@@ -35,7 +35,7 @@ elif [ "$mode" = "prerelease" ] ; then
   # lsof used in post_install.sh
   # systemd-container provides machinectl, which is used in post_install.sh
   # 'libasound2, libnss3, libxss1, libxtst6' is required by the GUI (issue #9872 and #17365)
-  dependencies="Depends: libappindicator1 | libayatana-appindicator1, fuse, libgconf-2-4, psmisc, lsof, procps, libasound2, libnss3, libxss1, libxtst6, libgtk-3-0"
+  dependencies="Depends: libayatana-appindicator3-1, fuse, psmisc, lsof, procps, libasound2, libnss3, libxss1, libxtst6, libgtk-3-0"
 elif [ "$mode" = "staging" ] ; then
   # Note: This doesn't exist yet. But we need to be distinct from the
   # production URL, because we're moving to a model where we build a clean repo


### PR DESCRIPTION
libgconf-2-4 is not available in Debian since Aug 2023 and was required only for Gnome2, not a hard dependency as per https://github.com/keybase/client/pull/26149 libayatana-appindicator1 has been replaced with
libayatana-appindicator3-1 some time ago also

Closes: https://github.com/keybase/client/issues/26082 and https://github.com/keybase/client/pull/26149