### PR TITLE
Use KeyboardStickyView for crypto input action bars on iOS

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,14 @@
       "Bash(yarn tsc:*)",
       "Bash(yarn ios:pod*)",
       "Bash(yarn coverage:*)",
-      "Bash(yarn maestro*)"
+      "Bash(yarn maestro*)",
+      "mcp__codegraph__codegraph_search",
+      "mcp__codegraph__codegraph_context",
+      "mcp__codegraph__codegraph_callers",
+      "mcp__codegraph__codegraph_callees",
+      "mcp__codegraph__codegraph_impact",
+      "mcp__codegraph__codegraph_node",
+      "mcp__codegraph__codegraph_status"
     ]
   },
   "hooks": {

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ shared/tests/results/
 CLAUDE.md
 .tsOuts
 docs
+.codegraph
+.mcp.json

--- a/shared/crypto/decrypt.tsx
+++ b/shared/crypto/decrypt.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import * as T from '@/constants/types'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import {CryptoBanner, DragAndDrop, Input, InputActionsBar} from './input'
+import {KeyboardStickyView} from 'react-native-keyboard-controller'
 import {CryptoOutput, CryptoOutputActionsBar, CryptoSignedSender} from './output'
 import {
   beginRun,
@@ -138,6 +139,8 @@ export const DecryptInput = (_props: unknown) => {
   const {params} = useRoute() as RootRouteProps<'decryptTab'>
   const controller = useDecryptState(params)
   const navigateAppend = C.Router2.navigateAppend
+  const insets = Kb.useSafeAreaInsets()
+  const stickyOffset = React.useMemo(() => ({closed: -insets.bottom, opened: 0}), [insets.bottom])
 
   const onRun = () => {
     const f = async () => {
@@ -149,8 +152,31 @@ export const DecryptInput = (_props: unknown) => {
     C.ignorePromise(f())
   }
 
-  const contents = (
-    <>
+  if (!isMobile) {
+    return (
+      <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
+        <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
+        <Input
+          allowDirectories={false}
+          emptyInputWidth={inputEmptyWidth}
+          fileIcon={inputFileIcon}
+          inputPlaceholder={inputPlaceholder}
+          state={controller.state}
+          textInputType="cipher"
+          onSetInput={controller.setInput}
+          onClearInput={controller.clearInput}
+        />
+      </Kb.Box2>
+    )
+  }
+
+  return (
+    <Kb.Box2
+      direction="vertical"
+      fullHeight={true}
+      relative={true}
+      testID={TestIDs.CRYPTO_DECRYPT_INPUT}
+    >
       <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
       <Input
         allowDirectories={false}
@@ -162,17 +188,9 @@ export const DecryptInput = (_props: unknown) => {
         onSetInput={controller.setInput}
         onClearInput={controller.clearInput}
       />
-    </>
-  )
-
-  return isMobile ? (
-    <Kb.KeyboardAvoidingView2 testID={TestIDs.CRYPTO_DECRYPT_INPUT}>
-      {contents}
-      <InputActionsBar runLabel="Decrypt" onRun={onRun} />
-    </Kb.KeyboardAvoidingView2>
-  ) : (
-    <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
-      {contents}
+      <KeyboardStickyView offset={stickyOffset}>
+        <InputActionsBar runLabel="Decrypt" onRun={onRun} />
+      </KeyboardStickyView>
     </Kb.Box2>
   )
 }

--- a/shared/crypto/encrypt.tsx
+++ b/shared/crypto/encrypt.tsx
@@ -6,6 +6,7 @@ import * as T from '@/constants/types'
 import Recipients from './recipients'
 import {openURL} from '@/util/misc'
 import {CryptoBanner, DragAndDrop, Input, InputActionsBar} from './input'
+import {KeyboardStickyView} from 'react-native-keyboard-controller'
 import {CryptoOutput, CryptoOutputActionsBar, CryptoSignedSender, OutputInfoBanner} from './output'
 import {
   type CommonOutputRouteParams,
@@ -449,6 +450,8 @@ const EncryptInputBody = ({params}: {params?: EncryptRouteParams}) => {
   const blurCBRef = React.useRef(() => {})
   const navigateAppend = C.Router2.navigateAppend
   const appendEncryptRecipientsBuilder = C.Router2.appendEncryptRecipientsBuilder
+  const insets = Kb.useSafeAreaInsets()
+  const stickyOffset = React.useMemo(() => ({closed: -insets.bottom, opened: 0}), [insets.bottom])
 
   const onRun = () => {
     const f = async () => {
@@ -460,32 +463,46 @@ const EncryptInputBody = ({params}: {params?: EncryptRouteParams}) => {
     C.ignorePromise(f())
   }
 
-  const options = isMobile ? (
-    <InputActionsBar runLabel="Encrypt" blurCBRef={blurCBRef} onRun={onRun}>
-      <EncryptOptionsPanel
-        hasRecipients={controller.state.meta.hasRecipients}
-        hasSBS={controller.state.meta.hasSBS}
-        hideIncludeSelf={controller.state.meta.hideIncludeSelf}
-        includeSelf={controller.state.options.includeSelf}
-        inProgress={controller.state.inProgress}
-        setEncryptOptions={controller.setEncryptOptions}
-        sign={controller.state.options.sign}
-      />
-    </InputActionsBar>
-  ) : (
-    <EncryptOptionsPanel
-      hasRecipients={controller.state.meta.hasRecipients}
-      hasSBS={controller.state.meta.hasSBS}
-      hideIncludeSelf={controller.state.meta.hideIncludeSelf}
-      includeSelf={controller.state.options.includeSelf}
-      inProgress={controller.state.inProgress}
-      setEncryptOptions={controller.setEncryptOptions}
-      sign={controller.state.options.sign}
-    />
-  )
+  if (!isMobile) {
+    return (
+      <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
+        <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
+        <Recipients
+          recipients={controller.state.recipients}
+          inProgress={controller.state.inProgress}
+          onAddRecipients={appendEncryptRecipientsBuilder}
+          onClearRecipients={controller.clearRecipients}
+        />
+        <Input
+          allowDirectories={true}
+          emptyInputWidth={inputEmptyWidth}
+          fileIcon={inputFileIcon}
+          inputPlaceholder={inputPlaceholder}
+          state={controller.state}
+          textInputType="plain"
+          onSetInput={controller.setInput}
+          onClearInput={controller.clearInput}
+        />
+        <EncryptOptionsPanel
+          hasRecipients={controller.state.meta.hasRecipients}
+          hasSBS={controller.state.meta.hasSBS}
+          hideIncludeSelf={controller.state.meta.hideIncludeSelf}
+          includeSelf={controller.state.options.includeSelf}
+          inProgress={controller.state.inProgress}
+          setEncryptOptions={controller.setEncryptOptions}
+          sign={controller.state.options.sign}
+        />
+      </Kb.Box2>
+    )
+  }
 
-  const content = (
-    <>
+  return (
+    <Kb.Box2
+      direction="vertical"
+      fullHeight={true}
+      relative={true}
+      testID={TestIDs.CRYPTO_ENCRYPT_INPUT}
+    >
       <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
       <Recipients
         recipients={controller.state.recipients}
@@ -504,15 +521,19 @@ const EncryptInputBody = ({params}: {params?: EncryptRouteParams}) => {
         onSetInput={controller.setInput}
         onClearInput={controller.clearInput}
       />
-      {options}
-    </>
-  )
-
-  return isMobile ? (
-    <Kb.KeyboardAvoidingView2 testID={TestIDs.CRYPTO_ENCRYPT_INPUT}>{content}</Kb.KeyboardAvoidingView2>
-  ) : (
-    <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
-      {content}
+      <KeyboardStickyView offset={stickyOffset}>
+        <InputActionsBar runLabel="Encrypt" blurCBRef={blurCBRef} onRun={onRun}>
+          <EncryptOptionsPanel
+            hasRecipients={controller.state.meta.hasRecipients}
+            hasSBS={controller.state.meta.hasSBS}
+            hideIncludeSelf={controller.state.meta.hideIncludeSelf}
+            includeSelf={controller.state.options.includeSelf}
+            inProgress={controller.state.inProgress}
+            setEncryptOptions={controller.setEncryptOptions}
+            sign={controller.state.options.sign}
+          />
+        </InputActionsBar>
+      </KeyboardStickyView>
     </Kb.Box2>
   )
 }

--- a/shared/crypto/sign.tsx
+++ b/shared/crypto/sign.tsx
@@ -6,6 +6,7 @@ import * as T from '@/constants/types'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import {openURL} from '@/util/misc'
 import {CryptoBanner, DragAndDrop, Input, InputActionsBar} from './input'
+import {KeyboardStickyView} from 'react-native-keyboard-controller'
 import {CryptoOutput, CryptoOutputActionsBar, CryptoSignedSender, OutputInfoBanner} from './output'
 import {
   beginRun,
@@ -147,6 +148,8 @@ export const SignInput = (_props: unknown) => {
   const controller = useSignState(params)
   const blurCBRef = React.useRef(() => {})
   const navigateAppend = C.Router2.navigateAppend
+  const insets = Kb.useSafeAreaInsets()
+  const stickyOffset = React.useMemo(() => ({closed: -insets.bottom, opened: 0}), [insets.bottom])
 
   const onRun = () => {
     const f = async () => {
@@ -158,8 +161,31 @@ export const SignInput = (_props: unknown) => {
     C.ignorePromise(f())
   }
 
-  const content = (
-    <>
+  if (!isMobile) {
+    return (
+      <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
+        <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
+        <Input
+          allowDirectories={true}
+          emptyInputWidth={inputEmptyWidth}
+          fileIcon={inputFileIcon}
+          inputPlaceholder={inputPlaceholder}
+          state={controller.state}
+          textInputType="plain"
+          onSetInput={controller.setInput}
+          onClearInput={controller.clearInput}
+        />
+      </Kb.Box2>
+    )
+  }
+
+  return (
+    <Kb.Box2
+      direction="vertical"
+      fullHeight={true}
+      relative={true}
+      testID={TestIDs.CRYPTO_SIGN_INPUT}
+    >
       <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
       <Input
         allowDirectories={true}
@@ -172,15 +198,9 @@ export const SignInput = (_props: unknown) => {
         onSetInput={controller.setInput}
         onClearInput={controller.clearInput}
       />
-      {isMobile ? <InputActionsBar runLabel="Sign" blurCBRef={blurCBRef} onRun={onRun} /> : null}
-    </>
-  )
-
-  return isMobile ? (
-    <Kb.KeyboardAvoidingView2 testID={TestIDs.CRYPTO_SIGN_INPUT}>{content}</Kb.KeyboardAvoidingView2>
-  ) : (
-    <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
-      {content}
+      <KeyboardStickyView offset={stickyOffset}>
+        <InputActionsBar runLabel="Sign" blurCBRef={blurCBRef} onRun={onRun} />
+      </KeyboardStickyView>
     </Kb.Box2>
   )
 }

--- a/shared/crypto/verify.tsx
+++ b/shared/crypto/verify.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import * as T from '@/constants/types'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import {CryptoBanner, DragAndDrop, Input, InputActionsBar} from './input'
+import {KeyboardStickyView} from 'react-native-keyboard-controller'
 import {CryptoOutput, CryptoOutputActionsBar, CryptoSignedSender} from './output'
 import {
   beginRun,
@@ -138,6 +139,8 @@ export const VerifyInput = (_props: unknown) => {
   const {params} = useRoute() as RootRouteProps<'verifyTab'>
   const controller = useVerifyState(params)
   const navigateAppend = C.Router2.navigateAppend
+  const insets = Kb.useSafeAreaInsets()
+  const stickyOffset = React.useMemo(() => ({closed: -insets.bottom, opened: 0}), [insets.bottom])
 
   const onRun = () => {
     const f = async () => {
@@ -149,8 +152,31 @@ export const VerifyInput = (_props: unknown) => {
     C.ignorePromise(f())
   }
 
-  const content = (
-    <>
+  if (!isMobile) {
+    return (
+      <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
+        <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
+        <Input
+          allowDirectories={false}
+          emptyInputWidth={inputEmptyWidth}
+          fileIcon={inputFileIcon}
+          inputPlaceholder={inputPlaceholder}
+          state={controller.state}
+          textInputType="cipher"
+          onSetInput={controller.setInput}
+          onClearInput={controller.clearInput}
+        />
+      </Kb.Box2>
+    )
+  }
+
+  return (
+    <Kb.Box2
+      direction="vertical"
+      fullHeight={true}
+      relative={true}
+      testID={TestIDs.CRYPTO_VERIFY_INPUT}
+    >
       <CryptoBanner infoMessage={bannerMessage} state={controller.state} />
       <Input
         allowDirectories={false}
@@ -162,15 +188,9 @@ export const VerifyInput = (_props: unknown) => {
         onSetInput={controller.setInput}
         onClearInput={controller.clearInput}
       />
-      {isMobile ? <InputActionsBar runLabel="Verify" onRun={onRun} /> : null}
-    </>
-  )
-
-  return isMobile ? (
-    <Kb.KeyboardAvoidingView2 testID={TestIDs.CRYPTO_VERIFY_INPUT}>{content}</Kb.KeyboardAvoidingView2>
-  ) : (
-    <Kb.Box2 direction="vertical" fullHeight={true} style={Crypto.inputDesktopMaxHeight}>
-      {content}
+      <KeyboardStickyView offset={stickyOffset}>
+        <InputActionsBar runLabel="Verify" onRun={onRun} />
+      </KeyboardStickyView>
     </Kb.Box2>
   )
 }


### PR DESCRIPTION
Replaces KeyboardAvoidingView2 with KeyboardStickyView (react-native-keyboard-controller) for the bottom action bar on all four crypto input pages (encrypt, decrypt, sign, verify). The sticky view uses Reanimated to track keyboard height frame-by-frame on the UI thread, eliminating the layout-recalculation lag that caused the bar to trail the keyboard animation.