### PR TITLE
Fix outstanding appendGUILogs session in node process

### DIFF
--- a/shared/logger/index.tsx
+++ b/shared/logger/index.tsx
@@ -109,8 +109,13 @@ class AggregateLoggerImpl {
 
   sendLogsToService = async (lines: Array<LogLineWithLevelISOTimestamp>) => {
     if (!isMobile) {
-      // don't want main node thread making these calls
+      // don't want main node thread making these calls — the node engine's
+      // NativeTransport forwards responses to the renderer without processing
+      // them locally, so RPCs sent from node never get responses.
       try {
+        if (typeof process !== 'undefined' && process.type !== 'renderer') {
+          return await Promise.resolve()
+        }
         const {hasEngine} = require('../engine/require') as {hasEngine: typeof HasEngineType}
         if (!hasEngine()) {
           return await Promise.resolve()


### PR DESCRIPTION
The node engine's NativeTransport.packetize_data forwards all responses to the renderer without processing them locally, so RPCs sent from the node process never get responses. The logger's periodic dump was sending appendGUILogs through the node engine, creating a session that stayed outstanding forever.

Check process.type to skip log sending in the node (main) process.