### PR TITLE
noop Close implementation for SharedKeybaseTransport

### DIFF
--- a/go/kbfs/libkbfs/shared_keybase_transport.go
+++ b/go/kbfs/libkbfs/shared_keybase_transport.go
@@ -81,14 +81,5 @@ func (kt *SharedKeybaseTransport) Finalize() {
 
 // Close is an implementation of the ConnectionTransport interface.
 func (kt *SharedKeybaseTransport) Close() {
-	kt.mutex.Lock()
-	defer kt.mutex.Unlock()
-	if kt.transport != nil {
-		kt.transport.Close()
-	}
-	kt.transport = nil
-	if kt.stagedTransport != nil {
-		kt.stagedTransport.Close()
-	}
-	kt.stagedTransport = nil
+	// Since this is a shared connection, do nothing.
 }


### PR DESCRIPTION
https://github.com/keybase/client/pull/28591 incorrectly implemented a the `Close` method on the shared transport cause the shared transport to be shutdown early. This was noticeable in git operations which would fail with EOF

```
 keybase git create repo2.git
▶ ERROR EOF
``` 

@mmaxim @songgao 