### PR TITLE
fix case where placeholders are left

### DIFF
--- a/shared/constants/chat2/message.tsx
+++ b/shared/constants/chat2/message.tsx
@@ -1014,6 +1014,8 @@ const validUIMessagetoMessage = (
     case T.RPCChat.MessageType.edit: // fallthrough
     case T.RPCChat.MessageType.delete: // fallthrough
     case T.RPCChat.MessageType.deletehistory: // fallthrough
+      // make deleted so we can cleanup placeholders
+      return makeMessageDeleted({...common})
     default:
       return
   }


### PR DESCRIPTION
There's 2 flows where we get messages. On a load and incoming messages. We treat the messages slightly differently. Normal messages flow through the same but messages that are 'mutations' do not. These are edit/delete/deleteHistory etc. On a normal load we ignore those messages as their mutations are resolved already. When they come in as incoming we do the resolution.

If we get a placeholder value and its resolved later as a mutation message we didn't handle it correctly and therefore you could get a placeholder thats stuck until the next load. The reason is different for the two flows

When a placeholder is resolved on a load we'd try and convert the incoming message to our internal FE message type and return null and basically ignore it. Instead we now resolve it to the 'deleted' type so we can resolve existing placeholders.
If we get an incoming message that's a mutation that replaces a placeholder we now will search for existing placeholders and delete them.