### PR TITLE
fix(native): correctness and perf fixes in iOS/Android bridge

### DIFF
--- a/rnmodules/kb-common/src/ItemProviderHelper.swift
+++ b/rnmodules/kb-common/src/ItemProviderHelper.swift
@@ -124,78 +124,41 @@ public class ItemProviderHelper: NSObject {
     return incomingShareFolderURL.appendingPathComponent("manifest.json")
   }
 
-  private func ensureArray(ofType type: String) -> [[String: Any]] {
-    if typeToArray[type] == nil {
-      typeToArray[type] = []
+  private func completeItemAndAppend(type: String, entry: [String: Any]) {
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      self.typeToArray[type, default: []].append(entry)
+      self.completeProcessingItemAlreadyInMainThread()
     }
-    return typeToArray[type]!
   }
 
   private func completeItemAndAppendManifest(type: String, originalFileURL: URL) {
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      var arr = self.ensureArray(ofType: type)
-      arr.append([
-        "type": type,
-        "originalPath": originalFileURL.absoluteURL.path,
-      ])
-      self.typeToArray[type] = arr
-      self.completeProcessingItemAlreadyInMainThread()
-    }
+    completeItemAndAppend(type: type, entry: [
+      "type": type,
+      "originalPath": originalFileURL.absoluteURL.path,
+    ])
   }
 
   private func completeItemAndAppendManifest(type: String, content: String) {
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      var arr = self.ensureArray(ofType: type)
-      arr.append([
-        "type": type,
-        "content": content,
-      ])
-      self.typeToArray[type] = arr
-      self.completeProcessingItemAlreadyInMainThread()
-    }
-  }
-
-  private func completeItemAndAppendManifest(type: String, originalFileURL: URL, content: String) {
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      var arr = self.ensureArray(ofType: type)
-      arr.append([
-        "type": type,
-        "originalPath": originalFileURL.absoluteURL.path,
-        "content": content,
-      ])
-      self.typeToArray[type] = arr
-      self.completeProcessingItemAlreadyInMainThread()
-    }
+    completeItemAndAppend(type: type, entry: [
+      "type": type,
+      "content": content,
+    ])
   }
 
   private func completeItemAndAppendManifest(type: String, originalFileURL: URL, scaledFileURL: URL)
   {
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      var arr = self.ensureArray(ofType: type)
-      arr.append([
-        "type": type,
-        "originalPath": originalFileURL.absoluteURL.path,
-        "scaledPath": scaledFileURL.absoluteURL.path,
-      ])
-      self.typeToArray[type] = arr
-      self.completeProcessingItemAlreadyInMainThread()
-    }
+    completeItemAndAppend(type: type, entry: [
+      "type": type,
+      "originalPath": originalFileURL.absoluteURL.path,
+      "scaledPath": scaledFileURL.absoluteURL.path,
+    ])
   }
 
   private func completeItemAndAppendManifestAndLogError(text: String, error: Error?) {
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      var arr = self.ensureArray(ofType: "error")
-      arr.append([
-        "error": "\(text): \(error != nil ? String(describing: error!) : "<empty>")"
-      ])
-      self.typeToArray["error"] = arr
-      self.completeProcessingItemAlreadyInMainThread()
-    }
+    completeItemAndAppend(type: "error", entry: [
+      "error": "\(text): \(error != nil ? String(describing: error!) : "<empty>")"
+    ])
   }
 
   private func writeManifest() {
@@ -404,7 +367,7 @@ public class ItemProviderHelper: NSObject {
     }
 
     let imageHandler: @Sendable (NSSecureCoding?, Error?) -> Void = { item, error in
-      var imgData: Data?  // Changed to var so we can modify it
+      var imgData: Data?
       if error == nil {
         if let url = item as? URL {
           imgData = try? Data(contentsOf: url)
@@ -431,7 +394,7 @@ public class ItemProviderHelper: NSObject {
     }
 
     let secureTextHandler: @Sendable (NSSecureCoding?, Error?) -> Void = { item, error in
-      var text: String?  // Changed to var so we can modify it
+      var text: String?
       if error == nil {
         if let str = item as? String {
           text = str
@@ -448,7 +411,6 @@ public class ItemProviderHelper: NSObject {
       self.sendText(text ?? "")
     }
 
-    // Rest of the method remains the same...
     for items in itemArrs as! [[NSItemProvider]] {
       // Only handle one from itemArrs if we're already processing
       objc_sync_enter(self)
@@ -495,16 +457,8 @@ public class ItemProviderHelper: NSObject {
               forTypeIdentifier: "public.vcard", completionHandler: contactHandler)
             break
           }
-          // Plain Text (two attempts - direct and coerced)
+          // Plain Text
           else if type.conforms(to: .plainText) {
-            incrementUnprocessed()
-            item.loadItem(
-              forTypeIdentifier: "public.plain-text", options: nil,
-              completionHandler: { (item: NSSecureCoding?, error: Error?) in
-                let text = item as? String ?? ""
-                self.sendText(text)
-              })
-
             incrementUnprocessed()
             item.loadItem(
               forTypeIdentifier: "public.plain-text", options: nil,

--- a/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
+++ b/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
@@ -5,16 +5,12 @@ import android.app.DownloadManager
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
-import android.content.res.AssetFileDescriptor
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.os.Handler
-import android.os.Looper
 import android.provider.Settings
 import android.text.format.DateFormat
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.FileProvider
@@ -22,17 +18,12 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings
 import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder
 import com.facebook.proguard.annotations.DoNotStrip
-import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
@@ -41,39 +32,17 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileReader
 import java.io.IOException
-import java.io.InputStreamReader
-import java.lang.reflect.Field
 import java.lang.reflect.Method
-import java.util.HashMap
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import keybase.Keybase
 import keybase.Keybase.readArr
 import keybase.Keybase.version
 import keybase.Keybase.writeArr
-import android.media.MediaMetadataRetriever
-import androidx.media3.transformer.TransformationRequest
-import androidx.media3.transformer.Transformer
-import androidx.media3.transformer.EditedMediaItem
-import androidx.media3.transformer.Effects
-import androidx.media3.effect.ScaleAndRotateTransformation
-import androidx.media3.common.MediaItem
-import androidx.media3.common.MimeTypes
-import androidx.media3.transformer.Transformer.Listener
-import androidx.media3.transformer.Composition
-import androidx.media3.transformer.ExportException
-import androidx.media3.transformer.ExportResult
-import androidx.media3.transformer.VideoEncoderSettings
-import androidx.media3.transformer.DefaultEncoderFactory
-import java.nio.ByteBuffer
-import kotlin.math.min
 
 class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), TurboModuleWithJSIBindings {
     private val misTestDevice: Boolean
-    private val initialIntent: HashMap<String?, String?>? = null
     private val reactContext: ReactApplicationContext
 
     @DoNotStrip
@@ -81,6 +50,7 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
     private external fun nativeOnDataFromGo(data: ByteArray)
 
     private var executor: ExecutorService? = null
+    private var lifecycleListenerRegistered = false
 
     override fun getName(): String {
         return NAME
@@ -103,29 +73,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
     override fun setEnablePasteImage(enabled: Boolean) {
         // not used
     }
-
-    private fun calculateOutputDimensions(width: Int, height: Int, maxPixels: Int): Pair<Int, Int> {
-        val pixelCount = width * height
-        if (pixelCount <= maxPixels) {
-            return Pair(width, height)
-        }
-
-        val scale = kotlin.math.sqrt(maxPixels.toDouble() / pixelCount)
-        val newWidth = (width * scale).toInt().let { if (it % 2 == 0) it else it - 1 }
-        val newHeight = (height * scale).toInt().let { if (it % 2 == 0) it else it - 1 }
-        return Pair(newWidth, newHeight)
-    }
-
-    private fun calculateBitrate(width: Int, height: Int): Int {
-        val pixelCount = width * height
-        return when {
-            pixelCount > 1920 * 1080 -> 8000000 // 8 Mbps for > 1080p
-            pixelCount > 1280 * 720 -> 5000000  // 5 Mbps for 1080p
-            else -> 3000000 // 3 Mbps for 720p and below
-        }
-    }
-
-
 
     /**
      * Gets a field from the project's BuildConfig. This is useful when, for example, flavors
@@ -345,10 +292,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         misTestDevice = isTestDevice(reactContext)
     }
 
-    private fun isAsset(path: String): Boolean {
-        return path.startsWith(FILE_PREFIX_BUNDLE_ASSET)
-    }
-
     private fun normalizePath(path: String): String {
         if (!Regex("""\w+\:.*""").matches(path)) {
             return path
@@ -361,38 +304,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
             return path
         } else {
             return PathResolver.getRealPathFromURI(reactContext, uri) ?: ""
-        }
-    }
-
-    // download
-    private fun statFile(_path: String): WritableMap? {
-        var path  = _path
-        return try {
-            path = normalizePath(path)
-            val stat: WritableMap = Arguments.createMap()
-            if (isAsset(path)) {
-                val name: String = path.replace(FILE_PREFIX_BUNDLE_ASSET, "")
-                val fd: AssetFileDescriptor = reactContext.assets.openFd(name)
-                stat.putString("filename", name)
-                stat.putString("path", path)
-                stat.putString("type", "asset")
-                stat.putString("size", fd.length.toString())
-                stat.putInt("lastModified", 0)
-            } else {
-                val target = File(path)
-                if (!target.exists()) {
-                    return null
-                }
-                stat.putString("filename", target.name)
-                stat.putString("path", target.path)
-                stat.putString("type", if (target.isDirectory) "directory" else "file")
-                stat.putString("size", target.length().toString())
-                val lastModified: String = target.lastModified().toString()
-                stat.putString("lastModified", lastModified)
-            }
-            stat
-        } catch (err: Exception) {
-            null
         }
     }
 
@@ -410,14 +321,8 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
             return
         }
         try {
-            val stat: WritableMap? = statFile(path)
-            var size = 0L
-            if (stat != null) {
-                val sizeStr = stat.getString("size")
-                if (sizeStr != null) {
-                    size = sizeStr.toLong()
-                }
-            }
+            val target = File(path)
+            val size = if (target.exists()) target.length() else 0L
             @Suppress("DEPRECATION")
             dm.addCompletedDownload(
                     if (config.hasKey("title")) config.getString("title") else "",
@@ -457,7 +362,9 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
 
     @ReactMethod
     override fun getInitialNotification(promise: Promise) {
+        // Clear on read so it behaves as a one-shot, matching iOS.
         val bundle = KbModule.initialNotificationBundle
+        KbModule.initialNotificationBundle = null
         if (bundle != null) {
             try {
                 @Suppress("UNCHECKED_CAST")
@@ -472,18 +379,15 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
     }
 
     private fun emitPushNotificationInternal(notification: Bundle) {
-        android.util.Log.d("KbModule", "emitPushNotificationInternal called")
         if (reactContext.hasActiveReactInstance()) {
-            android.util.Log.d("KbModule", "emitPushNotificationInternal has active react instance, emitting event")
             try {
                 val payload = Arguments.fromBundle(notification)
                 reactContext.emitDeviceEvent("onPushNotification", payload)
-                android.util.Log.d("KbModule", "emitPushNotificationInternal event emitted successfully")
             } catch (e: Exception) {
-                android.util.Log.e("KbModule", "emitPushNotificationInternal failed to emit: " + e.message)
+                NativeLogger.error("emitPushNotificationInternal failed to emit: " + e.message)
             }
         } else {
-            android.util.Log.w("KbModule", "emitPushNotificationInternal no active react instance")
+            NativeLogger.warn("emitPushNotificationInternal no active react instance")
         }
     }
 
@@ -522,12 +426,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         promise.resolve(null)
     }
 
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    override fun install(): Boolean {
-        // No-op: JSI bindings are now installed via TurboModuleWithJSIBindings.getBindingsInstaller()
-        return true
-    }
-
     @ReactMethod
     override fun engineReset() {
         try {
@@ -545,41 +443,39 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
             // Signal to Go that JS is ready
             Keybase.notifyJSReady()
 
-            // Start the executor to read from Go
-            if (executor == null) {
-                val ex = Executors.newSingleThreadExecutor()
-                executor = ex
-                ex.execute(ReadFromKBLib(reactContext))
+            startReadLoop()
+
+            // Register once; restart the read loop on resume, tear down on destroy.
+            if (!lifecycleListenerRegistered) {
+                lifecycleListenerRegistered = true
+                reactContext.addLifecycleEventListener(object : LifecycleEventListener {
+                    override fun onHostResume() {
+                        startReadLoop()
+                    }
+
+                    override fun onHostPause() {
+                    }
+
+                    override fun onHostDestroy() {
+                        destroy()
+                    }
+                })
             }
         } catch (e: Exception) {
             NativeLogger.error("Exception in notifyJSReady", e)
         }
     }
 
-    // JSI
-    private inner class ReadFromKBLib(reactContext: ReactApplicationContext) : Runnable {
-        private val reactContext: ReactApplicationContext
-
-        init {
-            this.reactContext = reactContext
-            reactContext.addLifecycleEventListener(object : LifecycleEventListener {
-                override fun onHostResume() {
-                    if (executor == null) {
-                        val ex = Executors.newSingleThreadExecutor()
-                        executor = ex
-                        ex.execute(ReadFromKBLib(reactContext))
-                    }
-                }
-
-                override fun onHostPause() {
-                }
-
-                override fun onHostDestroy() {
-                    destroy()
-                }
-            })
+    private fun startReadLoop() {
+        if (executor == null) {
+            val ex = Executors.newSingleThreadExecutor()
+            executor = ex
+            ex.execute(ReadFromKBLib(reactContext))
         }
+    }
 
+    // JSI
+    private inner class ReadFromKBLib(private val reactContext: ReactApplicationContext) : Runnable {
         override fun run() {
             do {
                 try {
@@ -625,7 +521,9 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         }
     }
 
-    @ReactMethod
+    // Called from JNI (cpp-adapter writeToGo), not from JS. DoNotStrip keeps it
+    // from being removed/renamed by ProGuard since the only caller is reflective.
+    @DoNotStrip
     fun rpcOnGo(arr: ByteArray) {
         try {
             writeArr(arr)
@@ -651,7 +549,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         }
 
         const val NAME: String = "Kb"
-        private const val RN_NAME: String = "ReactNativeJS"
         private const val RPC_META_EVENT_NAME: String = "kb-meta-engine-event"
         private const val RPC_META_EVENT_ENGINE_RESET: String = "kb-engine-reset"
         private const val MAX_TEXT_FILE_SIZE = 100 * 1024 // 100 kiB
@@ -679,12 +576,13 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
 
         @JvmStatic
         fun emitPushNotification(notification: Bundle) {
-            if (instance == null) {
+            val module = instance
+            if (module == null) {
+                // NativeLogger writes to the Go service, which may not be up here.
                 android.util.Log.w("KbModule", "emitPushNotification called but instance is null (app may not be running)")
                 return
             }
-            android.util.Log.d("KbModule", "emitPushNotification called, instance exists")
-            instance?.emitPushNotificationInternal(notification)
+            module.emitPushNotificationInternal(notification)
         }
 
         // Is this a robot controlled test device? (i.e. pre-launch report?)

--- a/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/NativeLogger.kt
+++ b/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/NativeLogger.kt
@@ -3,13 +3,8 @@ package com.reactnativekb
 import android.util.Log
 import keybase.Keybase
 
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.bridge.WritableArray
 
 class NativeLogger(reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext) {
     override fun getName(): String {
@@ -18,10 +13,6 @@ class NativeLogger(reactContext: ReactApplicationContext?) : ReactContextBaseJav
 
     companion object {
         private const val NAME: String = "NativeLogger"
-        private const val RN_NAME: String = "ReactNativeJS"
-        fun rawLog(tag: String, jsonLog: String) {
-            Log.i(tag + NAME, jsonLog)
-        }
 
         private fun formatLine(tagPrefix: String, toLog: String): String {
             // Copies the Style JS outputs in native/logger.native.tsx

--- a/rnmodules/react-native-kb/cpp/react-native-kb.cpp
+++ b/rnmodules/react-native-kb/cpp/react-native-kb.cpp
@@ -185,12 +185,17 @@ void KBBridge::convertJSIToMP(Runtime &runtime, const Value &value,
     double d = value.getNumber();
     // Doubles can exactly represent integers up to 2^53. Encode exact
     // integers as msgpack int/uint (matching @msgpack/msgpack JS behavior)
-    // so Go's decoder sees integer types, not float64.
+    // so Go's decoder sees integer types, not float64. Integer-valued
+    // doubles outside [INT64_MIN, UINT64_MAX] would be UB to cast, so
+    // those stay float64. 18446744073709551616.0 == 2^64 and
+    // -9223372036854775808.0 == -2^63 are both exact doubles.
     if (d == std::floor(d) && std::isfinite(d)) {
-      if (d >= 0) {
+      if (d >= 0 && d < 18446744073709551616.0) {
         pk.pack(static_cast<uint64_t>(d));
-      } else {
+      } else if (d < 0 && d >= -9223372036854775808.0) {
         pk.pack(static_cast<int64_t>(d));
+      } else {
+        pk.pack(d);
       }
     } else {
       pk.pack(d);

--- a/rnmodules/react-native-kb/ios/Kb.h
+++ b/rnmodules/react-native-kb/ios/Kb.h
@@ -16,7 +16,7 @@
 
 // Singleton to get the paths
 @interface FsPathsHolder : NSObject
-@property(nonatomic, retain) NSDictionary *fsPaths;
+@property(nonatomic, copy) NSDictionary *fsPaths;
 + (instancetype)sharedFsPathsHolder;
 @end
 
@@ -24,7 +24,6 @@
 FOUNDATION_EXPORT void KbSetDeviceToken(NSString *token);
 FOUNDATION_EXPORT void KbSetInitialNotification(NSDictionary *notification);
 FOUNDATION_EXPORT void KbEmitPushNotification(NSDictionary *notification);
-FOUNDATION_EXPORT NSDictionary *KbGetAndClearInitialNotification(void);
-
-// Init result - stored for inclusion in ReadArr error logs
-FOUNDATION_EXPORT void KbSetInitResult(NSString *result);
+// Re-emits a stored user-interaction notification once when the app becomes
+// active (covers notification taps that arrive before React Native is ready).
+FOUNDATION_EXPORT void KbEmitStoredNotificationOnBecomeActive(void);

--- a/rnmodules/react-native-kb/ios/Kb.mm
+++ b/rnmodules/react-native-kb/ios/Kb.mm
@@ -31,19 +31,8 @@ using namespace kb;
   return sharedMyManager;
 }
 
-- (id)init {
-  if (self = [super init]) {
-  }
-  return self;
-}
-
-- (void)dealloc {
-  // Should never be called, but just here for clarity really.
-}
-
 @end
 
-static const NSString *tagName = @"NativeLogger";
 static NSString *const metaEventName = @"kb-meta-engine-event";
 static NSString *const metaEventEngineReset = @"kb-engine-reset";
 
@@ -51,7 +40,6 @@ static __weak Kb *kbSharedInstance = nil;
 static BOOL kbPasteImageEnabled = NO;
 static NSString *kbStoredDeviceToken = nil;
 static NSDictionary *kbInitialNotification = nil;
-static NSString *kbInitResult = nil;
 
 @interface Kb ()
 @property dispatch_queue_t readQueue;
@@ -102,22 +90,26 @@ RCT_EXPORT_MODULE()
 + (void)handlePastedImages:(NSArray<UIImage *> *)images {
   if (!kbSharedInstance || images.count == 0) return;
 
-  NSMutableArray *uris = [NSMutableArray array];
-  for (UIImage *image in images) {
-    NSData *data = UIImagePNGRepresentation(image);
-    if (!data) continue;
+  // Encoding and writing pasted images can be slow for large images; keep it
+  // off the main thread. sendEventWithName is safe to call from any thread.
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    NSMutableArray *uris = [NSMutableArray array];
+    for (UIImage *image in images) {
+      NSData *data = UIImagePNGRepresentation(image);
+      if (!data) continue;
 
-    NSString *filename = [NSString stringWithFormat:@"paste_%@.png", [[NSUUID UUID] UUIDString]];
-    NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
+      NSString *filename = [NSString stringWithFormat:@"paste_%@.png", [[NSUUID UUID] UUIDString]];
+      NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
 
-    if ([data writeToFile:tempPath atomically:YES]) {
-      [uris addObject:tempPath];
+      if ([data writeToFile:tempPath atomically:YES]) {
+        [uris addObject:tempPath];
+      }
     }
-  }
 
-  if (uris.count > 0) {
-    [kbSharedInstance sendEventWithName:@"onPasteImage" body:@{@"uris": uris}];
-  }
+    if (uris.count > 0) {
+      [kbSharedInstance sendEventWithName:@"onPasteImage" body:@{@"uris": uris}];
+    }
+  });
 }
 
 - (void)invalidate {
@@ -142,7 +134,6 @@ RCT_EXPORT_METHOD(setEnablePasteImage:(BOOL)enabled) {
   kbPasteImageEnabled = enabled;
 }
 
-// Don't compile this code when we build for the old architecture.
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
 (const facebook::react::ObjCTurboModule::InitParams &)params {
     return std::make_shared<facebook::react::NativeKbSpecJSI>(params);
@@ -220,9 +211,6 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTypedConstants) {
   NSString *serverConfig = [self setupServerConfig];
   NSString *guiConfig = [self setupGuiConfig];
 
-  // Dark mode available since iOS 13.0; app targets iOS 15.1+
-  NSString *darkModeSupported = @"1";
-
   NSString *appVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   if (appVersionString == nil) {
     appVersionString = @"";
@@ -244,7 +232,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTypedConstants) {
     @"androidIsTestDevice" : @NO,
     @"appVersionCode" : appBuildString,
     @"appVersionName" : appVersionString,
-    @"darkModeSupported" : darkModeSupported,
+    @"darkModeSupported" : @YES,
     @"fsCacheDir" : cacheDir,
     @"fsDownloadDir" : downloadDir,
     @"guiConfig" : guiConfig,
@@ -266,16 +254,15 @@ RCT_EXPORT_METHOD(engineReset) {
   }
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
-    // No-op: JSI bindings are now installed via installJSIBindingsWithRuntime:callInvoker:
-    return @YES;
-}
-
 RCT_EXPORT_METHOD(notifyJSReady) {
   __weak __typeof__(self) weakSelf = self;
 
   NSLog(@"notifyJSReady: called from JS, queuing main thread block");
   dispatch_async(dispatch_get_main_queue(), ^{
+    if (self.readQueue) {
+      NSLog(@"notifyJSReady: read loop already running, ignoring");
+      return;
+    }
 
     self.readQueue = dispatch_queue_create("go_bridge_queue_read", DISPATCH_QUEUE_SERIAL);
 
@@ -319,7 +306,7 @@ RCT_EXPORT_METHOD(logSend:(NSString *)status feedback:(NSString *)feedback sendL
   if (err == nil) {
     resolve(logId);
   } else {
-    resolve(@"");
+    reject(@"log_send_error", err.localizedDescription, err);
   }
 }
 
@@ -464,22 +451,6 @@ RCT_EXPORT_METHOD(addNotificationRequest: (JS::NativeKb::SpecAddNotificationRequ
   }];
 }
 
-/*
-RCT_EXPORT_METHOD(processVideo:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
-  NSURL * videoURL = [NSURL URLWithString:path];
-
-  [MediaUtils processVideoFromOriginal:videoURL completion:^(NSError * _Nullable error, NSURL * _Nullable processedURL) {
-    if (error) {
-      reject(@"compression_error", error.localizedDescription, error);
-    } else if (processedURL) {
-      resolve(processedURL.path);
-    } else {
-      reject(@"compression_error", @"No processed video URL returned", nil);
-    }
-  }];
-}
-*/
-
 + (void)setDeviceToken:(NSString *)token {
   kbStoredDeviceToken = token;
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -570,12 +541,24 @@ void KbEmitPushNotification(NSDictionary *notification) {
   [Kb emitPushNotification:notification];
 }
 
-NSDictionary *KbGetAndClearInitialNotification(void) {
-  NSDictionary *notification = kbInitialNotification;
+void KbEmitStoredNotificationOnBecomeActive(void) {
+  NSDictionary *stored = kbInitialNotification;
   kbInitialNotification = nil;
-  return notification;
-}
-
-void KbSetInitResult(NSString *result) {
-  kbInitResult = result;
+  if (!stored) {
+    NSLog(@"KbEmitStoredNotificationOnBecomeActive: no stored notification");
+    return;
+  }
+  if (![stored[@"userInteraction"] boolValue]) {
+    // Not from a user tap; nothing to re-emit.
+    return;
+  }
+  if ([stored[@"reEmittedInBecomeActive"] boolValue]) {
+    // Already re-emitted once; keep it stored for getInitialNotification.
+    kbInitialNotification = stored;
+    return;
+  }
+  [Kb emitPushNotification:stored];
+  NSMutableDictionary *copy = [stored mutableCopy];
+  copy[@"reEmittedInBecomeActive"] = @YES;
+  kbInitialNotification = copy;
 }

--- a/rnmodules/react-native-kb/ios/Kb.mm
+++ b/rnmodules/react-native-kb/ios/Kb.mm
@@ -94,7 +94,18 @@ RCT_EXPORT_MODULE()
   // off the main thread. sendEventWithName is safe to call from any thread.
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
     NSMutableArray *uris = [NSMutableArray array];
-    for (UIImage *image in images) {
+    for (UIImage *rawImage in images) {
+      UIImage *image = rawImage;
+      // UIImagePNGRepresentation encodes the raw pixels and PNG has no
+      // orientation tag, so bake imageOrientation in by redrawing.
+      if (image.imageOrientation != UIImageOrientationUp) {
+        UIGraphicsImageRenderer *renderer =
+            [[UIGraphicsImageRenderer alloc] initWithSize:image.size];
+        UIImage *src = image;
+        image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *ctx) {
+          [src drawInRect:CGRectMake(0, 0, src.size.width, src.size.height)];
+        }];
+      }
       NSData *data = UIImagePNGRepresentation(image);
       if (!data) continue;
 

--- a/rnmodules/react-native-kb/src/NativeKb.ts
+++ b/rnmodules/react-native-kb/src/NativeKb.ts
@@ -1,7 +1,6 @@
 import {TurboModuleRegistry, type TurboModule} from 'react-native'
 
 export interface Spec extends TurboModule {
-  install: () => boolean
   addListener: (eventType: string) => void
   removeListeners: (count: number) => void
   getTypedConstants(): {
@@ -48,7 +47,6 @@ export interface Spec extends TurboModule {
   shareListenersRegistered(): void
   setEnablePasteImage(enabled: boolean): void
   clearLocalLogs(): Promise<void>
-  //processVideo(path: string): Promise<string>
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('Kb')

--- a/rnmodules/react-native-kb/src/index.tsx
+++ b/rnmodules/react-native-kb/src/index.tsx
@@ -1,4 +1,4 @@
-import {Platform, NativeEventEmitter} from 'react-native'
+import {Platform, NativeEventEmitter, type EmitterSubscription} from 'react-native'
 import KbNative from './NativeKb'
 
 const Kb = KbNative
@@ -14,9 +14,6 @@ export const logSend = (
   return Kb.logSend(status, feedback, sendLogs, sendMaxBytes, traceDir, cpuProfileDir)
 }
 
-export const install = () => {
-  // No-op: JSI bindings are now installed automatically via TurboModuleWithJSIBindings
-}
 export const iosGetHasShownPushPrompt = (): Promise<boolean> => {
   if (Platform.OS === 'ios') {
     return Kb.iosGetHasShownPushPrompt()
@@ -48,7 +45,7 @@ export const androidAddCompleteDownload = (o: {
   if (Platform.OS === 'android') {
     return Kb.androidAddCompleteDownload(o)
   }
-  return Promise.reject()
+  return Promise.reject(new Error('wrong platform'))
 }
 
 export const androidAppColorSchemeChanged = (mode: 'system' | 'alwaysDark' | 'alwaysLight' | ''): void => {
@@ -86,7 +83,7 @@ export const addNotificationRequest = (config: {body: string; id: string}): Prom
 }
 
 // Hardware keyboard events
-const hwKeyPressedListeners: any[] = []
+const hwKeyPressedListeners: Array<EmitterSubscription> = []
 
 export const onHWKeyPressed = (callback: (event: {pressedKey: string}) => void): void => {
   const emitter = getNativeEmitter()
@@ -95,7 +92,7 @@ export const onHWKeyPressed = (callback: (event: {pressedKey: string}) => void):
 }
 
 export const removeOnHWKeyPressed = (): void => {
-  hwKeyPressedListeners.forEach(listener => listener?.remove())
+  hwKeyPressedListeners.forEach(listener => listener.remove())
   hwKeyPressedListeners.length = 0
 }
 
@@ -131,11 +128,10 @@ export const clearLocalLogs = (): Promise<void> => {
   return Kb.clearLocalLogs()
 }
 
-// export const processVideo = (path: string): Promise<string> => {
-//   return Kb.processVideo(Platform.OS === 'android' ? path.replace('file://', '') : path)
-// }
+let nativeEmitter: NativeEventEmitter | undefined
 export const getNativeEmitter = () => {
-  return new NativeEventEmitter(Kb as any)
+  nativeEmitter ??= new NativeEventEmitter(Kb as any)
+  return nativeEmitter
 }
 
 const KBC = Kb.getTypedConstants()

--- a/shared/app/index.native.tsx
+++ b/shared/app/index.native.tsx
@@ -19,7 +19,6 @@ import {setServiceDecoration} from '@/common-adapters/markdown/react'
 import ServiceDecoration from '@/common-adapters/markdown/service-decoration'
 import {useUnmountAll} from '@/util/debug-react'
 import {darkModeSupported, guiConfig} from 'react-native-kb'
-import {install} from 'react-native-kb'
 import * as DarkMode from '@/stores/darkmode'
 import {initPlatformListener, onEngineConnected, onEngineDisconnected, onEngineIncoming} from '@/constants/init/index'
 import logger from '@/logger'
@@ -134,7 +133,6 @@ const useInit = () => {
     inited = true
     initDarkMode()
     Animated.addWhitelistedNativeProps({text: true})
-    install()
     const {batch} = C.useWaitingState.getState().dispatch
     const eng = makeEngine(batch, c => {
       if (c) {

--- a/shared/common-adapters/list.tsx
+++ b/shared/common-adapters/list.tsx
@@ -55,6 +55,9 @@ const styles = Styles.styleSheetCreate(
     ({
       outerView: {
         flexGrow: 1,
+        // without shrink, content taller than the available space keeps its
+        // content height and paints past the parent (e.g. over modal footers)
+        flexShrink: 1,
         position: 'relative',
       },
     }) as const

--- a/shared/common-adapters/progress-bar.tsx
+++ b/shared/common-adapters/progress-bar.tsx
@@ -36,6 +36,7 @@ const styles = Styles.styleSheetCreate(() => ({
   flatLeft: {borderBottomLeftRadius: 0, borderTopLeftRadius: 0},
   flatRight: {borderBottomRightRadius: 0, borderTopRightRadius: 0},
   inner: {
+    alignSelf: 'flex-start',
     backgroundColor: Styles.globalColors.blue,
     ...Styles.globalStyles.rounded,
     height: 4,

--- a/shared/fs/routes.tsx
+++ b/shared/fs/routes.tsx
@@ -6,7 +6,7 @@ import * as FS from '@/constants/fs'
 import {Actions, MainBanner, MobileHeader, Title} from './nav-header'
 import {IosHeaderRightItems, IosHeaderTitle} from './nav-header/ios-header'
 import {Filename, ItemIcon} from './common'
-import {OriginalOrCompressedButton} from '@/incoming-share'
+import {getIncomingShareSizes, OriginalOrCompressedButton} from '@/incoming-share'
 import {defineRouteMap} from '@/constants/types/router'
 
 const FsRoot = React.lazy(async () => import('.'))
@@ -30,9 +30,14 @@ const DestPickerHeaderLeft = ({source}: {source: T.FS.MoveOrCopySource | T.FS.In
   )
 }
 
-const DestPickerHeaderRight = ({source}: {source: T.FS.MoveOrCopySource | T.FS.IncomingShareSource}) => {
-  if (source.type !== T.FS.DestinationPickerSource.IncomingShare) return null
-  return <OriginalOrCompressedButton incomingShareItems={source.source} />
+// undefined when there's nothing to show: a set headerRight rendering null
+// still gets an empty liquid glass circle on iOS 26
+const destPickerHeaderRight = (source: T.FS.MoveOrCopySource | T.FS.IncomingShareSource) => {
+  if (source.type !== T.FS.DestinationPickerSource.IncomingShare) return undefined
+  if (getIncomingShareSizes(source.source).originalOnly) return undefined
+  const items = source.source
+  const HeaderRight = () => <OriginalOrCompressedButton incomingShareItems={items} />
+  return HeaderRight
 }
 
 const DestPickerHeaderTitle = (props: {
@@ -147,7 +152,7 @@ export const newModalRoutes = defineRouteMap({
     {
       getOptions: ({route}) => ({
         headerLeft: () => <DestPickerHeaderLeft source={route.params.source} />,
-        headerRight: () => <DestPickerHeaderRight source={route.params.source} />,
+        headerRight: destPickerHeaderRight(route.params.source),
         headerTitle: () => (
           <DestPickerHeaderTitle parentPath={route.params.parentPath} source={route.params.source} />
         ),

--- a/shared/incoming-share/index.tsx
+++ b/shared/incoming-share/index.tsx
@@ -9,14 +9,19 @@ import * as FS from '@/constants/fs'
 import {useConfigState} from '@/stores/config'
 import {ensureError} from '@/util/errors'
 import {getInboxConversationMeta} from '@/chat/inbox/metadata'
+import {useSafeAreaFrame} from 'react-native-safe-area-context'
 
-export const OriginalOrCompressedButton = ({incomingShareItems}: IncomingShareProps) => {
+export const getIncomingShareSizes = (incomingShareItems: ReadonlyArray<T.RPCGen.IncomingShareItem>) => {
   const originalTotalSize = incomingShareItems.reduce((bytes, item) => bytes + (item.originalSize ?? 0), 0)
   const scaledTotalSize = incomingShareItems.reduce(
     (bytes, item) => bytes + (item.scaledSize ?? item.originalSize ?? 0),
     0
   )
-  const originalOnly = originalTotalSize <= scaledTotalSize
+  return {originalOnly: originalTotalSize <= scaledTotalSize, originalTotalSize, scaledTotalSize}
+}
+
+export const OriginalOrCompressedButton = ({incomingShareItems}: IncomingShareProps) => {
+  const {originalOnly, originalTotalSize, scaledTotalSize} = getIncomingShareSizes(incomingShareItems)
   const setUseOriginalInStore = useConfigState(s => s.dispatch.setIncomingShareUseOriginal)
 
   const setUseOriginalInService = (useOriginal: boolean) => {
@@ -129,16 +134,23 @@ export const getContentDescriptionText = (items: ReadonlyArray<T.RPCGen.Incoming
   return name || `1 ${incomingShareTypeToString(item.type, false, false)}`
 }
 
-const IncomingShareHeaderTitle = ({title}: {title?: string}) => (
-  <Kb.Box2 direction="vertical" fullWidth={true} centerChildren={true}>
-    {title ? (
-      <Kb.Text type="BodyTiny" lineClamp={1}>
-        {title}
-      </Kb.Text>
-    ) : null}
-    <Kb.Text type="BodyBig">Share to...</Kb.Text>
-  </Kb.Box2>
-)
+// Content-sized so the native header centers it in the bar; fullWidth would fill
+// the asymmetric space between the Cancel pill and the right item and center
+// within that instead. maxWidth keeps long filenames clear of both sides — same
+// trick as fs/nav-header/ios-header.
+const IncomingShareHeaderTitle = ({title}: {title?: string}) => {
+  const {width} = useSafeAreaFrame()
+  return (
+    <Kb.Box2 direction="vertical" centerChildren={true} style={{maxWidth: width - 240}}>
+      {title ? (
+        <Kb.Text type="BodyTiny" lineClamp={1}>
+          {title}
+        </Kb.Text>
+      ) : null}
+      <Kb.Text type="BodyBig">Share to...</Kb.Text>
+    </Kb.Box2>
+  )
+}
 
 const useFooter = (incomingShareItems: ReadonlyArray<T.RPCGen.IncomingShareItem>) => {
   const navigateAppend = C.Router2.navigateAppend
@@ -222,11 +234,23 @@ const IncomingShare = (props: IncomingShareWithSelectionProps) => {
   const footer = useFooter(props.incomingShareItems)
   const contentDescription = getContentDescriptionText(props.incomingShareItems)
 
+  // When there's no compress choice the header button renders nothing, but a set
+  // headerRight still gets an empty liquid glass circle on iOS 26 — so don't set
+  // it at all. The button's originalOnly store sync must then happen here.
+  const {originalOnly} = getIncomingShareSizes(props.incomingShareItems)
+  const setUseOriginalInStore = useConfigState(s => s.dispatch.setIncomingShareUseOriginal)
+  React.useEffect(() => {
+    if (originalOnly) {
+      setUseOriginalInStore(true)
+    }
+  }, [originalOnly, setUseOriginalInStore])
+
   React.useEffect(() => {
     navigation.setOptions({
-      headerRight: props.incomingShareItems.length
-        ? () => <OriginalOrCompressedButton incomingShareItems={props.incomingShareItems} />
-        : undefined,
+      headerRight:
+        props.incomingShareItems.length && !originalOnly
+          ? () => <OriginalOrCompressedButton incomingShareItems={props.incomingShareItems} />
+          : undefined,
       headerTitle: () => <IncomingShareHeaderTitle title={contentDescription} />,
     })
     return () => {
@@ -235,7 +259,7 @@ const IncomingShare = (props: IncomingShareWithSelectionProps) => {
         headerTitle: () => <IncomingShareHeaderTitle />,
       })
     }
-  }, [contentDescription, navigation, props.incomingShareItems])
+  }, [contentDescription, navigation, originalOnly, props.incomingShareItems])
 
   if (canDirectNav) {
     return (

--- a/shared/incoming-share/routes.tsx
+++ b/shared/incoming-share/routes.tsx
@@ -12,9 +12,11 @@ const IncomingShareHeaderLeft = () => {
   )
 }
 
+// Content-sized so the native header centers it in the bar (fullWidth would
+// center within the asymmetric space between the left/right items instead)
 const IncomingShareHeaderTitle = () => {
   return (
-    <Kb.Box2 direction="vertical" fullWidth={true} centerChildren={true}>
+    <Kb.Box2 direction="vertical" centerChildren={true}>
       <Kb.Text type="BodyBig">Share to...</Kb.Text>
     </Kb.Box2>
   )

--- a/shared/ios/Keybase/AppDelegate.swift
+++ b/shared/ios/Keybase/AppDelegate.swift
@@ -53,8 +53,7 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    let skipLogFile = false
-    self.fsPaths = FsHelper().setupFs(skipLogFile, setupSharedHome: true)
+    self.fsPaths = FsHelper().setupFs(false, setupSharedHome: true)
     FsPathsHolder.shared().fsPaths = self.fsPaths
 
     self.writeStartupTimingLog("didFinishLaunchingWithOptions start")
@@ -198,8 +197,6 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
   func setupGo() {
     // uncomment to get more console.logs
     // RCTSetLogThreshold(RCTLogLevel.info.rawValue - 1)
-    FsPathsHolder.shared().fsPaths = self.fsPaths
-
     let systemVer = UIDevice.current.systemVersion
     let isIPad = UIDevice.current.userInterfaceIdiom == .pad
     let isIOS = true
@@ -219,12 +216,10 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
     Keybasego.KeybaseInit(self.fsPaths["homedir"], self.fsPaths["sharedHome"], self.fsPaths["logFile"], "prod", securityAccessGroupOverride, nil, nil, systemVer, isIPad, nil, isIOS, shareIntentDonator, &err)
     if let err {
       let initResult = "FAILED: \(err.localizedDescription) (code=\(err.code) domain=\(err.domain))"
-      KbSetInitResult(initResult)
       log.error("KeybaseInit FAILED: \(err.localizedDescription, privacy: .public)")
       self.writeStartupTimingLog("KeybaseInit \(initResult)")
       fatalError("KeybaseInit failed: \(initResult)")
     } else {
-      KbSetInitResult("succeeded")
       self.writeStartupTimingLog("KeybaseInit succeeded")
     }
 
@@ -313,14 +308,27 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
   func handleAppRefresh(task: BGAppRefreshTask) {
     scheduleAppRefresh()
 
+    // setTaskCompleted must be called exactly once, whether the sync finishes
+    // or the task expires first.
+    let completionQueue = DispatchQueue(label: "kb.bg.refresh.completion")
+    var completed = false
+    let completeOnce: (Bool) -> Void = { success in
+      completionQueue.sync {
+        guard !completed else { return }
+        completed = true
+        task.setTaskCompleted(success: success)
+      }
+    }
+
     task.expirationHandler = {
       log.warning("Background refresh task expired")
+      completeOnce(false)
     }
 
     DispatchQueue.global(qos: .default).async {
       log.info("Background fetch started...")
       Keybasego.KeybaseBackgroundSync()
-      task.setTaskCompleted(success: true)
+      completeOnce(true)
       log.info("Background fetch completed...")
     }
   }
@@ -332,7 +340,10 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
   }
 
   override func application(_ application: UIApplication, didReceiveRemoteNotification notification: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-    guard let type = notification["type"] as? String else { return }
+    guard let type = notification["type"] as? String else {
+      completionHandler(.noData)
+      return
+    }
     if type == "chat.newmessageSilent_2" {
       DispatchQueue.global(qos: .default).async {
         let convID = notification["c"] as? String
@@ -423,26 +434,29 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
     log.info("applicationDidEnterBackground: after notifying go.")
 
     if requestTime && (self.shutdownTask == UIBackgroundTaskIdentifier.invalid) {
-      let app = UIApplication.shared
-      self.shutdownTask = app.beginBackgroundTask {
+      self.shutdownTask = UIApplication.shared.beginBackgroundTask {
+        // Expiration handler runs on the main thread.
         log.info("applicationDidEnterBackground: shutdown task run.")
         Keybasego.KeybaseAppWillExit(PushNotifier())
-        let task = self.shutdownTask
-        if task != .invalid {
-          app.endBackgroundTask(task)
-          self.shutdownTask = .invalid
-        }
+        self.endShutdownTask()
       }
 
       DispatchQueue.global(qos: .default).async {
         Keybasego.KeybaseAppBeginBackgroundTask(PushNotifier())
-        let task = self.shutdownTask
-        if task != .invalid {
-          app.endBackgroundTask(task)
-          self.shutdownTask = .invalid
+        DispatchQueue.main.async {
+          self.endShutdownTask()
         }
       }
     }
+  }
+
+  // Main thread only: serializes the expiration handler and the background
+  // work both trying to end the same task.
+  private func endShutdownTask() {
+    let task = self.shutdownTask
+    guard task != .invalid else { return }
+    self.shutdownTask = .invalid
+    UIApplication.shared.endBackgroundTask(task)
   }
 
   override func applicationDidBecomeActive(_ application: UIApplication) {
@@ -451,29 +465,8 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
     log.info("applicationDidBecomeActive: notifying service.")
     notifyAppState(application)
 
-    // Check if there's a stored notification with userInteraction that needs to be processed
-    // This handles the case where app was backgrounded and notification was clicked
-    // but React Native wasn't ready yet
-    if let storedNotification = KbGetAndClearInitialNotification() {
-      let userInteraction = storedNotification["userInteraction"] as? Bool ?? false
-
-      if userInteraction {
-        let alreadyReEmitted = (storedNotification["reEmittedInBecomeActive"] as? Bool) == true
-        if alreadyReEmitted {
-          KbSetInitialNotification(storedNotification)
-        } else {
-          log.info("applicationDidBecomeActive: stored notification has userInteraction=true, emitting")
-          KbEmitPushNotification(storedNotification)
-          var copy = storedNotification
-          copy["reEmittedInBecomeActive"] = true
-          KbSetInitialNotification(copy)
-        }
-      } else {
-        log.info("applicationDidBecomeActive: stored notification has userInteraction=false, skipping")
-      }
-    } else {
-      log.info("applicationDidBecomeActive: no stored notification found")
-    }
+    // Re-emit a notification the user tapped while React Native wasn't ready yet.
+    KbEmitStoredNotificationOnBecomeActive()
   }
 
   override func applicationWillEnterForeground(_ application: UIApplication) {

--- a/shared/ios/Keybase/Fs.swift
+++ b/shared/ios/Keybase/Fs.swift
@@ -6,6 +6,11 @@ private let log = Logger(subsystem: "com.keybase.app", category: "fs")
 @objc class FsHelper: NSObject {
     private static let cacheKeybaseURL = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Caches/Keybase")
     private static let appSupportKeybaseURL = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support/Keybase")
+    private static let fileProtectionAttrs = [FileAttributeKey.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
+
+    // Directories whose existing contents still need the relaxed protection
+    // attribute; swept on a background queue after setup completes.
+    private var pendingAttributeSweeps: [String] = []
 
     @objc func setupFs(_ skipLogFile: Bool, setupSharedHome shouldSetupSharedHome: Bool) -> [String: String] {
         let setupFsStartTime = CFAbsoluteTimeGetCurrent()
@@ -15,7 +20,7 @@ private let log = Logger(subsystem: "com.keybase.app", category: "fs")
         let sharedURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.keybase")
         var sharedHome = sharedURL?.path ?? ""
 
-        home = setupAppHome(home: home, sharedHome: sharedHome)
+        home = setupAppHome(home: home)
         if shouldSetupSharedHome {
             sharedHome = setupSharedHome(home: home, sharedHome: sharedHome)
         }
@@ -47,10 +52,24 @@ private let log = Logger(subsystem: "com.keybase.app", category: "fs")
             "kbfs_settings",
             "synced_tlf_config"
         ].forEach {
-            createBackgroundReadableDirectory(path: appKeybaseURL.appendingPathComponent($0).path, setAllFiles: true)
+            createBackgroundReadableDirectory(path: appKeybaseURL.appendingPathComponent($0).path)
         }
-        createBackgroundReadableDirectory(path: logURL.path, setAllFiles: true)
-        createBackgroundReadableDirectory(path: Self.cacheKeybaseURL.appendingPathComponent("avatars").path, setAllFiles: true)
+        createBackgroundReadableDirectory(path: logURL.path)
+        createBackgroundReadableDirectory(path: Self.cacheKeybaseURL.appendingPathComponent("avatars").path)
+
+        // The per-file sweep over existing cache contents can be slow for big
+        // caches, so it runs off the launch path. Dispatched after migration so
+        // it never races moving files between dirs. The enumerator is recursive,
+        // so drop paths nested under another swept path.
+        var sweepRoots: [String] = []
+        for path in pendingAttributeSweeps.sorted() {
+            if let last = sweepRoots.last, path.hasPrefix(last + "/") { continue }
+            sweepRoots.append(path)
+        }
+        pendingAttributeSweeps = []
+        DispatchQueue.global(qos: .utility).async {
+            sweepRoots.forEach { Self.setAttributesRecursively(path: $0) }
+        }
 
         let setupFsElapsed = CFAbsoluteTimeGetCurrent() - setupFsStartTime
         log.info("setupFs: completed in \(setupFsElapsed, format: .fixed(precision: 3)) seconds")
@@ -62,56 +81,52 @@ private let log = Logger(subsystem: "com.keybase.app", category: "fs")
         ]
     }
 
-    private func addSkipBackupAttribute(to path: String) -> Bool {
+    private func addSkipBackupAttribute(to path: String) {
         var url = URL(fileURLWithPath: path)
         do {
             var resourceValues = URLResourceValues()
             resourceValues.isExcludedFromBackup = true
             try url.setResourceValues(resourceValues)
-            return true
         } catch {
             log.error("Error excluding \(url.lastPathComponent, privacy: .public) from backup \(error.localizedDescription, privacy: .public)")
-            return false
         }
     }
 
-    private func createBackgroundReadableDirectory(path: String, setAllFiles: Bool) {
-        let dirStartTime = CFAbsoluteTimeGetCurrent()
+    private func createBackgroundReadableDirectory(path: String) {
         let fm = FileManager.default
         // Setting NSFileProtectionCompleteUntilFirstUserAuthentication makes the
         // directory accessible as long as the user has unlocked the phone once. The
         // files are still stored on the disk encrypted (note for the chat database,
         // it means we are encrypting it twice), and are inaccessible otherwise.
-        let noProt = [FileAttributeKey.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
-        log.info("creating background readable directory: path: \(path, privacy: .public) setAllFiles: \(setAllFiles)")
-        _ = try? fm.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: noProt)
+        log.info("creating background readable directory: path: \(path, privacy: .public)")
+        _ = try? fm.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: Self.fileProtectionAttrs)
         do {
-            try fm.setAttributes(noProt, ofItemAtPath: path)
+            try fm.setAttributes(Self.fileProtectionAttrs, ofItemAtPath: path)
         } catch {
             log.error("Error setting file attributes on path: \(path, privacy: .public) error: \(error.localizedDescription, privacy: .public)")
         }
+        pendingAttributeSweeps.append(path)
+    }
 
-        guard setAllFiles else {
-            log.info("setAllFiles is false, so returning now")
-            return
-        }
-        log.info("setAllFiles is true charging forward")
-
-        // Recursively set attributes on all subdirectories and files
+    // Recursively set the relaxed protection attribute on existing contents.
+    // Catch-up for files created before the attribute was in place.
+    private static func setAttributesRecursively(path: String) {
+        let dirStartTime = CFAbsoluteTimeGetCurrent()
+        let fm = FileManager.default
         let pathURL = URL(fileURLWithPath: path)
         var fileCount = 0
         if let enumerator = fm.enumerator(atPath: path) {
             for case let file as String in enumerator {
                 let filePath = pathURL.appendingPathComponent(file).path
                 do {
-                    try fm.setAttributes(noProt, ofItemAtPath: filePath)
+                    try fm.setAttributes(fileProtectionAttrs, ofItemAtPath: filePath)
                     fileCount += 1
                 } catch {
                     log.error("Error setting file attributes on: \(filePath, privacy: .public) error: \(error.localizedDescription, privacy: .public)")
                 }
             }
             let dirElapsed = CFAbsoluteTimeGetCurrent() - dirStartTime
-            log.info("createBackgroundReadableDirectory completed for: \(path, privacy: .public), processed \(fileCount) files, total: \(dirElapsed, format: .fixed(precision: 3)) seconds")
+            log.info("setAttributesRecursively completed for: \(path, privacy: .public), processed \(fileCount) files, total: \(dirElapsed, format: .fixed(precision: 3)) seconds")
         } else {
             log.error("Error creating enumerator for path: \(path, privacy: .public)")
         }
@@ -157,15 +172,15 @@ private let log = Logger(subsystem: "com.keybase.app", category: "fs")
         return appSupportKeybaseURL.appendingPathComponent("eraseablekvstore/device-eks").path
     }
 
-    private func setupAppHome(home: String, sharedHome: String) -> String {
+    private func setupAppHome(home: String) -> String {
         let dyldDir = FileManager.default.temporaryDirectory.appendingPathComponent("com.apple.dyld").path
         let appKeybasePath = Self.getAppKeybasePath()
         let appEraseableKVPath = Self.getEraseableKVPath()
 
-        createBackgroundReadableDirectory(path: dyldDir, setAllFiles: true)
-        createBackgroundReadableDirectory(path: appKeybasePath, setAllFiles: true)
-        createBackgroundReadableDirectory(path: appEraseableKVPath, setAllFiles: true)
-        _ = addSkipBackupAttribute(to: appKeybasePath)
+        createBackgroundReadableDirectory(path: dyldDir)
+        createBackgroundReadableDirectory(path: appKeybasePath)
+        createBackgroundReadableDirectory(path: appEraseableKVPath)
+        addSkipBackupAttribute(to: appKeybasePath)
 
         return home
     }
@@ -176,9 +191,9 @@ private let log = Logger(subsystem: "com.keybase.app", category: "fs")
         let sharedKeybasePath = URL(fileURLWithPath: sharedHome).appendingPathComponent("Library/Application Support/Keybase").path
         let sharedEraseableKVPath = URL(fileURLWithPath: sharedKeybasePath).appendingPathComponent("eraseablekvstore/device-eks").path
 
-        createBackgroundReadableDirectory(path: sharedKeybasePath, setAllFiles: true)
-        createBackgroundReadableDirectory(path: sharedEraseableKVPath, setAllFiles: true)
-        _ = addSkipBackupAttribute(to: sharedKeybasePath)
+        createBackgroundReadableDirectory(path: sharedKeybasePath)
+        createBackgroundReadableDirectory(path: sharedEraseableKVPath)
+        addSkipBackupAttribute(to: sharedKeybasePath)
 
         guard maybeMigrateDirectory(source: appKeybasePath, dest: sharedKeybasePath),
               maybeMigrateDirectory(source: appEraseableKVPath, dest: sharedEraseableKVPath) else {

--- a/shared/ios/KeybaseShare/ShareViewController.swift
+++ b/shared/ios/KeybaseShare/ShareViewController.swift
@@ -18,10 +18,9 @@ public class ShareViewController: UIViewController {
   var iph: ItemProviderHelper?
   var alert: UIAlertController?
   var selectedConvID: String?
-
-  public override func didReceiveMemoryWarning() {
-    super.didReceiveMemoryWarning()
-  }
+  // viewDidAppear fires again when the progress alert is dismissed; only
+  // process the share once.
+  private var didStartProcessing = false
 
   func openApp() {
     let path = selectedConvID.map { "keybase://incoming-share/\($0)" } ?? "keybase://incoming-share"
@@ -69,6 +68,8 @@ public class ShareViewController: UIViewController {
 
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
+    guard !didStartProcessing else { return }
+    didStartProcessing = true
     if let intent = extensionContext?.intent as? INSendMessageIntent {
       selectedConvID = intent.conversationIdentifier
     }


### PR DESCRIPTION
Correctness:
- call push fetchCompletionHandler on unknown notification type
- complete BG refresh task exactly once, including on expiry
- serialize shutdownTask ending (expiration vs worker double-end race)
- register read-loop lifecycle listener once (was accumulating per resume)
- clear Android initial notification on read, matching iOS
- guard ShareViewController against viewDidAppear re-entrancy
- bound integer msgpack casts to int64/uint64 range (UB otherwise)
- darkModeSupported constant is a bool, not "1"

Perf:
- move per-file protection-attribute sweep off the launch path to a background queue; dedupe nested sweep roots
- encode pasted images off the main thread
- cache a single NativeEventEmitter

Cleanup:
- remove dead install() end-to-end, kbInitResult, commented processVideo, unused Kotlin imports/helpers; move stored-notification re-emit dance into Kb.mm next to its storage; logSend rejects instead of swallowing; rpcOnGo gets @DoNotStrip (JNI-only caller, lost @ReactMethod)

NativeKb.ts spec changed: pod install required to regen RNKbSpec.