### PR TITLE
add custom emoji offset

### DIFF
--- a/shared/util/custom-emoji.native.tsx
+++ b/shared/util/custom-emoji.native.tsx
@@ -5,6 +5,7 @@ const CustomEmoji = (props: Props) => {
   const {size, src} = props
   const dimensions = {
     height: size,
+    transform: [{translateY: 6}],
     width: size,
     ...props.style,
   }


### PR DESCRIPTION
not sure why this is necessary. other alignment things don't work, likely due to the limitations of components inside of text in fabric or something

maybe related https://github.com/facebook/react-native/issues/53092