### PR TITLE
kbfs: don't start archiver bg goroutines until SFS is initialized

### DIFF
--- a/go/kbfs/simplefs/simplefs.go
+++ b/go/kbfs/simplefs/simplefs.go
@@ -4054,6 +4054,13 @@ func (k *SimpleFS) notifyUIArchiveStateChange(ctx context.Context,
 	}
 }
 
+// isInitialized returns whether things that use SimpleFS directly can
+// start making calls yet.  We use MDOps as a stand-in for
+// initialization, since that's required to start resolving TLF IDs.
+func (k *SimpleFS) isInitialized() bool {
+	return k.config.MDOps() != nil
+}
+
 // Shutdown shuts down SimpleFS.
 func (k *SimpleFS) Shutdown(ctx context.Context) error {
 	k.shutdownLock.Lock()


### PR DESCRIPTION
If the archiver starts making SFS calls before the `MDOps` instance is set in the config (which happens during an asynchronous init process), it could try to lookup TLF handles and IDs too early, resulting in it thinking it needs to create new TLFs over existing TLFs.

Instead just wait for that part of init to finish with a dumb loop.