### PR TITLE
fix missing darkmode css in menubar

### DIFF
--- a/shared/desktop/renderer/dark-injector.desktop.tsx
+++ b/shared/desktop/renderer/dark-injector.desktop.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import * as C from '@/constants'
+export const DarkCSSInjector = () => {
+  const isDark = C.useDarkModeState(s => s.isDarkMode())
+  const [lastIsDark, setLastIsDark] = React.useState<boolean | undefined>()
+  if (lastIsDark !== isDark) {
+    setTimeout(() => {
+      setLastIsDark(isDark)
+    }, 0)
+    // inject it in body so modals get darkMode also
+    if (isDark) {
+      document.body.classList.add('darkMode')
+      document.body.classList.remove('lightMode')
+    } else {
+      document.body.classList.remove('darkMode')
+      document.body.classList.add('lightMode')
+    }
+  }
+  return null
+}

--- a/shared/desktop/renderer/style.css
+++ b/shared/desktop/renderer/style.css
@@ -487,9 +487,15 @@ input {
 
 .lightMode {
   background-color: #ffffff;
+  &.isWidget {
+    background-color: transparent;
+  }
 }
 .darkMode {
   background-color: #191919;
+  &.isWidget {
+    background-color: transparent;
+  }
 }
 
 .addInviteAndLinkBox {

--- a/shared/menubar/index.desktop.tsx
+++ b/shared/menubar/index.desktop.tsx
@@ -15,6 +15,7 @@ import {isLinux, isDarwin} from '@/constants/platform'
 import {type _InnerMenuItem} from '@/common-adapters/floating-menu/menu-layout'
 import {useUploadCountdown} from '@/fs/footer/use-upload-countdown'
 import type {DeserializeProps} from './remote-serializer.desktop'
+import {DarkCSSInjector} from '@/desktop/renderer/dark-injector.desktop'
 
 const {hideWindow, ctlQuit} = KB2.functions
 
@@ -336,14 +337,14 @@ const MenubarRender = (p: Props) => {
     content = <LoggedOut daemonHandshakeState={daemonHandshakeState} loggedIn={loggedIn} />
   }
 
+  React.useEffect(() => {
+    document.body.classList.add('isWidget')
+  }, [])
+
   return (
     <Kb.Styles.DarkModeContext.Provider value={darkMode}>
-      <Kb.Box2
-        direction="vertical"
-        style={styles.widgetContainer}
-        className={darkMode ? 'darkMode' : 'lightMode'}
-        key={darkMode ? 'darkMode' : 'light'}
-      >
+      <DarkCSSInjector />
+      <Kb.Box2 direction="vertical" style={styles.widgetContainer} key={darkMode ? 'darkMode' : 'light'}>
         {isDarwin && <ArrowTick />}
         <IconBar {...p} showBadges={loggedIn} />
         {content}


### PR DESCRIPTION
The menu renderer doesn't have the darkMode css in body so some things don't render darkmode aware