### PR TITLE
fix(mobile): NameWithIcon avatar click no longer dead

### DIFF
--- a/shared/common-adapters/box.tsx
+++ b/shared/common-adapters/box.tsx
@@ -310,7 +310,7 @@ const nativeStyles = {
 } as const
 
 export type ClickableBoxProps = Box2Props & {
-  onClick?: (e?: React.SyntheticEvent) => void
+  onClick?: (e?: React.BaseSyntheticEvent) => void
   onLongPress?: () => void
   hitSlop?: number
 }
@@ -352,7 +352,7 @@ export const ClickableBox = (p: ClickableBoxProps & {ref?: React.Ref<MeasureRef 
       hitSlop={hitSlop}
       onLayout={onLayout}
       onLongPress={onLongPress}
-      onPress={onClick ? () => { onClick() } : undefined}
+      onPress={onClick ? e => { onClick(e) } : undefined}
       pointerEvents={pointerEvents}
       style={s}
       testID={box2p.testID}

--- a/shared/common-adapters/name-with-icon.tsx
+++ b/shared/common-adapters/name-with-icon.tsx
@@ -63,11 +63,9 @@ export type NameWithIconProps = {
 export const NameWithIcon = (props: NameWithIconProps) => {
   const {onClick, username = '', teamname, size} = props
   const _onClickWrapper = onClick
-    ? (event: React.BaseSyntheticEvent) => {
-        if (!event.defaultPrevented) {
-          if (username) {
-            onClick(username)
-          }
+    ? (event?: React.BaseSyntheticEvent) => {
+        if (!event?.defaultPrevented && username) {
+          onClick(username)
         }
       }
     : undefined
@@ -237,7 +235,7 @@ export const NameWithIcon = (props: NameWithIconProps) => {
 
   // ClickableBox only when clickable: it renders Pressable/clickable-box2 with different semantics
   return _onClickWrapper ? (
-    <ClickableBox {...boxProps} onClick={e => e && _onClickWrapper(e)}>
+    <ClickableBox {...boxProps} onClick={_onClickWrapper}>
       {children}
     </ClickableBox>
   ) : (


### PR DESCRIPTION
Native ClickableBox called onClick with no arguments, so NameWithIcon's `e => e && _onClickWrapper(e)` guard swallowed every press. Desktop passed the DOM event, so only mobile was affected.

Forward the press event from Pressable, and let the wrapper accept an absent event instead of dropping the click.