### PR TITLE
bump RPC library with memleak fix

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/keybase/clockwork v0.1.1-0.20161209210251-976f45f4a979
 	github.com/keybase/go-codec v0.0.0-20180928230036-164397562123
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4
-	github.com/keybase/go-framed-msgpack-rpc v0.0.0-20251023202109-e6f0a8bc3c34
+	github.com/keybase/go-framed-msgpack-rpc v0.0.0-20251030172521-fcbc135cd8e5
 	github.com/keybase/go-jsonw v0.0.0-20200325173637-df90f282c233
 	github.com/keybase/go-kext v0.0.0-20250106202153-9105fd1e4e98
 	github.com/keybase/go-keychain v0.0.0-20250107162724-3747e5bfbb71

--- a/go/go.sum
+++ b/go/go.sum
@@ -547,8 +547,8 @@ github.com/keybase/go-codec v0.0.0-20180928230036-164397562123 h1:yg56lYPqh9suJe
 github.com/keybase/go-codec v0.0.0-20180928230036-164397562123/go.mod h1:r/eVVWCngg6TsFV/3HuS9sWhDkAzGG8mXhiuYA+Z/20=
 github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4 h1:cTxwSmnaqLoo+4tLukHoB9iqHOu3LmLhRmgUxZo6Vp4=
 github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
-github.com/keybase/go-framed-msgpack-rpc v0.0.0-20251023202109-e6f0a8bc3c34 h1:9CPbhPb6GWLbcfiL4zWhLBQPFox2zbimiWukSY4rEao=
-github.com/keybase/go-framed-msgpack-rpc v0.0.0-20251023202109-e6f0a8bc3c34/go.mod h1:eN3SkY2uA256gdfW294PZpBGXJHlEJHwX8hx8Hmn+Qs=
+github.com/keybase/go-framed-msgpack-rpc v0.0.0-20251030172521-fcbc135cd8e5 h1:IPL82AbpLi24MOK58m1fi8lNJPXR8a4RMU0h8hl8Y/k=
+github.com/keybase/go-framed-msgpack-rpc v0.0.0-20251030172521-fcbc135cd8e5/go.mod h1:eN3SkY2uA256gdfW294PZpBGXJHlEJHwX8hx8Hmn+Qs=
 github.com/keybase/go-git v4.0.0-rc9.0.20190209005256-3a78daa8ce8e+incompatible h1:vGk0ZpLiX9X58raUx86zSlmvmJmEEoUBz/Wr0aIYHIs=
 github.com/keybase/go-git v4.0.0-rc9.0.20190209005256-3a78daa8ce8e+incompatible/go.mod h1:UXHGv5gdZq3WKJwTqUz51rTso8HiW4pPAq6h8bCBGUY=
 github.com/keybase/go-jsonw v0.0.0-20200325173637-df90f282c233 h1:zLk+cB/0ShMCBcgBOXYgellLZiZahXFicJleKyrlqiM=


### PR DESCRIPTION
brings in the memleak fix from https://github.com/keybase/go-framed-msgpack-rpc/pull/204

@mmaxim 