### PR TITLE
perf: fix chat re-render hotspots, drop react-compiler bailouts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# Copilot Instructions
+
+## React
+
+- We use modern React (19+). Contexts are rendered directly as providers: `<MyContext value={...}>`, not `<MyContext.Provider value={...}>`. Do not suggest adding `.Provider`.
+- We use the React Compiler. Components and hooks are memoized automatically:
+  - Do not suggest adding `useMemo`, `useCallback`, or `React.memo` for performance — the compiler handles it.
+  - Avoid patterns that make the compiler bail out, e.g. `try`/`catch` in a component or hook body (move it into a helper function instead).
+  - `'use no memo'` directives are intentional opt-outs; do not flag or remove them.

--- a/shared/chat/audio/audio-recorder.native.tsx
+++ b/shared/chat/audio/audio-recorder.native.tsx
@@ -328,6 +328,29 @@ const recordingOptions = {
   web: {},
 }
 
+const checkPerms = async (setCommandStatusInfo: (info?: T.Chat.CommandStatusInfo) => void) => {
+  try {
+    let {status} = await AudioModule.getRecordingPermissionsAsync()
+    if (status === 'undetermined') {
+      const askRes = await AudioModule.requestRecordingPermissionsAsync()
+      status = askRes.status
+    }
+    if (status === 'denied') {
+      throw new Error('Please allow Keybase to access the microphone in the phone settings.')
+    }
+    return true
+  } catch (_error) {
+    const error = _error as {message: string}
+    logger.info('failed to get audio perms: ' + error.message)
+    setCommandStatusInfo({
+      actions: [T.RPCChat.UICommandStatusActionTyp.appsettings],
+      displayText: `Failed to access audio. ${error.message}`,
+      displayType: T.RPCChat.UICommandStatusDisplayTyp.error,
+    })
+  }
+  return false
+}
+
 // Hook for interfacing with the native recorder
 const useRecorder = (p: {ampSV: SVN; setShowAudioSend: (s: boolean) => void; showAudioSend: boolean}) => {
   const {ampSV, setShowAudioSend, showAudioSend} = p
@@ -399,31 +422,9 @@ const useRecorder = (p: {ampSV: SVN; setShowAudioSend: (s: boolean) => void; sho
   const setCommandStatusInfo = InputState.useConversationInputDispatch(s => s.setCommandStatusInfo)
 
   const startRecording = () => {
-    const checkPerms = async () => {
-      try {
-        let {status} = await AudioModule.getRecordingPermissionsAsync()
-        if (status === 'undetermined') {
-          const askRes = await AudioModule.requestRecordingPermissionsAsync()
-          status = askRes.status
-        }
-        if (status === 'denied') {
-          throw new Error('Please allow Keybase to access the microphone in the phone settings.')
-        }
-        return true
-      } catch (_error) {
-        const error = _error as {message: string}
-        logger.info('failed to get audio perms: ' + error.message)
-        setCommandStatusInfo({
-          actions: [T.RPCChat.UICommandStatusActionTyp.appsettings],
-          displayText: `Failed to access audio. ${error.message}`,
-          displayType: T.RPCChat.UICommandStatusDisplayTyp.error,
-        })
-      }
-      return false
-    }
     const impl = async () => {
       await onReset()
-      const goodPerms = await checkPerms()
+      const goodPerms = await checkPerms(setCommandStatusInfo)
       if (!goodPerms) {
         throw new Error("Couldn't get audio permissions")
       }

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -187,6 +187,35 @@ type Props = {
 
 const blankCommands: Array<T.RPCChat.ConversationCommand> = []
 
+const addBotMember = async (p: {
+  botUsername: string
+  conversationIDKey: T.Chat.ConversationIDKey
+  installInConvs: ReadonlyArray<string>
+  installWithCommands: boolean
+  installWithMentions: boolean
+  installWithRestrict: boolean
+}) => {
+  const {botUsername, conversationIDKey, installInConvs} = p
+  const {installWithCommands, installWithMentions, installWithRestrict} = p
+  try {
+    await T.RPCChat.localAddBotMemberRpcPromise(
+      {
+        botSettings: installWithRestrict
+          ? {cmds: installWithCommands, convs: installInConvs, mentions: installWithMentions}
+          : null,
+        convID: T.Chat.keyToConversationID(conversationIDKey),
+        role: installWithRestrict ? T.RPCGen.TeamRole.restrictedbot : T.RPCGen.TeamRole.bot,
+        username: botUsername,
+      },
+      C.waitingKeyChatBotAdd
+    )
+  } catch (error) {
+    if (error instanceof RPCError) {
+      logger.info('addBotMember: failed to add bot member: ' + error.message)
+    }
+  }
+}
+
 const InstallBotPopup = (props: Props) => {
   const {botUsername, conversationIDKey} = props
   // state
@@ -255,26 +284,16 @@ const InstallBotPopup = (props: Props) => {
     }
     dispatchClearWaiting([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
     setPendingMutation('add')
-    const f = async () => {
-      try {
-        await T.RPCChat.localAddBotMemberRpcPromise(
-          {
-            botSettings: installWithRestrict
-              ? {cmds: installWithCommands, convs: installInConvs, mentions: installWithMentions}
-              : null,
-            convID: T.Chat.keyToConversationID(conversationIDKey),
-            role: installWithRestrict ? T.RPCGen.TeamRole.restrictedbot : T.RPCGen.TeamRole.bot,
-            username: botUsername,
-          },
-          C.waitingKeyChatBotAdd
-        )
-      } catch (error) {
-        if (error instanceof RPCError) {
-          logger.info('addBotMember: failed to add bot member: ' + error.message)
-        }
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      addBotMember({
+        botUsername,
+        conversationIDKey,
+        installInConvs,
+        installWithCommands,
+        installWithMentions,
+        installWithRestrict,
+      })
+    )
   }
   const onEdit = () => {
     if (!conversationIDKey) {

--- a/shared/chat/conversation/center-context.tsx
+++ b/shared/chat/conversation/center-context.tsx
@@ -14,15 +14,18 @@ type CenterState = {
   threadSearchVisible: boolean
 }
 
-type CenterContextType = {
+type CenterStateContextType = {
+  centeredHighlightOrdinal: T.Chat.Ordinal | undefined
+  centeredOrdinal: T.Chat.Ordinal | undefined
+  hasCenter: boolean
+}
+
+type CenterActionsContextType = {
   centerOnMessage: (
     messageID: T.Chat.MessageID,
     highlightMode: T.Chat.CenterOrdinalHighlightMode
   ) => void
-  centeredHighlightOrdinal: T.Chat.Ordinal | undefined
-  centeredOrdinal: T.Chat.Ordinal | undefined
   clearCenter: () => void
-  hasCenter: boolean
   jumpToRecent: () => void
 }
 
@@ -30,17 +33,25 @@ const missingContext = () => {
   throw new Error('Missing ConversationCenterContext in the tree')
 }
 
-const CenterContext = React.createContext<CenterContextType>({
-  centerOnMessage: missingContext,
+// Split contexts: the state changes when centering/highlighting, the actions stay
+// stable. Per-row consumers that only dispatch (e.g. reply-quote click) subscribe
+// to actions only, so a highlight change doesn't re-render every row.
+const CenterStateContext = React.createContext<CenterStateContextType>({
   centeredHighlightOrdinal: undefined,
   centeredOrdinal: undefined,
-  clearCenter: missingContext,
   hasCenter: false,
+})
+CenterStateContext.displayName = 'ConversationCenterStateContext'
+
+const CenterActionsContext = React.createContext<CenterActionsContextType>({
+  centerOnMessage: missingContext,
+  clearCenter: missingContext,
   jumpToRecent: missingContext,
 })
-CenterContext.displayName = 'ConversationCenterContext'
+CenterActionsContext.displayName = 'ConversationCenterActionsContext'
 
-export const useConversationCenter = () => React.useContext(CenterContext)
+export const useConversationCenter = () => React.useContext(CenterStateContext)
+export const useConversationCenterActions = () => React.useContext(CenterActionsContext)
 
 const stateForThreadSearchVisible = (state: CenterState, threadSearchVisible: boolean): CenterState => {
   if (state.threadSearchVisible === threadSearchVisible) {
@@ -135,14 +146,20 @@ export const ConversationCenterProvider = function ConversationCenterProvider(p:
 
   const center = currentCenterState.center
   const centeredHighlightOrdinal = center && center.highlightMode !== 'none' ? center.ordinal : undefined
-  const value = {
-    centerOnMessage,
+  const stateValue = {
     centeredHighlightOrdinal,
     centeredOrdinal: center?.ordinal,
-    clearCenter,
     hasCenter: !!center,
+  }
+  const actionsValue = {
+    centerOnMessage,
+    clearCenter,
     jumpToRecent,
   }
 
-  return <CenterContext value={value}>{children}</CenterContext>
+  return (
+    <CenterActionsContext value={actionsValue}>
+      <CenterStateContext value={stateValue}>{children}</CenterStateContext>
+    </CenterActionsContext>
+  )
 }

--- a/shared/chat/conversation/info-panel/attachments.tsx
+++ b/shared/chat/conversation/info-panel/attachments.tsx
@@ -460,6 +460,155 @@ const updateAttachmentViewMap = (
   return nextMap
 }
 
+const runAttachmentViewLoad = async (p: {
+  conversationIDKey: T.Chat.ConversationIDKey
+  viewType: T.RPCChat.GalleryItemTyp
+  fromMsgID: T.Chat.MessageID | undefined
+  reason: AttachmentLoadReason
+  generation: number
+  isCurrentLoad: () => boolean
+  lastOrdinalRef: {current: T.Chat.Ordinal}
+  updateCurrentAttachmentViewMap: (
+    viewType: T.RPCChat.GalleryItemTyp,
+    updateInfo: (info: T.Chat.AttachmentViewInfo) => void
+  ) => void
+}) => {
+  const {conversationIDKey, viewType, fromMsgID, reason, generation} = p
+  const {isCurrentLoad, lastOrdinalRef, updateCurrentAttachmentViewMap} = p
+  const convID = T.Chat.keyToConversationID(conversationIDKey)
+  const pendingMessages: Array<T.Chat.Message> = []
+  let flushTimeout: ReturnType<typeof setTimeout> | undefined
+  const flushPendingMessages = () => {
+    if (flushTimeout) {
+      clearTimeout(flushTimeout)
+      flushTimeout = undefined
+    }
+    if (!pendingMessages.length) {
+      return
+    }
+    const messages = pendingMessages.splice(0)
+    if (!isCurrentLoad()) {
+      return
+    }
+    const dedupedMessages = new Array<T.Chat.Message>()
+    const seenMessageIDs = new Set<T.Chat.MessageID>()
+    for (const message of messages) {
+      if (!seenMessageIDs.has(message.id)) {
+        seenMessageIDs.add(message.id)
+        dedupedMessages.push(message)
+      }
+    }
+    updateCurrentAttachmentViewMap(viewType, info => {
+      const existingMessageIDs = new Set(info.messages.map(item => item.id))
+      const nextMessages = [...info.messages]
+      let changed = false
+      for (const message of dedupedMessages) {
+        if (!existingMessageIDs.has(message.id)) {
+          existingMessageIDs.add(message.id)
+          nextMessages.push(message)
+          changed = true
+        }
+      }
+      if (changed) {
+        info.messages = nextMessages.sort((l, r) => r.id - l.id)
+      }
+    })
+  }
+  const scheduleFlushPendingMessages = () => {
+    if (flushTimeout) {
+      return
+    }
+    flushTimeout = setTimeout(() => {
+      flushPendingMessages()
+    }, 16)
+  }
+  try {
+    const {deviceName, username} = useCurrentUserState.getState()
+    const getLastOrdinal = () => lastOrdinalRef.current
+    const res = await T.RPCChat.localLoadGalleryRpcListener({
+      incomingCallMap: {
+        'chat.1.chatUi.chatLoadGalleryHit': hit => {
+          const message = Message.uiMessageToMessage(
+            conversationIDKey,
+            hit.message,
+            username,
+            getLastOrdinal,
+            deviceName
+          )
+
+          if (message) {
+            if (T.Chat.ordinalToNumber(message.ordinal) > T.Chat.ordinalToNumber(lastOrdinalRef.current)) {
+              lastOrdinalRef.current = message.ordinal
+            }
+            pendingMessages.push({
+              ...message,
+              conversationMessage: false,
+            })
+            scheduleFlushPendingMessages()
+          }
+        },
+      },
+      params: {
+        convID,
+        fromMsgID,
+        num: 50,
+        typ: viewType,
+      },
+    })
+    flushPendingMessages()
+    if (!isCurrentLoad()) {
+      logger.info('attachment gallery load stale success ignored', {
+        conversationIDKey,
+        fromMsgID,
+        generation,
+        reason,
+        viewType,
+      })
+      return
+    }
+    logger.info('attachment gallery load success', {
+      conversationIDKey,
+      fromMsgID,
+      generation,
+      last: !!res.last,
+      reason,
+      viewType,
+    })
+    updateCurrentAttachmentViewMap(viewType, info => {
+      info.last = !!res.last
+      info.status = 'success'
+    })
+  } catch (error) {
+    flushPendingMessages()
+    if ((error instanceof RPCError || error instanceof Error) && isCurrentLoad()) {
+      logger.error('failed to load attachment view: ' + error.message, {
+        conversationIDKey,
+        fromMsgID,
+        generation,
+        reason,
+        viewType,
+      })
+      updateCurrentAttachmentViewMap(viewType, info => {
+        info.last = false
+        info.status = 'error'
+      })
+    } else if (error instanceof RPCError || error instanceof Error) {
+      logger.info('attachment gallery load stale error ignored', {
+        conversationIDKey,
+        error: error.message,
+        fromMsgID,
+        generation,
+        reason,
+        viewType,
+      })
+    }
+  } finally {
+    if (flushTimeout) {
+      clearTimeout(flushTimeout)
+    }
+  }
+}
+
 const useAttachmentViewState = (conversationIDKey: T.Chat.ConversationIDKey) => {
   const lastOrdinalRef = React.useRef(T.Chat.numberToOrdinal(0))
   const [attachmentViewState, setAttachmentViewState] = React.useState<AttachmentViewState>(() => ({
@@ -508,141 +657,18 @@ const useAttachmentViewState = (conversationIDKey: T.Chat.ConversationIDKey) => 
         viewType,
       })
       const isCurrentLoad = () => loadGenerationRef.current === generation
-      const f = async () => {
-        const convID = T.Chat.keyToConversationID(conversationIDKey)
-        const pendingMessages: Array<T.Chat.Message> = []
-        let flushTimeout: ReturnType<typeof setTimeout> | undefined
-        const flushPendingMessages = () => {
-          if (flushTimeout) {
-            clearTimeout(flushTimeout)
-            flushTimeout = undefined
-          }
-          if (!pendingMessages.length) {
-            return
-          }
-          const messages = pendingMessages.splice(0)
-          if (!isCurrentLoad()) {
-            return
-          }
-          const dedupedMessages = new Array<T.Chat.Message>()
-          const seenMessageIDs = new Set<T.Chat.MessageID>()
-          for (const message of messages) {
-            if (!seenMessageIDs.has(message.id)) {
-              seenMessageIDs.add(message.id)
-              dedupedMessages.push(message)
-            }
-          }
-          updateCurrentAttachmentViewMap(viewType, info => {
-            const existingMessageIDs = new Set(info.messages.map(item => item.id))
-            const nextMessages = [...info.messages]
-            let changed = false
-            for (const message of dedupedMessages) {
-              if (!existingMessageIDs.has(message.id)) {
-                existingMessageIDs.add(message.id)
-                nextMessages.push(message)
-                changed = true
-              }
-            }
-            if (changed) {
-              info.messages = nextMessages.sort((l, r) => r.id - l.id)
-            }
-          })
-        }
-        const scheduleFlushPendingMessages = () => {
-          if (flushTimeout) {
-            return
-          }
-          flushTimeout = setTimeout(() => {
-            flushPendingMessages()
-          }, 16)
-        }
-        try {
-          const {deviceName, username} = useCurrentUserState.getState()
-          const getLastOrdinal = () => lastOrdinalRef.current
-          const res = await T.RPCChat.localLoadGalleryRpcListener({
-            incomingCallMap: {
-              'chat.1.chatUi.chatLoadGalleryHit': hit => {
-                const message = Message.uiMessageToMessage(
-                  conversationIDKey,
-                  hit.message,
-                  username,
-                  getLastOrdinal,
-                  deviceName
-                )
-
-                if (message) {
-                  if (T.Chat.ordinalToNumber(message.ordinal) > T.Chat.ordinalToNumber(lastOrdinalRef.current)) {
-                    lastOrdinalRef.current = message.ordinal
-                  }
-                  pendingMessages.push({
-                    ...message,
-                    conversationMessage: false,
-                  })
-                  scheduleFlushPendingMessages()
-                }
-              },
-            },
-            params: {
-              convID,
-              fromMsgID,
-              num: 50,
-              typ: viewType,
-            },
-          })
-          flushPendingMessages()
-          if (!isCurrentLoad()) {
-            logger.info('attachment gallery load stale success ignored', {
-              conversationIDKey,
-              fromMsgID,
-              generation,
-              reason,
-              viewType,
-            })
-            return
-          }
-          logger.info('attachment gallery load success', {
-            conversationIDKey,
-            fromMsgID,
-            generation,
-            last: !!res.last,
-            reason,
-            viewType,
-          })
-          updateCurrentAttachmentViewMap(viewType, info => {
-            info.last = !!res.last
-            info.status = 'success'
-          })
-        } catch (error) {
-          flushPendingMessages()
-          if ((error instanceof RPCError || error instanceof Error) && isCurrentLoad()) {
-            logger.error('failed to load attachment view: ' + error.message, {
-              conversationIDKey,
-              fromMsgID,
-              generation,
-              reason,
-              viewType,
-            })
-            updateCurrentAttachmentViewMap(viewType, info => {
-              info.last = false
-              info.status = 'error'
-            })
-          } else if (error instanceof RPCError || error instanceof Error) {
-            logger.info('attachment gallery load stale error ignored', {
-              conversationIDKey,
-              error: error.message,
-              fromMsgID,
-              generation,
-              reason,
-              viewType,
-            })
-          }
-        } finally {
-          if (flushTimeout) {
-            clearTimeout(flushTimeout)
-          }
-        }
-      }
-      C.ignorePromise(f())
+      C.ignorePromise(
+        runAttachmentViewLoad({
+          conversationIDKey,
+          fromMsgID,
+          generation,
+          isCurrentLoad,
+          lastOrdinalRef,
+          reason,
+          updateCurrentAttachmentViewMap,
+          viewType,
+        })
+      )
     }
   )
 

--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -14,7 +14,7 @@ import {infoPanelWidthTablet} from '../../info-panel/common'
 import {assertionToDisplay} from '@/common-adapters/usernames'
 import {FocusContext, ScrollContext} from '@/chat/conversation/normal/context'
 import type {RefType as InputRef} from './input.shared'
-import {useConversationCenter} from '../../center-context'
+import {useConversationCenter, useConversationCenterActions} from '../../center-context'
 import {
   useConversationThreadID,
   useConversationThreadMessage,
@@ -158,7 +158,8 @@ const ConnectedPlatformInput = function ConnectedPlatformInput() {
   const setEditing = InputState.useConversationInputDispatch(s => s.setEditing)
   const updateUnsentText = InputState.useConversationInputDispatch(s => s.injectIntoInput)
   const sendComposerText = InputState.useConversationInputDispatch(s => s.sendComposerText)
-  const {hasCenter, jumpToRecent} = useConversationCenter()
+  const {hasCenter} = useConversationCenter()
+  const {jumpToRecent} = useConversationCenterActions()
   const toggleThreadSearch = useConversationThreadToggleSearch()
 
   const isExploding = explodingModeSecondsRaw !== 0

--- a/shared/chat/conversation/input-area/normal/input.tsx
+++ b/shared/chat/conversation/input-area/normal/input.tsx
@@ -3,6 +3,7 @@ import * as Kb from '@/common-adapters'
 import * as React from 'react'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import * as ChatTypes from '@/constants/types/chat/message'
+import type * as T from '@/constants/types'
 import * as InputState from '../input-state'
 import SetExplodingMessagePopup from './set-explode-popup'
 import Typing from './typing'
@@ -353,9 +354,7 @@ function NativeInput(p: InputLowLevelProps) {
         onChangeText(ti.text)
         setSelection(ti.selection)
       },
-      get value() {
-        return value
-      },
+      value,
     }
   }, [onChangeText, selection, value])
 
@@ -1080,57 +1079,62 @@ type NativeChatFilePickerProps = {
   showingPopup: boolean
   hidePopup: () => void
 }
+const launchNativeImagePickerImpl = async (
+  conversationIDKey: T.Chat.ConversationIDKey,
+  mediaType: string,
+  location: string
+) => {
+  const mt = mediaType as 'photo' | 'video' | 'mixed'
+  const handleSelection = (result: {canceled: boolean; assets: Array<{uri: string}> | null}) => {
+    if (result.canceled || !result.assets || result.assets.length === 0) {
+      return
+    }
+    const pathAndOutboxIDs = result.assets.map(a => ({path: a.uri}))
+    C.Router2.navigateAppend({
+      name: 'chatAttachmentGetTitles',
+      params: {conversationIDKey, pathAndOutboxIDs},
+    })
+  }
+
+  switch (location) {
+    case 'camera':
+      try {
+        const res = await launchCameraAsync(mt)
+        handleSelection(res)
+      } catch (error) {
+        filePickerError(new Error(String(error)))
+      }
+      break
+    case 'library':
+      try {
+        const res = await launchImageLibraryAsync(mt, true, true)
+        handleSelection(res)
+      } catch (error) {
+        filePickerError(new Error(String(error)))
+      }
+      break
+    case 'file':
+      try {
+        const res = await pickDocumentsAsync(true)
+        if (!res.canceled && res.assets.length > 0) {
+          const pathAndOutboxIDs = res.assets.map(a => ({path: a.uri}))
+          C.Router2.navigateAppend({
+            name: 'chatAttachmentGetTitles',
+            params: {conversationIDKey, pathAndOutboxIDs},
+          })
+        }
+      } catch (error) {
+        filePickerError(new Error(String(error)))
+      }
+      break
+  }
+}
+
 const NativeChatFilePicker = (p: NativeChatFilePickerProps) => {
   const {attachTo, showingPopup, hidePopup} = p
   const conversationIDKey = useConversationThreadID()
   const launchNativeImagePicker = (mediaType: string, location: string) => {
-    const f = async () => {
-      const mt = mediaType as 'photo' | 'video' | 'mixed'
-      const handleSelection = (result: {canceled: boolean; assets: Array<{uri: string}> | null}) => {
-        if (result.canceled || !result.assets || result.assets.length === 0) {
-          return
-        }
-        const pathAndOutboxIDs = result.assets.map(a => ({path: a.uri}))
-        C.Router2.navigateAppend({
-          name: 'chatAttachmentGetTitles',
-          params: {conversationIDKey, pathAndOutboxIDs},
-        })
-      }
-
-      switch (location) {
-        case 'camera':
-          try {
-            const res = await launchCameraAsync(mt)
-            handleSelection(res)
-          } catch (error) {
-            filePickerError(new Error(String(error)))
-          }
-          break
-        case 'library':
-          try {
-            const res = await launchImageLibraryAsync(mt, true, true)
-            handleSelection(res)
-          } catch (error) {
-            filePickerError(new Error(String(error)))
-          }
-          break
-        case 'file':
-          try {
-            const res = await pickDocumentsAsync(true)
-            if (!res.canceled && res.assets.length > 0) {
-              const pathAndOutboxIDs = res.assets.map(a => ({path: a.uri}))
-              C.Router2.navigateAppend({
-                name: 'chatAttachmentGetTitles',
-                params: {conversationIDKey, pathAndOutboxIDs},
-              })
-            }
-          } catch (error) {
-            filePickerError(new Error(String(error)))
-          }
-          break
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(launchNativeImagePickerImpl(conversationIDKey, mediaType, location))
   }
 
   return (

--- a/shared/chat/conversation/list-area/hooks.tsx
+++ b/shared/chat/conversation/list-area/hooks.tsx
@@ -1,6 +1,6 @@
 import * as C from '@/constants'
 import JumpToRecent from './jump-to-recent'
-import {useConversationCenter} from '../center-context'
+import {useConversationCenterActions} from '../center-context'
 import {
   useConversationThreadMarkThreadAsRead,
   useConversationThreadSelector,
@@ -17,7 +17,7 @@ export const useJumpToRecent = (scrollToBottom: () => void, numOrdinals: number)
     C.useShallow(s => ({loaded: s.loaded, moreToLoadForward: s.moreToLoadForward}))
   )
   const toggleThreadSearch = useConversationThreadToggleSearch()
-  const {jumpToRecent} = useConversationCenter()
+  const {jumpToRecent} = useConversationCenterActions()
 
   const onJump = () => {
     scrollToBottom()

--- a/shared/chat/conversation/list-area/index.tsx
+++ b/shared/chat/conversation/list-area/index.tsx
@@ -45,8 +45,9 @@ const noOrdinals: ReadonlyArray<T.Chat.Ordinal> = []
 
 const HighlightableRow = React.memo(({ordinal}: {ordinal: T.Chat.Ordinal}) => {
   const {centeredHighlightOrdinal} = useConversationCenter()
-  const editingOrdinal = InputState.useConversationInput(s => s.editing)
-  const isHighlighted = centeredHighlightOrdinal === ordinal || editingOrdinal === ordinal
+  // derived boolean: raw s.editing would re-render every row on edit start/stop
+  const isEditing = InputState.useConversationInput(s => s.editing === ordinal)
+  const isHighlighted = centeredHighlightOrdinal === ordinal || isEditing
   return (
     <div
       data-ordinal={ordinal}

--- a/shared/chat/conversation/messages/account-payment/wrapper.tsx
+++ b/shared/chat/conversation/messages/account-payment/wrapper.tsx
@@ -1,9 +1,9 @@
-import {WrapperMessage, useWrapperMessageWithMessage, type Props} from '../wrapper/wrapper'
+import {WrapperMessage, useWrapperMessage, type Props} from '../wrapper/wrapper'
 import type PaymentMessageType from './container'
 
 function WrapperPayment(p: Props) {
   const {ordinal, isCenteredHighlight} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {message} = wrapper.messageData
 
   if (message.type !== 'requestPayment' && message.type !== 'sendPayment') return null

--- a/shared/chat/conversation/messages/attachment/wrapper.tsx
+++ b/shared/chat/conversation/messages/attachment/wrapper.tsx
@@ -2,11 +2,11 @@ import type AudioAttachmentType from './audio'
 import type FileAttachmentType from './file'
 import type ImageAttachmentType from './image'
 import type VideoAttachmentType from './video'
-import {WrapperMessage, useWrapperMessageWithMessage, type Props} from '../wrapper/wrapper'
+import {WrapperMessage, useWrapperMessage, type Props} from '../wrapper/wrapper'
 
 export function WrapperAttachmentAudio(p: Props) {
   const {ordinal, isCenteredHighlight = false} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {message} = wrapper.messageData
   if (message.type !== 'attachment') {
     return null
@@ -20,7 +20,7 @@ export function WrapperAttachmentAudio(p: Props) {
 }
 export function WrapperAttachmentFile(p: Props) {
   const {ordinal, isCenteredHighlight = false} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {showPopup} = wrapper
   const {message, isEditing} = wrapper.messageData
   if (message.type !== 'attachment') {
@@ -37,7 +37,7 @@ export function WrapperAttachmentFile(p: Props) {
 }
 export function WrapperAttachmentVideo(p: Props) {
   const {ordinal, isCenteredHighlight = false} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {showPopup} = wrapper
   const {message} = wrapper.messageData
   if (message.type !== 'attachment') {
@@ -53,7 +53,7 @@ export function WrapperAttachmentVideo(p: Props) {
 }
 export function WrapperAttachmentImage(p: Props) {
   const {ordinal, isCenteredHighlight = false} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {showPopup} = wrapper
   const {message} = wrapper.messageData
   if (message.type !== 'attachment') {

--- a/shared/chat/conversation/messages/pin/index.tsx
+++ b/shared/chat/conversation/messages/pin/index.tsx
@@ -1,12 +1,12 @@
 import * as Kb from '@/common-adapters'
 import type * as T from '@/constants/types'
-import {useConversationCenter} from '../../center-context'
+import {useConversationCenterActions} from '../../center-context'
 
 type Props = {messageID: T.Chat.MessageID}
 
 const Pin = (props: Props) => {
   const {messageID} = props
-  const {centerOnMessage} = useConversationCenter()
+  const {centerOnMessage} = useConversationCenterActions()
   const onReplyClick = () => centerOnMessage(messageID, 'flash')
   return (
     <Kb.Text type="BodySmall" style={styles.text} onClick={onReplyClick}>

--- a/shared/chat/conversation/messages/separator.tsx
+++ b/shared/chat/conversation/messages/separator.tsx
@@ -24,24 +24,28 @@ const useSeparatorData = (trailingItem: T.Chat.Ordinal, leadingItem: T.Chat.Ordi
       const m = s.messageMap.get(ordinal) ?? missingMessage
       const orangeMessage = s.messageMap.get(orangeOrdinal || noOrdinal)
       const previous = RowMetadata.getPreviousOrdinal(messageOrdinals, ordinal)
-      const showUsername = RowMetadata.getMessageShowUsername({
-        message: m,
-        messageMap: s.messageMap,
-        messageOrdinals,
-        ordinal,
-        you,
-      })
-      const tooSoon = !m.timestamp || new Date().getTime() - m.timestamp < 1000 * 60 * 60 * 2
       const orangeOrdinalExists =
         !!orangeOrdinal && s.messageMap.has(orangeOrdinal) && orangeMessage?.type !== 'placeholder'
       const orangeLineAbove =
         orangeOrdinalExists &&
         (orangeOrdinal === ordinal || (orangeOrdinal < ordinal && orangeOrdinal > previous))
-      const isJoinLeave = m.type === 'systemJoined'
-      const orangeTime =
-        !isMobile && !showUsername && !tooSoon && !isJoinLeave
-          ? formatTimeForConversationList(m.timestamp)
-          : ''
+
+      // only pay for the time label when an orange line will actually render
+      let orangeTime = ''
+      if (orangeLineAbove && !isMobile) {
+        const showUsername = RowMetadata.getMessageShowUsername({
+          message: m,
+          messageMap: s.messageMap,
+          messageOrdinals,
+          ordinal,
+          you,
+        })
+        const tooSoon = !m.timestamp || Date.now() - m.timestamp < 1000 * 60 * 60 * 2
+        const isJoinLeave = m.type === 'systemJoined'
+        if (!showUsername && !tooSoon && !isJoinLeave) {
+          orangeTime = formatTimeForConversationList(m.timestamp)
+        }
+      }
 
       return {orangeLineAbove, orangeTime, ordinal}
     })

--- a/shared/chat/conversation/messages/system-sbs-resolve/wrapper.tsx
+++ b/shared/chat/conversation/messages/system-sbs-resolve/wrapper.tsx
@@ -1,11 +1,11 @@
-import {WrapperMessage, useWrapperMessageWithMessage, type Props} from '../wrapper/wrapper'
+import {WrapperMessage, useWrapperMessage, type Props} from '../wrapper/wrapper'
 import type SystemSBSResolvedType from './container'
 import type SystemJoinedType from '../system-joined/container'
 import {useCurrentUserState} from '@/stores/current-user'
 
 function WrapperSystemInvite(p: Props) {
   const {ordinal, isCenteredHighlight} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {message} = wrapper.messageData
   const you = useCurrentUserState(s => s.username)
 

--- a/shared/chat/conversation/messages/text/bottom.tsx
+++ b/shared/chat/conversation/messages/text/bottom.tsx
@@ -41,8 +41,8 @@ const WrapperTextBottom = function WrapperTextBottom(p: Props) {
   })()
 
   const unfurlList = (() => {
-    const {default: UnfurlList} = require('./unfurl/unfurl-list') as {default: typeof UnfurlListType}
     if (hasUnfurlList) {
+      const {default: UnfurlList} = require('./unfurl/unfurl-list') as {default: typeof UnfurlListType}
       return <UnfurlList author={author} conversationIDKey={conversationIDKey} key="UnfurlList" unfurls={unfurls} />
     }
     return null

--- a/shared/chat/conversation/messages/text/wrapper.tsx
+++ b/shared/chat/conversation/messages/text/wrapper.tsx
@@ -2,10 +2,10 @@ import * as Kb from '@/common-adapters'
 import {useReply} from './reply'
 import {useBottom} from './bottom'
 import {useOrdinal} from '../ids-context'
-import {WrapperMessage, useWrapperMessageWithMessage, type Props} from '../wrapper/wrapper'
+import {WrapperMessage, useWrapperMessage, type Props} from '../wrapper/wrapper'
 import type {StyleOverride} from '@/common-adapters/markdown'
 import {sharedStyles} from '../shared-styles'
-import {useConversationCenter} from '../../center-context'
+import {useConversationCenterActions} from '../../center-context'
 
 let _sentHighlighted: Kb.Styles.StylesCrossPlatform | undefined
 const getSentHighlighted = () => {
@@ -46,9 +46,9 @@ function MessageMarkdown({style, text}: {style: Kb.Styles.StylesCrossPlatform; t
 
 function WrapperText(p: Props) {
   const {ordinal, isCenteredHighlight = false} = p
-  const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+  const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
   const {messageData} = wrapper
-  const {centerOnMessage} = useConversationCenter()
+  const {centerOnMessage} = useConversationCenterActions()
   const {isEditing, message, replyTo} = messageData
 
   const {hasCoinFlip, hasUnfurlList, hasUnfurlPrompts, showCenteredHighlight, text, textType, type} =

--- a/shared/chat/conversation/messages/wrapper/shared-timers.tsx
+++ b/shared/chat/conversation/messages/wrapper/shared-timers.tsx
@@ -80,7 +80,7 @@ class Timers {
 
   _removeTimer = (key: string) => {
     const i = this._timers.findIndex(t => t.key === key)
-    if (i > 0) {
+    if (i >= 0) {
       clearTimeout(this._timers[i]?.timeoutID)
       this._timers.splice(i, 1)
     }

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -26,7 +26,7 @@ import {
   useConversationThreadSelector,
 } from '../../thread-context'
 import type {ConversationInputState} from '../../input-area/input-state'
-import {useChatTeamMembers} from '../../team-hooks'
+import {useChatTeamMemberRole} from '../../team-hooks'
 
 type AccountsInfoMap = ReadonlyMap<T.RPCChat.MessageID, T.Chat.ChatRequestInfo | T.Chat.ChatPaymentInfo>
 type PaymentStatusMap = ReadonlyMap<T.Wallets.PaymentID, T.Chat.ChatPaymentInfo>
@@ -120,8 +120,7 @@ const getRowActions = (
 function AuthorSection(p: AuthorProps) {
   const {author, botAlias, isAdhocBot, teamID, teamType, teamname, timestamp, showUsername} = p
 
-  const {members: teamMembers} = useChatTeamMembers(teamID)
-  const authorRoleInTeam = teamMembers.get(author)?.type
+  const authorRoleInTeam = useChatTeamMemberRole(teamID, author)
   const onAuthorClick = () => navToProfile(showUsername)
 
   const authorIsOwner = authorRoleInTeam === 'owner'
@@ -253,19 +252,17 @@ const getEcrType = (message: T.Chat.Message, you: string) => {
 
 const getCommonMessageData = ({
   accountsInfoMap,
-  editing,
   isCenteredHighlight,
+  isEditing,
   message,
-  ordinal,
   paymentStatusMap,
   unfurlPrompt,
   you,
 }: {
   accountsInfoMap: AccountsInfoMap
-  editing: T.Chat.Ordinal
   isCenteredHighlight?: boolean
+  isEditing: boolean
   message: T.Chat.Message
-  ordinal: T.Chat.Ordinal
   paymentStatusMap: PaymentStatusMap
   unfurlPrompt: UnfurlPromptMap
   you: string
@@ -321,7 +318,7 @@ const getCommonMessageData = ({
     hasReactions,
     hasUnfurlList,
     hasUnfurlPrompts,
-    isEditing: editing === ordinal,
+    isEditing,
     messageKey: isExplodingMessage ? getMessageKey(message) : '',
     reactions,
     replyTo,
@@ -359,9 +356,11 @@ const getEditCancelRetryData = (
 }
 
 // Combined selector hook that fetches all common wrapper data in a single subscription.
+// Subscribes to the derived isEditing boolean (not the raw editing ordinal) so only
+// the affected rows re-render when editing starts/stops.
 export const useMessageData = (ordinal: T.Chat.Ordinal, isCenteredHighlight?: boolean) => {
   const you = useCurrentUserState(s => s.username)
-  const editing = InputState.useConversationInput(s => s.editing)
+  const isEditing = InputState.useConversationInput(s => s.editing === ordinal)
   const uiDispatch = InputState.useConversationInputDispatch(
     C.useShallow(s => ({setEditing: s.setEditing, setReplyTo: s.setReplyTo}))
   )
@@ -373,49 +372,9 @@ export const useMessageData = (ordinal: T.Chat.Ordinal, isCenteredHighlight?: bo
       const message = getConversationThreadDisplayMessage(s, ordinal) ?? missingMessage
       const commonData = getCommonMessageData({
         accountsInfoMap: s.accountsInfoMap,
-        editing,
         isCenteredHighlight,
+        isEditing,
         message,
-        ordinal,
-        paymentStatusMap: s.paymentStatusMap,
-        unfurlPrompt: s.unfurlPrompt,
-        you,
-      })
-      const showUsername = RowMetadata.getMessageShowUsername({
-        message,
-        messageMap: s.messageMap,
-        messageOrdinals: s.messageOrdinals ?? [],
-        ordinal,
-        you,
-      })
-      return {
-        ...commonData,
-        ...getEditCancelRetryData(commonData.ecrType, message),
-        ...getRowActions(messageActions, uiDispatch, retryMessage),
-        ...getAuthorData(message, s.meta, s.participants, showUsername),
-      }
-    })
-  )
-}
-
-const useMessageDataWithMessage = (ordinal: T.Chat.Ordinal, isCenteredHighlight?: boolean) => {
-  const you = useCurrentUserState(s => s.username)
-  const editing = InputState.useConversationInput(s => s.editing)
-  const uiDispatch = InputState.useConversationInputDispatch(
-    C.useShallow(s => ({setEditing: s.setEditing, setReplyTo: s.setReplyTo}))
-  )
-  const {retryMessage} = useConversationThreadActions()
-  const messageActions = useConversationThreadMessageActions()
-
-  return useConversationThreadSelector(
-    C.useShallow(s => {
-      const message = getConversationThreadDisplayMessage(s, ordinal) ?? missingMessage
-      const commonData = getCommonMessageData({
-        accountsInfoMap: s.accountsInfoMap,
-        editing,
-        isCenteredHighlight,
-        message,
-        ordinal,
         paymentStatusMap: s.paymentStatusMap,
         unfurlPrompt: s.unfurlPrompt,
         you,
@@ -460,18 +419,13 @@ export const useWrapperMessage = (ordinal: T.Chat.Ordinal, isCenteredHighlight?:
   return {...useWrapperPopup(ordinal, messageData), messageData}
 }
 
-export const useWrapperMessageWithMessage = (ordinal: T.Chat.Ordinal, isCenteredHighlight?: boolean) => {
-  const messageData = useMessageDataWithMessage(ordinal, isCenteredHighlight)
-  return {...useWrapperPopup(ordinal, messageData), messageData}
-}
-
 export function makeMessageWrapper<Type extends T.Chat.Message['type']>(
   type: Type,
   render: (message: Extract<T.Chat.Message, {type: Type}>) => React.ReactNode
 ) {
   return function WrapperGenerated(p: Props) {
     const {ordinal, isCenteredHighlight} = p
-    const wrapper = useWrapperMessageWithMessage(ordinal, isCenteredHighlight)
+    const wrapper = useWrapperMessage(ordinal, isCenteredHighlight)
     const {message} = wrapper.messageData
     if (message.type !== type) return null
     const child = render(message as Extract<T.Chat.Message, {type: Type}>)

--- a/shared/chat/conversation/normal/index.tsx
+++ b/shared/chat/conversation/normal/index.tsx
@@ -8,7 +8,7 @@ import InvitationToBlock from '@/chat/blocking/invitation-to-block'
 import ListArea from '../list-area'
 import PinnedMessage from '../pinned-message'
 import ThreadLoadStatus from '../load-status'
-import {useConversationCenter} from '../center-context'
+import {useConversationCenterActions} from '../center-context'
 import {
   useConversationThreadID,
   useConversationThreadSelector,
@@ -68,7 +68,7 @@ const DesktopConversation = function DesktopConversation() {
       .catch(() => {})
   }
   const toggleThreadSearch = useConversationThreadToggleSearch()
-  const {clearCenter} = useConversationCenter()
+  const {clearCenter} = useConversationCenterActions()
   const onToggleThreadSearch = () => {
     if (showThreadSearch) {
       clearCenter()

--- a/shared/chat/conversation/pinned-message.tsx
+++ b/shared/chat/conversation/pinned-message.tsx
@@ -5,7 +5,7 @@ import * as T from '@/constants/types'
 import * as Kb from '@/common-adapters'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useChatTeam} from './team-hooks'
-import {useConversationCenter} from './center-context'
+import {useConversationCenterActions} from './center-context'
 import {useConversationThreadID, useConversationThreadSelector} from './thread-context'
 import logger from '@/logger'
 import {RPCError} from '@/util/errors'
@@ -19,7 +19,7 @@ const PinnedMessage = function PinnedMessage() {
       teamname: s.meta.teamname,
     }))
   )
-  const {centerOnMessage} = useConversationCenter()
+  const {centerOnMessage} = useConversationCenterActions()
   const you = useCurrentUserState(s => s.username)
   const {yourOperations} = useChatTeam(teamID, teamname)
   const unpinning = C.Waiting.useAnyWaiting(C.waitingKeyChatUnpin(conversationIDKey))

--- a/shared/chat/conversation/search.tsx
+++ b/shared/chat/conversation/search.tsx
@@ -6,7 +6,7 @@ import * as Kb from '@/common-adapters'
 import {RPCError} from '@/util/errors'
 import {formatTimeForMessages} from '@/util/timestamp'
 import {useCurrentUserState} from '@/stores/current-user'
-import {useConversationCenter} from './center-context'
+import {useConversationCenterActions} from './center-context'
 import {cancelActiveThreadSearchRPC, searchInboxRPC} from '../search-rpc'
 import {
   useConversationThreadID,
@@ -26,10 +26,80 @@ type SearchState = {
   status: T.Chat.ThreadSearchInfo['status']
 }
 
+const runSearchInbox = async (p: {
+  conversationIDKey: T.Chat.ConversationIDKey
+  deviceName: string
+  getLastOrdinal: () => T.Chat.Ordinal
+  onDone: () => void
+  pendingHitsRef: {current: Array<T.Chat.Message>}
+  pendingReplaceHitsRef: {current: Array<T.Chat.Message> | undefined}
+  query: string
+  scheduleFlush: () => void
+  updateIfCurrent: (updater: (state: SearchState) => SearchState) => void
+  username: string
+}) => {
+  const {conversationIDKey, deviceName, getLastOrdinal, onDone, query, username} = p
+  const {pendingHitsRef, pendingReplaceHitsRef, scheduleFlush, updateIfCurrent} = p
+  try {
+    await searchInboxRPC({
+      incomingCallMap: {
+        'chat.1.chatUi.chatSearchDone': onDone,
+        'chat.1.chatUi.chatSearchHit': hit => {
+          const message = Message.uiMessageToMessage(
+            conversationIDKey,
+            hit.searchHit.hitMessage,
+            username,
+            getLastOrdinal,
+            deviceName
+          )
+          if (!message) {
+            return
+          }
+          pendingHitsRef.current.push(message)
+          scheduleFlush()
+        },
+        'chat.1.chatUi.chatSearchInboxDone': onDone,
+        'chat.1.chatUi.chatSearchInboxHit': resp => {
+          const messages = (resp.searchHit.hits || []).reduce<Array<T.Chat.Message>>((result, hit) => {
+            const message = Message.uiMessageToMessage(
+              conversationIDKey,
+              hit.hitMessage,
+              username,
+              getLastOrdinal,
+              deviceName
+            )
+            if (message) {
+              result.push(message)
+            }
+            return result
+          }, [])
+          pendingHitsRef.current = []
+          pendingReplaceHitsRef.current = messages
+          scheduleFlush()
+        },
+        'chat.1.chatUi.chatSearchInboxStart': () => {
+          updateIfCurrent(state => ({...state, status: 'inprogress'}))
+        },
+      },
+      opts: {
+        convID: T.Chat.isValidConversationIDKey(conversationIDKey)
+          ? T.Chat.keyToConversationID(conversationIDKey)
+          : new Uint8Array(0),
+        maxHits: 1000,
+      },
+      query,
+    })
+  } catch (error) {
+    if (error instanceof RPCError) {
+      updateIfCurrent(state => ({...state, status: 'done'}))
+    }
+  }
+}
+
 const useCommon = (ownProps: CommonProps) => {
   const {conversationIDKey, initialQuery, style} = ownProps
   const toggleThreadSearch = useConversationThreadToggleSearch()
-  const {centerOnMessage, clearCenter} = useConversationCenter()
+  const {centerOnMessage, clearCenter} = useConversationCenterActions()
   const onToggleThreadSearch = () => {
     clearCenter()
     toggleThreadSearch()
@@ -129,63 +199,20 @@ const useCommon = (ownProps: CommonProps) => {
       flushPendingHits('done')
     }
 
-    const f = async () => {
-      try {
-        await searchInboxRPC({
-          incomingCallMap: {
-            'chat.1.chatUi.chatSearchDone': onDone,
-            'chat.1.chatUi.chatSearchHit': hit => {
-              const message = Message.uiMessageToMessage(
-                conversationIDKey,
-                hit.searchHit.hitMessage,
-                username,
-                getLastOrdinal,
-                deviceName
-              )
-              if (!message) {
-                return
-              }
-              pendingHitsRef.current.push(message)
-              scheduleFlush()
-            },
-            'chat.1.chatUi.chatSearchInboxDone': onDone,
-            'chat.1.chatUi.chatSearchInboxHit': resp => {
-              const messages = (resp.searchHit.hits || []).reduce<Array<T.Chat.Message>>((result, hit) => {
-                const message = Message.uiMessageToMessage(
-                  conversationIDKey,
-                  hit.hitMessage,
-                  username,
-                  getLastOrdinal,
-                  deviceName
-                )
-                if (message) {
-                  result.push(message)
-                }
-                return result
-              }, [])
-              pendingHitsRef.current = []
-              pendingReplaceHitsRef.current = messages
-              scheduleFlush()
-            },
-            'chat.1.chatUi.chatSearchInboxStart': () => {
-              updateIfCurrent(state => ({...state, status: 'inprogress'}))
-            },
-          },
-          opts: {
-            convID: T.Chat.isValidConversationIDKey(conversationIDKey)
-              ? T.Chat.keyToConversationID(conversationIDKey)
-              : new Uint8Array(0),
-            maxHits: 1000,
-          },
-          query,
-        })
-      } catch (error) {
-        if (error instanceof RPCError) {
-          updateIfCurrent(state => ({...state, status: 'done'}))
-        }
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      runSearchInbox({
+        conversationIDKey,
+        deviceName,
+        getLastOrdinal,
+        onDone,
+        pendingHitsRef,
+        pendingReplaceHitsRef,
+        query,
+        scheduleFlush,
+        updateIfCurrent,
+        username,
+      })
+    )
   })
 
   const runThreadSearch = (query: string) => {

--- a/shared/chat/conversation/team-hooks.tsx
+++ b/shared/chat/conversation/team-hooks.tsx
@@ -328,6 +328,16 @@ const useChatTeamMembersRaw = (teamID: T.Teams.TeamID, enabled = true): ChatTeam
   return {...visibleState, reload}
 }
 
+const loadTeamNameForID = async (teamID: T.Teams.TeamID) => {
+  try {
+    const teamname = (await T.RPCGen.teamsGetAnnotatedTeamRpcPromise({teamID})).name
+    return teamname ? ([teamID, teamname] as const) : undefined
+  } catch (error) {
+    logger.warn(`Failed to load chat team name for ${teamID}`, error)
+    return undefined
+  }
+}
+
 const useChatTeamNamesRaw = (teamIDs: ReadonlyArray<T.Teams.TeamID>, enabled = true): ChatTeamNames => {
   const username = useCurrentUserState(s => s.username)
   const teamIDsKey = [
@@ -350,17 +360,7 @@ const useChatTeamNamesRaw = (teamIDs: ReadonlyArray<T.Teams.TeamID>, enabled = t
   }
 
   const loadTeamNamesForIDs = React.useCallback(async (teamIDs: ReadonlyArray<T.Teams.TeamID>) => {
-    const resolvedTeamnames = await Promise.all(
-      teamIDs.map(async teamID => {
-        try {
-          const teamname = (await T.RPCGen.teamsGetAnnotatedTeamRpcPromise({teamID})).name
-          return teamname ? ([teamID, teamname] as const) : undefined
-        } catch (error) {
-          logger.warn(`Failed to load chat team name for ${teamID}`, error)
-          return undefined
-        }
-      })
-    )
+    const resolvedTeamnames = await Promise.all(teamIDs.map(loadTeamNameForID))
     const teamnames = new Map<T.Teams.TeamID, string>()
     resolvedTeamnames.forEach(entry => {
       if (entry) {
@@ -532,6 +532,18 @@ export const useChatTeamMembers = (teamID: T.Teams.TeamID): ChatTeamMembers => {
   const useContextValue = context?.teamID === teamID
   const raw = useChatTeamMembersRaw(teamID, !useContextValue)
   return useContextValue ? context.members : raw
+}
+
+// Context-only role lookup for per-message-row use. useChatTeamMembers mounts
+// engine listeners and a fetch fallback per caller, which is too heavy to run
+// once per visible row; rows always render under the conversation's
+// ChatTeamProvider so the context has the data.
+export const useChatTeamMemberRole = (
+  teamID: T.Teams.TeamID,
+  username: string
+): T.Teams.MemberInfo['type'] | undefined => {
+  const context = React.useContext(ChatTeamContext)
+  return context?.teamID === teamID ? context.members.members.get(username)?.type : undefined
 }
 
 export const useChatTeamNames = (teamIDs: ReadonlyArray<T.Teams.TeamID>): ChatTeamNames =>

--- a/shared/chat/inbox/use-inbox-search.tsx
+++ b/shared/chat/inbox/use-inbox-search.tsx
@@ -329,6 +329,8 @@ export function useInboxSearch(): InboxSearchController {
           updateIfActive(prev => ({...prev, indexPercent: resp.status.percentIndexed}))
         }
 
+        const maxNameConvs =
+          query.length > 0 ? inboxSearchMaxNameResults : inboxSearchMaxUnreadNameResults
         try {
           await searchInboxRPC({
             incomingCallMap: {
@@ -344,7 +346,7 @@ export function useInboxSearch(): InboxSearchController {
               maxBots: 10,
               maxConvsHit: inboxSearchMaxTextResults,
               maxHits: inboxSearchMaxTextMessages,
-              maxNameConvs: query.length > 0 ? inboxSearchMaxNameResults : inboxSearchMaxUnreadNameResults,
+              maxNameConvs,
               maxTeams: 10,
             },
             query,

--- a/shared/common-adapters/drag-and-drop.tsx
+++ b/shared/common-adapters/drag-and-drop.tsx
@@ -29,6 +29,20 @@ type DragEvent = {
   }
 }
 
+const containsDirectory = async (paths: Array<string>) => {
+  for (const path of paths) {
+    try {
+      const isDir = await (isDirectory?.(path) ?? Promise.resolve(false))
+      if (isDir) {
+        return true
+      }
+    } catch (error) {
+      logger.warn(`Error stating dropped attachment: ${String(error)}`)
+    }
+  }
+  return false
+}
+
 const DragAndDrop = (props: Props): React.ReactNode => {
   const [showDropOverlay, setShowDropOverlay] = React.useState(false)
 
@@ -44,18 +58,9 @@ const DragAndDrop = (props: Props): React.ReactNode => {
         ? Array.from({length: fileList.length}, (_, i) => getPathForFile?.(fileList[i] as File) ?? '')
         : []
       if (paths.length) {
-        if (!props.allowFolders) {
-          for (const path of paths) {
-            try {
-              const isDir = await (isDirectory?.(path) ?? Promise.resolve(false))
-              if (isDir) {
-                setShowDropOverlay(false)
-                return
-              }
-            } catch (error) {
-              logger.warn(`Error stating dropped attachment: ${String(error)}`)
-            }
-          }
+        if (!props.allowFolders && (await containsDirectory(paths))) {
+          setShowDropOverlay(false)
+          return
         }
         props.onAttach?.(paths)
       }

--- a/shared/common-adapters/image-icon.tsx
+++ b/shared/common-adapters/image-icon.tsx
@@ -57,19 +57,25 @@ const ImageIconDesktop = (props: ImageIconProps) => {
   return img
 }
 
+// Hoisted: resolving useColorScheme from require() during render makes the react
+// compiler bail (hooks must be the same function on every render). The require is
+// guarded so it never executes on desktop.
+const {Image: RNImage, useColorScheme} = isMobile
+  ? (require('react-native') as {
+      Image: typeof RNImageType
+      useColorScheme: () => 'light' | 'dark' | null | undefined
+    })
+  : {Image: undefined, useColorScheme: undefined}
+
 const ImageIconNative = (props: ImageIconProps) => {
-  const {Image: RNImage, useColorScheme} = require('react-native') as {
-    Image: typeof RNImageType
-    useColorScheme: () => 'light' | 'dark' | null | undefined
-  }
   const {type, style} = props
-  const isDarkMode = useColorScheme() === 'dark'
+  const isDarkMode = useColorScheme!() === 'dark'
 
   let source = (isDarkMode && iconMeta[type].requireDark) || iconMeta[type].require
   if (typeof source !== 'number') {
     source = undefined
   }
-  if (!source) return null
+  if (!source || !RNImage) return null
 
   return <RNImage source={source} style={style} />
 }

--- a/shared/common-adapters/keyboard-avoiding-view.tsx
+++ b/shared/common-adapters/keyboard-avoiding-view.tsx
@@ -1,6 +1,6 @@
-import type * as React from 'react'
+import * as React from 'react'
 import * as Styles from '@/styles'
-import {useHeaderHeight} from '@react-navigation/elements'
+import {HeaderHeightContext} from '@react-navigation/elements'
 import {KeyboardAvoidingView} from 'react-native-keyboard-controller'
 
 type Props = {
@@ -15,16 +15,9 @@ type Props = {
 
 const DesktopKeyboardAvoidingView = (p: Props): React.ReactNode => p.children || null
 
-// Custom hook — only called when NativeKeyboardAvoidingView renders (mobile only)
-function useSafeHeaderHeight(): number {
-  // useHeaderHeight throws when rendered outside a navigator; default to 0
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  try { return useHeaderHeight() } catch { return 0 }
-}
-
 const NativeKeyboardAvoidingView = (p: Props): React.ReactNode => {
-
-  const headerHeight = useSafeHeaderHeight()
+  // useHeaderHeight throws when rendered outside a navigator; read the context directly instead
+  const headerHeight = React.useContext(HeaderHeightContext) ?? 0
   const {extraOffset, behavior, children, testID} = p
   const keyboardVerticalOffset = headerHeight + (extraOffset ?? 0)
   return (

--- a/shared/common-adapters/markdown/index.tsx
+++ b/shared/common-adapters/markdown/index.tsx
@@ -464,53 +464,61 @@ const ErrorComponent = (p: {children: React.ReactNode}) => {
   )
 }
 
-function SimpleMarkdownComponent(p: Props) {
-  const {allowFontScaling, styleOverride = {}, paragraphTextClassName, messageType, children} = p
-  const {serviceOnly, preview, smallStandaloneEmoji, virtualText, lineClamp, style, selectable} = p
-  const {serviceOnlyNoWrap, disallowAnimation, context} = p
-  let parseTree: Array<SM.SingleASTNode>
-  let output: React.ReactNode
+// Kept outside the component: the react compiler can't yet compile value blocks
+// inside try/catch, so an inline try/catch would bail out the whole component and
+// re-parse the markdown on every render.
+const renderMarkdown = (
+  children: string | undefined,
+  messageType: Props['messageType'],
+  state: State,
+  kindOptions: Pick<Props, 'preview' | 'serviceOnly' | 'serviceOnlyNoWrap' | 'smallStandaloneEmoji'>
+): {parseFailed: boolean; output: React.ReactNode} => {
   try {
-    parseTree = parseMarkdown(children ?? '', {isMobile: isMobile, messageType})
-
-    const state = {
-      allowFontScaling,
-      context,
-      disallowAnimation,
-      messageType,
-      paragraphTextClassName,
-      selectable,
-      styleOverride,
-      virtualText,
-    }
-
-    const outputKind = getMarkdownOutputKind(parseTree, {
-      preview,
-      serviceOnly,
-      serviceOnlyNoWrap,
-      smallStandaloneEmoji,
-    })
-
+    const parseTree = parseMarkdown(children ?? '', {isMobile: isMobile, messageType})
+    const outputKind = getMarkdownOutputKind(parseTree, kindOptions)
     switch (outputKind) {
       case 'serviceOnlyNoWrap':
-        output = serviceOnlyNoWrapOutput(parseTree, state)
-        break
+        return {output: serviceOnlyNoWrapOutput(parseTree, state), parseFailed: false}
       case 'serviceOnly':
-        output = serviceOnlyOutput(parseTree, state)
-        break
+        return {output: serviceOnlyOutput(parseTree, state), parseFailed: false}
       case 'preview':
-        output = previewOutput(parseTree, state)
-        break
+        return {output: previewOutput(parseTree, state), parseFailed: false}
       case 'bigEmoji':
-        output = bigEmojiOutput(parseTree, state)
-        break
+        return {output: bigEmojiOutput(parseTree, state), parseFailed: false}
       default:
-        output = reactOutput(parseTree, state)
-        break
+        return {output: reactOutput(parseTree, state), parseFailed: false}
     }
   } catch (e) {
     logger.error('Error parsing markdown')
     logger.debug('Error parsing markdown', e)
+    return {output: null, parseFailed: true}
+  }
+}
+
+function SimpleMarkdownComponent(p: Props) {
+  const {allowFontScaling, styleOverride = {}, paragraphTextClassName, messageType, children} = p
+  const {serviceOnly, preview, smallStandaloneEmoji, virtualText, lineClamp, style, selectable} = p
+  const {serviceOnlyNoWrap, disallowAnimation, context} = p
+
+  const state = {
+    allowFontScaling,
+    context,
+    disallowAnimation,
+    messageType,
+    paragraphTextClassName,
+    selectable,
+    styleOverride,
+    virtualText,
+  }
+
+  const {output, parseFailed} = renderMarkdown(children, messageType, state, {
+    preview,
+    serviceOnly,
+    serviceOnlyNoWrap,
+    smallStandaloneEmoji,
+  })
+
+  if (parseFailed) {
     return <ErrorComponent>{children}</ErrorComponent>
   }
 

--- a/shared/constants/router.tsx
+++ b/shared/constants/router.tsx
@@ -242,14 +242,15 @@ export const useSafeFocusEffect = (fn: React.EffectCallback) => {
       return undefined
     }
     let cleanup: ReturnType<React.EffectCallback>
-    const runEffect = () => {
-      cleanup = fn()
-    }
     const runCleanup = () => {
       if (typeof cleanup === 'function') {
         cleanup()
       }
       cleanup = undefined
+    }
+    const runEffect = () => {
+      runCleanup()
+      cleanup = fn()
     }
     if (navigation.isFocused()) {
       runEffect()

--- a/shared/constants/router.tsx
+++ b/shared/constants/router.tsx
@@ -235,16 +235,32 @@ export const getRouteLoggedIn = (route: Array<Route>) => {
 // if a toast is inside of a portal then its not in nav so useFocusEffect would throw,
 // and maybe other places also. Read the navigation context directly and no-op when absent.
 // Like useFocusEffect, a non-memoized fn re-runs the effect every render while focused.
-export const useSafeFocusEffect = (fn: () => void) => {
+export const useSafeFocusEffect = (fn: React.EffectCallback) => {
   const navigation = React.useContext(NavigationContext)
   React.useEffect(() => {
     if (!navigation) {
       return undefined
     }
-    if (navigation.isFocused()) {
-      fn()
+    let cleanup: ReturnType<React.EffectCallback>
+    const runEffect = () => {
+      cleanup = fn()
     }
-    return navigation.addListener('focus', fn)
+    const runCleanup = () => {
+      if (typeof cleanup === 'function') {
+        cleanup()
+      }
+      cleanup = undefined
+    }
+    if (navigation.isFocused()) {
+      runEffect()
+    }
+    const unsubFocus = navigation.addListener('focus', runEffect)
+    const unsubBlur = navigation.addListener('blur', runCleanup)
+    return () => {
+      runCleanup()
+      unsubFocus()
+      unsubBlur()
+    }
   }, [navigation, fn])
 }
 

--- a/shared/constants/router.tsx
+++ b/shared/constants/router.tsx
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import * as T from './types'
 import type * as ChatInboxMetadataType from '@/chat/inbox/metadata'
 import type * as InboxLayoutStateType from '@/chat/inbox/layout-state'
@@ -10,7 +10,7 @@ import {
   TabActions,
   CommonActions,
   type NavigationContainerRef,
-  useFocusEffect,
+  NavigationContext,
   createNavigationContainerRef,
   type NavigationState,
 } from '@react-navigation/core'
@@ -232,12 +232,20 @@ export const getRouteLoggedIn = (route: Array<Route>) => {
   return route[0]?.name === 'loggedIn'
 }
 
-// if a toast is inside of a portal then its not in nav so we can't use useFocusEffect and
-// maybe other places also
+// if a toast is inside of a portal then its not in nav so useFocusEffect would throw,
+// and maybe other places also. Read the navigation context directly and no-op when absent.
+// Like useFocusEffect, a non-memoized fn re-runs the effect every render while focused.
 export const useSafeFocusEffect = (fn: () => void) => {
-  try {
-    useFocusEffect(fn)
-  } catch {}
+  const navigation = React.useContext(NavigationContext)
+  React.useEffect(() => {
+    if (!navigation) {
+      return undefined
+    }
+    if (navigation.isFocused()) {
+      fn()
+    }
+    return navigation.addListener('focus', fn)
+  }, [navigation, fn])
 }
 
 // Helper to reduce boilerplate in route definitions

--- a/shared/crypto/decrypt.tsx
+++ b/shared/crypto/decrypt.tsx
@@ -69,7 +69,8 @@ export const useDecryptState = (params?: CryptoInputRouteParams) => {
     commitState(clearInputState(stateRef.current))
   }, [commitState, stateRef])
 
-  const decrypt = React.useCallback(async (destinationDir = '', snapshot = stateRef.current) => {
+  const decrypt = React.useCallback(async (destinationDir = '', _snapshot?: CommonState) => {
+    const snapshot = _snapshot ?? stateRef.current
     commitState(beginRun(snapshot))
     try {
       if (snapshot.inputType === 'text') {

--- a/shared/crypto/encrypt.tsx
+++ b/shared/crypto/encrypt.tsx
@@ -187,7 +187,8 @@ export const useEncryptScreenState = (params?: EncryptRouteParams) => {
   const {commitState, state, stateRef} = useCommittedState(() => createEncryptState(params))
   const handledTeamBuilderNonceRef = React.useRef<string | undefined>(undefined)
 
-  const runEncrypt = React.useCallback(async (destinationDir = '', snapshot = stateRef.current) => {
+  const runEncrypt = React.useCallback(async (destinationDir = '', _snapshot?: EncryptState) => {
+    const snapshot = _snapshot ?? stateRef.current
     const username = useCurrentUserState.getState().username
     const signed = snapshot.options.sign
     const opts = {
@@ -219,10 +220,14 @@ export const useEncryptScreenState = (params?: EncryptRouteParams) => {
         usedUnresolvedSBS = result.usedUnresolvedSBS
       }
 
+      let warningMessage = ''
+      if (usedUnresolvedSBS) {
+        warningMessage = getWarningMessageForSBS(unresolvedSBSAssertion)
+      }
       const next = onSuccess(
         stateRef.current,
         stateRef.current.input === snapshot.input,
-        usedUnresolvedSBS ? getWarningMessageForSBS(unresolvedSBSAssertion) : '',
+        warningMessage,
         output,
         snapshot.inputType,
         signed,

--- a/shared/crypto/sign.tsx
+++ b/shared/crypto/sign.tsx
@@ -66,20 +66,23 @@ export const useSignState = (params?: CryptoInputRouteParams) => {
     commitState(clearInputState(stateRef.current))
   }, [commitState, stateRef])
 
-  const sign = React.useCallback(async (destinationDir = '', snapshot = stateRef.current) => {
+  const sign = React.useCallback(async (destinationDir = '', maybeSnapshot?: CommonState) => {
+    const snapshot = maybeSnapshot ?? stateRef.current
     commitState(beginRun(snapshot))
     try {
       const username = useCurrentUserState.getState().username
-      const output =
-        snapshot.inputType === 'text'
-          ? await T.RPCGen.saltpackSaltpackSignStringRpcPromise(
-              {plaintext: snapshot.input},
-              C.waitingKeyCrypto
-            )
-          : await T.RPCGen.saltpackSaltpackSignFileRpcPromise(
-              {destinationDir, filename: snapshot.input},
-              C.waitingKeyCrypto
-            )
+      let output: string
+      if (snapshot.inputType === 'text') {
+        output = await T.RPCGen.saltpackSaltpackSignStringRpcPromise(
+          {plaintext: snapshot.input},
+          C.waitingKeyCrypto
+        )
+      } else {
+        output = await T.RPCGen.saltpackSaltpackSignFileRpcPromise(
+          {destinationDir, filename: snapshot.input},
+          C.waitingKeyCrypto
+        )
+      }
       const next = onSuccess(
         stateRef.current,
         stateRef.current.input === snapshot.input,

--- a/shared/crypto/verify.tsx
+++ b/shared/crypto/verify.tsx
@@ -69,7 +69,8 @@ export const useVerifyState = (params?: CryptoInputRouteParams) => {
     commitState(clearInputState(stateRef.current))
   }, [commitState, stateRef])
 
-  const verify = React.useCallback(async (destinationDir = '', snapshot = stateRef.current) => {
+  const verify = React.useCallback(async (destinationDir = '', maybeSnapshot?: CommonState) => {
+    const snapshot = maybeSnapshot ?? stateRef.current
     commitState(beginRun(snapshot))
     try {
       if (snapshot.inputType === 'text') {

--- a/shared/devices/device-revoke.tsx
+++ b/shared/devices/device-revoke.tsx
@@ -61,31 +61,36 @@ const loadEndangeredTLF = async (actingDevice: string, targetDevice: string) => 
   return []
 }
 
+const revokeDevice = async (
+  username: string,
+  wasCurrentDevice: boolean,
+  deviceID: T.Devices.DeviceID,
+  deviceName: string
+) => {
+  if (wasCurrentDevice) {
+    try {
+      await T.RPCGen.loginDeprovisionRpcPromise({doRevoke: true, username}, C.waitingKeyDevices)
+      useConfigState.getState().dispatch.revoke(deviceName, wasCurrentDevice)
+    } catch {}
+  } else {
+    try {
+      await T.RPCGen.revokeRevokeDeviceRpcPromise(
+        {deviceID, forceLast: false, forceSelf: false},
+        C.waitingKeyDevices
+      )
+      useConfigState.getState().dispatch.revoke(deviceName, wasCurrentDevice)
+      C.Router2.navUpToScreen(isMobile ? settingsDevicesTab : 'devicesRoot')
+    } catch {}
+  }
+}
+
 const useRevoke = (device: T.Devices.Device) => {
   const username = useCurrentUserState(s => s.username)
   const wasCurrentDevice = device.currentDevice
-  const navUpToScreen = C.Router2.navUpToScreen
   const deviceID = device.deviceID
   const deviceName = device.name
   return () => {
-    const f = async () => {
-      if (wasCurrentDevice) {
-        try {
-          await T.RPCGen.loginDeprovisionRpcPromise({doRevoke: true, username}, C.waitingKeyDevices)
-          useConfigState.getState().dispatch.revoke(deviceName, wasCurrentDevice)
-        } catch {}
-      } else {
-        try {
-          await T.RPCGen.revokeRevokeDeviceRpcPromise(
-            {deviceID, forceLast: false, forceSelf: false},
-            C.waitingKeyDevices
-          )
-          useConfigState.getState().dispatch.revoke(deviceName, wasCurrentDevice)
-          navUpToScreen(isMobile ? settingsDevicesTab : 'devicesRoot')
-        } catch {}
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(revokeDevice(username, wasCurrentDevice, deviceID, deviceName))
   }
 }
 

--- a/shared/fs/browser/destination-picker.tsx
+++ b/shared/fs/browser/destination-picker.tsx
@@ -22,6 +22,57 @@ const canBackUp = isMobile
   ? (parentPath: T.FS.Path) => T.FS.getPathLevel(parentPath) > 1
   : () => false
 
+const doMoveOrCopy = async (
+  type: 'move' | 'copy',
+  source: T.FS.MoveOrCopySource | T.FS.IncomingShareSource,
+  parentPath: T.FS.Path,
+  errorToActionOrThrow: (error: unknown, path?: T.FS.Path) => void
+) => {
+  const params =
+    source.type === T.FS.DestinationPickerSource.MoveOrCopy
+      ? [
+          {
+            dest: FS.pathToRPCPath(T.FS.pathConcat(parentPath, T.FS.getPathName(source.path))),
+            opID: makeUUID(),
+            overwriteExistingFiles: false,
+            src: FS.pathToRPCPath(source.path),
+          },
+        ]
+      : source.source
+          .map(item => ({originalPath: item.originalPath ?? '', scaledPath: item.scaledPath}))
+          .filter(({originalPath}) => !!originalPath)
+          .map(({originalPath, scaledPath}) => ({
+            dest: FS.pathToRPCPath(
+              T.FS.pathConcat(
+                parentPath,
+                T.FS.getLocalPathName(originalPath)
+                // We use the local path name here since we only care about file name.
+              )
+            ),
+            opID: makeUUID(),
+            overwriteExistingFiles: false,
+            src: {
+              PathType: T.RPCGen.PathType.local,
+              local: T.FS.getNormalizedLocalPath(
+                useConfigState.getState().incomingShareUseOriginal
+                  ? originalPath
+                  : scaledPath || originalPath
+              ),
+            } as T.RPCGen.Path,
+          }))
+
+  try {
+    const rpc =
+      type === 'move'
+        ? T.RPCGen.SimpleFSSimpleFSMoveRpcPromise
+        : T.RPCGen.SimpleFSSimpleFSCopyRecursiveRpcPromise
+    await Promise.all(params.map(async param => rpc(param)))
+    await Promise.all(params.map(async ({opID}) => T.RPCGen.SimpleFSSimpleFSWaitRpcPromise({opID})))
+  } catch (error) {
+    errorToActionOrThrow(error, parentPath)
+  }
+}
+
 const ConnectedDestinationPicker = (ownProps: OwnProps) => {
   const {parentPath, source} = ownProps
   const parentPathItem = FsCommon.useFsPathMetadata(parentPath)
@@ -37,52 +88,7 @@ const ConnectedDestinationPicker = (ownProps: OwnProps) => {
   const nav = useSafeNavigation()
   const clearModals = C.Router2.clearModals
   const moveOrCopy = (type: 'move' | 'copy') => {
-    const f = async () => {
-      const params =
-        source.type === T.FS.DestinationPickerSource.MoveOrCopy
-          ? [
-              {
-                dest: FS.pathToRPCPath(T.FS.pathConcat(parentPath, T.FS.getPathName(source.path))),
-                opID: makeUUID(),
-                overwriteExistingFiles: false,
-                src: FS.pathToRPCPath(source.path),
-              },
-            ]
-          : source.source
-              .map(item => ({originalPath: item.originalPath ?? '', scaledPath: item.scaledPath}))
-              .filter(({originalPath}) => !!originalPath)
-              .map(({originalPath, scaledPath}) => ({
-                dest: FS.pathToRPCPath(
-                  T.FS.pathConcat(
-                    parentPath,
-                    T.FS.getLocalPathName(originalPath)
-                    // We use the local path name here since we only care about file name.
-                  )
-                ),
-                opID: makeUUID(),
-                overwriteExistingFiles: false,
-                src: {
-                  PathType: T.RPCGen.PathType.local,
-                  local: T.FS.getNormalizedLocalPath(
-                    useConfigState.getState().incomingShareUseOriginal
-                      ? originalPath
-                      : scaledPath || originalPath
-                  ),
-                } as T.RPCGen.Path,
-              }))
-
-      try {
-        const rpc =
-          type === 'move'
-            ? T.RPCGen.SimpleFSSimpleFSMoveRpcPromise
-            : T.RPCGen.SimpleFSSimpleFSCopyRecursiveRpcPromise
-        await Promise.all(params.map(async param => rpc(param)))
-        await Promise.all(params.map(async ({opID}) => T.RPCGen.SimpleFSSimpleFSWaitRpcPromise({opID})))
-      } catch (error) {
-        errorToActionOrThrow(error, parentPath)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(doMoveOrCopy(type, source, parentPath, errorToActionOrThrow))
   }
   const onBackUp =
     isShare || !canBackUp(parentPath)

--- a/shared/fs/browser/edit-state.tsx
+++ b/shared/fs/browser/edit-state.tsx
@@ -80,6 +80,17 @@ const resetBrowserEditState = () => {
   browserEditStateListeners.forEach(listener => listener())
 }
 
+const addBrowserEditProvider = () => {
+  ++browserEditProviderCount
+}
+
+const removeBrowserEditProvider = () => {
+  --browserEditProviderCount
+  if (!browserEditProviderCount) {
+    resetBrowserEditState()
+  }
+}
+
 const addOrReplaceEdit = (
   prevEdits: ReadonlyMap<T.FS.EditID, T.FS.Edit>,
   editID: T.FS.EditID,
@@ -119,6 +130,55 @@ const deleteSubmitting = (prevSubmitting: ReadonlySet<T.FS.EditID>, editID: T.FS
 
 export const useFsBrowserEdits = () => React.useContext(BrowserEditContext)
 
+const commitEditRPC = async (
+  edit: T.FS.Edit,
+  editID: T.FS.EditID,
+  errorToActionOrThrow: (error: unknown, path?: T.FS.Path) => void
+) => {
+  try {
+    switch (edit.type) {
+      case T.FS.EditType.NewFolder:
+        await T.RPCGen.SimpleFSSimpleFSOpenRpcPromise(
+          {
+            dest: Constants.pathToRPCPath(T.FS.pathConcat(edit.parentPath, edit.name)),
+            flags: T.RPCGen.OpenFlags.directory,
+            opID: makeUUID(),
+          },
+          S.waitingKeyFSCommitEdit
+        )
+        break
+      case T.FS.EditType.Rename: {
+        const opID = makeUUID()
+        await T.RPCGen.SimpleFSSimpleFSMoveRpcPromise({
+          dest: Constants.pathToRPCPath(T.FS.pathConcat(edit.parentPath, edit.name)),
+          opID,
+          overwriteExistingFiles: false,
+          src: Constants.pathToRPCPath(T.FS.pathConcat(edit.parentPath, edit.originalName)),
+        })
+        await T.RPCGen.SimpleFSSimpleFSWaitRpcPromise({opID}, S.waitingKeyFSCommitEdit)
+        break
+      }
+    }
+    setBrowserEdits(prevEdits => deleteEdit(prevEdits, editID))
+  } catch (error) {
+    if (
+      edit.type === T.FS.EditType.Rename &&
+      error instanceof RPCError &&
+      [T.RPCGen.StatusCode.scsimplefsdirnotempty, T.RPCGen.StatusCode.scsimplefsnameexists].includes(
+        error.code
+      )
+    ) {
+      setBrowserEdits(prevEdits =>
+        addOrReplaceEdit(prevEdits, editID, {...edit, error: error.desc || 'name exists'})
+      )
+      return
+    }
+    errorToActionOrThrow(error, edit.parentPath)
+  } finally {
+    setBrowserSubmitting(prevSubmitting => deleteSubmitting(prevSubmitting, editID))
+  }
+}
+
 const getStaleRenameEditIDs = (
   edits: ReadonlyMap<T.FS.EditID, T.FS.Edit>,
   pathItems: T.FS.PathItems
@@ -146,13 +206,8 @@ export const FsBrowserEditProvider = ({children}: {children: React.ReactNode}) =
   const pathItems = useFsLoadedPathItems()
 
   React.useEffect(() => {
-    browserEditProviderCount++
-    return () => {
-      browserEditProviderCount--
-      if (!browserEditProviderCount) {
-        resetBrowserEditState()
-      }
-    }
+    addBrowserEditProvider()
+    return removeBrowserEditProvider
   }, [])
 
   React.useEffect(() => {
@@ -180,51 +235,7 @@ export const FsBrowserEditProvider = ({children}: {children: React.ReactNode}) =
       return
     }
     setBrowserSubmitting(prevSubmitting => addSubmitting(prevSubmitting, editID))
-    const f = async () => {
-      try {
-        switch (edit.type) {
-          case T.FS.EditType.NewFolder:
-            await T.RPCGen.SimpleFSSimpleFSOpenRpcPromise(
-              {
-                dest: Constants.pathToRPCPath(T.FS.pathConcat(edit.parentPath, edit.name)),
-                flags: T.RPCGen.OpenFlags.directory,
-                opID: makeUUID(),
-              },
-              S.waitingKeyFSCommitEdit
-            )
-            break
-          case T.FS.EditType.Rename: {
-            const opID = makeUUID()
-            await T.RPCGen.SimpleFSSimpleFSMoveRpcPromise({
-              dest: Constants.pathToRPCPath(T.FS.pathConcat(edit.parentPath, edit.name)),
-              opID,
-              overwriteExistingFiles: false,
-              src: Constants.pathToRPCPath(T.FS.pathConcat(edit.parentPath, edit.originalName)),
-            })
-            await T.RPCGen.SimpleFSSimpleFSWaitRpcPromise({opID}, S.waitingKeyFSCommitEdit)
-            break
-          }
-        }
-        setBrowserEdits(prevEdits => deleteEdit(prevEdits, editID))
-      } catch (error) {
-        if (
-          edit.type === T.FS.EditType.Rename &&
-          error instanceof RPCError &&
-          [T.RPCGen.StatusCode.scsimplefsdirnotempty, T.RPCGen.StatusCode.scsimplefsnameexists].includes(
-            error.code
-          )
-        ) {
-          setBrowserEdits(prevEdits =>
-            addOrReplaceEdit(prevEdits, editID, {...edit, error: error.desc || 'name exists'})
-          )
-          return
-        }
-        errorToActionOrThrow(error, edit.parentPath)
-      } finally {
-        setBrowserSubmitting(prevSubmitting => deleteSubmitting(prevSubmitting, editID))
-      }
-    }
-    ignorePromise(f())
+    ignorePromise(commitEditRPC(edit, editID, errorToActionOrThrow))
   }
 
   const discardEdit = (editID: T.FS.EditID) => {

--- a/shared/fs/common/daemon.tsx
+++ b/shared/fs/common/daemon.tsx
@@ -22,6 +22,48 @@ const emptyFsDaemonActions: FsDaemonActions = {
 const FsDaemonStatusContext = React.createContext<T.FS.KbfsDaemonStatus | undefined>(undefined)
 const FsDaemonActionsContext = React.createContext<FsDaemonActions | undefined>(undefined)
 
+const waitForKbfsDaemon = async (
+  generation: number,
+  isCurrentAsyncGeneration: (generation: number) => boolean,
+  kbfsDaemonStatusRef: {current: T.FS.KbfsDaemonStatus},
+  kbfsDaemonRpcStatusChanged: (rpcStatus: T.FS.KbfsDaemonRpcStatus) => void,
+  waitForKbfsDaemonInProgressRef: {current: boolean},
+  asyncGenerationRef: {current: number}
+) => {
+  while (isCurrentAsyncGeneration(generation)) {
+    try {
+      const connected = await T.RPCGen.configWaitForClientRpcPromise({
+        clientType: T.RPCGen.ClientType.kbfs,
+        timeout: 0, // Don't wait; just check if it's there.
+      })
+      if (!isCurrentAsyncGeneration(generation)) {
+        return
+      }
+      const newStatus = connected ? T.FS.KbfsDaemonRpcStatus.Connected : T.FS.KbfsDaemonRpcStatus.Waiting
+      if (kbfsDaemonStatusRef.current.rpcStatus !== newStatus) {
+        kbfsDaemonRpcStatusChanged(newStatus)
+      }
+      if (newStatus === T.FS.KbfsDaemonRpcStatus.Connected) {
+        return
+      }
+      waitForKbfsDaemonInProgressRef.current = true
+      try {
+        await T.RPCGen.configWaitForClientRpcPromise({
+          clientType: T.RPCGen.ClientType.kbfs,
+          timeout: 60, // 1min. This is arbitrary since we're gonna check again anyway if we're not connected.
+        })
+      } catch {
+      } finally {
+        if (generation === asyncGenerationRef.current) {
+          waitForKbfsDaemonInProgressRef.current = false
+        }
+      }
+    } catch {
+      return
+    }
+  }
+}
+
 export const FsDaemonProvider = ({children}: {children: React.ReactNode}) => {
   const loggedIn = useConfigState(s => s.loggedIn)
   const userSwitching = useConfigState(s => s.userSwitching)
@@ -62,42 +104,16 @@ export const FsDaemonProvider = ({children}: {children: React.ReactNode}) => {
     if (waitForKbfsDaemonInProgressRef.current || !loggedIn || userSwitching) {
       return
     }
-    const generation = asyncGenerationRef.current
-    const f = async () => {
-      while (isCurrentAsyncGeneration(generation)) {
-        try {
-          const connected = await T.RPCGen.configWaitForClientRpcPromise({
-            clientType: T.RPCGen.ClientType.kbfs,
-            timeout: 0, // Don't wait; just check if it's there.
-          })
-          if (!isCurrentAsyncGeneration(generation)) {
-            return
-          }
-          const newStatus = connected ? T.FS.KbfsDaemonRpcStatus.Connected : T.FS.KbfsDaemonRpcStatus.Waiting
-          if (kbfsDaemonStatusRef.current.rpcStatus !== newStatus) {
-            kbfsDaemonRpcStatusChanged(newStatus)
-          }
-          if (newStatus === T.FS.KbfsDaemonRpcStatus.Connected) {
-            return
-          }
-          waitForKbfsDaemonInProgressRef.current = true
-          try {
-            await T.RPCGen.configWaitForClientRpcPromise({
-              clientType: T.RPCGen.ClientType.kbfs,
-              timeout: 60, // 1min. This is arbitrary since we're gonna check again anyway if we're not connected.
-            })
-          } catch {
-          } finally {
-            if (generation === asyncGenerationRef.current) {
-              waitForKbfsDaemonInProgressRef.current = false
-            }
-          }
-        } catch {
-          return
-        }
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      waitForKbfsDaemon(
+        asyncGenerationRef.current,
+        isCurrentAsyncGeneration,
+        kbfsDaemonStatusRef,
+        kbfsDaemonRpcStatusChanged,
+        waitForKbfsDaemonInProgressRef,
+        asyncGenerationRef
+      )
+    )
   })
 
   const onlineStatusChanged = React.useEffectEvent((onlineStatus: T.RPCGen.KbfsOnlineStatus) => {

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -201,6 +201,226 @@ const setTlfs = (setFsSharedData: SetFsSharedData, updater: (prevTlfs: T.FS.Tlfs
   )
 }
 
+type ErrorToActionOrThrow = (error: unknown, path?: T.FS.Path) => void
+type SoftErrorSetter = (path: T.FS.Path, softError?: T.FS.SoftError) => void
+
+const loadDownloadInfoAsync = async (
+  downloadID: string,
+  loadingDownloadInfos: Set<string>,
+  setFsSharedData: SetFsSharedData,
+  errorToActionOrThrow: ErrorToActionOrThrow
+) => {
+  try {
+    const res = await T.RPCGen.SimpleFSSimpleFSGetDownloadInfoRpcPromise({
+      downloadID,
+    })
+    setDownloadInfos(setFsSharedData, prevDownloadInfos => {
+      const old = prevDownloadInfos.get(downloadID)
+      const nextDownloadInfos = new Map(prevDownloadInfos)
+      nextDownloadInfos.set(downloadID, {
+        filename: res.filename,
+        intent: old?.intent,
+        isRegularDownload: res.isRegularDownload,
+        path: T.FS.stringToPath('/keybase' + res.path.path),
+        startTime: res.startTime,
+      })
+      return nextDownloadInfos
+    })
+  } catch (error) {
+    errorToActionOrThrow(error)
+  } finally {
+    loadingDownloadInfos.delete(downloadID)
+  }
+}
+
+const loadDownloadStatusAsync = async (
+  setFsSharedData: SetFsSharedData,
+  errorToActionOrThrow: ErrorToActionOrThrow
+) => {
+  try {
+    const res = await T.RPCGen.SimpleFSSimpleFSGetDownloadStatusRpcPromise()
+    const regularDownloads = [...(res.regularDownloadIDs || [])]
+    const state = new Map(
+      (res.states || []).map(s => [
+        s.downloadID,
+        {
+          canceled: s.canceled,
+          done: s.done,
+          endEstimate: s.endEstimate,
+          error: s.error,
+          localPath: s.localPath,
+          progress: s.progress,
+        },
+      ])
+    )
+    setDownloads(setFsSharedData, {regularDownloads, state})
+  } catch (error) {
+    errorToActionOrThrow(error)
+  }
+}
+
+const loadPathMetadataAsync = async (
+  path: T.FS.Path,
+  loadingPathMetadata: Set<T.FS.Path>,
+  setFsSharedData: SetFsSharedData,
+  errorToActionOrThrow: ErrorToActionOrThrow,
+  setPathSoftError: SoftErrorSetter,
+  setTlfSoftError: SoftErrorSetter
+) => {
+  try {
+    const dirent = await T.RPCGen.SimpleFSSimpleFSStatRpcPromise({
+      path: FS.pathToRPCPath(path),
+      refreshSubscription: false,
+    })
+    const pathItem = makeEntry(dirent)
+    setPathItems(setFsSharedData, prevPathItems => {
+      const nextPathItems = new Map(prevPathItems)
+      const oldPathItem = FS.getPathItem(prevPathItems, path)
+      nextPathItems.set(path, updatePathItem(oldPathItem, pathItem))
+      return nextPathItems
+    })
+    setPathSoftError(path)
+    const tlfPath = FS.getTlfPath(path)
+    if (tlfPath) {
+      setTlfSoftError(tlfPath)
+    }
+  } catch (error) {
+    errorToActionOrThrow(error, path)
+  } finally {
+    loadingPathMetadata.delete(path)
+  }
+}
+
+const loadFolderChildrenAsync = async (
+  rootPath: T.FS.Path,
+  initialLoadRecursive: boolean,
+  loadKey: string,
+  loadingFolderChildren: Set<string>,
+  setFsSharedData: SetFsSharedData,
+  errorToActionOrThrow: ErrorToActionOrThrow
+) => {
+  try {
+    const opID = makeUUID()
+    if (initialLoadRecursive) {
+      await T.RPCGen.SimpleFSSimpleFSListRecursiveToDepthRpcPromise({
+        depth: 1,
+        filter: T.RPCGen.ListFilter.filterSystemHidden,
+        opID,
+        path: FS.pathToRPCPath(rootPath),
+        refreshSubscription: false,
+      })
+    } else {
+      await T.RPCGen.SimpleFSSimpleFSListRpcPromise({
+        filter: T.RPCGen.ListFilter.filterSystemHidden,
+        opID,
+        path: FS.pathToRPCPath(rootPath),
+        refreshSubscription: false,
+      })
+    }
+
+    await T.RPCGen.SimpleFSSimpleFSWaitRpcPromise({opID})
+    const result = await T.RPCGen.SimpleFSSimpleFSReadListRpcPromise({opID})
+    const entries = result.entries || []
+
+    setPathItems(setFsSharedData, prevPathItems => {
+      const nextPathItems = new Map(prevPathItems)
+      const loadedPathItems = makePathItemsFromDirents({
+        entries,
+        isRecursive: initialLoadRecursive,
+        rootPath,
+        rootPathItem: FS.getPathItem(prevPathItems, rootPath),
+      })
+      loadedPathItems.forEach((pathItemFromAction, path) => {
+        const oldPathItem = FS.getPathItem(nextPathItems, path)
+        const nextPathItem = updatePathItem(oldPathItem, pathItemFromAction)
+        if (oldPathItem.type === T.FS.PathType.Folder) {
+          oldPathItem.children.forEach(name => {
+            if (nextPathItem.type !== T.FS.PathType.Folder || !nextPathItem.children.has(name)) {
+              nextPathItems.delete(T.FS.pathConcat(path, name))
+            }
+          })
+        }
+        nextPathItems.set(path, nextPathItem)
+      })
+      return nextPathItems
+    })
+  } catch (error) {
+    errorToActionOrThrow(error, rootPath)
+  } finally {
+    loadingFolderChildren.delete(loadKey)
+  }
+}
+
+const loadTlfsAsync = async (
+  username: string,
+  loadTlfsInProgressRef: {current: boolean},
+  setFsSharedData: SetFsSharedData,
+  errorToActionOrThrow: ErrorToActionOrThrow
+) => {
+  try {
+    const results = await T.RPCGen.SimpleFSSimpleFSListFavoritesRpcPromise()
+    setTlfs(setFsSharedData, prevTlfs => {
+      const nextTlfs = favoritesResultToTlfs(results, username, prevTlfs.additionalTlfs)
+      return isEqual(nextTlfs, prevTlfs) ? prevTlfs : nextTlfs
+    })
+  } catch (error) {
+    errorToActionOrThrow(error)
+  } finally {
+    loadTlfsInProgressRef.current = false
+  }
+}
+
+const loadAdditionalTlfAsync = async (
+  tlfPath: T.FS.Path,
+  username: string,
+  loadingAdditionalTlfs: Set<T.FS.Path>,
+  setFsSharedData: SetFsSharedData,
+  errorToActionOrThrow: ErrorToActionOrThrow
+) => {
+  if (T.FS.getPathLevel(tlfPath) !== 3) {
+    logger.warn('loadAdditionalTlf called on non-TLF path')
+    loadingAdditionalTlfs.delete(tlfPath)
+    return
+  }
+  try {
+    const result = await T.RPCGen.SimpleFSSimpleFSGetFolderRpcPromise({
+      path: FS.pathToRPCPath(tlfPath).kbfs,
+    })
+    const next = folderToTlf({
+      folder: result.folder,
+      isFavorite: result.isFavorite,
+      isIgnored: result.isIgnored,
+      isNew: result.isNew,
+      username,
+    })
+    if (!next) {
+      return
+    }
+    setTlfs(setFsSharedData, prevTlfs => {
+      const additionalTlfs = new Map(prevTlfs.additionalTlfs)
+      additionalTlfs.set(tlfPath, next.tlf)
+      return {
+        ...prevTlfs,
+        additionalTlfs,
+      }
+    })
+  } catch (error) {
+    if (error instanceof RPCError && error.code === T.RPCGen.StatusCode.scteamcontactsettingsblock) {
+      const fields = error.fields as undefined | Array<{key?: string; value?: string}>
+      const users = fields?.filter(elem => elem.key === 'usernames')
+      const usernames = users?.map(elem => elem.value ?? '') ?? []
+      C.Router2.navigateUp()
+      C.Router2.navigateAppend({
+        name: 'contactRestricted',
+        params: {source: 'newFolder', usernames},
+      })
+    }
+    errorToActionOrThrow(error, tlfPath)
+  } finally {
+    loadingAdditionalTlfs.delete(tlfPath)
+  }
+}
+
 export const FsDataProvider = ({
   children,
   initialLastModifiedTimestamp,
@@ -274,30 +494,9 @@ const FsDataProviderForUsername = ({
       return
     }
     loadingDownloadInfos.add(downloadID)
-    const f = async () => {
-      try {
-        const res = await T.RPCGen.SimpleFSSimpleFSGetDownloadInfoRpcPromise({
-          downloadID,
-        })
-        setDownloadInfos(setFsSharedData, prevDownloadInfos => {
-          const old = prevDownloadInfos.get(downloadID)
-          const nextDownloadInfos = new Map(prevDownloadInfos)
-          nextDownloadInfos.set(downloadID, {
-            filename: res.filename,
-            intent: old?.intent,
-            isRegularDownload: res.isRegularDownload,
-            path: T.FS.stringToPath('/keybase' + res.path.path),
-            startTime: res.startTime,
-          })
-          return nextDownloadInfos
-        })
-      } catch (error) {
-        errorToActionOrThrow(error)
-      } finally {
-        loadingDownloadInfos.delete(downloadID)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      loadDownloadInfoAsync(downloadID, loadingDownloadInfos, setFsSharedData, errorToActionOrThrow)
+    )
   }
 
   const recordDownloadStarted = (downloadID: string, path: T.FS.Path, type: DownloadStartType) => {
@@ -331,7 +530,9 @@ const FsDataProviderForUsername = ({
         if (activeDownloadIDSet.has(downloadID) || !seenDownloadIDs.has(downloadID)) {
           return
         }
-        nextDownloadInfos ??= new Map(prevDownloadInfos)
+        if (nextDownloadInfos === undefined) {
+          nextDownloadInfos = new Map(prevDownloadInfos)
+        }
         nextDownloadInfos.delete(downloadID)
         seenDownloadIDs.delete(downloadID)
       })
@@ -344,29 +545,7 @@ const FsDataProviderForUsername = ({
   }, [downloads.state])
 
   const loadDownloadStatus = () => {
-    const f = async () => {
-      try {
-        const res = await T.RPCGen.SimpleFSSimpleFSGetDownloadStatusRpcPromise()
-        const regularDownloads = [...(res.regularDownloadIDs || [])]
-        const state = new Map(
-          (res.states || []).map(s => [
-            s.downloadID,
-            {
-              canceled: s.canceled,
-              done: s.done,
-              endEstimate: s.endEstimate,
-              error: s.error,
-              localPath: s.localPath,
-              progress: s.progress,
-            },
-          ])
-        )
-        setDownloads(setFsSharedData, {regularDownloads, state})
-      } catch (error) {
-        errorToActionOrThrow(error)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(loadDownloadStatusAsync(setFsSharedData, errorToActionOrThrow))
   }
 
   const loadPathMetadata = (path: T.FS.Path) => {
@@ -375,31 +554,16 @@ const FsDataProviderForUsername = ({
       return
     }
     loadingPathMetadata.add(path)
-    const f = async () => {
-      try {
-        const dirent = await T.RPCGen.SimpleFSSimpleFSStatRpcPromise({
-          path: FS.pathToRPCPath(path),
-          refreshSubscription: false,
-        })
-        const pathItem = makeEntry(dirent)
-        setPathItems(setFsSharedData, prevPathItems => {
-          const nextPathItems = new Map(prevPathItems)
-          const oldPathItem = FS.getPathItem(prevPathItems, path)
-          nextPathItems.set(path, updatePathItem(oldPathItem, pathItem))
-          return nextPathItems
-        })
-        setPathSoftError(path)
-        const tlfPath = FS.getTlfPath(path)
-        if (tlfPath) {
-          setTlfSoftError(tlfPath)
-        }
-      } catch (error) {
-        errorToActionOrThrow(error, path)
-      } finally {
-        loadingPathMetadata.delete(path)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      loadPathMetadataAsync(
+        path,
+        loadingPathMetadata,
+        setFsSharedData,
+        errorToActionOrThrow,
+        setPathSoftError,
+        setTlfSoftError
+      )
+    )
   }
 
   const loadFolderChildren = (rootPath: T.FS.Path, initialLoadRecursive: boolean) => {
@@ -409,59 +573,16 @@ const FsDataProviderForUsername = ({
       return
     }
     loadingFolderChildren.add(loadKey)
-    const f = async () => {
-      try {
-        const opID = makeUUID()
-        if (initialLoadRecursive) {
-          await T.RPCGen.SimpleFSSimpleFSListRecursiveToDepthRpcPromise({
-            depth: 1,
-            filter: T.RPCGen.ListFilter.filterSystemHidden,
-            opID,
-            path: FS.pathToRPCPath(rootPath),
-            refreshSubscription: false,
-          })
-        } else {
-          await T.RPCGen.SimpleFSSimpleFSListRpcPromise({
-            filter: T.RPCGen.ListFilter.filterSystemHidden,
-            opID,
-            path: FS.pathToRPCPath(rootPath),
-            refreshSubscription: false,
-          })
-        }
-
-        await T.RPCGen.SimpleFSSimpleFSWaitRpcPromise({opID})
-        const result = await T.RPCGen.SimpleFSSimpleFSReadListRpcPromise({opID})
-        const entries = result.entries || []
-
-        setPathItems(setFsSharedData, prevPathItems => {
-          const nextPathItems = new Map(prevPathItems)
-          const loadedPathItems = makePathItemsFromDirents({
-            entries,
-            isRecursive: initialLoadRecursive,
-            rootPath,
-            rootPathItem: FS.getPathItem(prevPathItems, rootPath),
-          })
-          loadedPathItems.forEach((pathItemFromAction, path) => {
-            const oldPathItem = FS.getPathItem(nextPathItems, path)
-            const nextPathItem = updatePathItem(oldPathItem, pathItemFromAction)
-            if (oldPathItem.type === T.FS.PathType.Folder) {
-              oldPathItem.children.forEach(name => {
-                if (nextPathItem.type !== T.FS.PathType.Folder || !nextPathItem.children.has(name)) {
-                  nextPathItems.delete(T.FS.pathConcat(path, name))
-                }
-              })
-            }
-            nextPathItems.set(path, nextPathItem)
-          })
-          return nextPathItems
-        })
-      } catch (error) {
-        errorToActionOrThrow(error, rootPath)
-      } finally {
-        loadingFolderChildren.delete(loadKey)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      loadFolderChildrenAsync(
+        rootPath,
+        initialLoadRecursive,
+        loadKey,
+        loadingFolderChildren,
+        setFsSharedData,
+        errorToActionOrThrow
+      )
+    )
   }
 
   const loadTlfs = () => {
@@ -469,20 +590,7 @@ const FsDataProviderForUsername = ({
       return
     }
     loadTlfsInProgressRef.current = true
-    const f = async () => {
-      try {
-        const results = await T.RPCGen.SimpleFSSimpleFSListFavoritesRpcPromise()
-        setTlfs(setFsSharedData, prevTlfs => {
-          const nextTlfs = favoritesResultToTlfs(results, username, prevTlfs.additionalTlfs)
-          return isEqual(nextTlfs, prevTlfs) ? prevTlfs : nextTlfs
-        })
-      } catch (error) {
-        errorToActionOrThrow(error)
-      } finally {
-        loadTlfsInProgressRef.current = false
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(loadTlfsAsync(username, loadTlfsInProgressRef, setFsSharedData, errorToActionOrThrow))
   }
 
   const loadAdditionalTlf = (tlfPath: T.FS.Path) => {
@@ -491,51 +599,9 @@ const FsDataProviderForUsername = ({
       return
     }
     loadingAdditionalTlfs.add(tlfPath)
-    const f = async () => {
-      if (T.FS.getPathLevel(tlfPath) !== 3) {
-        logger.warn('loadAdditionalTlf called on non-TLF path')
-        loadingAdditionalTlfs.delete(tlfPath)
-        return
-      }
-      try {
-        const result = await T.RPCGen.SimpleFSSimpleFSGetFolderRpcPromise({
-          path: FS.pathToRPCPath(tlfPath).kbfs,
-        })
-        const next = folderToTlf({
-          folder: result.folder,
-          isFavorite: result.isFavorite,
-          isIgnored: result.isIgnored,
-          isNew: result.isNew,
-          username,
-        })
-        if (!next) {
-          return
-        }
-        setTlfs(setFsSharedData, prevTlfs => {
-          const additionalTlfs = new Map(prevTlfs.additionalTlfs)
-          additionalTlfs.set(tlfPath, next.tlf)
-          return {
-            ...prevTlfs,
-            additionalTlfs,
-          }
-        })
-      } catch (error) {
-        if (error instanceof RPCError && error.code === T.RPCGen.StatusCode.scteamcontactsettingsblock) {
-          const fields = error.fields as undefined | Array<{key?: string; value?: string}>
-          const users = fields?.filter(elem => elem.key === 'usernames')
-          const usernames = users?.map(elem => elem.value ?? '') ?? []
-          C.Router2.navigateUp()
-          C.Router2.navigateAppend({
-            name: 'contactRestricted',
-            params: {source: 'newFolder', usernames},
-          })
-        }
-        errorToActionOrThrow(error, tlfPath)
-      } finally {
-        loadingAdditionalTlfs.delete(tlfPath)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      loadAdditionalTlfAsync(tlfPath, username, loadingAdditionalTlfs, setFsSharedData, errorToActionOrThrow)
+    )
   }
 
   return (

--- a/shared/fs/common/sfmi.tsx
+++ b/shared/fs/common/sfmi.tsx
@@ -60,6 +60,62 @@ const makeInitialSfmiStateWithPermissionError = (initialKextPermissionError: boo
     : initialState
 }
 
+const refreshDriverStatusImpl = async (
+  previousDriverStatus: T.FS.DriverStatus,
+  setDriverStatus: (driverStatus: T.FS.DriverStatus) => void,
+  refreshMountDirs: (driverStatus: T.FS.DriverStatus) => Promise<{directMountDir: string}>,
+  errorToActionOrThrow: (error: unknown, path?: T.FS.Path) => void
+) => {
+  try {
+    const previousType = previousDriverStatus.type
+    const status = await refreshDriverStatusInPlatform()
+    const refreshedDriverStatus = fuseStatusToDriverStatus(status)
+    const driverStatus =
+      previousDriverStatus.type === T.FS.DriverStatusType.Disabled &&
+      previousDriverStatus.kextPermissionError &&
+      refreshedDriverStatus.type === T.FS.DriverStatusType.Disabled
+        ? {
+            ...refreshedDriverStatus,
+            kextPermissionError: true,
+          }
+        : refreshedDriverStatus
+    setDriverStatus(driverStatus)
+    const {directMountDir} = await refreshMountDirs(driverStatus)
+    if (status?.kextStarted && previousType === T.FS.DriverStatusType.Disabled) {
+      const path = T.FS.stringToPath('/keybase')
+      try {
+        await openPathInSystemFileManagerInPlatform(path, driverStatus, directMountDir)
+      } catch (error) {
+        errorToActionOrThrow(error, path)
+      }
+    }
+  } catch (error) {
+    errorToActionOrThrow(error)
+  }
+}
+
+const driverEnableImpl = async (
+  isRetry: boolean,
+  driverKextPermissionError: () => void,
+  refreshDriverStatus: () => Promise<void>,
+  errorToActionOrThrow: (error: unknown) => void
+) => {
+  try {
+    const result = await afterDriverEnabledInPlatform(isRetry)
+    if (result === 'kextPermissionError' || result === 'kextPermissionErrorRetry') {
+      driverKextPermissionError()
+      if (result === 'kextPermissionError') {
+        C.Router2.navigateAppend({name: 'kextPermission', params: {}})
+      }
+      return
+    }
+    await refreshDriverStatus()
+    notifySfmiReload()
+  } catch (error) {
+    errorToActionOrThrow(error)
+  }
+}
+
 export const SystemFileManagerIntegrationProvider = ({
   children,
   initialKextPermissionError = false,
@@ -146,33 +202,12 @@ export const SystemFileManagerIntegrationProvider = ({
   })
 
   const refreshDriverStatus = React.useEffectEvent(async () => {
-    try {
-      const previousDriverStatus = sfmiStateRef.current.driverStatus
-      const previousType = previousDriverStatus.type
-      const status = await refreshDriverStatusInPlatform()
-      const refreshedDriverStatus = fuseStatusToDriverStatus(status)
-      const driverStatus =
-        previousDriverStatus.type === T.FS.DriverStatusType.Disabled &&
-        previousDriverStatus.kextPermissionError &&
-        refreshedDriverStatus.type === T.FS.DriverStatusType.Disabled
-          ? {
-              ...refreshedDriverStatus,
-              kextPermissionError: true,
-            }
-          : refreshedDriverStatus
-      setDriverStatus(driverStatus)
-      const {directMountDir} = await refreshMountDirsDesktop(driverStatus)
-      if (status?.kextStarted && previousType === T.FS.DriverStatusType.Disabled) {
-        const path = T.FS.stringToPath('/keybase')
-        try {
-          await openPathInSystemFileManagerInPlatform(path, driverStatus, directMountDir)
-        } catch (error) {
-          defaultErrorToActionOrThrow(error, path)
-        }
-      }
-    } catch (error) {
-      defaultErrorToActionOrThrow(error)
-    }
+    await refreshDriverStatusImpl(
+      sfmiStateRef.current.driverStatus,
+      setDriverStatus,
+      refreshMountDirsDesktop,
+      defaultErrorToActionOrThrow
+    )
   })
 
   const refreshDriverStatusDesktop = React.useEffectEvent(() => {
@@ -259,20 +294,7 @@ export const SystemFileManagerIntegrationProvider = ({
         })
       )
       setSfmiBannerDismissed(false)
-      try {
-        const result = await afterDriverEnabledInPlatform(!!isRetry)
-        if (result === 'kextPermissionError' || result === 'kextPermissionErrorRetry') {
-          driverKextPermissionError()
-          if (result === 'kextPermissionError') {
-            C.Router2.navigateAppend({name: 'kextPermission', params: {}})
-          }
-          return
-        }
-        await refreshDriverStatus()
-        notifySfmiReload()
-      } catch (error) {
-        defaultErrorToActionOrThrow(error)
-      }
+      await driverEnableImpl(!!isRetry, driverKextPermissionError, refreshDriverStatus, defaultErrorToActionOrThrow)
     }
     C.ignorePromise(f())
   })

--- a/shared/fs/common/status.tsx
+++ b/shared/fs/common/status.tsx
@@ -78,6 +78,81 @@ const getJournalWaitDuration = (endEstimate: number | undefined, lower: number, 
   return diff < lower ? lower : diff > upper ? upper : diff
 }
 
+const loadUploadStatusImpl = async (
+  generation: number,
+  isCurrentGeneration: (generation: number) => boolean,
+  getStatusStateForCurrentGeneration: (status: FsStatusState) => FsStatusState,
+  setFsStatusState: React.Dispatch<React.SetStateAction<FsStatusState>>,
+  errorToActionOrThrow: (error: unknown) => void
+) => {
+  try {
+    const uploadStates = await T.RPCGen.SimpleFSSimpleFSGetUploadStatusRpcPromise()
+    if (!isCurrentGeneration(generation)) {
+      return
+    }
+    setFsStatusState(s => {
+      const currentState = getStatusStateForCurrentGeneration(s)
+      return C.produce(currentState, draft => {
+        const writingToJournal = new Map<T.FS.Path, T.RPCGen.UploadState>(
+          (uploadStates ?? []).map(uploadState => {
+            const path = rpcPathToPath(uploadState.targetPath)
+            const oldUploadState = currentState.uploads.writingToJournal.get(path)
+            return [
+              path,
+              oldUploadState &&
+              uploadState.error === oldUploadState.error &&
+              uploadState.canceled === oldUploadState.canceled &&
+              uploadState.uploadID === oldUploadState.uploadID
+                ? oldUploadState
+                : uploadState,
+            ] as const
+          })
+        )
+        if (!isEqual(writingToJournal, currentState.uploads.writingToJournal)) {
+          draft.uploads.writingToJournal = T.castDraft(writingToJournal)
+        }
+      })
+    })
+  } catch (error) {
+    if (!isCurrentGeneration(generation)) {
+      return
+    }
+    errorToActionOrThrow(error)
+  }
+}
+
+const pollJournalStatusImpl = async (
+  generation: number,
+  isCurrentGeneration: (generation: number) => boolean,
+  journalUpdate: (
+    syncingPaths: ReadonlyArray<T.FS.Path>,
+    totalSyncingBytes: number,
+    endEstimate?: number
+  ) => void,
+  onDone: () => void
+) => {
+  try {
+    while (isCurrentGeneration(generation)) {
+      const {syncingPaths, totalSyncingBytes, endEstimate} =
+        await T.RPCGen.SimpleFSSimpleFSSyncStatusRpcPromise({
+          filter: T.RPCGen.ListFilter.filterSystemHidden,
+        })
+      if (!isCurrentGeneration(generation)) {
+        return
+      }
+      journalUpdate((syncingPaths || []).map(T.FS.stringToPath), totalSyncingBytes, endEstimate ?? undefined)
+
+      if (totalSyncingBytes <= 0 && !syncingPaths?.length) {
+        break
+      }
+      useNotifState.getState().dispatch.badgeApp('kbfsUploading', true)
+      await C.timeoutPromise(getJournalWaitDuration(endEstimate || undefined, 100, 4000))
+    }
+  } finally {
+    onDone()
+  }
+}
+
 const FsStatusDataProvider = ({children}: {children: React.ReactNode}) => {
   const connected = useKbfsDaemonStatus().rpcStatus === T.FS.KbfsDaemonRpcStatus.Connected
   const {checkKbfsDaemonRpcStatus} = useFsDaemonActions()
@@ -145,43 +220,15 @@ const FsStatusDataProvider = ({children}: {children: React.ReactNode}) => {
 
   const loadUploadStatus = React.useEffectEvent(() => {
     const generation = generationRef.current
-    const f = async () => {
-      try {
-        const uploadStates = await T.RPCGen.SimpleFSSimpleFSGetUploadStatusRpcPromise()
-        if (!isCurrentGeneration(generation)) {
-          return
-        }
-        setFsStatusState(s => {
-          const currentState = getStatusStateForCurrentGeneration(s)
-          return C.produce(currentState, draft => {
-            const writingToJournal = new Map<T.FS.Path, T.RPCGen.UploadState>(
-              (uploadStates ?? []).map(uploadState => {
-                const path = rpcPathToPath(uploadState.targetPath)
-                const oldUploadState = currentState.uploads.writingToJournal.get(path)
-                return [
-                  path,
-                  oldUploadState &&
-                  uploadState.error === oldUploadState.error &&
-                  uploadState.canceled === oldUploadState.canceled &&
-                  uploadState.uploadID === oldUploadState.uploadID
-                    ? oldUploadState
-                    : uploadState,
-                ] as const
-              })
-            )
-            if (!isEqual(writingToJournal, currentState.uploads.writingToJournal)) {
-              draft.uploads.writingToJournal = T.castDraft(writingToJournal)
-            }
-          })
-        })
-      } catch (error) {
-        if (!isCurrentGeneration(generation)) {
-          return
-        }
-        errorToActionOrThrow(error)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      loadUploadStatusImpl(
+        generation,
+        isCurrentGeneration,
+        getStatusStateForCurrentGeneration,
+        setFsStatusState,
+        errorToActionOrThrow
+      )
+    )
   })
 
   const journalUpdate = React.useEffectEvent(
@@ -207,29 +254,8 @@ const FsStatusDataProvider = ({children}: {children: React.ReactNode}) => {
     pollJournalStatusPollingRef.current = true
     const generation = generationRef.current
 
-    const f = async () => {
-      try {
-        while (isCurrentGeneration(generation)) {
-          const {syncingPaths, totalSyncingBytes, endEstimate} =
-            await T.RPCGen.SimpleFSSimpleFSSyncStatusRpcPromise({
-              filter: T.RPCGen.ListFilter.filterSystemHidden,
-            })
-          if (!isCurrentGeneration(generation)) {
-            return
-          }
-          journalUpdate(
-            (syncingPaths || []).map(T.FS.stringToPath),
-            totalSyncingBytes,
-            endEstimate ?? undefined
-          )
-
-          if (totalSyncingBytes <= 0 && !syncingPaths?.length) {
-            break
-          }
-          useNotifState.getState().dispatch.badgeApp('kbfsUploading', true)
-          await C.timeoutPromise(getJournalWaitDuration(endEstimate || undefined, 100, 4000))
-        }
-      } finally {
+    C.ignorePromise(
+      pollJournalStatusImpl(generation, isCurrentGeneration, journalUpdate, () => {
         if (generation === generationRef.current) {
           pollJournalStatusPollingRef.current = false
         }
@@ -237,9 +263,8 @@ const FsStatusDataProvider = ({children}: {children: React.ReactNode}) => {
         if (isCurrentGeneration(generation)) {
           checkKbfsDaemonRpcStatus()
         }
-      }
-    }
-    C.ignorePromise(f())
+      })
+    )
   })
 
   const syncStatusChanged = React.useEffectEvent((status: T.RPCGen.FolderSyncStatus) => {

--- a/shared/fs/common/use-files-tab-upload-icon.tsx
+++ b/shared/fs/common/use-files-tab-upload-icon.tsx
@@ -19,6 +19,28 @@ const filesTabBadgeToUploadIcon = (badge: T.RPCGen.FilesTabBadge): T.FS.UploadIc
   }
 }
 
+const fetchUploadIcon = async (
+  generation: number,
+  generationRef: React.RefObject<number>,
+  connectedRef: React.RefObject<boolean>,
+  setUploadIcon: (icon: T.FS.UploadIcon | undefined) => void
+) => {
+  try {
+    const badge = await T.RPCGen.SimpleFSSimpleFSGetFilesTabBadgeRpcPromise()
+    if (generation === generationRef.current && connectedRef.current) {
+      setUploadIcon(filesTabBadgeToUploadIcon(badge))
+    }
+  } catch {
+    // Retry once; see HOTPOT-1226.
+    try {
+      const badge = await T.RPCGen.SimpleFSSimpleFSGetFilesTabBadgeRpcPromise()
+      if (generation === generationRef.current && connectedRef.current) {
+        setUploadIcon(filesTabBadgeToUploadIcon(badge))
+      }
+    } catch {}
+  }
+}
+
 export const useFilesTabUploadIcon = () => {
   const connected = useKbfsDaemonStatus().rpcStatus === T.FS.KbfsDaemonRpcStatus.Connected
   const connectedRef = React.useRef(connected)
@@ -36,23 +58,7 @@ export const useFilesTabUploadIcon = () => {
       return
     }
     const generation = ++generationRef.current
-    const f = async () => {
-      try {
-        const badge = await T.RPCGen.SimpleFSSimpleFSGetFilesTabBadgeRpcPromise()
-        if (generation === generationRef.current && connectedRef.current) {
-          setUploadIcon(filesTabBadgeToUploadIcon(badge))
-        }
-      } catch {
-        // Retry once; see HOTPOT-1226.
-        try {
-          const badge = await T.RPCGen.SimpleFSSimpleFSGetFilesTabBadgeRpcPromise()
-          if (generation === generationRef.current && connectedRef.current) {
-            setUploadIcon(filesTabBadgeToUploadIcon(badge))
-          }
-        } catch {}
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(fetchUploadIcon(generation, generationRef, connectedRef, setUploadIcon))
   })
   const [stableLoadUploadIcon] = React.useState(() => () => {
     loadUploadIcon()

--- a/shared/fs/common/use-non-folder-syncing-paths.tsx
+++ b/shared/fs/common/use-non-folder-syncing-paths.tsx
@@ -100,7 +100,9 @@ export const useNonFolderSyncingPaths = (syncingPaths: ReadonlySet<T.FS.Path>) =
             if (!latestSyncingPaths.current.has(path) || prevPathTypes.get(path) === type) {
               continue
             }
-            nextPathTypes ??= new Map(prevPathTypes)
+            if (nextPathTypes === undefined) {
+              nextPathTypes = new Map(prevPathTypes)
+            }
             nextPathTypes.set(path, type)
           }
           return nextPathTypes ?? prevPathTypes

--- a/shared/fs/filepreview/text-view.tsx
+++ b/shared/fs/filepreview/text-view.tsx
@@ -8,26 +8,34 @@ type Props = {
   onUrlError?: (err: string) => void
 }
 
+const fetchContent = (
+  url: string,
+  setContent: (content: string) => void,
+  onUrlError?: (err: string) => void
+) => {
+  const req = new XMLHttpRequest()
+  req.onreadystatechange = () => {
+    try {
+      if (req.readyState === XMLHttpRequest.DONE && req.status === 200) {
+        setContent(req.responseText)
+      }
+    } catch {
+      onUrlError?.('http request failed')
+    }
+  }
+  try {
+    req.open('GET', url)
+    req.send()
+  } catch {}
+}
+
 const TextView = (props: Props) => {
   const {onUrlError, url} = props
 
   const [content, setContent] = React.useState('')
   React.useEffect(() => {
     if (isMobile) return
-    const req = new XMLHttpRequest()
-    req.onreadystatechange = () => {
-      try {
-        if (req.readyState === XMLHttpRequest.DONE && req.status === 200) {
-          setContent(req.responseText)
-        }
-      } catch {
-        onUrlError?.('http request failed')
-      }
-    }
-    try {
-      req.open('GET', url)
-      req.send()
-    } catch {}
+    fetchContent(url, setContent, onUrlError)
   }, [onUrlError, url])
 
   if (!isMobile) {

--- a/shared/fs/top-bar/sync-toggle.tsx
+++ b/shared/fs/top-bar/sync-toggle.tsx
@@ -9,6 +9,26 @@ type OwnProps = {
   tlfPath: T.FS.Path
 }
 
+const setTlfSyncConfigRPC = async (
+  tlfPath: T.FS.Path,
+  enabled: boolean,
+  refreshTlf: () => void,
+  errorToActionOrThrow: (error: unknown, path?: T.FS.Path) => void
+) => {
+  try {
+    await T.RPCGen.SimpleFSSimpleFSSetFolderSyncConfigRpcPromise(
+      {
+        config: {mode: enabled ? T.RPCGen.FolderSyncMode.enabled : T.RPCGen.FolderSyncMode.disabled},
+        path: FS.pathToRPCPath(tlfPath),
+      },
+      C.waitingKeyFSSyncToggle
+    )
+    refreshTlf()
+  } catch (error) {
+    errorToActionOrThrow(error, tlfPath)
+  }
+}
+
 const SyncToggle = (ownProps: OwnProps) => {
   const {tlfPath} = ownProps
   const tlfPathItem = useFsFolderChildren(tlfPath)
@@ -18,21 +38,7 @@ const SyncToggle = (ownProps: OwnProps) => {
   const waiting = C.Waiting.useAnyWaiting(C.waitingKeyFSSyncToggle)
 
   const setTlfSyncConfig = (enabled: boolean) => {
-    const f = async () => {
-      try {
-        await T.RPCGen.SimpleFSSimpleFSSetFolderSyncConfigRpcPromise(
-          {
-            config: {mode: enabled ? T.RPCGen.FolderSyncMode.enabled : T.RPCGen.FolderSyncMode.disabled},
-            path: FS.pathToRPCPath(tlfPath),
-          },
-          C.waitingKeyFSSyncToggle
-        )
-        refreshTlf()
-      } catch (error) {
-        errorToActionOrThrow(error, tlfPath)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(setTlfSyncConfigRPC(tlfPath, enabled, refreshTlf, errorToActionOrThrow))
   }
 
   const enableSync = () => {

--- a/shared/menubar/remote-proxy.desktop.tsx
+++ b/shared/menubar/remote-proxy.desktop.tsx
@@ -220,6 +220,29 @@ function useEnsureWidgetData(
   }, [widgetList])
 }
 
+const loadUserFileEditsRPC = async (
+  generation: number,
+  generationRef: {current: number},
+  enabledRef: {current: boolean},
+  setTlfUpdateState: (state: TlfUpdateState) => void,
+  errorToActionOrThrow: (error: unknown) => void
+) => {
+  try {
+    const writerEdits = await T.RPCGen.SimpleFSSimpleFSUserEditHistoryRpcPromise()
+    if (generation !== generationRef.current || !enabledRef.current) {
+      return
+    }
+    setTlfUpdateState({
+      shouldClear: false,
+      tlfUpdates: userTlfHistoryRPCToState(writerEdits || []),
+    })
+  } catch (error) {
+    if (generation === generationRef.current && enabledRef.current) {
+      errorToActionOrThrow(error)
+    }
+  }
+}
+
 function useMenubarTlfUpdates(
   loggedIn: boolean,
   userSwitching: boolean,
@@ -254,23 +277,9 @@ function useMenubarTlfUpdates(
       return
     }
     const generation = ++generationRef.current
-    const f = async () => {
-      try {
-        const writerEdits = await T.RPCGen.SimpleFSSimpleFSUserEditHistoryRpcPromise()
-        if (generation !== generationRef.current || !enabledRef.current) {
-          return
-        }
-        setTlfUpdateState({
-          shouldClear: false,
-          tlfUpdates: userTlfHistoryRPCToState(writerEdits || []),
-        })
-      } catch (error) {
-        if (generation === generationRef.current && enabledRef.current) {
-          errorToActionOrThrow(error)
-        }
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(
+      loadUserFileEditsRPC(generation, generationRef, enabledRef, setTlfUpdateState, errorToActionOrThrow)
+    )
   }, 5000)
 
   React.useEffect(() => {

--- a/shared/package.json
+++ b/shared/package.json
@@ -49,6 +49,8 @@
     "ios:pod:install": "cd ios; pod install --repo-update",
     "ios:sim:push-chat": "bash tools/sim-push-chat.sh",
     "lint": "yarn run lint:specific .",
+    "lint:all": "yarn lint && yarn lint:bailouts && yarn tsc",
+    "lint:bailouts": "node --experimental-strip-types scripts/react-compiler-bailouts.mts --check .",
     "lint:daemon": "eslint_d --cache .",
     "lint:specific": "eslint --cache --quiet ",
     "lint:warn": "eslint .",

--- a/shared/profile/edit-avatar/index.tsx
+++ b/shared/profile/edit-avatar/index.tsx
@@ -210,6 +210,29 @@ type AvatarZoomRef = {
   getRect: () => {width: number; height: number; x: number; y: number} | undefined
 }
 
+const chooseAvatar = async (
+  onSelected: (image: ImageInfo) => void,
+  onCancel: () => void,
+  onError: (error: string) => void
+) => {
+  try {
+    const result = await launchImageLibraryAsync('photo')
+    const first = result.assets?.reduce<ImageInfo | undefined>((acc, a) => {
+      if (!acc && (a.type === 'image' || a.type === 'video')) {
+        return a as ImageInfo
+      }
+      return acc
+    }, undefined)
+    if (!result.canceled && first) {
+      onSelected(first)
+    } else {
+      onCancel()
+    }
+  } catch (error) {
+    onError(String(error))
+  }
+}
+
 const NativeAvatarUploadWrapper = (p: Props) => {
   const {newTeamWizard} = p
   const props = useHooks(p)
@@ -221,49 +244,23 @@ const NativeAvatarUploadWrapper = (p: Props) => {
   const navUp = () => nav.safeNavigateUp()
 
   const onChooseNewAvatar = () => {
-    const f = async () => {
-      try {
-        const result = await launchImageLibraryAsync('photo')
-        const first = result.assets?.reduce<ImageInfo | undefined>((acc, a) => {
-          if (!acc && (a.type === 'image' || a.type === 'video')) {
-            return a as ImageInfo
+    C.ignorePromise(
+      chooseAvatar(
+        setSelectedImage,
+        () => {
+          if (!props.wizard) {
+            navUp()
           }
-          return acc
-        }, undefined)
-        if (!result.canceled && first) {
-          setSelectedImage(first)
-        } else if (!props.wizard) {
-          navUp()
-        }
-      } catch (error) {
-        setImageError(String(error))
-      }
-    }
-    C.ignorePromise(f())
+        },
+        setImageError
+      )
+    )
   }
 
   const noImage = !image
   React.useEffect(() => {
     if (!wizard && noImage) {
-      const f = async () => {
-        try {
-          const result = await launchImageLibraryAsync('photo')
-          const first = result.assets?.reduce<ImageInfo | undefined>((acc, a) => {
-            if (!acc && (a.type === 'image' || a.type === 'video')) {
-              return a as ImageInfo
-            }
-            return acc
-          }, undefined)
-          if (!result.canceled && first) {
-            setSelectedImage(first)
-          } else {
-            nav.safeNavigateUp()
-          }
-        } catch (error) {
-          setImageError(String(error))
-        }
-      }
-      C.ignorePromise(f())
+      C.ignorePromise(chooseAvatar(setSelectedImage, () => nav.safeNavigateUp(), setImageError))
     }
   }, [noImage, wizard, nav])
 

--- a/shared/profile/generic/proofs-list.tsx
+++ b/shared/profile/generic/proofs-list.tsx
@@ -108,6 +108,248 @@ type Step =
   | PostProofStep
   | ConfirmOrPendingStep
 
+const checkProofAndNavigate = async (
+  proofPlatform: T.More.PlatformsExpandedType,
+  sigID: T.RPCGen.SigID,
+  username: string,
+  proofText: string,
+  mountedRef: React.RefObject<boolean>,
+  setStepSafe: (next: Step) => void
+) => {
+  try {
+    const {found, status} = await T.RPCGen.proveCheckProofRpcPromise({sigID}, C.waitingKeyProfile)
+    if (!mountedRef.current) return
+    if (!found && status >= T.RPCGen.ProofStatus.baseHardError) {
+      setStepSafe({
+        error: "We couldn't find your proof. Please retry!",
+        kind: 'postProof',
+        platform: proofPlatform,
+        proofText,
+        sigID,
+        username,
+      })
+    } else {
+      setStepSafe({
+        kind: 'confirmOrPending',
+        platform: proofPlatform,
+        proofFound: found,
+        proofStatus: status,
+        username,
+      })
+    }
+  } catch {
+    logger.warn('Error getting proof update')
+    setStepSafe({
+      error: "We couldn't verify your proof. Please retry!",
+      kind: 'postProof',
+      platform: proofPlatform,
+      proofText,
+      sigID,
+      username,
+    })
+  }
+}
+
+const runProofFlow = async (p: {
+  afterCheckProofRef: React.RefObject<undefined | (() => void)>
+  cancelCurrentRef: React.RefObject<undefined | (() => void)>
+  currentGenericParamsRef: React.RefObject<ProveGenericParams>
+  currentUsernameRef: React.RefObject<string>
+  genericService: string | null
+  loadCurrentProfile: () => void
+  mountedRef: React.RefObject<boolean>
+  navigateAppend: typeof C.Router2.navigateAppend
+  navigateUp: typeof C.Router2.navigateUp
+  proofPlatform: string
+  proofReason: 'appLink' | 'profile'
+  resetSession: () => void
+  service: T.More.PlatformsExpandedType | undefined
+  setStepSafe: (next: Step) => void
+  submitUsernameRef: React.RefObject<undefined | ((username: string) => void)>
+}) => {
+  const {
+    afterCheckProofRef,
+    cancelCurrentRef,
+    currentGenericParamsRef,
+    currentUsernameRef,
+    genericService,
+    loadCurrentProfile,
+    mountedRef,
+    navigateAppend,
+    navigateUp,
+    proofPlatform,
+    proofReason,
+    resetSession,
+    service,
+    setStepSafe,
+    submitUsernameRef,
+  } = p
+
+  const inputCancelError = {
+    code: T.RPCGen.StatusCode.scinputcanceled,
+    desc: 'Cancel Add Proof',
+  }
+
+  let canceled = false
+  let proofText = ''
+  currentUsernameRef.current = ''
+  currentGenericParamsRef.current = makeProveGenericParams()
+
+  const failIfCanceled = (response: {error: (arg0: {code: number; desc: string}) => void}) => {
+    if (canceled || !mountedRef.current) {
+      response.error(inputCancelError)
+      return true
+    }
+    return false
+  }
+
+  try {
+    const {sigID} = await T.RPCGen.proveStartProofRpcListener({
+      customResponseIncomingCallMap: {
+        'keybase.1.proveUi.checking': (_, response) => {
+          if (failIfCanceled(response)) {
+            return
+          }
+          response.result()
+        },
+        'keybase.1.proveUi.continueChecking': (_, response) =>
+          response.result(!(canceled || !mountedRef.current)),
+        'keybase.1.proveUi.okToCheck': (_, response) => response.result(true),
+        'keybase.1.proveUi.outputInstructions': ({proof}, response) => {
+          if (failIfCanceled(response)) {
+            return
+          }
+          afterCheckProofRef.current = () => {
+            afterCheckProofRef.current = undefined
+            response.result()
+          }
+          cancelCurrentRef.current = () => {
+            canceled = true
+            response.error(inputCancelError)
+          }
+
+          if (service && proof) {
+            proofText = proof
+            setStepSafe({
+              error: '',
+              kind: 'postProof',
+              platform: service,
+              proofText: proof,
+              username: currentUsernameRef.current,
+            })
+          } else if (proof) {
+            const genericParams = currentGenericParamsRef.current
+            setStepSafe({
+              error: '',
+              genericParams,
+              kind: 'genericEnterUsername',
+              proofUrl: proof,
+              service: genericService ?? '',
+              username: currentUsernameRef.current,
+            })
+            void openUrl(proof)
+            afterCheckProofRef.current()
+          }
+        },
+        'keybase.1.proveUi.preProofWarning': (_, response) => response.result(true),
+        'keybase.1.proveUi.promptOverwrite': (_, response) => response.result(true),
+        'keybase.1.proveUi.promptUsername': (args, response) => {
+          if (failIfCanceled(response)) {
+            return
+          }
+          const {parameters, prevError} = args
+          cancelCurrentRef.current = () => {
+            canceled = true
+            response.error(inputCancelError)
+          }
+          submitUsernameRef.current = (username: string) => {
+            const {normalized} = normalizeProofUsername(service, username)
+            currentUsernameRef.current = normalized
+            submitUsernameRef.current = undefined
+            response.result(normalized)
+          }
+          if (service) {
+            setStepSafe({
+              error: prevError?.desc ?? '',
+              kind: 'enterUsername',
+              platform: service,
+              username: currentUsernameRef.current,
+            })
+            cancelCurrentRef.current = () => {
+              canceled = true
+              response.error(inputCancelError)
+            }
+          } else if (genericService && parameters) {
+            currentGenericParamsRef.current = toProveGenericParams(parameters)
+            setStepSafe({
+              error: prevError?.desc ?? '',
+              genericParams: currentGenericParamsRef.current,
+              kind: 'genericEnterUsername',
+              service: genericService,
+              username: currentUsernameRef.current,
+            })
+          }
+          afterCheckProofRef.current = undefined
+        },
+      },
+      incomingCallMap: {
+        'keybase.1.proveUi.displayRecheckWarning': () => {},
+        'keybase.1.proveUi.outputPrechecks': () => {},
+      },
+      params: {
+        auto: false,
+        force: true,
+        promptPosted: !!genericService,
+        service: proofPlatform,
+        username: '',
+      },
+      waitingKey: C.waitingKeyProfile,
+    })
+
+    loadCurrentProfile()
+
+    if (service) {
+      ignorePromise(
+        checkProofAndNavigate(service, sigID, currentUsernameRef.current, proofText, mountedRef, setStepSafe)
+      )
+    } else {
+      setStepSafe({
+        error: '',
+        genericParams: currentGenericParamsRef.current,
+        kind: 'genericResult',
+        username: currentUsernameRef.current,
+      })
+    }
+  } catch (_error) {
+    loadCurrentProfile()
+    if (!(_error instanceof RPCError)) {
+      return
+    }
+    const error = _error
+    logger.warn('Error making proof')
+
+    if (genericService) {
+      setStepSafe({
+        error: error.desc || 'Failed to verify proof',
+        genericParams: currentGenericParamsRef.current,
+        kind: 'genericResult',
+        username: currentUsernameRef.current,
+      })
+    } else if (proofReason === 'appLink' && error.code === T.RPCGen.StatusCode.scgeneric) {
+      navigateUp()
+      navigateAppend({
+        name: 'keybaseLinkError',
+        params: {
+          error:
+            "We couldn't find a valid service for proofs in this link. The link might be bad, or your Keybase app might be out of date and need to be updated.",
+        },
+      })
+    }
+  } finally {
+    resetSession()
+  }
+}
+
 const Container = ({platform, reason = 'profile'}: Props) => {
   const currentUsername = useCurrentUserState(s => s.username)
   const {proofSuggestions} = useProofSuggestions()
@@ -180,46 +422,6 @@ const Container = ({platform, reason = 'profile'}: Props) => {
     navToProfile(currentUsername)
   }
 
-  const checkProofAndNavigate = async (
-    proofPlatform: T.More.PlatformsExpandedType,
-    sigID: T.RPCGen.SigID,
-    username: string,
-    proofText: string
-  ) => {
-    try {
-      const {found, status} = await T.RPCGen.proveCheckProofRpcPromise({sigID}, C.waitingKeyProfile)
-      if (!mountedRef.current) return
-      if (!found && status >= T.RPCGen.ProofStatus.baseHardError) {
-        setStepSafe({
-          error: "We couldn't find your proof. Please retry!",
-          kind: 'postProof',
-          platform: proofPlatform,
-          proofText,
-          sigID,
-          username,
-        })
-      } else {
-        setStepSafe({
-          kind: 'confirmOrPending',
-          platform: proofPlatform,
-          proofFound: found,
-          proofStatus: status,
-          username,
-        })
-      }
-    } catch {
-      logger.warn('Error getting proof update')
-      setStepSafe({
-        error: "We couldn't verify your proof. Please retry!",
-        kind: 'postProof',
-        platform: proofPlatform,
-        proofText,
-        sigID,
-        username,
-      })
-    }
-  }
-
   const startProof = (proofPlatform: string, proofReason: 'appLink' | 'profile') => {
     const service = T.More.asPlatformsExpandedType(proofPlatform)
     const genericService = service ? null : proofPlatform
@@ -241,170 +443,24 @@ const Container = ({platform, reason = 'profile'}: Props) => {
 
     setStepSafe({kind: 'loading'})
 
-    const inputCancelError = {
-      code: T.RPCGen.StatusCode.scinputcanceled,
-      desc: 'Cancel Add Proof',
-    }
-
-    let canceled = false
-    let proofText = ''
-    currentUsernameRef.current = ''
-    currentGenericParamsRef.current = makeProveGenericParams()
-
-    const failIfCanceled = (response: {error: (arg0: {code: number; desc: string}) => void}) => {
-      if (canceled || !mountedRef.current) {
-        response.error(inputCancelError)
-        return true
-      }
-      return false
-    }
-
     ignorePromise(
-      (async () => {
-        try {
-          const {sigID} = await T.RPCGen.proveStartProofRpcListener({
-            customResponseIncomingCallMap: {
-              'keybase.1.proveUi.checking': (_, response) => {
-                if (failIfCanceled(response)) {
-                  return
-                }
-                response.result()
-              },
-              'keybase.1.proveUi.continueChecking': (_, response) =>
-                response.result(!(canceled || !mountedRef.current)),
-              'keybase.1.proveUi.okToCheck': (_, response) => response.result(true),
-              'keybase.1.proveUi.outputInstructions': ({proof}, response) => {
-                if (failIfCanceled(response)) {
-                  return
-                }
-                afterCheckProofRef.current = () => {
-                  afterCheckProofRef.current = undefined
-                  response.result()
-                }
-                cancelCurrentRef.current = () => {
-                  canceled = true
-                  response.error(inputCancelError)
-                }
-
-                if (service && proof) {
-                  proofText = proof
-                  setStepSafe({
-                    error: '',
-                    kind: 'postProof',
-                    platform: service,
-                    proofText: proof,
-                    username: currentUsernameRef.current,
-                  })
-                } else if (proof) {
-                  const genericParams = currentGenericParamsRef.current
-                  setStepSafe({
-                    error: '',
-                    genericParams,
-                    kind: 'genericEnterUsername',
-                    proofUrl: proof,
-                    service: genericService ?? '',
-                    username: currentUsernameRef.current,
-                  })
-                  void openUrl(proof)
-                  afterCheckProofRef.current()
-                }
-              },
-              'keybase.1.proveUi.preProofWarning': (_, response) => response.result(true),
-              'keybase.1.proveUi.promptOverwrite': (_, response) => response.result(true),
-              'keybase.1.proveUi.promptUsername': (args, response) => {
-                if (failIfCanceled(response)) {
-                  return
-                }
-                const {parameters, prevError} = args
-                cancelCurrentRef.current = () => {
-                  canceled = true
-                  response.error(inputCancelError)
-                }
-                submitUsernameRef.current = (username: string) => {
-                  const {normalized} = normalizeProofUsername(service, username)
-                  currentUsernameRef.current = normalized
-                  submitUsernameRef.current = undefined
-                  response.result(normalized)
-                }
-                if (service) {
-                  setStepSafe({
-                    error: prevError?.desc ?? '',
-                    kind: 'enterUsername',
-                    platform: service,
-                    username: currentUsernameRef.current,
-                  })
-                  cancelCurrentRef.current = () => {
-                    canceled = true
-                    response.error(inputCancelError)
-                  }
-                } else if (genericService && parameters) {
-                  currentGenericParamsRef.current = toProveGenericParams(parameters)
-                  setStepSafe({
-                    error: prevError?.desc ?? '',
-                    genericParams: currentGenericParamsRef.current,
-                    kind: 'genericEnterUsername',
-                    service: genericService,
-                    username: currentUsernameRef.current,
-                  })
-                }
-                afterCheckProofRef.current = undefined
-              },
-            },
-            incomingCallMap: {
-              'keybase.1.proveUi.displayRecheckWarning': () => {},
-              'keybase.1.proveUi.outputPrechecks': () => {},
-            },
-            params: {
-              auto: false,
-              force: true,
-              promptPosted: !!genericService,
-              service: proofPlatform,
-              username: '',
-            },
-            waitingKey: C.waitingKeyProfile,
-          })
-
-          loadCurrentProfile()
-
-          if (service) {
-            ignorePromise(checkProofAndNavigate(service, sigID, currentUsernameRef.current, proofText))
-          } else {
-            setStepSafe({
-              error: '',
-              genericParams: currentGenericParamsRef.current,
-              kind: 'genericResult',
-              username: currentUsernameRef.current,
-            })
-          }
-        } catch (_error) {
-          loadCurrentProfile()
-          if (!(_error instanceof RPCError)) {
-            return
-          }
-          const error = _error
-          logger.warn('Error making proof')
-
-          if (genericService) {
-            setStepSafe({
-              error: error.desc || 'Failed to verify proof',
-              genericParams: currentGenericParamsRef.current,
-              kind: 'genericResult',
-              username: currentUsernameRef.current,
-            })
-          } else if (proofReason === 'appLink' && error.code === T.RPCGen.StatusCode.scgeneric) {
-            navigateUp()
-            navigateAppend({
-              name: 'keybaseLinkError',
-              params: {
-                error:
-                  "We couldn't find a valid service for proofs in this link. The link might be bad, or your Keybase app might be out of date and need to be updated.",
-              },
-            })
-          }
-        } finally {
-          resetSession()
-        }
-      })()
+      runProofFlow({
+        afterCheckProofRef,
+        cancelCurrentRef,
+        currentGenericParamsRef,
+        currentUsernameRef,
+        genericService,
+        loadCurrentProfile,
+        mountedRef,
+        navigateAppend,
+        navigateUp,
+        proofPlatform,
+        proofReason,
+        resetSession,
+        service,
+        setStepSafe,
+        submitUsernameRef,
+      })
     )
   }
 
@@ -544,7 +600,16 @@ const Container = ({platform, reason = 'profile'}: Props) => {
                 return
               }
               if (step.sigID) {
-                ignorePromise(checkProofAndNavigate(step.platform, step.sigID, step.username, step.proofText))
+                ignorePromise(
+                  checkProofAndNavigate(
+                    step.platform,
+                    step.sigID,
+                    step.username,
+                    step.proofText,
+                    mountedRef,
+                    setStepSafe
+                  )
+                )
               }
             }}
             step={step}

--- a/shared/profile/pgp/choice/index.tsx
+++ b/shared/profile/pgp/choice/index.tsx
@@ -28,6 +28,69 @@ const makeInitialForm = (): GeneratePgpArgs => ({
   pgpFullName: '',
 })
 
+const generatePgp = async (
+  args: GeneratePgpArgs,
+  mountedRef: React.RefObject<boolean>,
+  cancelCurrentRef: React.RefObject<undefined | (() => void)>,
+  finishCurrentRef: React.RefObject<undefined | ((shouldStoreKeyOnServer: boolean) => void)>,
+  setStepSafe: (next: Step) => void
+) => {
+  let canceled = false
+  let pgpKeyString = 'Error getting public key...'
+  const inputCancelError = {code: T.RPCGen.StatusCode.scinputcanceled, desc: 'Input canceled'}
+  const ids = [args.pgpEmail1, args.pgpEmail2, args.pgpEmail3].filter(Boolean).map(email => ({
+    comment: '',
+    email,
+    username: args.pgpFullName,
+  }))
+
+  cancelCurrentRef.current = () => {
+    canceled = true
+  }
+
+  try {
+    await T.RPCGen.pgpPgpKeyGenDefaultRpcListener({
+      customResponseIncomingCallMap: {
+        'keybase.1.pgpUi.keyGenerated': ({key}, response) => {
+          if (canceled || !mountedRef.current) {
+            response.error(inputCancelError)
+            return
+          }
+          pgpKeyString = key.key
+          response.result()
+        },
+        'keybase.1.pgpUi.shouldPushPrivate': ({prompt}, response) => {
+          if (canceled || !mountedRef.current) {
+            response.error(inputCancelError)
+            return
+          }
+          cancelCurrentRef.current = () => {
+            canceled = true
+            response.error(inputCancelError)
+          }
+          finishCurrentRef.current = (shouldStoreKeyOnServer: boolean) => {
+            finishCurrentRef.current = undefined
+            response.result(shouldStoreKeyOnServer)
+          }
+          setStepSafe({kind: 'finished', pgpKeyString, promptShouldStoreKeyOnServer: prompt})
+        },
+      },
+      incomingCallMap: {'keybase.1.pgpUi.finished': () => {}},
+      params: {createUids: {ids, useDefault: false}},
+    })
+  } catch (error) {
+    if (!(error instanceof RPCError)) {
+      return
+    }
+    if (error.code !== T.RPCGen.StatusCode.scinputcanceled) {
+      throw error
+    }
+  } finally {
+    cancelCurrentRef.current = undefined
+    finishCurrentRef.current = undefined
+  }
+}
+
 export const PgpMobileUnsupported = ({onCancel}: {onCancel: () => void}) => (
   <Modal onCancel={onCancel}>
     <Kb.Box2 direction="vertical" gap="small" gapEnd={true}>
@@ -100,64 +163,7 @@ export default function Choice() {
     const args = form
     setStepSafe({kind: 'generate'})
 
-    ignorePromise(
-      (async () => {
-        let canceled = false
-        let pgpKeyString = 'Error getting public key...'
-        const inputCancelError = {code: T.RPCGen.StatusCode.scinputcanceled, desc: 'Input canceled'}
-        const ids = [args.pgpEmail1, args.pgpEmail2, args.pgpEmail3].filter(Boolean).map(email => ({
-          comment: '',
-          email,
-          username: args.pgpFullName,
-        }))
-
-        cancelCurrentRef.current = () => {
-          canceled = true
-        }
-
-        try {
-          await T.RPCGen.pgpPgpKeyGenDefaultRpcListener({
-            customResponseIncomingCallMap: {
-              'keybase.1.pgpUi.keyGenerated': ({key}, response) => {
-                if (canceled || !mountedRef.current) {
-                  response.error(inputCancelError)
-                  return
-                }
-                pgpKeyString = key.key
-                response.result()
-              },
-              'keybase.1.pgpUi.shouldPushPrivate': ({prompt}, response) => {
-                if (canceled || !mountedRef.current) {
-                  response.error(inputCancelError)
-                  return
-                }
-                cancelCurrentRef.current = () => {
-                  canceled = true
-                  response.error(inputCancelError)
-                }
-                finishCurrentRef.current = (shouldStoreKeyOnServer: boolean) => {
-                  finishCurrentRef.current = undefined
-                  response.result(shouldStoreKeyOnServer)
-                }
-                setStepSafe({kind: 'finished', pgpKeyString, promptShouldStoreKeyOnServer: prompt})
-              },
-            },
-            incomingCallMap: {'keybase.1.pgpUi.finished': () => {}},
-            params: {createUids: {ids, useDefault: false}},
-          })
-        } catch (error) {
-          if (!(error instanceof RPCError)) {
-            return
-          }
-          if (error.code !== T.RPCGen.StatusCode.scinputcanceled) {
-            throw error
-          }
-        } finally {
-          cancelCurrentRef.current = undefined
-          finishCurrentRef.current = undefined
-        }
-      })()
-    )
+    ignorePromise(generatePgp(args, mountedRef, cancelCurrentRef, finishCurrentRef, setStepSafe))
   }
 
   const content = (() => {

--- a/shared/profile/use-proof-suggestions.tsx
+++ b/shared/profile/use-proof-suggestions.tsx
@@ -62,6 +62,38 @@ const rpcSuggestionToAssertion = (suggestion: T.RPCGen.ProofSuggestion): T.Track
   }
 }
 
+const loadProofSuggestions = async (
+  version: number,
+  requestVersionRef: React.RefObject<number>,
+  enabled: boolean,
+  loadKey: number,
+  setProofSuggestionsState: React.Dispatch<React.SetStateAction<ProofSuggestionsState>>
+) => {
+  try {
+    const {suggestions} = await T.RPCGen.userProofSuggestionsRpcPromise(
+      undefined,
+      waitingKeyTrackerProfileLoad
+    )
+    if (requestVersionRef.current !== version) {
+      return
+    }
+    const nextSuggestions = suggestions?.map(rpcSuggestionToAssertion) ?? emptyProofSuggestions
+    setProofSuggestionsState(state =>
+      state.enabled === enabled && state.loadKey === loadKey
+        ? {...state, suggestions: nextSuggestions}
+        : state
+    )
+  } catch (error) {
+    if (!(error instanceof RPCError)) {
+      return
+    }
+    if (requestVersionRef.current !== version) {
+      return
+    }
+    logger.error(`Error loading proof suggestions: ${error.message}`)
+  }
+}
+
 export const useProofSuggestions = (enabled = true) => {
   const uid = useCurrentUserState(s => s.uid)
   const [proofSuggestionsState, setProofSuggestionsState] = React.useState<ProofSuggestionsState>({
@@ -86,33 +118,7 @@ export const useProofSuggestions = (enabled = true) => {
     const version = requestVersionRef.current + 1
     requestVersionRef.current = version
 
-    const load = async () => {
-      try {
-        const {suggestions} = await T.RPCGen.userProofSuggestionsRpcPromise(
-          undefined,
-          waitingKeyTrackerProfileLoad
-        )
-        if (requestVersionRef.current !== version) {
-          return
-        }
-        const nextSuggestions = suggestions?.map(rpcSuggestionToAssertion) ?? emptyProofSuggestions
-        setProofSuggestionsState(state =>
-          state.enabled === enabled && state.loadKey === loadKey
-            ? {...state, suggestions: nextSuggestions}
-            : state
-        )
-      } catch (error) {
-        if (!(error instanceof RPCError)) {
-          return
-        }
-        if (requestVersionRef.current !== version) {
-          return
-        }
-        logger.error(`Error loading proof suggestions: ${error.message}`)
-      }
-    }
-
-    ignorePromise(load())
+    ignorePromise(loadProofSuggestions(version, requestVersionRef, enabled, loadKey, setProofSuggestionsState))
   }, [enabled, loadKey])
 
   React.useEffect(() => {

--- a/shared/profile/user/hooks.tsx
+++ b/shared/profile/user/hooks.tsx
@@ -24,6 +24,34 @@ const headerBackgroundColorType = (
   }
 }
 
+const loadSharedTeams = async (
+  requestUsernameKey: string,
+  requestID: number,
+  requestIDRef: {current: number},
+  setSharedTeamsState: (s: {teams?: ReadonlyArray<T.RPCChat.SharedTeam>; usernameKey: string}) => void
+) => {
+  try {
+    const res = await T.RPCChat.localGetMutualTeamsLocalRpcPromise(
+      {usernames: [requestUsernameKey]},
+      C.waitingKeyTrackerSharedTeams(requestUsernameKey)
+    )
+    if (requestIDRef.current !== requestID) {
+      return
+    }
+    const teams = res.teams ?? []
+    setSharedTeamsState({teams, usernameKey: requestUsernameKey})
+  } catch (error) {
+    if (requestIDRef.current !== requestID) {
+      return
+    }
+    if (error instanceof RPCError) {
+      logger.error(`Error loading shared teams: ${error.message}`)
+    } else {
+      logger.error('Error loading shared teams: non-RPC error', error)
+    }
+  }
+}
+
 const useUserData = (username: string) => {
   const myName = useCurrentUserState(s => s.username)
   const usernameKey = username.toLowerCase()
@@ -51,29 +79,7 @@ const useUserData = (username: string) => {
     const requestUsernameKey = usernameKey
     const requestID = requestIDRef.current + 1
     requestIDRef.current = requestID
-    const f = async () => {
-      try {
-        const res = await T.RPCChat.localGetMutualTeamsLocalRpcPromise(
-          {usernames: [requestUsernameKey]},
-          C.waitingKeyTrackerSharedTeams(requestUsernameKey)
-        )
-        if (requestIDRef.current !== requestID) {
-          return
-        }
-        const teams = res.teams ?? []
-        setSharedTeamsState({teams, usernameKey: requestUsernameKey})
-      } catch (error) {
-        if (requestIDRef.current !== requestID) {
-          return
-        }
-        if (error instanceof RPCError) {
-          logger.error(`Error loading shared teams: ${error.message}`)
-        } else {
-          logger.error('Error loading shared teams: non-RPC error', error)
-        }
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(loadSharedTeams(requestUsernameKey, requestID, requestIDRef, setSharedTeamsState))
     return () => {
       if (requestIDRef.current === requestID) {
         requestIDRef.current += 1

--- a/shared/provision/code-page/qr-scan/scanner.tsx
+++ b/shared/provision/code-page/qr-scan/scanner.tsx
@@ -7,12 +7,18 @@ type Props = {
   style: Kb.Styles.StylesCrossPlatform
 }
 
+// Hoisted: resolving useCameraPermissions from require() during render makes the react
+// compiler bail (hooks must be the same function on every render). The require is
+// guarded so it never executes on desktop.
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type ExpoCamera = typeof import('expo-camera')
+const {CameraView, useCameraPermissions} = isMobile
+  ? (require('expo-camera') as ExpoCamera)
+  : ({} as Partial<ExpoCamera>)
+
 const QRScannerMobile = (p: Props): React.ReactElement | null => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const {CameraView, useCameraPermissions} = require('expo-camera') as typeof import('expo-camera')
   const [scanned, setScanned] = React.useState(false)
-  const [permission, requestPermission] = useCameraPermissions()
+  const [permission, requestPermission] = useCameraPermissions!()
 
   React.useEffect(() => {
     if (!permission) {
@@ -30,6 +36,7 @@ const QRScannerMobile = (p: Props): React.ReactElement | null => {
   if (!permission.granted) {
     return p.notAuthorizedView || null
   }
+  if (!CameraView) return null
 
   return (
     <CameraView

--- a/shared/scripts/react-compiler-bailouts.mts
+++ b/shared/scripts/react-compiler-bailouts.mts
@@ -12,7 +12,7 @@
 // as bailouts.
 import * as babel from '@babel/core'
 import {readFileSync, readdirSync, statSync} from 'fs'
-import {join, extname} from 'path'
+import {basename, join, extname} from 'path'
 
 type CompilerEvent = {
   kind: string
@@ -26,7 +26,7 @@ const skipDirs = new Set(['node_modules', '.git', 'dist'])
 const collectFiles = (path: string, out: Array<string>) => {
   const st = statSync(path)
   if (st.isDirectory()) {
-    if (skipDirs.has(path.split('/').at(-1) ?? '')) return
+    if (skipDirs.has(basename(path))) return
     for (const entry of readdirSync(path)) {
       collectFiles(join(path, entry), out)
     }

--- a/shared/scripts/react-compiler-bailouts.mts
+++ b/shared/scripts/react-compiler-bailouts.mts
@@ -64,6 +64,7 @@ const isOptedOut = (sourceLines: Array<string>, fnStartLine: number | undefined)
 let totalOk = 0
 let totalBail = 0
 let totalOptOut = 0
+let totalParseFailed = 0
 for (const file of files) {
   const source = readFileSync(file, 'utf8')
   const events: Array<CompilerEvent> = []
@@ -76,6 +77,7 @@ for (const file of files) {
       presets: [['@babel/preset-typescript', {allExtensions: true, isTSX: true}]],
     })
   } catch (e) {
+    totalParseFailed++
     console.log(`${file}: PARSE FAILED ${e instanceof Error ? e.message.split('\n')[0] : ''}`)
     continue
   }
@@ -94,9 +96,17 @@ for (const file of files) {
     }
   }
 }
-console.log(`\n${totalOk} compiled, ${totalBail} bailed out, ${totalOptOut} opted out, ${files.length} files`)
-if (checkMode && totalBail > 0) {
-  console.log("\nNew react-compiler bailouts. Fix them (often: move try/catch out of the component")
-  console.log("body into a helper) or add a 'use no memo' directive for an intentional opt-out.")
+console.log(
+  `\n${totalOk} compiled, ${totalBail} bailed out, ${totalOptOut} opted out, ${totalParseFailed} parse failed, ${files.length} files`
+)
+if (checkMode && (totalBail > 0 || totalParseFailed > 0)) {
+  if (totalParseFailed > 0) {
+    console.log('\nSome files failed to parse, so they could not be checked for bailouts.')
+  }
+  if (totalBail > 0) {
+    console.log(
+      "\nNew react-compiler bailouts. Fix them (often: move try/catch out of the component body into a helper) or add a 'use no memo' directive for an intentional opt-out."
+    )
+  }
   process.exit(1)
 }

--- a/shared/scripts/react-compiler-bailouts.mts
+++ b/shared/scripts/react-compiler-bailouts.mts
@@ -1,0 +1,102 @@
+// Reports react-compiler bailouts (components/hooks that did NOT get memoized).
+// The eslint react-hooks rules only surface rules-of-react violations, not
+// "Todo"-category syntax bailouts (e.g. value blocks inside try/catch), so this
+// uses the babel plugin's logger to see every compile attempt.
+//
+// Usage (from shared/):
+//   node --experimental-strip-types scripts/react-compiler-bailouts.mts <file-or-dir> [...more]
+//   node --experimental-strip-types scripts/react-compiler-bailouts.mts --check .   # exit 1 on any bailout
+//
+// Common fix: move try/catch out of the component body into a module-level helper.
+// Intentional opt-outs ('use no memo') are skipped by the compiler and don't count
+// as bailouts.
+import * as babel from '@babel/core'
+import {readFileSync, readdirSync, statSync} from 'fs'
+import {join, extname} from 'path'
+
+type CompilerEvent = {
+  kind: string
+  fnLoc?: {start?: {line: number}}
+  detail?: {options?: {reason?: string; category?: string; loc?: {start?: {line: number}}}}
+}
+
+const exts = new Set(['.tsx', '.ts'])
+const skipDirs = new Set(['node_modules', '.git', 'dist'])
+
+const collectFiles = (path: string, out: Array<string>) => {
+  const st = statSync(path)
+  if (st.isDirectory()) {
+    if (skipDirs.has(path.split('/').at(-1) ?? '')) return
+    for (const entry of readdirSync(path)) {
+      collectFiles(join(path, entry), out)
+    }
+  } else if (exts.has(extname(path)) && !path.endsWith('.d.ts')) {
+    out.push(path)
+  }
+}
+
+const args = process.argv.slice(2)
+const checkMode = args.includes('--check')
+const targets = args.filter(a => !a.startsWith('--'))
+if (targets.length === 0) {
+  console.error('usage: react-compiler-bailouts.mts [--check] <file-or-dir> [...more]')
+  process.exit(1)
+}
+
+const files: Array<string> = []
+for (const t of targets) {
+  collectFiles(t, files)
+}
+
+// The compiler logs a CompileError even for functions opted out via 'use no memo',
+// so treat a directive shortly after the function start as intentional. The window is
+// generous because the directive sits after the parameter list, which can span many
+// lines when props are destructured.
+const optOutWindow = 40
+const isOptedOut = (sourceLines: Array<string>, fnStartLine: number | undefined) => {
+  if (fnStartLine === undefined) return false
+  for (let l = fnStartLine - 1; l < Math.min(fnStartLine + optOutWindow, sourceLines.length); l++) {
+    if (sourceLines[l]?.includes('use no memo')) return true
+  }
+  return false
+}
+
+let totalOk = 0
+let totalBail = 0
+let totalOptOut = 0
+for (const file of files) {
+  const source = readFileSync(file, 'utf8')
+  const events: Array<CompilerEvent> = []
+  try {
+    babel.transformSync(source, {
+      babelrc: false,
+      configFile: false,
+      filename: file,
+      plugins: [['babel-plugin-react-compiler', {logger: {logEvent: (_: string, e: CompilerEvent) => events.push(e)}}]],
+      presets: [['@babel/preset-typescript', {allExtensions: true, isTSX: true}]],
+    })
+  } catch (e) {
+    console.log(`${file}: PARSE FAILED ${e instanceof Error ? e.message.split('\n')[0] : ''}`)
+    continue
+  }
+  const sourceLines = source.split('\n')
+  for (const e of events) {
+    if (e.kind === 'CompileSuccess') {
+      totalOk++
+    } else if (e.kind === 'CompileError') {
+      if (isOptedOut(sourceLines, e.fnLoc?.start?.line)) {
+        totalOptOut++
+        continue
+      }
+      totalBail++
+      const o = e.detail?.options
+      console.log(`${file}:${e.fnLoc?.start?.line ?? '?'} [${o?.category ?? '?'}] ${o?.reason ?? 'unknown'}`)
+    }
+  }
+}
+console.log(`\n${totalOk} compiled, ${totalBail} bailed out, ${totalOptOut} opted out, ${files.length} files`)
+if (checkMode && totalBail > 0) {
+  console.log("\nNew react-compiler bailouts. Fix them (often: move try/catch out of the component")
+  console.log("body into a helper) or add a 'use no memo' directive for an intentional opt-out.")
+  process.exit(1)
+}

--- a/shared/settings/feedback/shared.tsx
+++ b/shared/settings/feedback/shared.tsx
@@ -9,41 +9,47 @@ export const getExtraChatLogsForLogSend = () => {
   return {}
 }
 
+const sendFeedbackToDaemon = async (
+  feedback: string,
+  sendLogs: boolean,
+  sendMaxBytes: boolean,
+  setError: (e: string) => void
+) => {
+  // We don't want test devices (pre-launch reports) to send us log sends.
+  if (androidIsTestDevice) {
+    return
+  }
+  try {
+    setError('')
+    if (sendLogs) {
+      await logger.dump()
+    }
+    const status = {version}
+    logger.info(`Sending ${sendLogs ? 'log' : 'feedback'} to daemon`)
+    const extra = sendLogs ? {...status, ...getExtraChatLogsForLogSend()} : status
+    const logSendId = await T.RPCGen.configLogSendRpcPromise(
+      {
+        feedback: feedback || '',
+        sendLogs,
+        sendMaxBytes,
+        statusJSON: JSON.stringify(extra),
+      },
+      C.waitingKeySettingsSendFeedback
+    )
+    logger.info('logSendId is', logSendId)
+  } catch (error) {
+    if (!(error instanceof RPCError)) {
+      return
+    }
+    logger.warn('err in sending logs', error)
+    setError(error.desc)
+  }
+}
+
 export const useSendFeedback = () => {
   const [error, setError] = React.useState('')
   const sendFeedback = (feedback: string, sendLogs: boolean, sendMaxBytes: boolean) => {
-    const f = async () => {
-      // We don't want test devices (pre-launch reports) to send us log sends.
-      if (androidIsTestDevice) {
-        return
-      }
-      try {
-        setError('')
-        if (sendLogs) {
-          await logger.dump()
-        }
-        const status = {version}
-        logger.info(`Sending ${sendLogs ? 'log' : 'feedback'} to daemon`)
-        const extra = sendLogs ? {...status, ...getExtraChatLogsForLogSend()} : status
-        const logSendId = await T.RPCGen.configLogSendRpcPromise(
-          {
-            feedback: feedback || '',
-            sendLogs,
-            sendMaxBytes,
-            statusJSON: JSON.stringify(extra),
-          },
-          C.waitingKeySettingsSendFeedback
-        )
-        logger.info('logSendId is', logSendId)
-      } catch (error) {
-        if (!(error instanceof RPCError)) {
-          return
-        }
-        logger.warn('err in sending logs', error)
-        setError(error.desc)
-      }
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(sendFeedbackToDaemon(feedback, sendLogs, sendMaxBytes, setError))
   }
 
   return {error, sendFeedback}

--- a/shared/settings/files/index.tsx
+++ b/shared/settings/files/index.tsx
@@ -184,6 +184,8 @@ const ThresholdDropdown = (
 
 const FilesSettings = () => {
   const props = useFiles()
+  // unconditional: a hook inside the isMobile branch makes the react compiler bail
+  const waitingToggleSyncOnCellular = C.Waiting.useAnyWaiting(C.waitingKeyFSSetSyncOnCellular)
   if (isMobile) {
     const {
       onDisableSyncNotifications,
@@ -196,7 +198,6 @@ const FilesSettings = () => {
     const toggleSyncOnCellular = () => {
       setSyncOnCellular(!syncOnCellular)
     }
-    const waitingToggleSyncOnCellular = C.Waiting.useAnyWaiting(C.waitingKeyFSSetSyncOnCellular)
     return (
       <Kb.Box2
         direction="vertical"

--- a/shared/settings/notifications/use-notification-settings.tsx
+++ b/shared/settings/notifications/use-notification-settings.tsx
@@ -170,6 +170,58 @@ export const buildNotificationSavePayload = (
   return {JSONPayload, chatGlobalArg}
 }
 
+const saveNotificationSettings = async (
+  nextGroups: Map<string, NotificationsGroupState>,
+  prevGroups: Map<string, NotificationsGroupState>,
+  saveSubscriptionsRPC: (
+    args: Parameters<typeof T.RPCGen.apiserverPostJSONRpcPromise>,
+    setResult: (r: T.RPCGen.APIRes) => void,
+    setError: (e: RPCError) => void
+  ) => void,
+  saveGlobalSettingsRPC: (
+    args: Parameters<typeof T.RPCChat.localSetGlobalAppNotificationSettingsLocalRpcPromise>,
+    setResult: () => void,
+    setError: (e: RPCError) => void
+  ) => void,
+  setGroups: (groups: Map<string, NotificationsGroupState>) => void,
+  setAllowEdit: (allowEdit: boolean) => void
+) => {
+  try {
+    if (!nextGroups.get('email')) {
+      throw new Error('No notifications loaded yet')
+    }
+    const {JSONPayload, chatGlobalArg} = buildNotificationSavePayload(nextGroups)
+    const result = await new Promise<T.RPCGen.APIRes>((resolve, reject) => {
+      saveSubscriptionsRPC(
+        [
+          {
+            JSONPayload,
+            args: [],
+            endpoint: 'account/subscribe',
+          },
+          S.waitingKeySettingsGeneric,
+        ],
+        resolve,
+        reject
+      )
+    })
+    await new Promise<void>((resolve, reject) => {
+      saveGlobalSettingsRPC([{settings: {...chatGlobalArg}}, S.waitingKeySettingsGeneric], () => resolve(), reject)
+    })
+    if (
+      !result.body ||
+      (JSON.parse(result.body) as {status?: {code?: number}} | undefined)?.status?.code !== 0
+    ) {
+      throw new Error(`Invalid response ${result.body || '(no result)'}`)
+    }
+  } catch (error) {
+    logger.warn('Failed to save notification settings', error)
+    setGroups(prevGroups)
+  } finally {
+    setAllowEdit(true)
+  }
+}
+
 const useNotificationSettings = (): UseNotificationSettingsResult => {
   const loadSubscriptionsRPC = C.useRPC(T.RPCGen.apiserverGetWithSessionRpcPromise)
   const loadGlobalSettingsRPC = C.useRPC(T.RPCChat.localGetGlobalAppNotificationSettingsLocalRpcPromise)
@@ -238,47 +290,16 @@ const useNotificationSettings = (): UseNotificationSettingsResult => {
       setAllowEdit(false)
       setGroups(nextGroups)
 
-      const f = async () => {
-        try {
-          if (!nextGroups.get('email')) {
-            throw new Error('No notifications loaded yet')
-          }
-          const {JSONPayload, chatGlobalArg} = buildNotificationSavePayload(nextGroups)
-          const result = await new Promise<T.RPCGen.APIRes>((resolve, reject) => {
-            saveSubscriptionsRPC(
-              [
-                {
-                  JSONPayload,
-                  args: [],
-                  endpoint: 'account/subscribe',
-                },
-                S.waitingKeySettingsGeneric,
-              ],
-              resolve,
-              reject
-            )
-          })
-          await new Promise<void>((resolve, reject) => {
-            saveGlobalSettingsRPC(
-              [{settings: {...chatGlobalArg}}, S.waitingKeySettingsGeneric],
-              () => resolve(),
-              reject
-            )
-          })
-          if (
-            !result.body ||
-            (JSON.parse(result.body) as {status?: {code?: number}} | undefined)?.status?.code !== 0
-          ) {
-            throw new Error(`Invalid response ${result.body || '(no result)'}`)
-          }
-        } catch (error) {
-          logger.warn('Failed to save notification settings', error)
-          setGroups(prevGroups)
-        } finally {
-          setAllowEdit(true)
-        }
-      }
-      ignorePromise(f())
+      ignorePromise(
+        saveNotificationSettings(
+          nextGroups,
+          prevGroups,
+          saveSubscriptionsRPC,
+          saveGlobalSettingsRPC,
+          setGroups,
+          setAllowEdit
+        )
+      )
     },
     [allowEdit, groups, saveGlobalSettingsRPC, saveSubscriptionsRPC]
   )

--- a/shared/signup/device-name.tsx
+++ b/shared/signup/device-name.tsx
@@ -17,6 +17,69 @@ import {
 
 type Props = StaticScreenProps<{inviteCode?: string; username?: string}>
 
+const checkDeviceNameAndSignup = async (
+  devicename: string,
+  username: string,
+  inviteCode: string,
+  setError: (error: string) => void,
+  showPermissionsPrompt: (p: {justSignedUp: boolean}) => void,
+  navigateAppend: typeof C.Router2.navigateAppend
+) => {
+  try {
+    await T.RPCGen.deviceCheckDeviceNameFormatRpcPromise({name: devicename}, C.waitingKeySignup)
+  } catch (error_) {
+    if (error_ instanceof RPCError) {
+      setError(error_.desc)
+    }
+    return
+  }
+
+  if (!username || !devicename) {
+    logger.warn('Missing data during signup phase', username, devicename)
+    return
+  }
+
+  try {
+    showPermissionsPrompt({justSignedUp: true})
+    await T.RPCGen.signupSignupRpcListener({
+      customResponseIncomingCallMap: {
+        'keybase.1.gpgUi.wantToAddGPGKey': (_, response) => {
+          response.result(false)
+        },
+      },
+      incomingCallMap: {
+        'keybase.1.loginUi.displayPrimaryPaperKey': () => {},
+      },
+      params: {
+        botToken: '',
+        deviceName: devicename,
+        deviceType: isMobile ? T.RPCGen.DeviceType.mobile : T.RPCGen.DeviceType.desktop,
+        email: '',
+        genPGPBatch: false,
+        genPaper: false,
+        inviteCode,
+        passphrase: '',
+        randomPw: true,
+        skipGPG: true,
+        skipMail: true,
+        storeSecret: true,
+        username,
+        verifyEmail: true,
+      },
+      waitingKey: C.waitingKeySignup,
+    })
+    clearSignupDeviceNameDraft()
+  } catch (error_) {
+    if (error_ instanceof RPCError) {
+      showPermissionsPrompt({justSignedUp: false})
+      navigateAppend({
+        name: 'signupError',
+        params: {errorCode: error_.code, errorMessage: error_.desc},
+      })
+    }
+  }
+}
+
 const ConnectedEnterDevicename = (p: Props) => {
   const showPermissionsPrompt = usePushState(s => s.dispatch.showPermissionsPrompt)
   const initialDevicename = getSignupDeviceNameDraft()
@@ -28,62 +91,9 @@ const ConnectedEnterDevicename = (p: Props) => {
   const onContinue = (devicename: string) => {
     setError('')
     setSignupDeviceNameDraft(devicename)
-    const f = async () => {
-      try {
-        await T.RPCGen.deviceCheckDeviceNameFormatRpcPromise({name: devicename}, C.waitingKeySignup)
-      } catch (error_) {
-        if (error_ instanceof RPCError) {
-          setError(error_.desc)
-        }
-        return
-      }
-
-      if (!username || !devicename) {
-        logger.warn('Missing data during signup phase', username, devicename)
-        return
-      }
-
-      try {
-        showPermissionsPrompt({justSignedUp: true})
-        await T.RPCGen.signupSignupRpcListener({
-          customResponseIncomingCallMap: {
-            'keybase.1.gpgUi.wantToAddGPGKey': (_, response) => {
-              response.result(false)
-            },
-          },
-          incomingCallMap: {
-            'keybase.1.loginUi.displayPrimaryPaperKey': () => {},
-          },
-          params: {
-            botToken: '',
-            deviceName: devicename,
-            deviceType: isMobile ? T.RPCGen.DeviceType.mobile : T.RPCGen.DeviceType.desktop,
-            email: '',
-            genPGPBatch: false,
-            genPaper: false,
-            inviteCode,
-            passphrase: '',
-            randomPw: true,
-            skipGPG: true,
-            skipMail: true,
-            storeSecret: true,
-            username,
-            verifyEmail: true,
-          },
-          waitingKey: C.waitingKeySignup,
-        })
-        clearSignupDeviceNameDraft()
-      } catch (error_) {
-        if (error_ instanceof RPCError) {
-          showPermissionsPrompt({justSignedUp: false})
-          navigateAppend({
-            name: 'signupError',
-            params: {errorCode: error_.code, errorMessage: error_.desc},
-          })
-        }
-      }
-    }
-    ignorePromise(f())
+    ignorePromise(
+      checkDeviceNameAndSignup(devicename, username, inviteCode, setError, showPermissionsPrompt, navigateAppend)
+    )
   }
 
   return <EnterDevicename error={error} initialDevicename={initialDevicename} onBack={navigateUp} onContinue={onContinue} waiting={waiting} />

--- a/shared/teams/add-members-wizard/add-contacts.tsx
+++ b/shared/teams/add-members-wizard/add-contacts.tsx
@@ -28,8 +28,31 @@ type ContactsModule = {
   EnableContactsPopup: React.ComponentType<{noAccess: boolean; onClose: () => void}>
 }
 
+// Hoisted: resolving useContacts from require() during render makes the react
+// compiler bail (hooks must be the same function on every render). The require is
+// guarded so it never executes on desktop.
+// On desktop nothing here renders (AddContacts bails on !isMobile) so the empty
+// fallback is never dereferenced.
+const {
+  default: ContactsList,
+  useContacts,
+  EnableContactsPopup,
+} = (isMobile ? require('../common/contacts-list.native') : {}) as ContactsModule
+
+const addPreparedMembersToWizard = async (
+  wizard: AddMembersWizard,
+  members: Parameters<typeof addMembersToWizard>[1],
+  onError: (message: string) => void
+) => {
+  try {
+    const nextWizard = await addMembersToWizard(wizard, members)
+    C.Router2.navUpToScreen({name: 'teamAddToTeamConfirm', params: {wizard: nextWizard}}, true)
+  } catch (err) {
+    onError(err instanceof Error ? err.message : String(err))
+  }
+}
+
 const AddContactsMobile = ({wizard}: {wizard: AddMembersWizard}) => {
-  const {default: ContactsList, useContacts, EnableContactsPopup} = require('../common/contacts-list.native') as ContactsModule
   const onBack = C.Router2.navigateUp
   const [search, setSearch] = React.useState('')
   const [selectedPhones, setSelectedPhones] = React.useState(new Set<string>())
@@ -72,24 +95,16 @@ const AddContactsMobile = ({wizard}: {wizard: AddMembersWizard}) => {
         [{emails: [...selectedEmails].join(','), phoneNumbers: [...selectedPhones]}],
         r => {
           if (r?.length) {
-            const f = async () => {
-              try {
-                const nextWizard = await addMembersToWizard(
-                  wizard,
-                  r.map(m => ({
-                    ...(m.foundUser
-                      ? {assertion: m.username, resolvedFrom: m.assertion}
-                      : {assertion: m.assertion}),
-                    role: 'writer',
-                  }))
-                )
-                C.Router2.navUpToScreen({name: 'teamAddToTeamConfirm', params: {wizard: nextWizard}}, true)
-              } catch (err) {
+            const members = r.map(m => ({
+              ...(m.foundUser ? {assertion: m.username, resolvedFrom: m.assertion} : {assertion: m.assertion}),
+              role: 'writer' as const,
+            }))
+            C.ignorePromise(
+              addPreparedMembersToWizard(wizard, members, message => {
                 setWaiting(false)
-                setError(err instanceof Error ? err.message : String(err))
-              }
-            }
-            C.ignorePromise(f())
+                setError(message)
+              })
+            )
           } else {
             setWaiting(false)
             setError('Could not add any of the selected contacts. Try another contact or method.')

--- a/shared/teams/channel/create-channels.tsx
+++ b/shared/teams/channel/create-channels.tsx
@@ -12,6 +12,39 @@ const CreateChannels = (props: Props) => {
   return <CreateChannelsInner key={props.teamID} teamID={props.teamID} />
 }
 
+const submitChannels = async (
+  channels: Array<string>,
+  teamID: T.Teams.TeamID,
+  teamname: string,
+  setError: (error: string) => void,
+  setSuccess: (success: boolean) => void,
+  setWaiting: (waiting: boolean) => void
+) => {
+  try {
+    for (const channelname of channels) {
+      await T.RPCChat.localNewConversationLocalRpcPromise(
+        {
+          identifyBehavior: T.RPCGen.TLFIdentifyBehavior.chatGui,
+          membersType: T.RPCChat.ConversationMembersType.team,
+          tlfName: teamname,
+          tlfVisibility: T.RPCGen.TLFVisibility.private,
+          topicName: channelname,
+          topicType: T.RPCChat.TopicType.chat,
+        },
+        C.waitingKeyTeamsCreateChannel(teamID)
+      )
+    }
+    setSuccess(true)
+    C.Router2.clearModals()
+  } catch (error_) {
+    if (error_ instanceof RPCError) {
+      setError(error_.desc)
+    }
+  } finally {
+    setWaiting(false)
+  }
+}
+
 const CreateChannelsInner = (props: Props) => {
   const teamID = props.teamID
   const {
@@ -42,32 +75,7 @@ const CreateChannelsInner = (props: Props) => {
     setSuccess(false)
     setWaiting(true)
 
-    const f = async () => {
-      try {
-        for (const channelname of channels) {
-          await T.RPCChat.localNewConversationLocalRpcPromise(
-            {
-              identifyBehavior: T.RPCGen.TLFIdentifyBehavior.chatGui,
-              membersType: T.RPCChat.ConversationMembersType.team,
-              tlfName: teamname,
-              tlfVisibility: T.RPCGen.TLFVisibility.private,
-              topicName: channelname,
-              topicType: T.RPCChat.TopicType.chat,
-            },
-            C.waitingKeyTeamsCreateChannel(teamID)
-          )
-        }
-        setSuccess(true)
-        C.Router2.clearModals()
-      } catch (error_) {
-        if (error_ instanceof RPCError) {
-          setError(error_.desc)
-        }
-      } finally {
-        setWaiting(false)
-      }
-    }
-    void f()
+    void submitChannels(channels, teamID, teamname, setError, setSuccess, setWaiting)
   }
   return (
     <CreateChannelsModal

--- a/shared/teams/invite-by-contact/team-invite-by-contacts.tsx
+++ b/shared/teams/invite-by-contact/team-invite-by-contacts.tsx
@@ -77,6 +77,23 @@ const generateSMSBody = (teamname: string, seitan: string): string => {
   return `Join the ${team} on Keybase. Copy this message into the "Teams" tab.\n\ntoken: ${seitan.toLowerCase()}\n\ninstall: keybase.io/_/go`
 }
 
+const sendSMSInvite = async (
+  contact: Contact,
+  teamname: string,
+  seitan: string,
+  setInviteErrorMessage: (message: string) => void,
+  updateLoadingInvite: (loadingKey: string, isLoading: boolean) => void
+) => {
+  try {
+    await openSMS([contact.valueFormatted || contact.value], generateSMSBody(teamname, seitan))
+  } catch (error) {
+    logger.info('Error sending SMS', error)
+    setInviteErrorMessage('Failed to open SMS composer.')
+  } finally {
+    updateLoadingInvite(contact.value, false)
+  }
+}
+
 const TeamInviteByContactMobile = (props: Props) => {
   const {teamID} = props
   const {contacts, region, errorMessage} = useContacts()
@@ -153,16 +170,7 @@ const TeamInviteByContactMobile = (props: Props) => {
           ],
           seitan => {
             C.ignorePromise(
-              (async () => {
-                try {
-                  await openSMS([contact.valueFormatted || contact.value], generateSMSBody(teamname, seitan))
-                } catch (error) {
-                  logger.info('Error sending SMS', error)
-                  setInviteErrorMessage('Failed to open SMS composer.')
-                } finally {
-                  updateLoadingInvite(contact.value, false)
-                }
-              })()
+              sendSMSInvite(contact, teamname, seitan, setInviteErrorMessage, updateLoadingInvite)
             )
           },
           error => {

--- a/shared/teams/team/rows/invite-row/invite.tsx
+++ b/shared/teams/team/rows/invite-row/invite.tsx
@@ -78,19 +78,9 @@ type OwnProps = {
  */
 const labelledInviteRegex = /^(.+?) \((.+)\)$/
 
-// TODO: when removing flags.teamsRedesign, move this into the component itself
-const Container = (ownProps: OwnProps) => {
-  const {teamID} = ownProps
-  const {teamDetails} = useLoadedTeam(teamID)
-  const invites = teamDetails.invites
-
-  const user = [...invites].find(invite => invite.id === ownProps.id) || Teams.emptyInviteInfo
-
+const getLabels = (user: T.Teams.InviteInfo) => {
   let label = user.username || user.name || user.email || user.phone
   let subLabel: undefined | string = user.name ? user.phone || user.email : undefined
-  const role = user.role
-  const isKeybaseUser = !!user.username
-  const onCancelInvite = () => removePendingInvite(teamID, ownProps.id)
   if (!subLabel && labelledInviteRegex.test(label)) {
     const match = labelledInviteRegex.exec(label)!
     label = match[1] ?? ''
@@ -100,6 +90,21 @@ const Container = (ownProps: OwnProps) => {
     label = label === user.phone ? formatPhoneNumber('+' + label) : label
     subLabel = subLabel === user.phone ? formatPhoneNumber('+' + subLabel) : subLabel
   } catch {}
+  return {label, subLabel}
+}
+
+// TODO: when removing flags.teamsRedesign, move this into the component itself
+const Container = (ownProps: OwnProps) => {
+  const {teamID} = ownProps
+  const {teamDetails} = useLoadedTeam(teamID)
+  const invites = teamDetails.invites
+
+  const user = [...invites].find(invite => invite.id === ownProps.id) || Teams.emptyInviteInfo
+
+  const {label, subLabel} = getLabels(user)
+  const role = user.role
+  const isKeybaseUser = !!user.username
+  const onCancelInvite = () => removePendingInvite(teamID, ownProps.id)
   return <TeamInviteRow firstItem={ownProps.firstItem} isKeybaseUser={isKeybaseUser} label={label} onCancelInvite={onCancelInvite} role={role} subLabel={subLabel} />
 }
 

--- a/shared/teams/team/settings-tab/index.tsx
+++ b/shared/teams/team/settings-tab/index.tsx
@@ -367,9 +367,11 @@ const Container = (ownProps: OwnProps) => {
   const savePublicity = React.useCallback(
     (settings: T.Teams.PublicitySettings) => {
       void (async () => {
+        const openChanged =
+          openTeam !== settings.openTeam || (settings.openTeam && openTeamRole !== settings.openTeamRole)
         try {
           let changed = false
-          if (openTeam !== settings.openTeam || (settings.openTeam && openTeamRole !== settings.openTeamRole)) {
+          if (openChanged) {
             changed = true
             await callRPC(setTeamSettingsRPC, [
               {

--- a/shared/teams/team/settings-tab/retention/index.tsx
+++ b/shared/teams/team/settings-tab/retention/index.tsx
@@ -382,6 +382,28 @@ const policyToExplanation = (
   return exp
 }
 
+const loadTeamRetentionPolicy = async (
+  teamID: T.Teams.TeamID,
+  shouldApply: () => boolean,
+  setTeamRetentionPolicy: (policy?: T.RPCChat.RetentionPolicy | null) => void
+) => {
+  try {
+    const servicePolicy = await T.RPCChat.localGetTeamRetentionLocalRpcPromise(
+      {teamID},
+      C.waitingKeyTeamsLoadRetentionPolicy(teamID)
+    )
+    if (!shouldApply()) {
+      return
+    }
+    setTeamRetentionPolicy(servicePolicy)
+  } catch {
+    if (!shouldApply()) {
+      return
+    }
+    setTeamRetentionPolicy(undefined)
+  }
+}
+
 const useLoadedTeamRetentionPolicy = (teamID: T.Teams.TeamID) => {
   type TeamRetentionState = {
     loadedTeamID?: T.Teams.TeamID
@@ -402,21 +424,11 @@ const useLoadedTeamRetentionPolicy = (teamID: T.Teams.TeamID) => {
 
   const reload = React.useCallback(async () => {
     const requestVersion = ++requestVersionRef.current
-    try {
-      const servicePolicy = await T.RPCChat.localGetTeamRetentionLocalRpcPromise(
-        {teamID},
-        C.waitingKeyTeamsLoadRetentionPolicy(teamID)
-      )
-      if (requestVersion !== requestVersionRef.current) {
-        return
-      }
-      setTeamRetentionPolicy(servicePolicy)
-    } catch {
-      if (requestVersion !== requestVersionRef.current) {
-        return
-      }
-      setTeamRetentionPolicy(undefined)
-    }
+    await loadTeamRetentionPolicy(
+      teamID,
+      () => requestVersion === requestVersionRef.current,
+      setTeamRetentionPolicy
+    )
   }, [setTeamRetentionPolicy, teamID])
 
   React.useEffect(() => {
@@ -429,24 +441,11 @@ const useLoadedTeamRetentionPolicy = (teamID: T.Teams.TeamID) => {
   React.useEffect(() => {
     let canceled = false
     const requestVersion = ++requestVersionRef.current
-    const load = async () => {
-      try {
-        const servicePolicy = await T.RPCChat.localGetTeamRetentionLocalRpcPromise(
-          {teamID},
-          C.waitingKeyTeamsLoadRetentionPolicy(teamID)
-        )
-        if (canceled || requestVersion !== requestVersionRef.current) {
-          return
-        }
-        setTeamRetentionPolicy(servicePolicy)
-      } catch {
-        if (canceled || requestVersion !== requestVersionRef.current) {
-          return
-        }
-        setTeamRetentionPolicy(undefined)
-      }
-    }
-    void load()
+    void loadTeamRetentionPolicy(
+      teamID,
+      () => !canceled && requestVersion === requestVersionRef.current,
+      setTeamRetentionPolicy
+    )
     return () => {
       canceled = true
     }

--- a/shared/teams/use-cached-resource.tsx
+++ b/shared/teams/use-cached-resource.tsx
@@ -121,6 +121,49 @@ export const getCachedResourceCache = <T, K>(
   return created
 }
 
+const runLoad = async <T, K>(
+  cache: CachedResourceCache<T, K>,
+  cacheKey: K,
+  initialData: T,
+  load: () => Promise<T>,
+  onError: ((error: unknown) => void) | undefined,
+  requestVersion: number,
+  requestVersionRef: React.RefObject<number>,
+  setState: React.Dispatch<React.SetStateAction<StoredCachedResourceState<T, K>>>
+) => {
+  let request: Promise<T> | undefined
+  try {
+    const inFlight = cache.getInFlight()
+    if (inFlight) {
+      const data = await inFlight
+      if (requestVersion === requestVersionRef.current) {
+        setState(storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false}))
+      }
+      return
+    }
+    const generation = cache.getGeneration()
+    request = load().then(data => {
+      cache.setDataLoaded(data, generation)
+      return data
+    })
+    cache.setInFlight(request)
+    const data = await request
+    if (requestVersion === requestVersionRef.current) {
+      setState(storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false}))
+    }
+  } catch (error) {
+    if (requestVersion !== requestVersionRef.current) {
+      return
+    }
+    onError?.(error)
+    setState(prev => ({...prev, loading: false}))
+  } finally {
+    if (request) {
+      cache.clearInFlight(request)
+    }
+  }
+}
+
 export const useCachedResource = <T, K>(props: Props<T, K>) => {
   const {cache, cacheKey, enabled = true, initialData, load, onError, refreshKey, staleMs} = props
   const [state, setState] = React.useState<StoredCachedResourceState<T, K>>(() =>
@@ -192,37 +235,7 @@ export const useCachedResource = <T, K>(props: Props<T, K>) => {
           ? {...prev, loading: true}
           : storedState(cache, cacheKey, initialData, {...emptyState(initialData), loading: true})
       )
-      let request: Promise<T> | undefined
-      try {
-        const inFlight = cache.getInFlight()
-        if (inFlight) {
-          const data = await inFlight
-          if (requestVersion === requestVersionRef.current) {
-            setState(storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false}))
-          }
-          return
-        }
-        const generation = cache.getGeneration()
-        request = load().then(data => {
-          cache.setDataLoaded(data, generation)
-          return data
-        })
-        cache.setInFlight(request)
-        const data = await request
-        if (requestVersion === requestVersionRef.current) {
-          setState(storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false}))
-        }
-      } catch (error) {
-        if (requestVersion !== requestVersionRef.current) {
-          return
-        }
-        onError?.(error)
-        setState(prev => ({...prev, loading: false}))
-      } finally {
-        if (request) {
-          cache.clearInFlight(request)
-        }
-      }
+      await runLoad(cache, cacheKey, initialData, load, onError, requestVersion, requestVersionRef, setState)
     },
     []
   )

--- a/shared/tracker/use-profile.tsx
+++ b/shared/tracker/use-profile.tsx
@@ -24,6 +24,52 @@ type Options = {
   reloadOnFocus?: boolean
 }
 
+const loadNonUserDetails = async (
+  username: string,
+  version: number,
+  requestVersionRef: React.RefObject<number>,
+  setNonUserDetails: React.Dispatch<
+    React.SetStateAction<{details: T.Tracker.NonUserDetails; username: string}>
+  >
+) => {
+  const assertion = username
+  try {
+    const res = await T.RPCGen.userSearchGetNonUserDetailsRpcPromise({assertion})
+    if (requestVersionRef.current !== version || !res.isNonUser) {
+      return
+    }
+    const common = {
+      assertionKey: res.assertionKey,
+      assertionValue: res.assertionValue,
+      description: res.description,
+      siteIcon: res.siteIcon || [],
+      siteIconDarkmode: res.siteIconDarkmode || [],
+      siteIconFull: res.siteIconFull || [],
+      siteIconFullDarkmode: res.siteIconFullDarkmode || [],
+      siteURL: '',
+    }
+    if (res.service) {
+      setNonUserDetails({details: {...noNonUserDetails, ...common, ...res.service}, username})
+    } else {
+      const {formatPhoneNumberInternational} = await import('@/util/phone-numbers')
+      const formattedName =
+        res.assertionKey === 'phone' ? formatPhoneNumberInternational('+' + res.assertionValue) : undefined
+      const fullName = res.contact?.contactName ?? ''
+      if (requestVersionRef.current !== version) {
+        return
+      }
+      setNonUserDetails({
+        details: {...noNonUserDetails, ...common, formattedName, fullName},
+        username,
+      })
+    }
+  } catch (error) {
+    if (error instanceof RPCError) {
+      logger.warn(`Error loading non user profile: ${error.message}`)
+    }
+  }
+}
+
 export const useTrackerProfile = (username: string, options?: Options) => {
   const currentUser = useCurrentUserState(
     C.useShallow(s => ({
@@ -48,46 +94,9 @@ export const useTrackerProfile = (username: string, options?: Options) => {
     if (!username) {
       return
     }
-    const assertion = username
-    const version = requestVersionRef.current
-    const f = async () => {
-      try {
-        const res = await T.RPCGen.userSearchGetNonUserDetailsRpcPromise({assertion})
-        if (requestVersionRef.current !== version || !res.isNonUser) {
-          return
-        }
-        const common = {
-          assertionKey: res.assertionKey,
-          assertionValue: res.assertionValue,
-          description: res.description,
-          siteIcon: res.siteIcon || [],
-          siteIconDarkmode: res.siteIconDarkmode || [],
-          siteIconFull: res.siteIconFull || [],
-          siteIconFullDarkmode: res.siteIconFullDarkmode || [],
-          siteURL: '',
-        }
-        if (res.service) {
-          setNonUserDetails({details: {...noNonUserDetails, ...common, ...res.service}, username})
-        } else {
-          const {formatPhoneNumberInternational} = await import('@/util/phone-numbers')
-          const formattedName =
-            res.assertionKey === 'phone' ? formatPhoneNumberInternational('+' + res.assertionValue) : undefined
-          const fullName = res.contact?.contactName ?? ''
-          if (requestVersionRef.current !== version) {
-            return
-          }
-          setNonUserDetails({
-            details: {...noNonUserDetails, ...common, formattedName, fullName},
-            username,
-          })
-        }
-      } catch (error) {
-        if (error instanceof RPCError) {
-          logger.warn(`Error loading non user profile: ${error.message}`)
-        }
-      }
-    }
-    ignorePromise(f())
+    ignorePromise(
+      loadNonUserDetails(username, requestVersionRef.current, requestVersionRef, setNonUserDetails)
+    )
   }, [username])
 
   const loadProfile = React.useCallback(

--- a/shared/util/zoom-toolkit/ResumableZoom.tsx
+++ b/shared/util/zoom-toolkit/ResumableZoom.tsx
@@ -32,6 +32,8 @@ const ResumableZoom = ({
   onUpdate,
   onSwipe,
 }: ResumableZoomProps) => {
+  // vendored reanimated gesture code; shared-value writes during render are intentional
+  'use no memo'
   if (userMaxScale < 1) {
     throw new Error('ResumableZoom: maxScale must be >= 1')
   }

--- a/shared/util/zoom-toolkit/commons/hooks/useDoubleTapCommons.ts
+++ b/shared/util/zoom-toolkit/commons/hooks/useDoubleTapCommons.ts
@@ -26,6 +26,8 @@ export const useDoubleTapCommons = ({
   boundsFn,
   onGestureEnd,
 }: DoubleTapOptions) => {
+  // vendored reanimated gesture code; shared-value writes during render are intentional
+  'use no memo'
   const [isPanGestureEnabled, setIsPanGestureEnabled] = useState<boolean>(true)
 
   const onDoubleTapStart = () => {

--- a/shared/util/zoom-toolkit/commons/hooks/usePanCommons.ts
+++ b/shared/util/zoom-toolkit/commons/hooks/usePanCommons.ts
@@ -41,6 +41,8 @@ type PanCommmonOptions = {
 type PanGestureUpdadeEvent = GestureUpdateEvent<PanGestureHandlerEventPayload & PanGestureChangeEventPayload>
 
 export const usePanCommons = (options: PanCommmonOptions) => {
+  // vendored reanimated gesture code; shared-value writes during render are intentional
+  'use no memo'
   const {container, translate, offset, panMode, decay, boundFn, userCallbacks} = options
   const {onSwipe, onGestureEnd, onOverPanning} = userCallbacks
 

--- a/shared/util/zoom-toolkit/commons/hooks/usePinchCommons.ts
+++ b/shared/util/zoom-toolkit/commons/hooks/usePinchCommons.ts
@@ -39,6 +39,8 @@ type PinchOptions = {
 type PinchGestueUpdateEvent = GestureUpdateEvent<PinchGestureHandlerEventPayload>
 
 export const usePinchCommons = (options: PinchOptions) => {
+  // vendored reanimated gesture code; shared-value writes during render are intentional
+  'use no memo'
   const {
     container,
     translate,

--- a/shared/util/zoom-toolkit/useImageResolution.ts
+++ b/shared/util/zoom-toolkit/useImageResolution.ts
@@ -11,6 +11,8 @@ export type FetchImageResolutionResult = {
 }
 
 export default function useImageResolution(source: Source | number): FetchImageResolutionResult {
+  // vendored code with an eslint suppression the compiler refuses to optimize past
+  'use no memo'
   const deps = JSON.stringify(source)
   const [resolvedDeps, setResolvedDeps] = useState('')
   const [resolution, setResolution] = useState<SizeVector<number> | undefined>(undefined)


### PR DESCRIPTION
Chat thread rows: split center-context into state/actions contexts so action-only consumers skip highlight re-renders, subscribe to derived isEditing instead of the raw editing ordinal, replace the per-row team-members hook with a context-only role lookup, compute separator orange-line labels only when shown, and merge the duplicated useMessageData hooks.

The react compiler bailed out of 81 components/hooks — notably the markdown component, which re-parsed on every text row render. Move try/catch/finally, ??=, getters, dynamic imports, and render-time require()d hooks out of compiled function bodies; opt vendored zoom-toolkit out via 'use no memo'. Now 0 bailouts repo-wide.

Add yarn lint:bailouts (scripts/react-compiler-bailouts.mts) and yarn lint:all (eslint + bailouts + tsc). eslint cannot report Todo-category bailouts, so the script is the only guard against new ones.

Also fix shared-timers _removeTimer off-by-one that never cleared the first timer.