### PR TITLE
Fix typo in README for package dependencies

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -85,7 +85,7 @@ cd $GOPATH/src/github.com/keybase/client/go/test
 ./run_tests.sh
 ```
 
-### Calculate package dependenies
+### Calculate package dependencies
 
 ```bash
 make gen-deps


### PR DESCRIPTION
Stumbled over this while reading your docs. Dependenies -> dependencies