### PR TITLE
Fix provision logging user back out after successful sign-in

### DIFF
--- a/shared/constants/init/shared.tsx
+++ b/shared/constants/init/shared.tsx
@@ -278,7 +278,13 @@ const onHandshakeStateChanged = (handshakeState: DaemonState['handshakeState']) 
   }
 }
 
-const onStartProvisionTriggerChanged = () => {
+const onStartProvisionTriggerChanged = (value: number, previous: number) => {
+  // The trigger only counts up when a provision actually starts. A reset (resetState /
+  // resetAllStores) rewinds it to 0; ignore that, otherwise resetState after a successful
+  // provision would log the just-provisioned user back out.
+  if (value <= previous) {
+    return
+  }
   useConfigState.getState().dispatch.setLoginError()
   useConfigState.getState().dispatch.resetRevokedSelf()
   const f = async () => {


### PR DESCRIPTION
resetState rewinds startProvisionTrigger 1->0, which subscribeValue treats as a change and re-fires onStartProvisionTriggerChanged. After a successful provision (loggedIn now true) that handler logs the just-provisioned user back out, leaving them stuck on the login screen.

Guard the handler to only run on an increment (a real provision start), ignoring the reset-to-0 rewind.