### PR TITLE
fix orange line showing on reactions while not active

### DIFF
--- a/shared/chat/conversation/normal/container.tsx
+++ b/shared/chat/conversation/normal/container.tsx
@@ -19,7 +19,6 @@ const useOrangeLine = () => {
         identifyBehavior: T.RPCGen.TLFIdentifyBehavior.chatGui,
         readMsgID: readMsgID < 0 ? 0 : readMsgID,
       })
-
       setOrangeLine(T.Chat.numberToOrdinal(unreadlineRes.unreadlineID ? unreadlineRes.unreadlineID : 0))
     }
     C.ignorePromise(f())
@@ -30,11 +29,11 @@ const useOrangeLine = () => {
     loadOrangeLine()
   }, [loadOrangeLine])
 
-  const {markedAsUnread, maxMsgID, readMsgID} = C.useChatContext(
+  const {markedAsUnread, maxVisibleMsgID} = C.useChatContext(
     C.useShallow(s => {
-      const {maxMsgID, readMsgID} = s.meta
+      const {maxVisibleMsgID} = s.meta
       const {markedAsUnread} = s
-      return {markedAsUnread, maxMsgID, readMsgID}
+      return {markedAsUnread, maxVisibleMsgID}
     })
   )
 
@@ -47,13 +46,14 @@ const useOrangeLine = () => {
     }
   }, [loadOrangeLine, markedAsUnread])
 
-  // we're not looking add a line
+  // just use the rpc for orange line if we're not active
+  // if we are active we want to keep whatever state we had so it is maintained
   const active = C.useActiveState(s => s.active)
   React.useEffect(() => {
-    if (!active && readMsgID < maxMsgID) {
-      setOrangeLine(T.Chat.numberToOrdinal(readMsgID + 0.0001))
+    if (!active) {
+      loadOrangeLine()
     }
-  }, [active, maxMsgID, readMsgID])
+  }, [maxVisibleMsgID, loadOrangeLine, active])
 
   // mobile backgrounded us
   const mobileAppState = C.useConfigState(s => s.mobileAppState)


### PR DESCRIPTION
repro:
1. send message
2. lose focus
3. receive reaction on the message from 1
4. bring focus back (move mouse also)
5. send
6. orange line appears

this is a case where the `maxMsgID` and the max ordinals we see won't ever line up so when we come back to focus we inject an orange line. instead of bookeeping this logic ourselves when we lose focus we just call the rpc to get the orange line. we only do this when inactive as calling this while active will clear the line but if we have a line we want it to scroll up and stay there.
with this fix we don't get this extra orange line and when you background the existing one does go away (which is good i think)