### PR TITLE
fix initial scrolldown

### DIFF
--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -260,7 +260,10 @@ const ConversationList = React.memo(function ConversationList() {
               keyboardShouldPersistTaps="handled"
               keyExtractor={keyExtractor}
               ref={listRef}
-              maintainVisibleContentPosition={maintainVisibleContentPosition}
+              maintainVisibleContentPosition={
+                // MUST do this else if you come into a new thread it'll slowly scroll down when it loads
+                numOrdinals ? maintainVisibleContentPosition : undefined
+              }
               // onlayout={onLayout}
             />
             {jumpToRecent}


### PR DESCRIPTION
in certain threads when you first come in it'll scroll down in an animated scroll on initial load without this. This is a side effect of the `maintainVisibleContentPosition` which is why we turned it off before but we still need it on to resolve another issue