### PR TITLE
stop menu side from making calls and erroring

### DIFF
--- a/shared/constants/config.tsx
+++ b/shared/constants/config.tsx
@@ -219,7 +219,7 @@ interface State extends Store {
     setHTTPSrvInfo: (address: string, token: string) => void
     setIncomingShareUseOriginal: (use: boolean) => void
     setJustDeletedSelf: (s: string) => void
-    setLoggedIn: (l: boolean, causedByStartup: boolean) => void
+    setLoggedIn: (l: boolean, causedByStartup: boolean, fromMenubar?: boolean) => void
     setMobileAppState: (nextAppState: 'active' | 'background' | 'inactive') => void
     setNotifySound: (n: boolean) => void
     setStartupDetails: (st: Omit<Store['startup'], 'loaded'>) => void
@@ -1076,12 +1076,14 @@ export const useConfigState_ = Z.createZustand<State>((set, get) => {
         s.justDeletedSelf = self
       })
     },
-    setLoggedIn: (loggedIn, causedByStartup) => {
+    setLoggedIn: (loggedIn, causedByStartup, fromMenubar = false) => {
       const changed = get().loggedIn !== loggedIn
       set(s => {
         s.loggedIn = loggedIn
         s.loggedInCausedbyStartup = causedByStartup
       })
+
+      if (fromMenubar) return
 
       if (!changed) return
 

--- a/shared/menubar/remote-container.desktop.tsx
+++ b/shared/menubar/remote-container.desktop.tsx
@@ -24,7 +24,7 @@ const RemoteContainer = (d: DeserializeProps) => {
       replaceUsername(username)
       setHTTPSrvInfo(httpSrvAddress, httpSrvToken)
       setOutOfDate(outOfDate)
-      setLoggedIn(loggedIn, false)
+      setLoggedIn(loggedIn, false, true)
       for (const [id, unread] of unreadMap) {
         C.getConvoState(id).dispatch.unreadUpdated(unread)
       }


### PR DESCRIPTION
menubar console is logging errors when this helper tries to make some other calls when this value changes. this is benign but shouldn't be happening. for now we plumb a flag