### PR TITLE
Remove old React Context .Provider pattern and delete CanFixOverdrawC…

### DIFF
--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -159,10 +159,8 @@ const Keybase = () => {
           <PortalProvider>
             <SafeAreaProvider initialMetrics={initialWindowMetrics} pointerEvents="box-none">
               <StoreHelper>
-                <Kb.Styles.CanFixOverdrawContext.Provider value={true}>
-                  <Main />
-                  {unmountAll}
-                </Kb.Styles.CanFixOverdrawContext.Provider>
+                <Main />
+                {unmountAll}
               </StoreHelper>
             </SafeAreaProvider>
           </PortalProvider>

--- a/shared/chat/conversation/input-area/filepicker-popup/index.native.tsx
+++ b/shared/chat/conversation/input-area/filepicker-popup/index.native.tsx
@@ -68,7 +68,7 @@ const FilePickerPopup = (p: Props) => {
 
   const header = <Prompt />
   return (
-    <Kb.FloatingModalContext.Provider value="bottomsheet">
+    <Kb.FloatingModalContext value="bottomsheet">
       <Kb.FloatingMenu
         header={header}
         attachTo={p.attachTo}
@@ -77,7 +77,7 @@ const FilePickerPopup = (p: Props) => {
         visible={p.visible}
         closeOnSelect={true}
       />
-    </Kb.FloatingModalContext.Provider>
+    </Kb.FloatingModalContext>
   )
 }
 

--- a/shared/chat/conversation/input-area/normal/moremenu-popup.native.tsx
+++ b/shared/chat/conversation/input-area/normal/moremenu-popup.native.tsx
@@ -53,9 +53,9 @@ const MoreMenuPopup = (props: Props) => {
     },
   ]
   return (
-    <Kb.FloatingModalContext.Provider value="bottomsheet">
+    <Kb.FloatingModalContext value="bottomsheet">
       <Kb.FloatingMenu closeOnSelect={true} items={items} onHidden={onHidden} visible={visible} />
-    </Kb.FloatingModalContext.Provider>
+    </Kb.FloatingModalContext>
   )
 }
 

--- a/shared/chat/conversation/input-area/normal/set-explode-popup/index.native.tsx
+++ b/shared/chat/conversation/input-area/normal/set-explode-popup/index.native.tsx
@@ -23,7 +23,7 @@ const SetExplodePopup = (p: Props) => {
   }))
 
   return (
-    <Kb.FloatingModalContext.Provider value="bottomsheet">
+    <Kb.FloatingModalContext value="bottomsheet">
       <Kb.FloatingMenu
         header={<Prompt />}
         closeOnSelect={true}
@@ -31,7 +31,7 @@ const SetExplodePopup = (p: Props) => {
         onHidden={props.onHidden}
         visible={props.visible}
       />
-    </Kb.FloatingModalContext.Provider>
+    </Kb.FloatingModalContext>
   )
 }
 

--- a/shared/chat/conversation/list-area/index.native.tsx
+++ b/shared/chat/conversation/list-area/index.native.tsx
@@ -270,8 +270,8 @@ const ConversationList = function ConversationList() {
 
   return (
     <Kb.ErrorBoundary>
-      <SetRecycleTypeContext.Provider value={setRecycleType}>
-        <ForceListRedrawContext.Provider value={forceListRedraw}>
+      <SetRecycleTypeContext value={setRecycleType}>
+        <ForceListRedrawContext value={forceListRedraw}>
           <PerfProfiler id="MessageList">
           <Kb.Box2 direction="vertical" fullWidth={true} flex={1} relative={true}>
             <List
@@ -306,8 +306,8 @@ const ConversationList = function ConversationList() {
             {debugWhichList}
           </Kb.Box2>
           </PerfProfiler>
-        </ForceListRedrawContext.Provider>
-      </SetRecycleTypeContext.Provider>
+        </ForceListRedrawContext>
+      </SetRecycleTypeContext>
     </Kb.ErrorBoundary>
   )
 }

--- a/shared/chat/conversation/messages/ids-context.tsx
+++ b/shared/chat/conversation/messages/ids-context.tsx
@@ -2,13 +2,11 @@ import * as React from 'react'
 import * as T from '@/constants/types'
 
 export type MessageContextValue = {
-  canFixOverdraw: boolean
   isHighlighted: boolean
   ordinal: T.Chat.Ordinal
 }
 
 const defaultValue = {
-  canFixOverdraw: true,
   isHighlighted: false,
   ordinal: T.Chat.numberToOrdinal(0),
 } satisfies MessageContextValue
@@ -18,4 +16,3 @@ export const MessageContext = React.createContext<MessageContextValue>(defaultVa
 // Convenience hooks for accessing individual values
 export const useOrdinal = () => React.useContext(MessageContext).ordinal
 export const useIsHighlighted = () => React.useContext(MessageContext).isHighlighted
-export const useCanFixOverdraw = () => React.useContext(MessageContext).canFixOverdraw

--- a/shared/chat/conversation/messages/message-popup/index.tsx
+++ b/shared/chat/conversation/messages/message-popup/index.tsx
@@ -86,7 +86,7 @@ export const MessagePopupModal = (p: ModalProps) => {
   const makePopup = (p: Kb.Popup2Parms) => {
     const {attachTo} = p
     return pop ? (
-      <Kb.FloatingModalContext.Provider value={true}>
+      <Kb.FloatingModalContext value={true}>
         <MessagePopup
           ordinal={ordinal}
           key="popup"
@@ -95,7 +95,7 @@ export const MessagePopupModal = (p: ModalProps) => {
           position="top right"
           visible={true}
         />
-      </Kb.FloatingModalContext.Provider>
+      </Kb.FloatingModalContext>
     ) : null
   }
   const {popup, popupAnchor, showPopup, showingPopup} = Kb.usePopup2(makePopup)
@@ -121,7 +121,7 @@ export const useMessagePopup = (p: {
     const {attachTo, hidePopup} = p
     return (shouldShow?.() ?? true) ? (
       <Chat.ChatProvider id={conversationIDKey}>
-        <Kb.FloatingModalContext.Provider value="bottomsheet">
+        <Kb.FloatingModalContext value="bottomsheet">
           <MessagePopup
             ordinal={ordinal}
             key="popup"
@@ -131,7 +131,7 @@ export const useMessagePopup = (p: {
             style={style}
             visible={true}
           />
-        </Kb.FloatingModalContext.Provider>
+        </Kb.FloatingModalContext>
       </Chat.ChatProvider>
     ) : null
   }

--- a/shared/chat/conversation/messages/reaction-tooltip.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip.tsx
@@ -69,7 +69,7 @@ const ReactionTooltip = (p: OwnProps) => {
   }
   const insets = Kb.useSafeAreaInsets()
   const conversationIDKey = Chat.useChatContext(s => s.id)
-  const messageContext = {canFixOverdraw: false, isHighlighted: false, ordinal}
+  const messageContext = {isHighlighted: false, ordinal}
   if (!visible) {
     return null
   }
@@ -92,7 +92,7 @@ const ReactionTooltip = (p: OwnProps) => {
     >
       {/* need context since this uses a portal... */}
       <Chat.ChatProvider id={conversationIDKey}>
-        <MessageContext.Provider value={messageContext}>
+        <MessageContext value={messageContext}>
           <Kb.Box2
             onMouseLeave={onMouseLeave}
             onMouseOver={onMouseOver}
@@ -129,7 +129,7 @@ const ReactionTooltip = (p: OwnProps) => {
               </Kb.ButtonBar>
             )}
           </Kb.Box2>
-        </MessageContext.Provider>
+        </MessageContext>
       </Chat.ChatProvider>
     </Kb.Overlay>
   )

--- a/shared/chat/conversation/messages/text/reply.tsx
+++ b/shared/chat/conversation/messages/text/reply.tsx
@@ -142,9 +142,9 @@ function Reply() {
   const showImage = !!replyTo.previewURL
 
   return (
-    <ReplyToContext.Provider value={replyTo}>
+    <ReplyToContext value={replyTo}>
       <ReplyStructure isDeleted={isDeleted} showImage={showImage} showEdited={showEdited} onClick={onClick} />
-    </ReplyToContext.Provider>
+    </ReplyToContext>
   )
 }
 

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -513,8 +513,6 @@ export function WrapperMessage(p: WMProps) {
   const {ecrType, showSendIndicator, showRevoked, showExplodingCountdown, exploding} = mdata
   const {reactionsPopupPosition, showCoinsIcon, botname, you} = mdata
 
-  const canFixOverdraw = !showCenteredHighlight && !isEditing
-
   const isHighlighted = showCenteredHighlight || isEditing
   const tsprops = {
     botname,
@@ -540,15 +538,13 @@ export function WrapperMessage(p: WMProps) {
     you,
   }
 
-  const messageContext = {canFixOverdraw, isHighlighted: showCenteredHighlight, ordinal}
+  const messageContext = {isHighlighted: showCenteredHighlight, ordinal}
 
   return (
-    <MessageContext.Provider value={messageContext}>
-      <Kb.Styles.CanFixOverdrawContext.Provider value={canFixOverdraw}>
-        <TextAndSiblings {...tsprops} />
-        {popup}
-      </Kb.Styles.CanFixOverdrawContext.Provider>
-    </MessageContext.Provider>
+    <MessageContext value={messageContext}>
+      <TextAndSiblings {...tsprops} />
+      {popup}
+    </MessageContext>
   )
 }
 

--- a/shared/chat/conversation/normal/container.tsx
+++ b/shared/chat/conversation/normal/container.tsx
@@ -86,13 +86,13 @@ const useOrangeLine = () => {
 const NormalWrapper = function NormalWrapper() {
   const orangeLine = useOrangeLine()
   return (
-    <OrangeLineContext.Provider value={orangeLine}>
+    <OrangeLineContext value={orangeLine}>
       <FocusProvider>
         <ScrollProvider>
           <Normal />
         </ScrollProvider>
       </FocusProvider>
-    </OrangeLineContext.Provider>
+    </OrangeLineContext>
   )
 }
 export default NormalWrapper

--- a/shared/chat/conversation/normal/context.tsx
+++ b/shared/chat/conversation/normal/context.tsx
@@ -16,7 +16,7 @@ export const FocusProvider = function FocusProvider({children}: {children: React
     inputRef.current?.focus()
   }
   const value = {focusInput, setInputRef}
-  return <FocusContext.Provider value={value}>{children}</FocusContext.Provider>
+  return <FocusContext value={value}>{children}</FocusContext>
 }
 
 type ScrollType = {
@@ -51,5 +51,5 @@ export const ScrollProvider = function ScrollProvider({children}: {children: Rea
     scrollRef.current?.scrollToBottom()
   }
   const value = {scrollDown, scrollToBottom, scrollUp, setScrollRef}
-  return <ScrollContext.Provider value={value}>{children}</ScrollContext.Provider>
+  return <ScrollContext value={value}>{children}</ScrollContext>
 }

--- a/shared/chat/conversation/normal/index.native.tsx
+++ b/shared/chat/conversation/normal/index.native.tsx
@@ -49,9 +49,9 @@ const Conversation = function Conversation() {
       </Kb.Box2>
       <InvitationToBlock />
       <Banner />
-      <MaxInputAreaContext.Provider value={maxInputArea}>
+      <MaxInputAreaContext value={maxInputArea}>
         <InputArea />
-      </MaxInputAreaContext.Provider>
+      </MaxInputAreaContext>
     </Kb.BoxGrow>
   )
 

--- a/shared/chat/inbox/row/big-team-channel.tsx
+++ b/shared/chat/inbox/row/big-team-channel.tsx
@@ -90,36 +90,34 @@ const BigTeamChannel = (props: Props) => {
   ) : null
 
   return (
-    <Kb.Styles.CanFixOverdrawContext.Provider value={!Kb.Styles.isTablet}>
-      <Kb.ClickableBox2 onClick={onSelectConversation} style={styles.container}>
-        <Kb.Box2 direction="horizontal" fullHeight={true} style={styles.rowContainer}>
+    <Kb.ClickableBox2 onClick={onSelectConversation} style={styles.container}>
+      <Kb.Box2 direction="horizontal" fullHeight={true} style={styles.rowContainer}>
+        <Kb.Box2
+          className="hover_background_color_blueGreyDark"
+          direction="horizontal"
+          fullWidth={!Kb.Styles.isMobile}
+          style={Kb.Styles.collapseStyles([
+            styles.channelBackground,
+            selected && styles.selectedChannelBackground,
+          ])}
+        >
+          {name}
+          {mutedIcon}
           <Kb.Box2
-            className="hover_background_color_blueGreyDark"
             direction="horizontal"
-            fullWidth={!Kb.Styles.isMobile}
-            style={Kb.Styles.collapseStyles([
-              styles.channelBackground,
-              selected && styles.selectedChannelBackground,
-            ])}
+            alignSelf="center"
+            alignItems="center"
+            justifyContent="flex-end"
+            flex={1}
+            tooltip={outboxTooltip || hasDraft ? 'Draft message' : undefined}
           >
-            {name}
-            {mutedIcon}
-            <Kb.Box2
-              direction="horizontal"
-              alignSelf="center"
-              alignItems="center"
-              justifyContent="flex-end"
-              flex={1}
-              tooltip={outboxTooltip || hasDraft ? 'Draft message' : undefined}
-            >
-              {draftIcon}
-              {outboxIcon}
-              {hasBadge && <Kb.Box2 direction="vertical" style={styles.unread} />}
-            </Kb.Box2>
+            {draftIcon}
+            {outboxIcon}
+            {hasBadge && <Kb.Box2 direction="vertical" style={styles.unread} />}
           </Kb.Box2>
         </Kb.Box2>
-      </Kb.ClickableBox2>
-    </Kb.Styles.CanFixOverdrawContext.Provider>
+      </Kb.Box2>
+    </Kb.ClickableBox2>
   )
 }
 

--- a/shared/common-adapters/key-event-handler.desktop.tsx
+++ b/shared/common-adapters/key-event-handler.desktop.tsx
@@ -80,7 +80,7 @@ const GlobalKeyEventHandler = (props: GlobalProps) => {
     setStack(prevStack => prevStack.filter(handler => handler !== receiver))
   }
 
-  return <KeyEventContext.Provider value={{add, remove}}>{props.children}</KeyEventContext.Provider>
+  return <KeyEventContext value={{add, remove}}>{props.children}</KeyEventContext>
 }
 
 type EscapeHandlerProps = {

--- a/shared/desktop/remote/component-loader.desktop.tsx
+++ b/shared/desktop/remote/component-loader.desktop.tsx
@@ -5,7 +5,6 @@ import * as Kb from '@/common-adapters'
 import * as R from '@/constants/remote'
 import * as RemoteGen from '@/actions/remote-gen'
 import {GlobalKeyEventHandler} from '@/common-adapters/key-event-handler.desktop'
-import {CanFixOverdrawContext} from '@/styles'
 import {disableDragDrop} from '@/util/drag-drop.desktop'
 import ErrorBoundary from '@/common-adapters/error-boundary'
 import {initDesktopStyles} from '@/styles/index.desktop'
@@ -57,7 +56,7 @@ function RemoteComponentLoader<P>(p: Props<P>) {
     <div id="RemoteComponentRoot" style={Kb.Styles.collapseStylesDesktop([p.style ?? styles.container])}>
       <ErrorBoundary closeOnClick={closeWindow} fallbackStyle={styles.errorFallback}>
         <GlobalKeyEventHandler>
-          <CanFixOverdrawContext.Provider value={true}>{p.child(value)}</CanFixOverdrawContext.Provider>
+          {p.child(value)}
         </GlobalKeyEventHandler>
       </ErrorBoundary>
     </div>

--- a/shared/desktop/renderer/main2.desktop.tsx
+++ b/shared/desktop/renderer/main2.desktop.tsx
@@ -6,7 +6,6 @@ import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import type * as RemoteGen from '@/actions/remote-gen'
 import {GlobalKeyEventHandler} from '@/common-adapters/key-event-handler.desktop'
-import {CanFixOverdrawContext} from '@/styles'
 import {makeEngine} from '@/engine'
 import {disableDragDrop} from '@/util/drag-drop.desktop'
 import {initDesktopStyles} from '@/styles/index.desktop'
@@ -110,7 +109,7 @@ const Root = ({children}: {children: React.ReactNode}) => {
   useDarkHookup()
   return (
     <GlobalKeyEventHandler>
-      <CanFixOverdrawContext.Provider value={true}>{children}</CanFixOverdrawContext.Provider>
+      {children}
     </GlobalKeyEventHandler>
   )
 }

--- a/shared/devices/index.tsx
+++ b/shared/devices/index.tsx
@@ -109,7 +109,7 @@ function ReloadableDevices() {
       reloadOnMount={true}
       title=""
     >
-      <NewContext.Provider value={badged}>
+      <NewContext value={badged}>
         <Kb.Box2 direction="vertical" fullHeight={true} fullWidth={true} relative={true}>
           {Kb.Styles.isMobile ? (
             <Kb.ClickableBox onClick={() => onAddDevice()} style={headerStyles.container}>
@@ -122,7 +122,7 @@ function ReloadableDevices() {
             <Kb.List bounces={false} items={items} renderItem={renderItem} itemHeight={itemHeight} keyProperty="key" />
           </Kb.BoxGrow2>
         </Kb.Box2>
-      </NewContext.Provider>
+      </NewContext>
     </Kb.Reloadable>
   )
 }

--- a/shared/git/index.tsx
+++ b/shared/git/index.tsx
@@ -97,7 +97,7 @@ const Container = (ownProps: OwnProps) => {
             <Kb.Text type="BodyBigLink">New encrypted git repository...</Kb.Text>
           </Kb.ClickableBox>
         )}
-        <NewContext.Provider value={badged}>
+        <NewContext value={badged}>
           <Kb.SectionList
             keyExtractor={item => item}
             extraData={expandedSet}
@@ -118,7 +118,7 @@ const Container = (ownProps: OwnProps) => {
               {data: teams, loading: loading, title: 'Team'},
             ]}
           />
-        </NewContext.Provider>
+        </NewContext>
         {popup}
       </Kb.Box2>
     </Kb.Reloadable>

--- a/shared/profile/routes.tsx
+++ b/shared/profile/routes.tsx
@@ -19,9 +19,7 @@ export const newRoutes = {
       getOptions: {
         headerLeft: p => {
           return (
-            <Kb.Styles.CanFixOverdrawContext.Provider value={false}>
-              <HeaderLeftArrowCanGoBack tintColor={p.tintColor} />
-            </Kb.Styles.CanFixOverdrawContext.Provider>
+            <HeaderLeftArrowCanGoBack tintColor={p.tintColor} />
           )
         },
         headerShown: true,

--- a/shared/settings/account/add-modals.tsx
+++ b/shared/settings/account/add-modals.tsx
@@ -293,9 +293,7 @@ export const VerifyPhone = () => {
       header={{
         hideBorder: true,
         leftButton: Kb.Styles.isMobile ? (
-          <Kb.Styles.CanFixOverdrawContext.Provider value={false}>
-            <Kb.BackButton onClick={onClose} iconColor={Kb.Styles.globalColors.white} />
-          </Kb.Styles.CanFixOverdrawContext.Provider>
+          <Kb.BackButton onClick={onClose} iconColor={Kb.Styles.globalColors.white} />
         ) : null,
         style: styles.blueBackground,
         title: (

--- a/shared/settings/sub-nav/left-nav.tsx
+++ b/shared/settings/sub-nav/left-nav.tsx
@@ -21,8 +21,7 @@ const LeftNav = (props: Props) => {
     navigate(Settings.settingsLogOutTab)
   }
   return (
-    <Kb.Styles.CanFixOverdrawContext.Provider value={false}>
-      <Kb.ScrollView style={styles.container}>
+    <Kb.ScrollView style={styles.container}>
         {Kb.Styles.isTablet && (
           <>
             <SettingsItem
@@ -135,8 +134,7 @@ const LeftNav = (props: Props) => {
         {/* TODO: Do something with logoutInProgress once Offline is
         removed from the settings page. */}
         <SettingsItem text="Sign out" selected={false} type={'nope'} onClick={onSignout} />
-      </Kb.ScrollView>
-    </Kb.Styles.CanFixOverdrawContext.Provider>
+    </Kb.ScrollView>
   )
 }
 

--- a/shared/stores/convostate.tsx
+++ b/shared/stores/convostate.tsx
@@ -3464,7 +3464,7 @@ export function ChatProvider({canBeNull, children, ...props}: ConvoProviderProps
       throw new Error('No convo id in provider')
     }
   }
-  return <Context.Provider value={createConvoStore(props.id)}>{children}</Context.Provider>
+  return <Context value={createConvoStore(props.id)}>{children}</Context>
 }
 
 export function useHasContext() {
@@ -3476,7 +3476,7 @@ export function useHasContext() {
 export function useChatContext<T>(selector: (state: ConvoState) => T): T {
   const store = React.useContext(Context)
   if (!store) {
-    throw new Error('Missing ConvoContext.Provider in the tree')
+    throw new Error('Missing ConvoContext in the tree')
   }
   return useStore(store, selector)
 }

--- a/shared/stores/team-building.tsx
+++ b/shared/stores/team-building.tsx
@@ -520,11 +520,11 @@ const Context = React.createContext<MadeStore | null>(null)
 
 type TBProviderProps = React.PropsWithChildren<{namespace: T.TB.AllowedNamespace}>
 export function TBProvider({children, ...props}: TBProviderProps) {
-  return <Context.Provider value={createTBStore(props.namespace)}>{children}</Context.Provider>
+  return <Context value={createTBStore(props.namespace)}>{children}</Context>
 }
 
 export function useTBContext<T>(selector: (state: State) => T): T {
   const store = React.useContext(Context)
-  if (!store) throw new Error('Missing TeambuildingContext.Provider in the tree')
+  if (!store) throw new Error('Missing TeambuildingContext in the tree')
   return useStore(store, selector)
 }

--- a/shared/styles/index.d.ts
+++ b/shared/styles/index.d.ts
@@ -139,7 +139,6 @@ export type {
   _StylesMobile,
 } from './css'
 export {default as classNames} from 'classnames'
-export declare const CanFixOverdrawContext: React.Context<boolean>
 export declare const undynamicColor: (col: string) => string
 // add file:// if its a pure path
 export declare const normalizePath: (p: string) => string

--- a/shared/styles/styles-base.tsx
+++ b/shared/styles/styles-base.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react'
-
 export const urlEscapeFilePath = (path: string) => {
   if (path.startsWith('file://')) {
     const parts = path.split('/')
@@ -12,6 +10,3 @@ export const urlEscapeFilePath = (path: string) => {
 export const castStyleDesktop = (style: unknown) => style
 export const castStyleNative = (style: unknown) => style
 
-export const CanFixOverdrawContext = React.createContext(false)
-export const dontFixOverdraw = {canFixOverdraw: false}
-export const yesFixOverdraw = {canFixOverdraw: true}

--- a/shared/teams/team/index.tsx
+++ b/shared/teams/team/index.tsx
@@ -162,8 +162,7 @@ const Team = (props: Props) => {
   }
 
   return (
-    <Kb.Styles.CanFixOverdrawContext.Provider value={false}>
-      <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} flex={1} style={styles.container} relative={true}>
+    <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} flex={1} style={styles.container} relative={true}>
         <Kb.SectionList
           renderSectionHeader={renderSectionHeader}
           stickySectionHeadersEnabled={Kb.Styles.isMobile}
@@ -178,8 +177,7 @@ const Team = (props: Props) => {
           }
           teamID={teamID}
         />
-      </Kb.Box2>
-    </Kb.Styles.CanFixOverdrawContext.Provider>
+    </Kb.Box2>
   )
 }
 


### PR DESCRIPTION
…ontext

React 19 supports using <Context value={...}> directly instead of <Context.Provider value={...}>. Migrate all context providers to the new syntax and remove the deprecated CanFixOverdrawContext entirely.