### PR TITLE
ios 26 styling

### DIFF
--- a/shared/common-adapters/image2.native.tsx
+++ b/shared/common-adapters/image2.native.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import LoadingStateView from './loading-state-view'
 import type {Props} from './image2'
-import {Image, type ImageLoadEventData} from 'expo-image'
+import {Image, type ImageLoadEventData, type ImageErrorEventData} from 'expo-image'
 
 const Image2 = (p: Props) => {
   const {
@@ -30,9 +30,9 @@ const Image2 = (p: Props) => {
   }
 
   const _onError = React.useCallback(
-    (e: unknown) => {
+    (e: ImageErrorEventData) => {
       setLoading(false)
-      console.log('Image2 load error', e)
+      console.log('Image2 load error', e.error)
       onError?.()
     },
     [setLoading, onError]

--- a/shared/ios/Keybase/Info.plist
+++ b/shared/ios/Keybase/Info.plist
@@ -111,5 +111,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+  <key>UIDesignRequiresCompatibility</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
We need to disable the glass styling until its supported by our nav library

https://github.com/software-mansion/react-native-screens/pull/2987
https://github.com/react-navigation/react-navigation/pull/12657