### PR TITLE
move go init all the way before rn init

### DIFF
--- a/shared/ios/Keybase/AppDelegate.swift
+++ b/shared/ios/Keybase/AppDelegate.swift
@@ -83,8 +83,6 @@ public class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UID
       self.didLaunchSetupAfter(application: application, rootView: rootView)
     }
     
-    setupGo()
-    
     return true
   }
   
@@ -146,6 +144,7 @@ public class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UID
   }
   
   func didLaunchSetupBefore() {
+    setupGo()
     try? AVAudioSession.sharedInstance().setCategory(.ambient)
     UNUserNotificationCenter.current().delegate = self
   }


### PR DESCRIPTION
I've moved this around a couple of times. There are issues (i believe) when its between rn init and when the other modules load (expo). There are races if its after that flow so i'm going to move it to basically be the first thing that inits. This plus the additional sync points we put in I hope will alleviate some of these startup races