### PR TITLE
Fix signup crash: click event laundered into username route param

### DIFF
--- a/shared/login/join-or-login.tsx
+++ b/shared/login/join-or-login.tsx
@@ -20,7 +20,7 @@ const Intro = () => {
   const startProvision = useProvisionState(s => s.dispatch.startProvision)
   const requestAutoInvite = useRequestAutoInvite()
   const onLogin = () => startProvision()
-  const onSignup = () => requestAutoInvite()
+  const onSignup = () => requestAutoInvite('')
   const showProxySettings = () => {
     C.Router2.navigateAppend({name: 'proxySettingsModal', params: {}})
   }

--- a/shared/login/relogin/container.tsx
+++ b/shared/login/relogin/container.tsx
@@ -17,7 +17,8 @@ const ReloginContainer = () => {
     C.Router2.navigateAppend({name: 'signupSendFeedbackLoggedOut', params: {}})
   }
   const onLogin = useConfigState(s => s.dispatch.login)
-  const onSignup = useRequestAutoInvite()
+  const requestAutoInvite = useRequestAutoInvite()
+  const onSignup = () => requestAutoInvite('')
   const onSomeoneElse = useProvisionState(s => s.dispatch.startProvision)
   const error = perror?.desc || ''
   const loggedInMap = new Map<string, boolean>(_users.map(account => [account.username, account.hasStoredSecret]))

--- a/shared/signup/use-request-auto-invite.tsx
+++ b/shared/signup/use-request-auto-invite.tsx
@@ -7,7 +7,7 @@ const useRequestAutoInvite = () => {
   const waiting = C.Waiting.useAnyWaiting(C.waitingKeySignup)
   const {navigateAppend, navigateUp} = C.Router2
 
-  return (username?: string) => {
+  return (username: string) => {
     if (waiting) {
       return
     }


### PR DESCRIPTION
ReloginContainer wired useRequestAutoInvite()'s raw fn directly as onSignup, so the click event became the `username` arg, flowed through navigateAppend as a route param, and crashed signup's username.trim().

Make the hook param required (username: string) so a bare assignment to a () => void handler prop is now a compile error, preventing the event from being laundered into a string-typed slot. No-username callers pass '' explicitly.