### PR TITLE
use background context for refresh

### DIFF
--- a/go/teams/opensearch/search.go
+++ b/go/teams/opensearch/search.go
@@ -136,6 +136,7 @@ func Local(mctx libkb.MetaContext, query string, limit int) (res []keybase1.Team
 	tracer := mctx.G().CTimeTracer(mctx.Ctx(), "OpenSearch.Local", true)
 	defer tracer.Finish()
 	defer func() {
+		mctx := libkb.NewMetaContextBackground(mctx.G())
 		go refreshOpenTeams(mctx, false)
 	}()
 	if si, err = getOpenTeams(mctx); err != nil {


### PR DESCRIPTION
@mmaxim 

Otherwise the context would get cancelled prematurely when the RPC completes