### PR TITLE
Move socket path on osx

### DIFF
--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -232,7 +232,7 @@ func (d Darwin) SandboxCacheDir() string {
 	// The container name "keybase" is the group name specified in the entitlement for sandboxed extensions
 	// Note: this was added for kbfs finder integration, which was never activated.
 	// keybased.sock and kbfsd.sock live in this directory.
-	return d.appDir(d.Home(false), "Library", "Group Containers", "keybase", "Library", "Caches")
+	return d.appDir(d.Home(false), "Library", "keybase", "Library", "Caches")
 }
 func (d Darwin) ConfigDir() string {
 	return d.appDir(d.sharedHome(), "Library", "Application Support")

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -229,7 +229,7 @@ func (d Darwin) SandboxCacheDir() string {
 	if d.isIOS() {
 		return ""
 	}
-	return CacheDir()
+	return d.CacheDir()
 	// The container name "keybase" is the group name specified in the entitlement for sandboxed extensions
 	// Note: this was added for kbfs finder integration, which was never activated.
 	// keybased.sock and kbfsd.sock live in this directory.

--- a/go/libkb/home.go
+++ b/go/libkb/home.go
@@ -229,10 +229,11 @@ func (d Darwin) SandboxCacheDir() string {
 	if d.isIOS() {
 		return ""
 	}
+	return CacheDir()
 	// The container name "keybase" is the group name specified in the entitlement for sandboxed extensions
 	// Note: this was added for kbfs finder integration, which was never activated.
 	// keybased.sock and kbfsd.sock live in this directory.
-	return d.appDir(d.Home(false), "Library", "keybase", "Library", "Caches")
+	// return d.appDir(d.Home(false), "Library", "keybase", "Library", "Caches")
 }
 func (d Darwin) ConfigDir() string {
 	return d.appDir(d.sharedHome(), "Library", "Application Support")

--- a/osx/Keybase.entitlements
+++ b/osx/Keybase.entitlements
@@ -6,12 +6,6 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.keybase</string>
-	</array>
 </dict>
 </plist>
 

--- a/osx/Keybase.entitlements
+++ b/osx/Keybase.entitlements
@@ -6,6 +6,12 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.keybase</string>
+	</array>
 </dict>
 </plist>
 

--- a/packaging/prerelease/build_keybase.sh
+++ b/packaging/prerelease/build_keybase.sh
@@ -2,7 +2,7 @@
 
 set -e -u -o pipefail # Fail on error
 
-dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$dir"
 client_dir="$dir/../../go"
 
@@ -18,23 +18,25 @@ tags=${TAGS:-"prerelease production"}
 ldflags="-X github.com/keybase/client/go/libkb.PrereleaseBuild=$keybase_build -s -w"
 arch=${ARCH:-"amd64"}
 
+echo "------------------ Building go ------------------"
 echo "Building $build_dir/keybase ($keybase_build) with $(go version) on arch: $arch"
 (cd "$client_dir" && GOARCH="$arch" go build -a -tags "$tags" -ldflags "$ldflags" -o "$build_dir/keybase" "github.com/keybase/client/go/keybase")
+echo "------------------ Building go ------------------"
 
 if [ "$PLATFORM" = "darwin" ] || [ "$PLATFORM" = "darwin-arm64" ]; then
-  echo "Signing binary..."
-  code_sign_identity="90524F7BEAEACD94C7B473787F4949582F904104" # "Developer ID Application: Keybase, Inc. (99229SGT5K)"
-  codesign --verbose --force --deep --timestamp --options runtime --sign "$code_sign_identity" "$build_dir/keybase"
+	echo "Signing binary..."
+	code_sign_identity="90524F7BEAEACD94C7B473787F4949582F904104" # "Developer ID Application: Keybase, Inc. (99229SGT5K)"
+	codesign --verbose --force --deep --timestamp --options runtime --sign "$code_sign_identity" "$build_dir/keybase"
 elif [ "$PLATFORM" = "linux" ]; then
-  echo "No codesigning for Linux"
+	echo "No codesigning for Linux"
 elif [ "$PLATFORM" = "windows" ]; then
-  echo "No codesigning for Windows"
+	echo "No codesigning for Windows"
 else
-  echo "Invalid PLATFORM"
-  exit 1
+	echo "Invalid PLATFORM"
+	exit 1
 fi
 
 if [ ! "$PLATFORM" = "darwin-arm64" ]; then # we can't run the arm64 binary on the amd64 build machine!
-  version=$("$build_dir"/keybase version -S)
-  echo "Keybase version: $version"
+	version=$("$build_dir"/keybase version -S)
+	echo "Keybase version: $version"
 fi

--- a/packaging/prerelease/build_updater.sh
+++ b/packaging/prerelease/build_updater.sh
@@ -2,7 +2,7 @@
 
 set -e -u -o pipefail # Fail on error
 
-dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 cd "$dir"
 
 build_dir=${BUILD_DIR:-/tmp/keybase}
@@ -16,23 +16,25 @@ cd "$src_dir"
 
 mkdir -p "$build_dir"
 
+echo "------------------ Building updater go ------------------"
 echo "Building $build_dir/updater with $(go version) on arch: $arch"
 GOARCH="$arch" go build -a -o "$dest" "$package"
+echo "------------------ Building updater go ------------------"
 
 if [ "$PLATFORM" = "darwin" ] || [ "$PLATFORM" = "darwin-arm64" ]; then
-  echo "Signing binary..."
-  code_sign_identity="90524F7BEAEACD94C7B473787F4949582F904104" # "Developer ID Application: Keybase, Inc. (99229SGT5K)"
-  codesign --verbose --force --deep --timestamp --options runtime --sign "$code_sign_identity" "$dest"
+	echo "Signing binary..."
+	code_sign_identity="90524F7BEAEACD94C7B473787F4949582F904104" # "Developer ID Application: Keybase, Inc. (99229SGT5K)"
+	codesign --verbose --force --deep --timestamp --options runtime --sign "$code_sign_identity" "$dest"
 elif [ "$PLATFORM" = "linux" ]; then
-  echo "No codesigning for Linux"
+	echo "No codesigning for Linux"
 elif [ "$PLATFORM" = "windows" ]; then
-  echo "No codesigning for Windows"
+	echo "No codesigning for Windows"
 else
-  echo "Invalid PLATFORM"
-  exit 1
+	echo "Invalid PLATFORM"
+	exit 1
 fi
 
 if [ ! "$PLATFORM" = "darwin-arm64" ]; then # we can't run the arm64 binary on the amd64 build machine!
-  updater_version=$("$build_dir"/updater -version)
-  echo "Updater version: $updater_version"
+	updater_version=$("$build_dir"/updater -version)
+	echo "Updater version: $updater_version"
 fi

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -109,7 +109,7 @@ const getDarwinPaths = () => {
     jsonDebugFileName: `${logDir}${appName}.app.debug`,
     logDir,
     serverConfigFileName: `${logDir}${appName}.app.serverConfig`,
-    socketPath: join(`${libraryDir}keybase/Library/Caches`, appName, socketName),
+    socketPath: join(`${libraryDir}Caches`, appName, socketName),
   }
 }
 

--- a/shared/constants/platform.desktop.tsx
+++ b/shared/constants/platform.desktop.tsx
@@ -109,7 +109,7 @@ const getDarwinPaths = () => {
     jsonDebugFileName: `${logDir}${appName}.app.debug`,
     logDir,
     serverConfigFileName: `${logDir}${appName}.app.serverConfig`,
-    socketPath: join(`${libraryDir}Group Containers/keybase/Library/Caches`, appName, socketName),
+    socketPath: join(`${libraryDir}keybase/Library/Caches`, appName, socketName),
   }
 }
 


### PR DESCRIPTION
On Sequoia 15.0 so we get a new popup since the socket was in the group containers, moving it fixes this

Added some lines to the logs so its clear where we're building go since it can be swamped by git output