### PR TITLE
fix: fix cannot clear unread icon in taskbar issue

### DIFF
--- a/shared/desktop/app/menu-bar.desktop.tsx
+++ b/shared/desktop/app/menu-bar.desktop.tsx
@@ -127,7 +127,9 @@ const MenuBar = () => {
             action.payload.desktopAppBadgeCount > 0
               ? getAssetPath('images', 'icons', 'icon-windows-badge.png')
               : null
-          overlay && mw?.setOverlayIcon(Electron.nativeImage.createFromPath(overlay), 'new activity')
+          overlay 
+            ? mw?.setOverlayIcon(Electron.nativeImage.createFromPath(overlay), 'new activity')
+            : mw?.setOverlayIcon(null, 'no recent activity');
         }
 
         break


### PR DESCRIPTION
this happens a while.
under win 10, keybase cannot clear unread icon 
![image](https://github.com/user-attachments/assets/04b9830a-99b8-4f3f-828a-a15b814992da)
the red badge will always show up until close keybase window and reopen it from notification area of taskbar

now it can clear now.
did not find which version introduced this error, it should happens over 1 year.