### PR TITLE
fix(chat): don't pause background audio when giphy autoplays (iOS)

### DIFF
--- a/shared/chat/conversation/messages/text/unfurl/unfurl-list/image/video.tsx
+++ b/shared/chat/conversation/messages/text/unfurl/unfurl-list/image/video.tsx
@@ -109,6 +109,10 @@ const NativeActiveVideo = (props: NativeActiveVideoProps) => {
     try {
       p.loop = true
       p.muted = true
+      // Don't interrupt the user's background audio (e.g. music). Default
+      // 'auto' grabs an exclusive iOS audio session and pauses other apps,
+      // even though this player is muted.
+      p.audioMixingMode = 'mixWithOthers'
       if (autoPlay) {
         p.play()
       }


### PR DESCRIPTION
expo-video's default audioMixingMode of 'auto' claims an exclusive iOS audio session when a giphy unfurl autoplays, pausing the user's music even though the player is muted. Set 'mixWithOthers' so background audio continues.