### PR TITLE
paginate inbox loading

### DIFF
--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -21,6 +21,56 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	inboxPageSizeCI      = 3
+	inboxPageSizeMobile  = 500
+	inboxPageSizeDesktop = 1000
+)
+
+func getInboxPageSize(g *globals.Context) int {
+	if g.GetEnv().RunningInCI() {
+		return inboxPageSizeCI
+	}
+	if g.IsMobileAppType() {
+		return inboxPageSizeMobile
+	}
+	return inboxPageSizeDesktop
+}
+
+// fetchInboxPaginated fetches all pages of the inbox via GetInboxRemote, accumulating
+// conversations and using only the first full response's Vers for the combined result.
+func fetchInboxPaginated(ctx context.Context, getChatInterface func() chat1.RemoteInterface,
+	query *chat1.GetInboxQuery, pageSize int,
+) (convs []chat1.Conversation, vers chat1.InboxVers, err error) {
+	arg := chat1.GetInboxRemoteArg{
+		Query:      query,
+		Pagination: &chat1.Pagination{Num: pageSize},
+	}
+	ib, err := getChatInterface().GetInboxRemote(ctx, arg)
+	if err != nil {
+		return nil, 0, err
+	}
+	full := ib.Inbox.Full()
+	convs = append(convs, full.Conversations...)
+	vers = full.Vers
+	for full.Pagination != nil && !full.Pagination.Last && len(full.Pagination.Next) > 0 {
+		arg = chat1.GetInboxRemoteArg{
+			Query: query,
+			Pagination: &chat1.Pagination{
+				Num:  pageSize,
+				Next: full.Pagination.Next,
+			},
+		}
+		ib, err = getChatInterface().GetInboxRemote(ctx, arg)
+		if err != nil {
+			return nil, 0, err
+		}
+		full = ib.Inbox.Full()
+		convs = append(convs, full.Conversations...)
+	}
+	return convs, vers, nil
+}
+
 func filterConvLocals(convLocals []chat1.ConversationLocal, rquery *chat1.GetInboxQuery,
 	query *chat1.GetInboxLocalQuery, nameInfo types.NameInfo,
 ) (res []chat1.ConversationLocal, err error) {
@@ -341,15 +391,15 @@ func (s *RemoteInboxSource) ReadUnverified(ctx context.Context, uid gregor1.UID,
 	if s.IsOffline(ctx) {
 		return types.Inbox{}, OfflineError{}
 	}
-	ib, err := s.getChatInterface().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
-		Query: s.setDefaultParticipantMode(rquery),
-	})
+	query := s.setDefaultParticipantMode(rquery)
+	pageSize := getInboxPageSize(s.G())
+	convs, vers, err := fetchInboxPaginated(ctx, s.getChatInterface, query, pageSize)
 	if err != nil {
 		return types.Inbox{}, err
 	}
 	return types.Inbox{
-		Version:         ib.Inbox.Full().Vers,
-		ConvsUnverified: utils.RemoteConvs(ib.Inbox.Full().Conversations),
+		Version:         vers,
+		ConvsUnverified: utils.RemoteConvs(convs),
 	}, nil
 }
 
@@ -982,9 +1032,9 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 	}
 	rquery.SummarizeMaxMsgs = true // always summarize max msgs
 
-	ib, err := s.getChatInterface().GetInboxRemote(ctx, chat1.GetInboxRemoteArg{
-		Query: s.setDefaultParticipantMode(&rquery),
-	})
+	remoteQuery := s.setDefaultParticipantMode(&rquery)
+	pageSize := getInboxPageSize(s.G())
+	convs, vers, err := fetchInboxPaginated(ctx, s.getChatInterface, remoteQuery, pageSize)
 	if err != nil {
 		return types.Inbox{}, err
 	}
@@ -997,7 +1047,7 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 		maxBgEnqueued = 3
 	}
 
-	for _, conv := range ib.Inbox.Full().Conversations {
+	for _, conv := range convs {
 		// Retention policy expunge
 		expunge := conv.GetExpunge()
 		if expunge != nil {
@@ -1024,11 +1074,11 @@ func (s *HybridInboxSource) fetchRemoteInbox(ctx context.Context, uid gregor1.UI
 			bgEnqueued++
 		}
 	}
-	convs := utils.RemoteConvs(ib.Inbox.Full().Conversations)
-	convs = utils.ApplyInboxQuery(ctx, s.DebugLabeler, query, convs)
+	convsUnverified := utils.RemoteConvs(convs)
+	convsUnverified = utils.ApplyInboxQuery(ctx, s.DebugLabeler, query, convsUnverified)
 	return types.Inbox{
-		Version:         ib.Inbox.Full().Vers,
-		ConvsUnverified: convs,
+		Version:         vers,
+		ConvsUnverified: convsUnverified,
 	}, nil
 }
 

--- a/go/chat/inboxsource_test.go
+++ b/go/chat/inboxsource_test.go
@@ -233,3 +233,44 @@ func TestChatConversationDeleted(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// TestInboxPaginationMultiPage exercises the pagination path against the real server.
+// It creates a team conversation and numConvs distinct channels so the server returns
+// multiple pages when the client uses page size 3 (e.g. under KEYBASE_RUN_CI=1).
+func TestInboxPaginationMultiPage(t *testing.T) {
+	useRemoteMock = false
+	defer func() { useRemoteMock = true }()
+	ctc := makeChatTestContext(t, "TestInboxPaginationMultiPage", 3)
+	defer ctc.cleanup()
+
+	users := ctc.users()
+	listener := newServerChatListener()
+	ctc.as(t, users[0]).h.G().NotifyRouter.AddListener(listener)
+	ctc.world.Tcs[users[0].Username].ChatG.UIInboxLoader = types.DummyUIInboxLoader{}
+	ctc.world.Tcs[users[0].Username].ChatG.Syncer.(*Syncer).isConnected = true
+
+	ctx := ctc.as(t, users[0]).startCtx
+	tc := ctc.world.Tcs[users[0].Username]
+	uid := users[0].User.GetUID().ToBytes()
+
+	// Create a team conversation (default channel), then numConvs distinct channels.
+	const numConvs = 25
+	teamConv := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_TEAM, users[1], users[2])
+	consumeNewConversation(t, listener, teamConv.Id)
+
+	for i := range numConvs {
+		topicName := fmt.Sprintf("pagination-%d", i+1)
+		conv := mustCreateChannelForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+			&topicName, chat1.ConversationMembersType_TEAM, users[1], users[2])
+		consumeNewConversation(t, listener, conv.Id)
+	}
+
+	minConvs := 1 + numConvs // team + channels
+	ib, err := tc.Context().InboxSource.ReadUnverified(ctx, uid, types.InboxSourceDataSourceRemoteOnly, nil)
+	require.NoError(t, err)
+	require.NotNil(t, ib.ConvsUnverified, "inbox convs should be non-nil")
+	require.GreaterOrEqual(t, len(ib.ConvsUnverified), minConvs,
+		"inbox should contain at least %d conversations (team + channels) to exercise pagination", minConvs)
+	require.GreaterOrEqual(t, ib.Version, chat1.InboxVers(0), "inbox version should be set")
+}


### PR DESCRIPTION
paginate requests for the inbox, 1000 for desktop, 500 for mobile and 3 in CI to exercise this path. we cache the `InboxVersion` of the first page. Subsequent pages may have a later version which can technically result in us re-fetching data we already partially had.

@mmaxim 