### PR TITLE
use rn pressable to fix double menu issues

### DIFF
--- a/shared/common-adapters/clickable-box.native.tsx
+++ b/shared/common-adapters/clickable-box.native.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react'
 import * as Styles from '@/styles'
 import Box from './box'
-import {View, TouchableOpacity, TouchableWithoutFeedback} from 'react-native'
+import {Pressable, View, TouchableOpacity, TouchableWithoutFeedback} from 'react-native'
 import type {Props, Props2} from './clickable-box'
 import type {MeasureRef} from './measure-ref'
-import {Pressable} from 'react-native-gesture-handler'
 
 const Kb = {
   Box,


### PR DESCRIPTION
originally did this to fix the issue w/ gesture handler on android but i think they fixed that so we can revert this workaround