### PR TITLE
if we dont have the acutal dimensions dont try and force

### DIFF
--- a/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/index.desktop.tsx
@@ -52,7 +52,7 @@ const Fullscreen = React.memo(function Fullscreen(p: Props) {
   const imgSrc = usePreviewFallback(path, previewPath, isVideo, data.showPreview, preload)
 
   const forceDims = React.useMemo(() => {
-    return {height: fullHeight, width: fullWidth}
+    return fullHeight && fullWidth ? {height: fullHeight, width: fullWidth} : undefined
   }, [fullHeight, fullWidth])
 
   const vidRef = React.useRef<HTMLVideoElement>(null)


### PR DESCRIPTION
if we show an image attachment full screen and the service doesnt have the actual size, dont force 0x0