### PR TITLE
fix(chat): surface real Google Maps error and handle map load failure

### DIFF
--- a/go/chat/maps/maps.go
+++ b/go/chat/maps/maps.go
@@ -107,6 +107,14 @@ func MapReaderFromURL(ctx context.Context, g *globals.Context, url string) (res 
 	if err != nil {
 		return nil, 0, err
 	}
+	// Google Static Maps returns errors (e.g. "The provided API key is
+	// invalid.") as a non-200 text/plain body. Surface that message instead of
+	// handing the error body to png.Decode, which only reports "not a PNG file".
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, 0, fmt.Errorf("maps request failed: status=%d body=%q", resp.StatusCode, string(body))
+	}
 	return resp.Body, resp.ContentLength, nil
 }
 

--- a/shared/chat/location-map.tsx
+++ b/shared/chat/location-map.tsx
@@ -12,9 +12,21 @@ type Props = {
 const LocationMap = (props: Props) => {
   const {height, mapSrc, width} = props
   const [mapLoaded, setMapLoaded] = React.useState(false)
+  const [mapFailed, setMapFailed] = React.useState(false)
+  // mapSrc updates as the live location moves; reset load/error state so a new
+  // coordinate can recover from a transient failure.
+  const [prevMapSrc, setPrevMapSrc] = React.useState(mapSrc)
+  if (mapSrc !== prevMapSrc) {
+    setPrevMapSrc(mapSrc)
+    setMapLoaded(false)
+    setMapFailed(false)
+  }
   const onLoad = () => {
     setMapLoaded(true)
     props.onLoad?.()
+  }
+  const onError = () => {
+    setMapFailed(true)
   }
 
   const inner = (
@@ -26,8 +38,13 @@ const LocationMap = (props: Props) => {
       justifyContent="center"
       style={styles.container}
     >
-      {!!mapSrc && <Kb.Image src={mapSrc} style={{height, width}} onLoad={onLoad} />}
-      {!mapLoaded && <Kb.ProgressIndicator style={styles.loading} />}
+      {!!mapSrc && <Kb.Image src={mapSrc} style={{height, width}} onLoad={onLoad} onError={onError} />}
+      {!mapLoaded && !mapFailed && <Kb.ProgressIndicator style={styles.loading} />}
+      {mapFailed && (
+        <Kb.Text center={true} type="BodySmall" style={styles.error}>
+          Unable to load map.
+        </Kb.Text>
+      )}
       <Kb.Banner color="white" style={styles.banner}>
         <Kb.BannerParagraph
           bannerColor="white"
@@ -56,6 +73,9 @@ const styles = Kb.Styles.styleSheetCreate(
         left: 0,
         position: 'absolute',
         top: 0,
+      },
+      error: {
+        color: Kb.Styles.globalColors.redDark,
       },
       container: Kb.Styles.platformStyles({
         common: {


### PR DESCRIPTION
MapReaderFromURL ignored resp.StatusCode and handed Google's non-200 text error body (e.g. "The provided API key is invalid.") straight to png.Decode, which only reported "not a PNG file". Check the status and return the real message so the /map srv and unfurl packager log the actual cause.

LocationMap spun forever when the image failed (onLoad never fired). Add onError to stop the spinner and show an error, resetting on mapSrc change so live-location updates can recover.