### PR TITLE
fix(flip): keep half-asleep devices out of coin flips

### DIFF
--- a/go/chat/flipmanager.go
+++ b/go/chat/flipmanager.go
@@ -221,6 +221,11 @@ func (m *FlipManager) Start(ctx context.Context, uid gregor1.UID) {
 	go m.notificationLoop(shutdownCh)
 	go m.loadGameLoop(shutdownCh)
 	go m.maybeInjectLoop(shutdownCh)
+	if !m.G().IsMobileAppType() {
+		// so ShouldCommit can tell a dark wake or a missed suspend event from
+		// a machine that is really awake
+		m.G().DesktopAppState.StartWakeWatcher()
+	}
 }
 
 func (m *FlipManager) Stop(ctx context.Context) (ch chan struct{}) {
@@ -1568,13 +1573,27 @@ func (m *FlipManager) Me() flip.UserDevice {
 	}
 }
 
+// minFlipConnAge is how long the gregor connection must have been up before
+// this device will join someone else's flip.
+const minFlipConnAge = 30 * time.Second
+
 func (m *FlipManager) ShouldCommit(ctx context.Context) bool {
-	if !m.G().IsMobileAppType() {
-		should := m.G().DesktopAppState.AwakeAndUnlocked(m.G().MetaContext(ctx))
-		if !should {
-			m.Debug(ctx, "ShouldCommit -> false")
+	if m.G().IsMobileAppType() {
+		return true
+	}
+	if !m.G().DesktopAppState.AwakeAndUnlocked(m.G().MetaContext(ctx)) {
+		m.Debug(ctx, "ShouldCommit -> false (not awake and unlocked)")
+		return false
+	}
+	// A gregor connection this fresh usually means the machine just woke up
+	// or reconnected (dark wakes included), and may vanish again before it
+	// can reveal; sit this game out. Zero means no connection-age data
+	// available, which is not grounds for a veto.
+	if cs := m.G().ConnectivityMonitor.ConnectedSince(ctx); !cs.IsZero() {
+		if age := m.clock.Now().Sub(cs); age < minFlipConnAge {
+			m.Debug(ctx, "ShouldCommit -> false (gregor connection too young: %v)", age)
+			return false
 		}
-		return should
 	}
 	return true
 }

--- a/go/engine/bootstrap_test.go
+++ b/go/engine/bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,10 @@ type OfflineConnectivityMonitor struct{}
 
 func (s OfflineConnectivityMonitor) IsConnected(ctx context.Context) libkb.ConnectivityMonitorResult {
 	return libkb.ConnectivityMonitorNo
+}
+
+func (s OfflineConnectivityMonitor) ConnectedSince(ctx context.Context) time.Time {
+	return time.Time{}
 }
 
 func (s OfflineConnectivityMonitor) CheckReachability(ctx context.Context) error {

--- a/go/libkb/appstate.go
+++ b/go/libkb/appstate.go
@@ -173,6 +173,17 @@ func (a *MobileNetState) State() keybase1.MobileNetworkState {
 
 // --------------------------------------------------
 
+const (
+	// wakeWatchInterval is how often the wake watcher samples the wall clock.
+	wakeWatchInterval = 10 * time.Second
+	// wakeWatchGap is the wall-clock gap between samples that we take to mean
+	// the machine was asleep.
+	wakeWatchGap = 30 * time.Second
+	// wakeQuarantine is how long after an unexplained wake AwakeAndUnlocked
+	// keeps reporting false.
+	wakeQuarantine = 60 * time.Second
+)
+
 type DesktopAppState struct {
 	Contextified
 	sync.Mutex
@@ -180,18 +191,62 @@ type DesktopAppState struct {
 	suspended        bool
 	locked           bool
 	updateSuspendChs []chan bool
+	wakeWatcherOnce  sync.Once
+	wakeWatcherStop  chan struct{}
+	// wokeAt is the last time the wake watcher saw the machine come back from
+	// sleep without a corresponding power event (dark wake, lost "suspend"
+	// event, or no GUI connected to send one).
+	wokeAt time.Time
 }
 
 func NewDesktopAppState(g *GlobalContext) *DesktopAppState {
-	d := &DesktopAppState{Contextified: NewContextified(g)}
+	d := &DesktopAppState{Contextified: NewContextified(g), wakeWatcherStop: make(chan struct{})}
 	g.PushShutdownHook(func(mctx MetaContext) error {
 		d.Lock()
 		defer d.Unlock()
 		// reset power state on shutdown
 		d.resetLocked()
+		select {
+		case <-d.wakeWatcherStop:
+		default:
+			close(d.wakeWatcherStop)
+		}
 		return nil
 	})
 	return d
+}
+
+// StartWakeWatcher spawns a loop that detects the machine sleeping when no
+// "suspend" power event told us about it: the event lost a race with sleep,
+// or no Electron GUI is connected to send power events at all. Detection is
+// a wall-clock gap between samples; anything past wakeWatchGap means we were
+// suspended.
+func (a *DesktopAppState) StartWakeWatcher() {
+	a.wakeWatcherOnce.Do(func() {
+		go a.wakeWatchLoop()
+	})
+}
+
+func (a *DesktopAppState) wakeWatchLoop() {
+	// Round(0) strips the monotonic reading so Sub measures wall-clock time,
+	// which keeps advancing across sleeps regardless of platform monotonic
+	// clock behavior.
+	last := time.Now().Round(0)
+	for {
+		select {
+		case <-time.After(wakeWatchInterval):
+		case <-a.wakeWatcherStop:
+			return
+		}
+		now := time.Now().Round(0)
+		if gap := now.Sub(last); gap > wakeWatchGap {
+			a.G().Log.Debug("DesktopAppState: wake with no power event, gap %v", gap)
+			a.Lock()
+			a.wokeAt = now
+			a.Unlock()
+		}
+		last = now
+	}
 }
 
 func (a *DesktopAppState) NextSuspendUpdate(lastState *bool) chan bool {
@@ -218,12 +273,16 @@ func (a *DesktopAppState) Update(mctx MetaContext, event string, provider rpc.Tr
 		a.suspended = true
 	case "resume":
 		a.suspended = false
+		// a power event arrived for this wake, so it's a real resume with the
+		// GUI alive, not a dark wake.
+		a.wokeAt = time.Time{}
 	case "shutdown":
 	case "lock-screen":
 		a.locked = true
 	case "unlock-screen":
 		a.suspended = false
 		a.locked = false
+		a.wokeAt = time.Time{}
 	}
 	for _, ch := range a.updateSuspendChs {
 		ch <- a.suspended
@@ -247,7 +306,17 @@ func (a *DesktopAppState) Disconnected(provider rpc.Transporter) {
 func (a *DesktopAppState) AwakeAndUnlocked(mctx MetaContext) bool {
 	a.Lock()
 	defer a.Unlock()
-	return !a.suspended && !a.locked
+	if a.suspended || a.locked {
+		return false
+	}
+	// A recent wake with no power event is either a dark wake or a machine
+	// with nothing reporting power state; don't claim awake until it has
+	// stayed up for a while.
+	if !a.wokeAt.IsZero() && time.Since(a.wokeAt) < wakeQuarantine {
+		mctx.Debug("DesktopAppState: in post-wake quarantine, woke %v ago", time.Since(a.wokeAt))
+		return false
+	}
+	return true
 }
 
 func (a *DesktopAppState) resetLocked() {

--- a/go/libkb/connectivity_monitor.go
+++ b/go/libkb/connectivity_monitor.go
@@ -2,12 +2,17 @@ package libkb
 
 import (
 	"context"
+	"time"
 )
 
 type NullConnectivityMonitor struct{}
 
 func (s NullConnectivityMonitor) IsConnected(ctx context.Context) ConnectivityMonitorResult {
 	return ConnectivityMonitorYes
+}
+
+func (s NullConnectivityMonitor) ConnectedSince(ctx context.Context) time.Time {
+	return time.Time{}
 }
 
 func (s NullConnectivityMonitor) CheckReachability(ctx context.Context) error {

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -707,6 +707,9 @@ const (
 
 type ConnectivityMonitor interface {
 	IsConnected(ctx context.Context) ConnectivityMonitorResult
+	// ConnectedSince returns when the current gregor connection was
+	// established, or the zero time if disconnected or unknown.
+	ConnectedSince(ctx context.Context) time.Time
 	CheckReachability(ctx context.Context) error
 }
 

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -214,6 +214,9 @@ type gregorHandler struct {
 	firstConnectMu sync.Mutex
 	firstConnect   bool
 
+	connectedAtMu sync.Mutex
+	connectedAt   time.Time
+
 	// Function for determining if a new BroadcastMessage should trigger
 	// a pushState call to firehose handlers
 	pushStateFilter func(m gregor.Message) bool
@@ -894,9 +897,22 @@ func (g *gregorHandler) OnConnect(ctx context.Context, conn *rpc.Connection,
 	// No longer first connect if we are now connected
 	g.chatLog.Debug(ctx, "setting first connect to false")
 	g.setFirstConnect(false)
+	g.setConnectedAt(time.Now())
 	g.chatLog.Debug(ctx, "OnConnect complete")
 
 	return nil
+}
+
+func (g *gregorHandler) setConnectedAt(t time.Time) {
+	g.connectedAtMu.Lock()
+	defer g.connectedAtMu.Unlock()
+	g.connectedAt = t
+}
+
+func (g *gregorHandler) connectedSince() time.Time {
+	g.connectedAtMu.Lock()
+	defer g.connectedAtMu.Unlock()
+	return g.connectedAt
 }
 
 func (g *gregorHandler) OnConnectError(err error, reconnectThrottleDuration time.Duration) {
@@ -918,6 +934,7 @@ func (g *gregorHandler) OnConnectError(err error, reconnectThrottleDuration time
 func (g *gregorHandler) OnDisconnected(ctx context.Context, status rpc.DisconnectStatus) {
 	ctx = libkb.WithLogTag(ctx, "GRGRONDISC")
 	g.chatLog.Debug(ctx, "disconnected: %v", status)
+	g.setConnectedAt(time.Time{})
 
 	// Alert chat syncer that we are now disconnected
 	g.G().Syncer.Disconnected(ctx)
@@ -1354,6 +1371,7 @@ func (g *gregorHandler) Shutdown(ctx context.Context) {
 	g.conn.Shutdown()
 	g.conn = nil
 	g.cli = nil
+	g.setConnectedAt(time.Time{})
 }
 
 func (g *gregorHandler) Reset() error {

--- a/go/service/reachability.go
+++ b/go/service/reachability.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -79,6 +80,10 @@ func (h *reachability) check(ctx context.Context) (k keybase1.Reachability) {
 	}
 	h.setReachability(k)
 	return k
+}
+
+func (h *reachability) ConnectedSince(ctx context.Context) time.Time {
+	return h.gh.connectedSince()
 }
 
 func (h *reachability) IsConnected(ctx context.Context) libkb.ConnectivityMonitorResult {

--- a/go/systests/rpc_test.go
+++ b/go/systests/rpc_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/client"
@@ -41,6 +42,10 @@ func (f *fakeConnectivityMonitor) Set(r libkb.ConnectivityMonitorResult) {
 	f.Lock()
 	defer f.Unlock()
 	f.res = r
+}
+
+func (f *fakeConnectivityMonitor) ConnectedSince(ctx context.Context) time.Time {
+	return time.Time{}
 }
 
 func (f *fakeConnectivityMonitor) CheckReachability(ctx context.Context) error {

--- a/shared/chat/conversation/input-area/input-state.test.tsx
+++ b/shared/chat/conversation/input-area/input-state.test.tsx
@@ -12,8 +12,9 @@ import {ConversationInputProvider, useConversationInput} from './input-state'
 import {ConversationThreadProvider, useConversationThreadActions} from '../thread-context'
 
 let mockRouteParams: Record<string, unknown> = {}
+// useChatThreadRouteParams only honors params on the chat thread routes, so the mock needs a matching name
 jest.mock('@react-navigation/native', () => ({
-  useRoute: () => ({params: mockRouteParams}),
+  useRoute: () => ({name: 'chatConversation', params: mockRouteParams}),
 }))
 
 jest.mock('@/chat/inbox/rows-state', () => ({

--- a/shared/ios/Keybase/AppDelegate.swift
+++ b/shared/ios/Keybase/AppDelegate.swift
@@ -60,6 +60,12 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
 
     self.didLaunchSetupBefore()
 
+    // Tell Go the real app state right after init. Go defaults to foreground,
+    // so a background launch (silent push, background fetch) would otherwise
+    // look foregrounded until didLaunchSetupAfter runs — long enough to join
+    // a coin flip it can't finish.
+    self.notifyAppState(application)
+
     if let remoteNotification = launchOptions?[.remoteNotification] as? [AnyHashable: Any] {
       let notificationDict = Dictionary(uniqueKeysWithValues: remoteNotification.map { (String(describing: $0.key), $0.value) })
       KbSetInitialNotification(notificationDict)


### PR DESCRIPTION
## Problem

`/flip` sometimes fails with `AbsenteesError`: the commitment gather includes a device that then never reveals, and one missing reveal fails the whole game. Retrying works because the bad device's gregor connection is dead by then.

The commit decision (`FlipManager.ShouldCommit` + `shouldIgnoreInject`) trusted availability state that fails open:

- **Desktop**: `DesktopAppState` assumes awake+unlocked when the Electron GUI disconnects or never connects (headless service), and the `suspend` power event can lose the race with sleep (async main → renderer IPC → RPC hop). A dark-waking closed laptop reconnects to gregor, commits, and goes back to sleep before the reveal window ends.
- **iOS**: Go's `MobileAppState` defaults to `FOREGROUND`, and the app only reports its real state after RN init. A background launch (silent push / background fetch) looks foregrounded long enough to join a flip that iOS then freezes.

## Fix

All bookkeeping — no new RPCs.

- **Wake watcher** (`libkb/appstate.go`): samples the wall clock every 10s; a >30s gap means the machine slept with no `suspend` event. `AwakeAndUnlocked` reports false for a 60s quarantine after such a wake, unless a `resume`/`unlock-screen` event arrives (proves a real, GUI-attended wake). Armed from `FlipManager.Start`, desktop only.
- **Connection age** (`ShouldCommit`): refuse to join a flip when the gregor connection is under 30s old, via new `ConnectivityMonitor.ConnectedSince` backed by a `connectedAt` stamp in gregor's `OnConnect`. Zero time (no data, e.g. tests) never vetoes. The leader is unaffected — it always commits.
- **iOS launch gap** (`AppDelegate.swift`): call `notifyAppState` immediately after `KeybaseInit` instead of waiting for RN init, so background launches report `BACKGROUND` before gregor can hand them a flip.

## Testing

- `go build` / `go vet` clean on `libkb`, `service`, `chat`, `engine`, `systests`
- `chat/flip` tests pass; test binaries for all touched packages compile
- Needs multi-device verification for the real scenario: closed-laptop device should sit out the gather instead of committing and ghosting

🤖 Generated with [Claude Code](https://claude.com/claude-code)