### PR TITLE
remove mesageMapAttachments and filter out gallery loads

### DIFF
--- a/shared/chat/conversation/attachment-fullscreen/hooks.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/hooks.tsx
@@ -9,7 +9,7 @@ export const useData = (initialOrdinal: T.Chat.Ordinal) => {
   const [ordinal, setOrdinal] = React.useState(initialOrdinal)
 
   const message: T.Chat.MessageAttachment = C.useChatContext(s => {
-    const m = s.messageMap.get(ordinal) ?? s.messageMapAttachments.get(ordinal)
+    const m = s.messageMap.get(ordinal)
     return m?.type === 'attachment' ? m : blankMessage
   })
 

--- a/shared/chat/conversation/messages/message-popup/attachment.tsx
+++ b/shared/chat/conversation/messages/message-popup/attachment.tsx
@@ -18,7 +18,7 @@ const emptyMessage = C.Chat.makeMessageAttachment({})
 
 const PopAttach = (ownProps: OwnProps) => {
   const {ordinal, attachTo, onHidden, position, style, visible} = ownProps
-  const m = C.useChatContext(s => s.messageMap.get(ordinal) ?? s.messageMapAttachments.get(ordinal))
+  const m = C.useChatContext(s => s.messageMap.get(ordinal))
   const message = m?.type === 'attachment' ? m : emptyMessage
   const {downloadPath, attachmentType} = message
   const pending = !!message.transferState

--- a/shared/chat/conversation/messages/message-popup/hooks.tsx
+++ b/shared/chat/conversation/messages/message-popup/hooks.tsx
@@ -9,7 +9,7 @@ import {formatTimeForPopup, formatTimeForRevoked} from '@/util/timestamp'
 const emptyText = C.Chat.makeMessageText({})
 
 export const useItems = (ordinal: T.Chat.Ordinal, onHidden: () => void) => {
-  const m = C.useChatContext(s => s.messageMap.get(ordinal) ?? s.messageMapAttachments.get(ordinal))
+  const m = C.useChatContext(s => s.messageMap.get(ordinal))
   const isAttach = m?.type === 'attachment'
   const message = m || emptyText
   const {author, id, deviceName, timestamp, deviceRevokedAt} = message
@@ -229,7 +229,7 @@ export const useItems = (ordinal: T.Chat.Ordinal, onHidden: () => void) => {
 }
 
 export const useHeader = (ordinal: T.Chat.Ordinal) => {
-  const m = C.useChatContext(s => s.messageMap.get(ordinal) ?? s.messageMapAttachments.get(ordinal))
+  const m = C.useChatContext(s => s.messageMap.get(ordinal))
   const you = C.useCurrentUserState(s => s.username)
   const message = m || emptyText
   const {author, deviceType, deviceName, botUsername, timestamp, exploding, explodingTime} = message

--- a/shared/chat/conversation/messages/message-popup/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/index.tsx
@@ -17,9 +17,7 @@ type Props = {
 
 const MessagePopup = React.memo(function MessagePopup(p: Props) {
   const {ordinal, attachTo, onHidden, position, style, visible} = p
-  const type = C.useChatContext(
-    s => s.messageMap.get(ordinal)?.type ?? s.messageMapAttachments.get(ordinal)?.type
-  )
+  const type = C.useChatContext(s => s.messageMap.get(ordinal)?.type)
   switch (type) {
     case 'text':
     case 'setChannelname':

--- a/shared/chat/conversation/messages/message-popup/journeycard.tsx
+++ b/shared/chat/conversation/messages/message-popup/journeycard.tsx
@@ -16,10 +16,7 @@ type OwnProps = {
 const JourneyCard = (ownProps: OwnProps) => {
   const {ordinal, attachTo, onHidden, style, visible, position} = ownProps
   const cardType = C.useChatContext(
-    s =>
-      s.messageMap.get(ordinal)?.cardType ??
-      s.messageMapAttachments.get(ordinal)?.cardType ??
-      T.RPCChat.JourneycardType.unused
+    s => s.messageMap.get(ordinal)?.cardType ?? T.RPCChat.JourneycardType.unused
   )
 
   const dismissJourneycard = C.useChatContext(s => s.dispatch.dismissJourneycard)

--- a/shared/chat/conversation/messages/message-popup/text.tsx
+++ b/shared/chat/conversation/messages/message-popup/text.tsx
@@ -19,7 +19,7 @@ const emptyMessage = C.Chat.makeMessageText({})
 
 const PopText = (ownProps: OwnProps) => {
   const {ordinal, attachTo, onHidden, position, style, visible} = ownProps
-  const m = C.useChatContext(s => s.messageMap.get(ordinal) ?? s.messageMapAttachments.get(ordinal))
+  const m = C.useChatContext(s => s.messageMap.get(ordinal))
   const you = C.useCurrentUserState(s => s.username)
   const message = m || emptyMessage
   const {conversationIDKey, author} = message

--- a/shared/constants/types/chat2/message.tsx
+++ b/shared/constants/types/chat2/message.tsx
@@ -114,6 +114,8 @@ interface _MessageCommon {
   readonly transferErrMsg?: string
   readonly transferState?: MessageAttachmentTransferState
   readonly unfurls?: UnfurlMap
+  // can be false for out of band calls like gallery load
+  readonly conversationMessage?: boolean
 }
 
 // Message types have a lot of copy and paste. Originally I had this split out but this


### PR DESCRIPTION
This is an iteration on this fix: https://github.com/keybase/client/pull/26476

There we introduced this idea that we'd split the messageMap into a new messageMapAttachments that held things we load from the info panel gallery view. The concept was if we inject random messages into the messageMap this'll create downstream issues as those messages will be used to mark maxRead and other things making our thread have gaps in it, which we never want.

A problem with this implementation is that a bunch of places have to now check both maps to get the data. There's been a steady stream of issues where certain flows were missing this check and the side effects were starting to grow (all message popup handlers needed to be fixed etc). 

Instead of moving further in that direction its simpler to roll that concept back and instead add a new flag onto the message that marks if its a 'conversation' message or not. When we sync up `messageMap` to `messageOrdinals` (etc) we now ignore those items so they exist in the map but don't participate in flows that create holes in the thread