### PR TITLE
packaging: kill only the main Keybase process in run_keybase

### DIFF
--- a/packaging/linux/run_keybase
+++ b/packaging/linux/run_keybase
@@ -27,7 +27,7 @@ kill_all() {
 
   # Only stop main Electron process; others have additional flags after the process name
   # Child Electron processes will be stopped by main process' handler
-  if main_electron_pids="$(pgrep 'Keybase$')"; then
+  if main_electron_pids="$(pgrep -f 'Keybase$')"; then
       # intentionally splitting pids
       # shellcheck disable=SC2046
       kill $(echo "$main_electron_pids" | xargs) &> /dev/null && echo Shutting down Keybase GUI...


### PR DESCRIPTION
On Linux, executing `run_keybase` while Keybase is already running causes electron to crash consistently (because e.g. the electron/chromium gpu-process gets killed). This fixes that by more carefully killing only the main electron/Keybase process.

A previous PR (https://github.com/keybase/client/pull/17463) tried to fix this, but it used `pgrep 'Keybase$'` which checks for matches against the process name. Adding `-f` makes it match against the full command line arguments.