### PR TITLE
fix msgpack to jsi object map key encoding issue

### DIFF
--- a/rnmodules/react-native-kb/cpp/react-native-kb.cpp
+++ b/rnmodules/react-native-kb/cpp/react-native-kb.cpp
@@ -71,14 +71,14 @@ Value convertMPToJSI(Runtime &runtime, msgpack::object &o) {
     for (; p < pend; ++p) {
       auto key = mpToString(p->key);
       auto val = convertMPToJSI(runtime, p->val);
-      obj.setProperty(runtime, key.c_str(), val);
+      obj.setProperty(runtime, jsi::String::createFromUtf8(runtime, key), val);
     }
     return obj;
   }
   case msgpack::type::BIN: {
     auto ptr = o.via.bin.ptr;
     int size = o.via.bin.size;
-    
+
       // make ArrayBuffer and copy in data
       Function arrayBufferCtor =
           runtime.global().getPropertyAsFunction(runtime, "ArrayBuffer");
@@ -86,7 +86,7 @@ Value convertMPToJSI(Runtime &runtime, msgpack::object &o) {
       Object abo = ab.getObject(runtime);
       ArrayBuffer abbuf = abo.getArrayBuffer(runtime);
       std::copy(ptr, ptr + size, abbuf.data(runtime));
-  
+
       // Wrap in Uint8Array
       Function uCtor = runtime.global().getPropertyAsFunction(runtime, "Uint8Array");
       Value uc = uCtor.callAsConstructor(runtime, std::move(abbuf));
@@ -96,8 +96,7 @@ Value convertMPToJSI(Runtime &runtime, msgpack::object &o) {
     auto size = o.via.array.size;
     jsi::Array arr(runtime, size);
     for (int i = 0; i < size; ++i) {
-      arr.setValueAtIndex(runtime, i,
-                          convertMPToJSI(runtime, o.via.array.ptr[i]));
+      arr.setValueAtIndex(runtime, i, convertMPToJSI(runtime, o.via.array.ptr[i]));
     }
     return arr;
   }


### PR DESCRIPTION
This was a tricky one. A simple repro is doing a reaction to a thread while you're in the thread. If you load the thread fresh its fine but if you stream in the emoji changing update it fails. The load actually sends it all as a single string which we convert on the JS side so it skirts the encoding issue. The update passes the emojis as keys to a map which is where the encoding issue is. It's not clear why this breaks now, maybe hermes handles this differently than JSC