### PR TITLE
mark decryption failed errors as non-retryable; atomic writes for EnrcyptedDB

### DIFF
--- a/go/chat/deliverer.go
+++ b/go/chat/deliverer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/chat/storage"
 	"github.com/keybase/client/go/chat/types"
 	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/encrypteddb"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/gregor1"
@@ -442,7 +443,12 @@ func (s *Deliverer) processAttachment(ctx context.Context, obr chat1.OutboxRecor
 	}
 	status, res, err := s.G().AttachmentUploader.Status(ctx, obr.OutboxID)
 	if err != nil {
-		return obr, NewAttachmentUploadError(err.Error(), false)
+		// If the uploader's stored state cannot be read back (e.g. the encrypted
+		// status file is corrupt and fails to decrypt), retrying can never recover
+		// and would block delivery of every later message queued behind it in this
+		// conversation. Fail permanently in that case so the outbox can drain.
+		perm := errors.Is(err, encrypteddb.ErrDecryptionFailed)
+		return obr, NewAttachmentUploadError(err.Error(), perm)
 	}
 	switch status {
 	case types.AttachmentUploaderTaskStatusSuccess:

--- a/go/chat/server.go
+++ b/go/chat/server.go
@@ -1226,7 +1226,9 @@ func (h *Server) MakeUploadTempFile(ctx context.Context, arg chat1.MakeUploadTem
 	if res, err = h.G().AttachmentUploader.GetUploadTempFile(ctx, arg.OutboxID, arg.Filename); err != nil {
 		return res, err
 	}
-	return res, os.WriteFile(res, arg.Data, 0o600)
+	// Write via a temp file + rename so an interrupted write can't leave a
+	// partially written upload payload behind.
+	return res, libkb.NewFile(res, arg.Data, 0o600).Save(h.G().ExternalG().Log)
 }
 
 func (h *Server) CancelUploadTempFile(ctx context.Context, outboxID chat1.OutboxID) (err error) {

--- a/go/encrypteddb/file.go
+++ b/go/encrypteddb/file.go
@@ -38,7 +38,11 @@ func (f *EncryptedFile) Put(ctx context.Context, data any) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(f.path, b, 0o600)
+	// Write via a temp file + rename (libkb.SafeWriteToFile) so that an
+	// interrupted write (app kill, crash, power loss) can never leave a
+	// partially written file behind. A torn file would later fail to decrypt
+	// and be indistinguishable from corruption.
+	return libkb.NewFile(f.path, b, 0o600).Save(f.G().Log)
 }
 
 func (f *EncryptedFile) Remove(ctx context.Context) error {


### PR DESCRIPTION
I think two bugs came together here:
1. mobile app killed caused a corrupted `EncryptedDB` file because of non-atomic writing
2. chat `Deliverer` retryed endless the corrupted outbox item blocking all other sends

this patch adds atomic writes for `EncryptedDB` and `MakeUploadTempFile` and puts some error classification for non-retryable errors

@mmaxim 