### PR TITLE
build(deps): bump vite 8.1.4, keyboard-controller 1.22.0

### DIFF
--- a/shared/ios/Podfile.lock
+++ b/shared/ios/Podfile.lock
@@ -1631,7 +1631,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller (1.21.14):
+  - react-native-keyboard-controller (1.22.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1643,7 +1643,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.21.14)
+    - react-native-keyboard-controller/common (= 1.22.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1654,7 +1654,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller/common (1.21.14):
+  - react-native-keyboard-controller/common (1.22.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2186,7 +2186,7 @@ PODS:
     - React-utils (= 0.86.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.86.0)
-  - ReactNavigation (8.0.0-alpha.34):
+  - ReactNavigation (8.0.0-alpha.35):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2966,7 +2966,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 354ab193a7ed66e42869c8a0c2c0d844e8e22f67
   React-mutationobservernativemodule: f53ad06cbe4b44d2a33df6aa3f01ca8e9b57e83b
   react-native-kb: 71289be80d93678d5abff5805cb638cd36d9e08e
-  react-native-keyboard-controller: 1ae58e1dc917b82e87c602a5108f8ab02de92654
+  react-native-keyboard-controller: 7035cde04633689d349fa197e755ad0111d7c26d
   react-native-netinfo: a05f9b897e76ad24b53f615fed1cbb731932363d
   react-native-safe-area-context: 0bbcdfba5c4a1b3203276f1ed9128e3239fdf199
   react-native-webview: da05bfc1780bcf7adb992de2976b09b559489d76
@@ -3005,7 +3005,7 @@ SPEC CHECKSUMS:
   ReactCodegen: cd296de5e1c422deebafff34134d1721b5c29704
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  ReactNavigation: 91c5ab38bc3725c73ea2399bf2bf9d0a38ca935a
+  ReactNavigation: a37921f7c7ac12ad91d4f69ceb43b5b456ff058d
   RNCMaskedView: 8069b4d4e23b3d28b4fcac70bf266be43ffc3d2e
   RNCPicker: a3921be99ae291e420e3e8940e5b2b53e572c543
   RNGestureHandler: 7ade813d6efb2b650e01afdd54d699bc435843fb

--- a/shared/package.json
+++ b/shared/package.json
@@ -136,7 +136,7 @@
     "react-native": "0.86.0",
     "react-native-gesture-handler": "3.0.2",
     "react-native-kb": "file:../rnmodules/react-native-kb",
-    "react-native-keyboard-controller": "1.21.14",
+    "react-native-keyboard-controller": "1.22.0",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "5.8.0",
     "react-native-screens": "4.25.2",
@@ -202,7 +202,7 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.63.0",
     "typescript-native": "npm:typescript@7.0.2",
-    "vite": "8.1.3",
+    "vite": "8.1.4",
     "webdriverio": "9.29.1"
   },
   "resolutions": {

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -10822,7 +10822,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.2:
+picomatch@^4.0.2, picomatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -11211,10 +11211,10 @@ react-native-is-edge-to-edge@^1.2.1, react-native-is-edge-to-edge@^1.3.1:
 "react-native-kb@file:../rnmodules/react-native-kb":
   version "0.1.1"
 
-react-native-keyboard-controller@1.21.14:
-  version "1.21.14"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.14.tgz#3d29d67e09824597d1b3904746f3a38593b37026"
-  integrity sha512-zUKGBecMlgeuafAYT4AUWCQarEm6RJ84K9yVJqitDnfVcQuU1AXc10E3SlVt0/qgipByeK2jdeRKjnLf68j8rA==
+react-native-keyboard-controller@1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.22.0.tgz#b3bf775f55983aa5478561d361ae2881dc4a30c4"
+  integrity sha512-FT8/xmb69o8rlqAxHg808p+m6+wigDLYWATKOnUgOoF2XlE2HV/2uPD6umKUg9sL6EX/uuLzoLMdsJlJGtwO9g==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 
@@ -11627,7 +11627,7 @@ rgb2hex@0.2.5:
   resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.2.5.tgz#f82230cd3ab1364fa73c99be3a691ed688f8dbdc"
   integrity sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==
 
-rolldown@~1.1.3:
+rolldown@~1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.1.5.tgz#339aae250844351fc55b74e2652d3ebd6fba389d"
   integrity sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==
@@ -13165,15 +13165,15 @@ vary@^1.1.2, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vite@8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.3.tgz#ce05b445b501014a10e5a8073811759c223e8ac2"
-  integrity sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==
+vite@8.1.4:
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.1.4.tgz#3cd711f31de805e5154ab47948349e693314d581"
+  integrity sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==
   dependencies:
     lightningcss "^1.32.0"
-    picomatch "^4.0.4"
+    picomatch "^4.0.5"
     postcss "^8.5.16"
-    rolldown "~1.1.3"
+    rolldown "~1.1.4"
     tinyglobby "^0.2.17"
   optionalDependencies:
     fsevents "~2.3.3"


### PR DESCRIPTION
Routine dependency pass.

- vite 8.1.3 -> 8.1.4 (patch)
- react-native-keyboard-controller 1.21.14 -> 1.22.0

Podfile.lock also picks up ReactNavigation alpha.34 -> alpha.35, which package.json was already pinned to; the pod lock was stale.

Held back deliberately:
- @babel/* 7.29.7 -> 8.x: major. @react-native/babel-preset and metro still ship v7-era plugins.
- typescript stays on 6.0.3 (classic compiler API) for typescript-eslint and analyze-styles.mts. typescript-native is already on 7.0.2.
- eslint-plugin-react-compiler: npm's rc.1-<hash> sorts after rc.2 but is older.

resolutions for serialize-javascript and uuid were tested for removal and are both still required; each is already pinned at its latest version.

yarn lint, yarn tsc, yarn audit, and the duplicate-install check are clean.