### PR TITLE
fix(mobile): restrict screen rotation to full-screen attachments

### DIFF
--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -183,7 +183,8 @@ export const newModalRoutes = defineRouteMap({
     React.lazy(async () => import('./conversation/attachment-fullscreen/screen')),
     {
       getOptions: {
-        ...(isIOS ? {orientation: 'all', presentation: 'transparentModal'} : {}),
+        orientation: 'all',
+        ...(isIOS ? {presentation: 'transparentModal'} : {}),
         headerShown: false,
         modalStyle: {flex: 1, maxHeight: 9999, width: '100%'},
         overlayStyle: {

--- a/shared/fs/routes.tsx
+++ b/shared/fs/routes.tsx
@@ -73,7 +73,11 @@ export const newRoutes = defineRouteMap({
     getOptions: (ownProps?) => {
       const path = ownProps?.route.params.path ?? FS.defaultPath
       return isMobile
-        ? {header: () => <MobileHeader path={path} />}
+        ? {
+            header: () => <MobileHeader path={path} />,
+            // Full-screen attachment preview is allowed to rotate.
+            ...(isIOS ? {orientation: 'all' as const} : {}),
+          }
         : {
             headerTitle: () => <Title path={path} />,
             title: T.FS.getPathName(path),

--- a/shared/fs/routes.tsx
+++ b/shared/fs/routes.tsx
@@ -76,7 +76,7 @@ export const newRoutes = defineRouteMap({
         ? {
             header: () => <MobileHeader path={path} />,
             // Full-screen attachment preview is allowed to rotate.
-            ...(isIOS ? {orientation: 'all' as const} : {}),
+            orientation: 'all' as const,
           }
         : {
             headerTitle: () => <Title path={path} />,

--- a/shared/router-v2/common.tsx
+++ b/shared/router-v2/common.tsx
@@ -33,6 +33,9 @@ type HeaderLeftProps = Parameters<NonNullable<HeaderOptions['headerLeft']>>[0]
 
 export const defaultNavigationOptions = isMobile
   ? ({
+      // Lock to portrait by default. Only full-screen attachment views (chat/files)
+      // opt back into rotation via orientation: 'all'.
+      orientation: 'portrait',
       headerBackButtonDisplayMode: 'minimal',
       headerBackTitle: '',
       headerBackVisible: false,

--- a/shared/router-v2/router.tsx
+++ b/shared/router-v2/router.tsx
@@ -540,6 +540,9 @@ if (isMobile) {
   const rootStackScreenOptions = {
     headerBackButtonDisplayMode: 'minimal',
     headerTitleAlign: isAndroid ? 'center' : undefined,
+    // Lock to portrait by default. Only full-screen attachment views (chat/files)
+    // opt back into rotation via orientation: 'all'.
+    orientation: 'portrait',
   } satisfies NativeStackNavigationOptions
 
   const modalScreenOptions = ({


### PR DESCRIPTION
Lock all mobile screens to portrait by default; only the chat and files full-screen attachment previews opt back into rotation via orientation: 'all'.