### PR TITLE
fix(packaging): update yarn script name package -> desktop:package

### DIFF
--- a/packaging/desktop/package_darwin.sh
+++ b/packaging/desktop/package_darwin.sh
@@ -207,7 +207,7 @@ package_electron() { (
 	rm -rf "$shared_dir/node_modules"
 
 	yarn modules
-	yarn run package -- --appVersion="$app_version" --comment="$comment" --icon="$icon_path" --saltpackIcon="$saltpack_icon" --outDir="$build_dir" --arch="$electron_arch"
+	yarn run desktop:package -- --appVersion="$app_version" --comment="$comment" --icon="$icon_path" --saltpackIcon="$saltpack_icon" --outDir="$build_dir" --arch="$electron_arch"
 
 	# Create symlink for Electron to overcome Gatekeeper bug https://github.com/keybase/client/go/updater/pull/4
 	cd "$out_dir/$app_name.app/Contents/MacOS"

--- a/packaging/linux/build_binaries.sh
+++ b/packaging/linux/build_binaries.sh
@@ -152,7 +152,7 @@ build_one_architecture() {
 	echo "Building Electron client for $electron_arch..."
 	(
 		cd "$this_repo/shared"
-		yarn run package -- --platform=linux --arch="$electron_arch" --appVersion="$version" --network-concurrency=8
+		yarn run desktop:package -- --platform=linux --arch="$electron_arch" --appVersion="$version" --network-concurrency=8
 		rsync -a "desktop/release/linux-${electron_arch}/Keybase-linux-${electron_arch}/" \
 			"$layout_dir/opt/keybase"
 		chmod 755 "$layout_dir/opt/keybase"

--- a/packaging/windows/buildui.cmd
+++ b/packaging/windows/buildui.cmd
@@ -13,7 +13,7 @@ IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1
 )
 
-cmd /C yarn run package --arch=x64 --platform=win32 --appVersion=%KEYBASE_VERSION% --icon=%GOPATH%\src\github.com\keybase\client\media\icons\Keybase.ico
+cmd /C yarn run desktop:package --arch=x64 --platform=win32 --appVersion=%KEYBASE_VERSION% --icon=%GOPATH%\src\github.com\keybase\client\media\icons\Keybase.ico
 IF %ERRORLEVEL% NEQ 0 (
   EXIT /B 1
 )

--- a/shared/constants/rpc/index.tsx
+++ b/shared/constants/rpc/index.tsx
@@ -1,4 +1,3 @@
-// NOTE: This file is GENERATED from json files in actions/json. Run 'yarn build-actions' to regenerate
 import type * as chat1Types from '@/constants/rpc/rpc-chat-gen'
 import type * as keybase1Types from '@/constants/rpc/rpc-gen'
 


### PR DESCRIPTION
The v670 rename namespaced package.json scripts (package -> desktop:package) but the packaging callers still invoked `yarn run package`, breaking the electron build with `error Command "package" not found`.

Update darwin/linux/windows packaging scripts. Also drop a stale comment in constants/rpc/index.tsx referencing the removed `yarn build-actions` generator.