### PR TITLE
Fix LegendList keyExtractor warning for all Kb.List consumers

### DIFF
--- a/shared/chat/conversation/info-panel/add-to-channel.tsx
+++ b/shared/chat/conversation/info-panel/add-to-channel.tsx
@@ -115,6 +115,7 @@ const AddToChannel = (props: Props) => {
       />
       <Kb.Box2 direction="vertical" fullWidth={true} style={styles.listContainer}>
         <Kb.List
+          keyProperty="username"
           items={membersFiltered}
           renderItem={(idx, item) => {
             const alreadyIn = participants.includes(item.username)

--- a/shared/common-adapters/list-common.tsx
+++ b/shared/common-adapters/list-common.tsx
@@ -2,7 +2,7 @@ import {smallHeight, largeHeight} from './list-item'
 import type {Props} from './list'
 
 export function useListProps<T>(p: Props<T>) {
-  const {items, renderItem, itemHeight, onEndReached, keyProperty, indexAsKey, estimatedItemHeight, extraData: extraDataProp, selectedIndex} = p
+  const {items, renderItem, itemHeight, onEndReached, keyProperty, estimatedItemHeight, extraData: extraDataProp, selectedIndex} = p
 
   const legendRenderItem = ({item, index}: {item: T; index: number}) => {
     return renderItem(index, item)
@@ -10,9 +10,7 @@ export function useListProps<T>(p: Props<T>) {
 
   const keyExtractor = keyProperty
     ? (item: T, _index: number) => String((item as Record<string, unknown>)[keyProperty])
-    : indexAsKey
-      ? (_item: T, index: number) => String(index)
-      : undefined
+    : (_item: T, index: number) => String(index)
 
   const getFixedItemSize =
     itemHeight.type === 'fixed'

--- a/shared/devices/index.tsx
+++ b/shared/devices/index.tsx
@@ -119,7 +119,7 @@ function ReloadableDevices() {
           {showPaperKeyNudge ? <PaperKeyNudge onAddDevice={() => onAddDevice(['paper key'])} /> : null}
           {waiting ? <Kb.ProgressIndicator style={styles.progress} /> : null}
           <Kb.BoxGrow2>
-            <Kb.List bounces={false} items={items} renderItem={renderItem} itemHeight={itemHeight} />
+            <Kb.List bounces={false} items={items} renderItem={renderItem} itemHeight={itemHeight} keyProperty="key" />
           </Kb.BoxGrow2>
         </Kb.Box2>
       </NewContext.Provider>

--- a/shared/fs/browser/rows/rows.tsx
+++ b/shared/fs/browser/rows/rows.tsx
@@ -125,6 +125,7 @@ function Rows(props: Props & {listKey: string}) {
     <Kb.BoxGrow>
       <Kb.List
         key={listKey}
+        keyProperty="key"
         items={items}
         bounces={true}
         itemHeight={{

--- a/shared/profile/generic/proofs-list.tsx
+++ b/shared/profile/generic/proofs-list.tsx
@@ -141,7 +141,7 @@ function Providers({filter, providerClicked, providers}: ProvidersProps) {
 
   return (
     <Kb.BoxGrow2>
-      <Kb.List items={items} renderItem={_renderItem} itemHeight={_itemHeight} />
+      <Kb.List items={items} renderItem={_renderItem} itemHeight={_itemHeight} keyProperty="key" />
     </Kb.BoxGrow2>
   )
 }

--- a/shared/teams/main/index.tsx
+++ b/shared/teams/main/index.tsx
@@ -189,7 +189,7 @@ const Teams = function Teams(p: Props) {
     <PerfProfiler id="TeamsList">
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.container}>
         <Kb.BoxGrow>
-          <Kb.List items={items} renderItem={renderItem} itemHeight={itemHeight} testID="teamsList" />
+          <Kb.List items={items} renderItem={renderItem} itemHeight={itemHeight} keyProperty="key" testID="teamsList" />
         </Kb.BoxGrow>
       </Kb.Box2>
     </PerfProfiler>

--- a/shared/teams/new-team/wizard/add-subteam-members.tsx
+++ b/shared/teams/new-team/wizard/add-subteam-members.tsx
@@ -118,6 +118,7 @@ const AddSubteamMembers = () => {
         </Kb.Box2>
         <Kb.BoxGrow>
           <Kb.List
+            keyProperty="username"
             items={filteredMembers}
             renderItem={renderItem}
             itemHeight={{sizeType: 'Small', type: 'fixedListItemAuto'}}


### PR DESCRIPTION
Default list-common.tsx to index-based keys when keyProperty is absent, and add keyProperty to 7 Kb.List sites that have natural unique keys.