### PR TITLE
fix slow device page load

### DIFF
--- a/go/libkb/apiarg.go
+++ b/go/libkb/apiarg.go
@@ -47,7 +47,7 @@ func NewRetryAPIArg(endpoint string) APIArg {
 	return APIArg{
 		Endpoint:        endpoint,
 		InitialTimeout:  HTTPRetryInitialTimeout,
-		RetryMultiplier: HTTPRetryMutliplier,
+		RetryMultiplier: HTTPRetryMultiplier,
 		RetryCount:      HTTPRetryCount,
 	}
 }

--- a/go/libkb/constants.go
+++ b/go/libkb/constants.go
@@ -520,7 +520,7 @@ const (
 // critical idempotent API calls
 const (
 	HTTPRetryInitialTimeout = 1 * time.Second
-	HTTPRetryMutliplier     = 1.5
+	HTTPRetryMultiplier     = 1.5
 	HTTPRetryCount          = 6
 )
 

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -560,7 +560,7 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 		},
 		SessionType:     APISessionTypeREQUIRED,
 		InitialTimeout:  HTTPRetryInitialTimeout,
-		RetryMultiplier: HTTPRetryMutliplier,
+		RetryMultiplier: HTTPRetryMultiplier,
 		RetryCount:      5, // It's pretty bad to fail this, so retry.
 	}, &resp)
 	if err != nil {

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -558,8 +558,10 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 			"generation": I{int(s.currentGenerationLocked())},
 			"device_id":  S{deviceID.String()},
 		},
-		SessionType: APISessionTypeREQUIRED,
-		RetryCount:  5, // It's pretty bad to fail this, so retry.
+		SessionType:     APISessionTypeREQUIRED,
+		InitialTimeout:  HTTPRetryInitialTimeout,
+		RetryMultiplier: HTTPRetryMutliplier,
+		RetryCount:      5, // It's pretty bad to fail this, so retry.
 	}, &resp)
 	if err != nil {
 		return nil, nil, err

--- a/go/libkb/per_user_key.go
+++ b/go/libkb/per_user_key.go
@@ -552,17 +552,13 @@ func (s *PerUserKeyring) fetchBoxesLocked(m MetaContext,
 	defer m.Trace("PerUserKeyring#fetchBoxesLocked", &err)()
 
 	var resp perUserKeySyncResp
-	err = m.G().API.GetDecode(m, APIArg{
-		Endpoint: "key/fetch_per_user_key_secrets",
-		Args: HTTPArgs{
-			"generation": I{int(s.currentGenerationLocked())},
-			"device_id":  S{deviceID.String()},
-		},
-		SessionType:     APISessionTypeREQUIRED,
-		InitialTimeout:  HTTPRetryInitialTimeout,
-		RetryMultiplier: HTTPRetryMultiplier,
-		RetryCount:      5, // It's pretty bad to fail this, so retry.
-	}, &resp)
+	apiArg := NewRetryAPIArg("key/fetch_per_user_key_secrets")
+	apiArg.Args = HTTPArgs{
+		"generation": I{int(s.currentGenerationLocked())},
+		"device_id":  S{deviceID.String()},
+	}
+	apiArg.SessionType = APISessionTypeREQUIRED
+	err = m.G().API.GetDecode(m, apiArg, &resp)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -128,10 +128,12 @@ func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceRel
 	}
 	var res *APIRes
 	res, err = ss.G().API.Get(m, APIArg{
-		Endpoint:    "key/fetch_private",
-		Args:        hargs,
-		SessionType: APISessionTypeREQUIRED,
-		RetryCount:  5, // It's pretty bad to fail this, so retry.
+		Endpoint:        "key/fetch_private",
+		Args:            hargs,
+		SessionType:     APISessionTypeREQUIRED,
+		InitialTimeout:  HTTPRetryInitialTimeout,
+		RetryMultiplier: HTTPRetryMutliplier,
+		RetryCount:      5, // It's pretty bad to fail this, so retry.
 	})
 	m.Debug("| syncFromServer -> %s", ErrToOk(err))
 	if err != nil {

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -132,7 +132,7 @@ func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceRel
 		Args:            hargs,
 		SessionType:     APISessionTypeREQUIRED,
 		InitialTimeout:  HTTPRetryInitialTimeout,
-		RetryMultiplier: HTTPRetryMutliplier,
+		RetryMultiplier: HTTPRetryMultiplier,
 		RetryCount:      5, // It's pretty bad to fail this, so retry.
 	})
 	m.Debug("| syncFromServer -> %s", ErrToOk(err))

--- a/go/libkb/sync_secret.go
+++ b/go/libkb/sync_secret.go
@@ -127,14 +127,10 @@ func (ss *SecretSyncer) syncFromServer(m MetaContext, uid keybase1.UID, forceRel
 		hargs.Add("version", I{ss.keys.Version})
 	}
 	var res *APIRes
-	res, err = ss.G().API.Get(m, APIArg{
-		Endpoint:        "key/fetch_private",
-		Args:            hargs,
-		SessionType:     APISessionTypeREQUIRED,
-		InitialTimeout:  HTTPRetryInitialTimeout,
-		RetryMultiplier: HTTPRetryMultiplier,
-		RetryCount:      5, // It's pretty bad to fail this, so retry.
-	})
+	apiArg := NewRetryAPIArg("key/fetch_private")
+	apiArg.Args = hargs
+	apiArg.SessionType = APISessionTypeREQUIRED
+	res, err = ss.G().API.Get(m, apiArg)
 	m.Debug("| syncFromServer -> %s", ErrToOk(err))
 	if err != nil {
 		return


### PR DESCRIPTION
key/fetch_private hangs 60s on stale connections, blocking devices screen

sync_secret.go and per_user_key.go both set RetryCount:5 on their APIArgs but left InitialTimeout at zero. In doRetry, when InitialTimeout==0 and RetryCount>0, the per-attempt timeout falls back to cli.cli.Timeout which is HTTPDefaultTimeout (60s). A stale keep-alive TCP connection in Go's HTTP pool causes the first attempt to silently hang for the full 60s before the OS detects the dead connection. Worst case with 5 retries: 5 minutes, which is why the devices screen appears to never load.

Fix: add InitialTimeout:HTTPRetryInitialTimeout (1s) and the standard RetryMultiplier to both sites. A stale connection now fails fast, and the retry gets a fresh connection and succeeds in a few seconds.