### PR TITLE
use first index for scroll to in keybase emojis

### DIFF
--- a/shared/chat/emoji-picker/index.tsx
+++ b/shared/chat/emoji-picker/index.tsx
@@ -201,6 +201,7 @@ const getSectionsAndBookmarks = (
 
   if (customEmojiGroups?.length) {
     const coveredSectionKeys = new Set<string>()
+    const sectionIndex = sections.length
     getCustomEmojiSections(customEmojiGroups, emojisPerLine).forEach(section => {
       coveredSectionKeys.add(section.key)
       sections.push(section)
@@ -208,7 +209,7 @@ const getSectionsAndBookmarks = (
     const bookmark = {
       coveredSectionKeys,
       iconType: 'iconfont-keybase',
-      sectionIndex: sections.length,
+      sectionIndex,
     } as Bookmark
     bookmarks.push(bookmark)
   }


### PR DESCRIPTION
clicking the keybase emoji section would take you to the very end vs the first custom section