### PR TITLE
More spoiler changes

### DIFF
--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"time"
+	"regexp"
 
 	"github.com/keybase/client/go/chat"
 	"github.com/keybase/client/go/chat/globals"
@@ -79,6 +80,8 @@ func HandlePostTextReply(strConvID, tlfName string, intMessageID int, body strin
 	return nil
 }
 
+
+var spoileRegexp = regexp.MustCompile(`!>(.*?)<!`)
 func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender string, intMembersType int,
 	displayPlaintext bool, intMessageID int, pushID string, badgeCount, unixTime int, soundName string,
 	pusher PushNotifier, showIfStale bool) (err error) {
@@ -149,7 +152,7 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 			switch msgUnboxed.GetMessageType() {
 			case chat1.MessageType_TEXT:
 				chatNotification.Message.Kind = "Text"
-				chatNotification.Message.Plaintext = msgUnboxed.Valid().MessageBody.Text().Body
+				chatNotification.Message.Plaintext = spoileRegexp.ReplaceAllString(msgUnboxed.Valid().MessageBody.Text().Body, "•••")
 			case chat1.MessageType_REACTION:
 				chatNotification.Message.Kind = "Reaction"
 				reaction, err := utils.GetReaction(msgUnboxed)

--- a/shared/common-adapters/markdown/react.tsx
+++ b/shared/common-adapters/markdown/react.tsx
@@ -112,9 +112,11 @@ export const markdownStyles = Styles.styleSheetCreate(
       }),
       quoteStyle: Styles.platformStyles({
         common: {
+          backgroundColor: Styles.globalColors.redLighter,
           borderLeftColor: Styles.globalColors.grey,
           borderLeftWidth: 3,
           borderStyle: 'solid',
+          color: Styles.globalColors.black,
         },
         isElectron: {
           display: 'block',
@@ -143,6 +145,43 @@ export const markdownStyles = Styles.styleSheetCreate(
       wrapStyle: Styles.platformStyles({isElectron: electronWrapStyle}),
     }) as const
 )
+
+const InlineCode = (p: {children: React.ReactNode; state: State}) => {
+  const {children, state} = p
+  return (
+    <Text
+      type="Body"
+      key={state.key}
+      style={Styles.collapseStyles([markdownStyles.codeSnippetStyle, state.styleOverride?.inlineCode])}
+      allowFontScaling={state['allowFontScaling']}
+    >
+      {children}
+    </Text>
+  )
+}
+
+const Fence = (p: {children: React.ReactNode; state: State}) => {
+  const {children, state} = p
+  return Styles.isMobile ? (
+    <Box key={state.key} style={markdownStyles.codeSnippetBlockTextStyle}>
+      <Text
+        type="Body"
+        style={Styles.collapseStyles([markdownStyles.codeSnippetBlockTextStyle, state.styleOverride?.fence])}
+        allowFontScaling={state['allowFontScaling']}
+      >
+        {children}
+      </Text>
+    </Box>
+  ) : (
+    <Text
+      key={state.key}
+      type="Body"
+      style={Styles.collapseStyles([markdownStyles.codeSnippetBlockStyle, state.styleOverride?.fence])}
+    >
+      {children}
+    </Text>
+  )
+}
 
 const reactComponentsForMarkdownType = {
   Array: {
@@ -229,41 +268,14 @@ const reactComponentsForMarkdownType = {
     ),
   },
   fence: {
-    react: (node: SM.SingleASTNode, _output: SM.ReactOutput, state: State) =>
-      Styles.isMobile ? (
-        <Box key={state.key} style={markdownStyles.codeSnippetBlockTextStyle}>
-          <Text
-            type="Body"
-            style={Styles.collapseStyles([
-              markdownStyles.codeSnippetBlockTextStyle,
-              state.styleOverride?.fence,
-            ])}
-            allowFontScaling={state['allowFontScaling']}
-          >
-            {node['content']}
-          </Text>
-        </Box>
-      ) : (
-        <Text
-          key={state.key}
-          type="Body"
-          style={Styles.collapseStyles([markdownStyles.codeSnippetBlockStyle, state.styleOverride?.fence])}
-        >
-          {node['content']}
-        </Text>
-      ),
+    react: (node: SM.SingleASTNode, _output: SM.ReactOutput, state: State) => {
+      return <Fence state={state}>{node['content']}</Fence>
+    },
   },
   inlineCode: {
-    react: (node: SM.SingleASTNode, _output: SM.ReactOutput, state: State) => (
-      <Text
-        type="Body"
-        key={state.key}
-        style={Styles.collapseStyles([markdownStyles.codeSnippetStyle, state.styleOverride?.inlineCode])}
-        allowFontScaling={state['allowFontScaling']}
-      >
-        {node['content']}
-      </Text>
-    ),
+    react: (node: SM.SingleASTNode, _output: SM.ReactOutput, state: State) => {
+      return <InlineCode state={state}>{node['content']}</InlineCode>
+    },
   },
   newline: {
     react: (_node: SM.SingleASTNode, output: SM.ReactOutput, state: State) =>

--- a/shared/common-adapters/markdown/react.tsx
+++ b/shared/common-adapters/markdown/react.tsx
@@ -457,7 +457,7 @@ export const previewOutput: SM.Output<any> = SimpleMarkdown.outputFor(
     spoiler: {
       react: (node: SM.SingleASTNode, output: SM.ReactOutput, state: State) => {
         return (
-          <Spoiler key={state.key} context={state.context} content={node['raw']} type="preview">
+          <Spoiler key={state.key} context={state.context} content={node['raw']}>
             {output(node['content'], state)}
           </Spoiler>
         )
@@ -492,7 +492,7 @@ export const serviceOnlyOutput: SM.Output<any> = SimpleMarkdown.outputFor(
     spoiler: {
       react: (node: SM.SingleASTNode, output: SM.ReactOutput, state: State) => {
         return (
-          <Spoiler key={state.key} context={state.context} content={node['raw']} type="service">
+          <Spoiler key={state.key} context={state.context} content={node['raw']}>
             {output(node['content'], state)}
           </Spoiler>
         )

--- a/shared/common-adapters/markdown/service-decoration.tsx
+++ b/shared/common-adapters/markdown/service-decoration.tsx
@@ -9,7 +9,6 @@ import Mention from '../mention-container'
 import PaymentStatus from '../../chat/payments/status/container'
 import Text, {type StylesTextCrossPlatform} from '@/common-adapters/text'
 import WithTooltip from '../with-tooltip'
-import {SpoilerContext, InnerSpoiled} from './spoiler'
 import type {StyleOverride} from '.'
 import type {
   emojiDataToRenderableEmoji as emojiDataToRenderableEmojiType,
@@ -24,10 +23,6 @@ const linkIsKeybaseLink = (link: string) => link.startsWith(prefix)
 const linkStyle = Styles.platformStyles({
   isElectron: {fontWeight: 'inherit'},
   isMobile: {fontWeight: undefined},
-})
-
-const spoilerStyle = Styles.platformStyles({
-  isMobile: {color: Styles.globalColors.black_on_white},
 })
 
 type KeybaseLinkProps = {
@@ -113,7 +108,6 @@ export type Props = {
 }
 
 const ServiceDecoration = (p: Props) => {
-  const inSpoiler = React.useContext(SpoilerContext)
   const {json, allowFontScaling, styles, styleOverride} = p
   const {disableBigEmojis, disableEmojiAnimation, messageType} = p
   // Parse JSON to get the type of the decoration
@@ -149,9 +143,7 @@ const ServiceDecoration = (p: Props) => {
       />
     )
   } else if (parsed.typ === T.RPCChat.UITextDecorationTyp.atmention && parsed.atmention) {
-    return inSpoiler ? (
-      <InnerSpoiled type="Body">{parsed.atmention}</InnerSpoiled>
-    ) : (
+    return (
       <Mention
         allowFontScaling={allowFontScaling || false}
         style={styles['wrapStyle']}
@@ -159,10 +151,7 @@ const ServiceDecoration = (p: Props) => {
       />
     )
   } else if (parsed.typ === T.RPCChat.UITextDecorationTyp.maybemention) {
-    const nameOrChannel = parsed.maybemention.name || parsed.maybemention.channel
-    return inSpoiler ? (
-      <InnerSpoiled type="Body">{nameOrChannel}</InnerSpoiled>
-    ) : (
+    return (
       <MaybeMention
         allowFontScaling={allowFontScaling || false}
         style={styles['wrapStyle']}
@@ -186,8 +175,6 @@ const ServiceDecoration = (p: Props) => {
         linkStyle={styleOverride?.link}
         wrapStyle={styles['wrapStyle']}
       />
-    ) : inSpoiler ? (
-      <InnerSpoiled type="BodyPrimaryLink">{parsed.link.url}</InnerSpoiled>
     ) : (
       <Text
         className="hover-underline hover_contained_color_blueDark"
@@ -208,15 +195,10 @@ const ServiceDecoration = (p: Props) => {
       <Text
         className="hover-underline hover_contained_color_blueDark"
         type="BodyPrimaryLink"
-        style={Styles.collapseStyles([
-          styles['wrapStyle'],
-          linkStyle,
-          styleOverride?.mailto,
-          inSpoiler && spoilerStyle,
-        ])}
+        style={Styles.collapseStyles([styles['wrapStyle'], linkStyle, styleOverride?.mailto])}
         title={parsed.mailto.url}
-        onClickURL={inSpoiler ? undefined : openUrl}
-        onLongPressURL={inSpoiler ? undefined : openUrl}
+        onClickURL={openUrl}
+        onLongPressURL={openUrl}
       >
         {parsed.mailto.url}
       </Text>

--- a/shared/common-adapters/markdown/spoiler.tsx
+++ b/shared/common-adapters/markdown/spoiler.tsx
@@ -24,19 +24,24 @@ const Spoiler = (p: Props) => {
     setShown(false)
   }
 
-  const onClick = React.useCallback(() => {
-    setShown(s => {
-      spoilerState.set(key, !s)
-      return !s
-    })
-  }, [key])
+  const onClick = React.useCallback(
+    (e: React.BaseSyntheticEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setShown(s => {
+        spoilerState.set(key, !s)
+        return !s
+      })
+    },
+    [key]
+  )
 
   const showMasked = isPreview && Styles.isMobile
   const smallContent = content.substring(0, 10)
   const len = smallContent.length
   const masked = React.useMemo(() => {
-    return showMasked ? Array(len).fill('•').join('') : ''
-  }, [showMasked, len])
+    return Array(len).fill('•').join('')
+  }, [len])
 
   return showMasked ? (
     <Text type="BodySmall">{masked}</Text>
@@ -48,7 +53,7 @@ const Spoiler = (p: Props) => {
       style={shown ? styles.shown : styles.hidden}
       title={shown ? '' : 'Click to reveal'}
     >
-      {shown ? children || content : smallContent}
+      {shown ? children || content : masked}
     </Text>
   )
 }

--- a/shared/common-adapters/markdown/spoiler.tsx
+++ b/shared/common-adapters/markdown/spoiler.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 import * as Styles from '@/styles'
 import Text, {type TextType} from '@/common-adapters/text'
 
-export const SpoilerContext = React.createContext<boolean>(false)
-
 type Props = {
   children: React.ReactNode
   context?: string
@@ -34,34 +32,23 @@ const Spoiler = (p: Props) => {
   }, [key])
 
   const showMasked = isPreview && Styles.isMobile
-  const len = content.length
+  const smallContent = content.substring(0, 10)
+  const len = smallContent.length
   const masked = React.useMemo(() => {
     return showMasked ? Array(len).fill('•').join('') : ''
   }, [showMasked, len])
 
-  return (
-    <SpoilerContext.Provider value={!shown}>
-      {showMasked ? (
-        <Text type="BodySmall">{masked}</Text>
-      ) : (
-        <Text
-          className={shown ? undefined : 'spoiler'}
-          type="BodySmall"
-          onClick={onClick}
-          style={shown ? styles.shown : styles.hidden}
-          title={shown ? '' : 'Click to reveal'}
-        >
-          {children || content}
-        </Text>
-      )}
-    </SpoilerContext.Provider>
-  )
-}
-
-export const InnerSpoiled = (p: {children: React.ReactNode; type: TextType; style?: any}) => {
-  return (
-    <Text className={'spoiler'} type="BodySmall" style={Styles.collapseStyles([p.style, styles.hidden])}>
-      {p.children}
+  return showMasked ? (
+    <Text type="BodySmall">{masked}</Text>
+  ) : (
+    <Text
+      className={shown ? undefined : 'spoiler'}
+      type="BodySmall"
+      onClick={onClick}
+      style={shown ? styles.shown : styles.hidden}
+      title={shown ? '' : 'Click to reveal'}
+    >
+      {shown ? children || content : smallContent}
     </Text>
   )
 }

--- a/shared/common-adapters/markdown/spoiler.tsx
+++ b/shared/common-adapters/markdown/spoiler.tsx
@@ -1,20 +1,17 @@
 import * as React from 'react'
 import * as Styles from '@/styles'
-import Text, {type TextType} from '@/common-adapters/text'
+import Text from '@/common-adapters/text'
 
 type Props = {
   children: React.ReactNode
   context?: string
   content: string
-  type?: 'service' | 'preview'
 }
 
 const spoilerState = new Map<string, boolean>()
 
 const Spoiler = (p: Props) => {
-  const {children, content, context, type} = p
-  const isPreview = type === 'preview'
-  // const isServiceOnly = type === 'service'
+  const {children, content, context} = p
   const key = `${context ?? ''}:${content}`
   const [shown, setShown] = React.useState(spoilerState.get(key))
 

--- a/shared/common-adapters/markdown/spoiler.tsx
+++ b/shared/common-adapters/markdown/spoiler.tsx
@@ -36,16 +36,13 @@ const Spoiler = (p: Props) => {
     [key]
   )
 
-  const showMasked = isPreview && Styles.isMobile
   const smallContent = content.substring(0, 10)
   const len = smallContent.length
   const masked = React.useMemo(() => {
     return Array(len).fill('•').join('')
   }, [len])
 
-  return showMasked ? (
-    <Text type="BodySmall">{masked}</Text>
-  ) : (
+  return (
     <Text
       className={shown ? undefined : 'spoiler'}
       type="BodySmall"

--- a/shared/common-adapters/text.css
+++ b/shared/common-adapters/text.css
@@ -46,13 +46,6 @@
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-family: Keybase;
-  .spoiler & {
-    color: var(--color-black_on_white);
-  }
-}
-
-.spoiler * {
-  pointer-events: none;
 }
 
 .darkMode {

--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -510,7 +510,9 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
     logger.info('invoking NotifyPopup for chat notification')
     const sound = C.useConfigState.getState().notifySound
 
-    NotifyPopup(title, {body, sound}, -1, author, onClick, onClose)
+    const cleanBody = body.replaceAll(/!>(.*?)<!/g, '•••')
+
+    NotifyPopup(title, {body: cleanBody, sound}, -1, author, onClick, onClose)
   }
 
   const messagesAdd = (messages: Array<T.Chat.Message>, why: string, markAsRead = true) => {


### PR DESCRIPTION
- [x] don't ever render inside a spoiler. we trade off size accuracy vs edge cases where styling shows the insides
- [x] hide desktop / ios notifications spoilers