### PR TITLE
set ios_version flag in gomobile bind

### DIFF
--- a/go/chat/attachments/preview_darwin.go
+++ b/go/chat/attachments/preview_darwin.go
@@ -40,19 +40,9 @@ VideoPreviewResult MakeVideoThumbnail(const char* inFilename) {
 	AVAssetImageGenerator *generateImg = [[AVAssetImageGenerator alloc] initWithAsset:asset];
 	[generateImg setAppliesPreferredTrackTransform:YES];
 	CMTime time = CMTimeMake(1, 1);
-
-    // Use the modern async API wrapped with a semaphore for synchronous behavior
-	__block CGImageRef image = NULL;
-	dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[generateImg generateCGImageAsynchronouslyForTime:time completionHandler:^(CGImageRef _Nullable imageRef, CMTime actualTime, NSError * _Nullable error) {
-		if (imageRef != NULL) {
-			image = CGImageRetain(imageRef);
-		}
-		dispatch_semaphore_signal(semaphore);
-	}];
-
-	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+	// NOTE Once iOS <16 support is dropped generateCGImageAsynchronouslyForTime can be used. https://github.com/keybase/client/pull/28530
+	NSError *error = NULL;
+	CGImageRef image = [generateImg copyCGImageAtTime:time actualTime:NULL error:&error];
 	result.duration = (int)CMTimeGetSeconds([asset duration]);
 
 	if (image != NULL) {

--- a/rnmodules/react-native-kb/ios/Kb.mm
+++ b/rnmodules/react-native-kb/ios/Kb.mm
@@ -272,10 +272,8 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTypedConstants) {
   NSString *serverConfig = [self setupServerConfig];
   NSString *guiConfig = [self setupGuiConfig];
 
-  NSString *darkModeSupported = @"0";
-  if (@available(iOS 13.0, *)) {
-    darkModeSupported = @"1";
-  };
+  // Dark mode available since iOS 13.0; app targets iOS 15.1+
+  NSString *darkModeSupported = @"1";
 
   NSString *appVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   if (appVersionString == nil) {

--- a/shared/react-native/gobuild.sh
+++ b/shared/react-native/gobuild.sh
@@ -62,13 +62,15 @@ build_gomobile() {
 if [ "$arg" = "ios" ]; then
 	ios_dir=${DEST_DIR:-"$client_dir/shared/ios"}
 	ios_dest="$ios_dir/keybasego.xcframework"
+	# Keep in sync with IPHONEOS_DEPLOYMENT_TARGET
+	ios_version="15.1"
 	echo "Building for iOS ($ios_dest)..."
 	set +e
-	OUTPUT="$(go tool gomobile bind -target=ios -tags="ios $tags" -ldflags "$ldflags" -o "$ios_dest" "$package" 2>&1)"
+	OUTPUT="$(go tool gomobile bind -target=ios -iosversion="$ios_version" -tags="ios $tags" -ldflags "$ldflags" -o "$ios_dest" "$package" 2>&1)"
 	set -e
 	if [[ $OUTPUT == *gomobile* ]]; then
 		build_gomobile
-		go tool gomobile bind -target=ios -tags="ios $tags" -ldflags "$ldflags" -o "$ios_dest" "$package"
+		go tool gomobile bind -target=ios -iosversion="$ios_version" -tags="ios $tags" -ldflags "$ldflags" -o "$ios_dest" "$package"
 	else
 		echo $OUTPUT
 	fi


### PR DESCRIPTION
https://github.com/keybase/client/pull/28530 added a function only available in iOS >= 16 while we currently target 15.1 we now treat this warning as an error


@chrisnojima @mmaxim 