### PR TITLE
workaround for auto focus not working on android

### DIFF
--- a/shared/chat/conversation/search/index.tsx
+++ b/shared/chat/conversation/search/index.tsx
@@ -261,7 +261,13 @@ const ThreadSearchMobile = (props: SearchProps & Props) => (
       <Kb.Box2 direction="horizontal" style={styles.inputContainer}>
         <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.queryContainer} centerChildren={true}>
           <Kb.PlainInput
-            autoFocus={true}
+            ref={r => {
+              // setting autofocus on android fails sometimes, this workaround seems to work
+              setTimeout(() => {
+                r?.focus()
+              }, 100)
+            }}
+            autoFocus={false}
             flexable={true}
             onChangeText={props.onChangedText}
             onEnterKeyDown={props.onEnter}


### PR DESCRIPTION
sometimes this chat search can be in a state where it doesn't update. seems to be a focus race. the input will have the cursor and the autocomplete system bar updates but the value never triggers js callbacks (onChangedText etc). delay setting focus fixes this 