### PR TITLE
show error states on chat create

### DIFF
--- a/shared/constants/chat2/convostate.tsx
+++ b/shared/constants/chat2/convostate.tsx
@@ -2079,6 +2079,10 @@ const createSlice: Z.ImmerStateCreator<ConvoState> = (set, get) => {
     navigateToThread: (_reason, highlightMessageID, pushBody) => {
       set(s => {
         s.threadSearchInfo.visible = false
+        // force loaded if we're an error
+        if (s.id === C.Chat.pendingErrorConversationIDKey) {
+          s.loaded = true
+        }
       })
 
       const loadMessages = () => {


### PR DESCRIPTION
if you start a convo and it errors out its invisible on desktop since we use opacity to hide not loaded threads yet, but the error convo never loads so its never visible. instead we force loaded on so everything shows