### PR TITLE
use s3 session token in chat s3 accesses for temp creds from server

### DIFF
--- a/go/chat/attachment_httpsrv.go
+++ b/go/chat/attachment_httpsrv.go
@@ -639,7 +639,10 @@ func (r *RemoteAttachmentFetcher) StreamAttachment(ctx context.Context, convID c
 	asset chat1.Asset, ri func() chat1.RemoteInterface, signer s3.Signer) (res io.ReadSeeker, err error) {
 	defer r.Trace(ctx, &err, "StreamAttachment")()
 	// Grab S3 params for the conversation
-	s3params, err := ri().GetS3Params(ctx, convID)
+	s3params, err := ri().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +654,10 @@ func (r *RemoteAttachmentFetcher) FetchAttachment(ctx context.Context, w io.Writ
 	ri func() chat1.RemoteInterface, signer s3.Signer, progress types.ProgressReporter) (err error) {
 	defer r.Trace(ctx, &err, "FetchAttachment")()
 	// Grab S3 params for the conversation
-	s3params, err := ri().GetS3Params(ctx, convID)
+	s3params, err := ri().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		return err
 	}
@@ -667,7 +673,10 @@ func (r *RemoteAttachmentFetcher) DeleteAssets(ctx context.Context,
 	}
 
 	// get s3 params from server
-	s3params, err := ri().GetS3Params(ctx, convID)
+	s3params, err := ri().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		r.Debug(ctx, "error getting s3params: %s", err)
 		return err
@@ -815,7 +824,10 @@ func (c *CachingAttachmentFetcher) FetchAttachment(ctx context.Context, w io.Wri
 	}
 
 	// Grab S3 params for the conversation
-	s3params, err := ri().GetS3Params(ctx, convID)
+	s3params, err := ri().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		return err
 	}
@@ -906,7 +918,10 @@ func (c *CachingAttachmentFetcher) DeleteAssets(ctx context.Context,
 	}
 
 	// get s3 params from server
-	s3params, err := ri().GetS3Params(ctx, convID)
+	s3params, err := ri().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		c.Debug(ctx, "error getting s3params: %s", err)
 		return err

--- a/go/chat/attachment_httpsrv_test.go
+++ b/go/chat/attachment_httpsrv_test.go
@@ -86,7 +86,7 @@ func (m mockSigningRemote) Sign(payload []byte) ([]byte, error) {
 	return nil, nil
 }
 
-func (m mockSigningRemote) GetS3Params(ctx context.Context, convID chat1.ConversationID) (res chat1.S3Params, err error) {
+func (m mockSigningRemote) GetS3Params(ctx context.Context, arg chat1.GetS3ParamsArg) (res chat1.S3Params, err error) {
 	return res, nil
 }
 

--- a/go/chat/attachments/s3.go
+++ b/go/chat/attachments/s3.go
@@ -86,7 +86,8 @@ type PutS3Result struct {
 func (a *S3Store) PutS3(ctx context.Context, r io.Reader, size int64, task *UploadTask, previous *AttachmentInfo) (res *PutS3Result, err error) {
 	defer a.Trace(ctx, &err, "PutS3")()
 	region := a.regionFromParams(task.S3Params)
-	b := a.s3Conn(task.S3Signer, region, task.S3Params.AccessKey).Bucket(task.S3Params.Bucket)
+	b := a.s3Conn(task.S3Signer, region, task.S3Params.AccessKey, task.S3Params.Token).Bucket(
+		task.S3Params.Bucket)
 
 	multiPartUpload := size > minMultiSize
 	if multiPartUpload && a.G().Env.GetAttachmentDisableMulti() {

--- a/go/chat/attachments/store.go
+++ b/go/chat/attachments/store.go
@@ -246,7 +246,7 @@ func (a *S3Store) uploadAsset(ctx context.Context, task *UploadTask, enc *SignEn
 
 func (a *S3Store) getAssetBucket(asset chat1.Asset, params chat1.S3Params, signer s3.Signer) s3.BucketInt {
 	region := a.regionFromAsset(asset)
-	return a.s3Conn(signer, region, params.AccessKey).Bucket(asset.Bucket)
+	return a.s3Conn(signer, region, params.AccessKey, params.Token).Bucket(asset.Bucket)
 }
 
 func (a *S3Store) GetAssetReader(ctx context.Context, params chat1.S3Params, asset chat1.Asset,
@@ -446,9 +446,10 @@ func (a *S3Store) regionFromAsset(asset chat1.Asset) s3.Region {
 	}
 }
 
-func (a *S3Store) s3Conn(signer s3.Signer, region s3.Region, accessKey string) s3.Connection {
+func (a *S3Store) s3Conn(signer s3.Signer, region s3.Region, accessKey string, sessionToken string) s3.Connection {
 	conn := a.s3c.New(a.G().ExternalG(), signer, region)
 	conn.SetAccessKey(accessKey)
+	conn.SetSessionToken(sessionToken)
 	return conn
 }
 
@@ -467,6 +468,6 @@ func (a *S3Store) DeleteAssets(ctx context.Context, params chat1.S3Params, signe
 
 func (a *S3Store) DeleteAsset(ctx context.Context, params chat1.S3Params, signer s3.Signer, asset chat1.Asset) error {
 	region := a.regionFromAsset(asset)
-	b := a.s3Conn(signer, region, params.AccessKey).Bucket(asset.Bucket)
+	b := a.s3Conn(signer, region, params.AccessKey, params.Token).Bucket(asset.Bucket)
 	return b.Del(ctx, asset.Path)
 }

--- a/go/chat/attachments/uploader.go
+++ b/go/chat/attachments/uploader.go
@@ -546,7 +546,10 @@ func (u *Uploader) upload(ctx context.Context, uid gregor1.UID, convID chat1.Con
 	g.Go(func() (err error) {
 		u.Debug(bgctx, "upload: fetching s3 params")
 		u.G().ActivityNotifier.AttachmentUploadStart(bgctx, uid, convID, outboxID)
-		if s3params, err = u.ri().GetS3Params(bgctx, convID); err != nil {
+		if s3params, err = u.ri().GetS3Params(bgctx, chat1.GetS3ParamsArg{
+			ConversationID: convID,
+			TempCreds:      true,
+		}); err != nil {
 			return err
 		}
 		close(paramsCh)

--- a/go/chat/attachments/uploader_test.go
+++ b/go/chat/attachments/uploader_test.go
@@ -33,7 +33,7 @@ type mockRemote struct {
 	chat1.RemoteInterface
 }
 
-func (r mockRemote) GetS3Params(context.Context, chat1.ConversationID) (chat1.S3Params, error) {
+func (r mockRemote) GetS3Params(context.Context, chat1.GetS3ParamsArg) (chat1.S3Params, error) {
 	return chat1.S3Params{}, nil
 }
 

--- a/go/chat/s3/interface.go
+++ b/go/chat/s3/interface.go
@@ -13,6 +13,7 @@ type Root interface {
 
 type Connection interface {
 	SetAccessKey(key string)
+	SetSessionToken(token string)
 	Bucket(name string) BucketInt
 }
 

--- a/go/chat/s3/mem.go
+++ b/go/chat/s3/mem.go
@@ -41,7 +41,8 @@ func (m *Mem) NewMemConn() *MemConn {
 
 var _ Connection = &MemConn{}
 
-func (s *MemConn) SetAccessKey(key string) {}
+func (s *MemConn) SetAccessKey(key string)    {}
+func (s *MemConn) SetSessionToken(key string) {}
 
 func (s *MemConn) Bucket(name string) BucketInt {
 	s.Lock()

--- a/go/chat/s3/s3.go
+++ b/go/chat/s3/s3.go
@@ -47,6 +47,10 @@ type S3 struct {
 	// ok for clients to know it.
 	AccessKey string
 
+	// This is needed for payload construction.  It's
+	// ok for clients to know it.
+	SessionToken string
+
 	// Signer signs payloads for s3 request authorization.
 	Signer Signer
 
@@ -150,6 +154,10 @@ func New(g *libkb.GlobalContext, signer Signer, region Region, client ...*http.C
 
 func (s3 *S3) SetAccessKey(key string) {
 	s3.AccessKey = key
+}
+
+func (s3 *S3) SetSessionToken(token string) {
+	s3.SessionToken = token
 }
 
 // Bucket returns a Bucket with the given name.

--- a/go/chat/sender.go
+++ b/go/chat/sender.go
@@ -1104,7 +1104,10 @@ func (s *BlockingSender) getSigningKeyPair(ctx context.Context) (kp libkb.NaclSi
 // Logs but does not return errors. Assets may be left undeleted.
 func (s *BlockingSender) deleteAssets(ctx context.Context, convID chat1.ConversationID, assets []chat1.Asset) error {
 	// get s3 params from server
-	params, err := s.getRi().GetS3Params(ctx, convID)
+	params, err := s.getRi().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		s.G().Log.Warning("error getting s3 params: %s", err)
 		return nil

--- a/go/chat/unfurl/packager.go
+++ b/go/chat/unfurl/packager.go
@@ -94,7 +94,10 @@ func (p *Packager) uploadAsset(ctx context.Context, uid gregor1.UID, convID chat
 		return res, fmt.Errorf("invalid asset for unfurl package: %v mime: %s", atyp, contentType)
 	}
 
-	s3params, err := p.ri().GetS3Params(ctx, convID)
+	s3params, err := p.ri().GetS3Params(ctx, chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	if err != nil {
 		return res, err
 	}

--- a/go/chat/unfurl/packager_test.go
+++ b/go/chat/unfurl/packager_test.go
@@ -32,7 +32,7 @@ type paramsRemote struct {
 	chat1.RemoteInterface
 }
 
-func (p paramsRemote) GetS3Params(ctx context.Context, convID chat1.ConversationID) (chat1.S3Params, error) {
+func (p paramsRemote) GetS3Params(ctx context.Context, arg chat1.GetS3ParamsArg) (chat1.S3Params, error) {
 	return chat1.S3Params{
 		Bucket:    "packager-test",
 		ObjectKey: libkb.RandStringB64(3),
@@ -107,7 +107,10 @@ func TestPackager(t *testing.T) {
 		require.True(t, bytes.Equal(dat, resDat))
 	}
 	var buf bytes.Buffer
-	s3params, err := ri().GetS3Params(context.TODO(), convID)
+	s3params, err := ri().GetS3Params(context.TODO(), chat1.GetS3ParamsArg{
+		ConversationID: convID,
+		TempCreds:      true,
+	})
 	require.NoError(t, err)
 	require.NoError(t, store.DownloadAsset(context.TODO(), s3params, *image, &buf, s3Signer, nil))
 	compareSol("nytogimage_sol.jpg", buf.Bytes())

--- a/go/kbtest/chat.go
+++ b/go/kbtest/chat.go
@@ -994,7 +994,7 @@ func (m *ChatRemoteMock) BroadcastGregorMessageToConv(ctx context.Context,
 	return nil
 }
 
-func (m *ChatRemoteMock) GetS3Params(context.Context, chat1.ConversationID) (chat1.S3Params, error) {
+func (m *ChatRemoteMock) GetS3Params(context.Context, chat1.GetS3ParamsArg) (chat1.S3Params, error) {
 	return chat1.S3Params{}, errors.New("GetS3Params not mocked")
 }
 

--- a/go/protocol/chat1/remote.go
+++ b/go/protocol/chat1/remote.go
@@ -1701,6 +1701,7 @@ type GetUnreadUpdateFullArg struct {
 
 type GetS3ParamsArg struct {
 	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
+	TempCreds      bool           `codec:"tempCreds" json:"tempCreds"`
 }
 
 type S3SignArg struct {
@@ -1912,7 +1913,7 @@ type RemoteInterface interface {
 	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes, error)
 	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes, error)
 	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull, error)
-	GetS3Params(context.Context, ConversationID) (S3Params, error)
+	GetS3Params(context.Context, GetS3ParamsArg) (S3Params, error)
 	S3Sign(context.Context, S3SignArg) ([]byte, error)
 	GetInboxVersion(context.Context, gregor1.UID) (InboxVers, error)
 	SyncInbox(context.Context, InboxVers) (SyncInboxRes, error)
@@ -2134,7 +2135,7 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[1]GetS3ParamsArg)(nil), args)
 						return
 					}
-					ret, err = i.GetS3Params(ctx, typedArgs[0].ConversationID)
+					ret, err = i.GetS3Params(ctx, typedArgs[0])
 					return
 				},
 			},
@@ -2773,8 +2774,7 @@ func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVe
 	return
 }
 
-func (c RemoteClient) GetS3Params(ctx context.Context, conversationID ConversationID) (res S3Params, err error) {
-	__arg := GetS3ParamsArg{ConversationID: conversationID}
+func (c RemoteClient) GetS3Params(ctx context.Context, __arg GetS3ParamsArg) (res S3Params, err error) {
 	err = c.Cli.CallCompressed(ctx, "chat.1.remote.getS3Params", []interface{}{__arg}, &res, rpc.CompressionGzip, 0*time.Millisecond)
 	return
 }

--- a/protocol/avdl/chat1/remote.avdl
+++ b/protocol/avdl/chat1/remote.avdl
@@ -185,7 +185,7 @@ protocol remote {
 
   // getS3Params returns S3 params that the client needs to make S3
   // requests.
-  S3Params getS3Params(ConversationID conversationID);
+  S3Params getS3Params(ConversationID conversationID, boolean tempCreds);
 
   // s3Sign signs a payload for S3 requests.
   bytes s3Sign(int version, bytes payload);

--- a/protocol/json/chat1/remote.json
+++ b/protocol/json/chat1/remote.json
@@ -1336,6 +1336,10 @@
         {
           "name": "conversationID",
           "type": "ConversationID"
+        },
+        {
+          "name": "tempCreds",
+          "type": "boolean"
         }
       ],
       "response": "S3Params"


### PR DESCRIPTION
Add HTTP header for using IAM temporary credentials on the client, where we need to pass in a session token value in addition to the access key ID. The client still doesn't know the secret, which it calls out to the server to make signatures.