### PR TITLE
fix(chat): size suggestion popup to whole rows on desktop

### DIFF
--- a/shared/chat/conversation/input-area/suggestors/channels.tsx
+++ b/shared/chat/conversation/input-area/suggestors/channels.tsx
@@ -23,6 +23,9 @@ export const transformer = (
 const keyExtractor = ({channelname, teamname}: ChannelType) =>
   teamname ? `${teamname}#${channelname}` : channelname
 
+// a bare channel row is a single line of BodySemibold, whose desktop line-height is 18
+const bareChannelRowHeight = Common.desktopRowHeight(18)
+
 const ItemRenderer = (p: Common.ItemRendererProps<ChannelType>) => {
   const {item, selected} = p
   const {channelname, teamname} = item
@@ -166,6 +169,10 @@ type ListProps = Pick<
 export const List = (p: ListProps) => {
   const {conversationIDKey, filter, ...rest} = p
   const {items, loading} = useDataSource(conversationIDKey, filter)
+  // suggestions are either all mutual-team channels or all bare channels, never mixed
+  const rowHeight = items.some(i => 'teamname' in i && i.teamname)
+    ? Common.avatarRowHeight
+    : bareChannelRowHeight
   return (
     <Common.List
       {...rest}
@@ -173,6 +180,7 @@ export const List = (p: ListProps) => {
       items={items}
       ItemRenderer={ItemRenderer}
       loading={loading}
+      rowHeight={rowHeight}
     />
   )
 }

--- a/shared/chat/conversation/input-area/suggestors/commands.tsx
+++ b/shared/chat/conversation/input-area/suggestors/commands.tsx
@@ -96,6 +96,10 @@ const getBotRestrictBlockMap = (
 }
 const blankCommands: Array<T.RPCChat.ConversationCommand> = []
 
+// two stacked lines, whose desktop line-heights are 18 (Body) and 17 (BodySmall); this is
+// taller than the optional leading avatar. Long descriptions can wrap and exceed this.
+const rowHeight = Common.desktopRowHeight(18 + 17)
+
 const ItemRenderer = (p: Common.ItemRendererProps<CommandType>) => {
   const {selected, item: command} = p
   const prefix = getCommandPrefix(command)
@@ -129,7 +133,7 @@ const ItemRenderer = (p: Common.ItemRendererProps<CommandType>) => {
         {backgroundColor: selected ? Kb.Styles.globalColors.blueLighter2 : Kb.Styles.globalColors.white},
       ])}
     >
-      {!!command.username && <Kb.Avatar size={32} username={command.username} />}
+      {!!command.username && <Kb.Avatar size={Common.avatarSize} username={command.username} />}
       <Kb.Box2
         fullWidth={true}
         direction="vertical"
@@ -239,6 +243,7 @@ export const List = (p: ListProps) => {
           items={items}
           ItemRenderer={ItemRenderer}
           loading={false}
+          rowHeight={rowHeight}
         />
       </BotCommandConversationContext.Provider>
     </BotCommandSettingsContext.Provider>

--- a/shared/chat/conversation/input-area/suggestors/common.tsx
+++ b/shared/chat/conversation/input-area/suggestors/common.tsx
@@ -23,6 +23,13 @@ export const standardTransformer = (
   return {selection: {end: newSelection, start: newSelection}, text: newText}
 }
 
+// rows have no explicit height on desktop, so each suggestor derives its row
+// height from its tallest child plus the padding `suggestionBase` adds
+export const desktopRowHeight = (contentHeight: number) => contentHeight + Kb.Styles.globalMargins.xtiny * 2
+export const avatarSize = 32
+// rows leading with an avatar (users, teams, channels-of-a-team)
+export const avatarRowHeight = desktopRowHeight(avatarSize)
+
 export const TeamSuggestion = (p: {teamname: string; channelname: string | undefined; selected: boolean}) => (
   <Kb.Box2
     direction="horizontal"
@@ -36,7 +43,7 @@ export const TeamSuggestion = (p: {teamname: string; channelname: string | undef
     ])}
     gap="tiny"
   >
-    <Kb.Avatar teamname={p.teamname} size={32} />
+    <Kb.Avatar teamname={p.teamname} size={avatarSize} />
     <Kb.Text type="BodyBold">{p.channelname ? p.teamname + ' #' + p.channelname : p.teamname}</Kb.Text>
   </Kb.Box2>
 )
@@ -49,6 +56,8 @@ export type ListProps<L> = {
   listStyle: Kb.Styles.StylesCrossPlatform
   spinnerStyle: Kb.Styles.StylesCrossPlatform
   loading: boolean
+  // desktop only, see SuggestionList
+  rowHeight: number
   onSelected: (item: L, final: boolean) => void
   setOnMoveRef: (r: (up: boolean) => void) => void
   setOnSubmitRef: (r: () => boolean) => void
@@ -56,7 +65,7 @@ export type ListProps<L> = {
 }
 
 export function List<T>(p: ListProps<T>) {
-  const {items, ItemRenderer, loading, keyExtractor, onSelected} = p
+  const {items, ItemRenderer, loading, keyExtractor, onSelected, rowHeight} = p
   const {suggestBotCommandsUpdateStatus, listStyle, spinnerStyle, setOnMoveRef, setOnSubmitRef} = p
   const [selectedIndex, setSelectedIndex] = React.useState(0)
 
@@ -105,6 +114,7 @@ export function List<T>(p: ListProps<T>) {
         items={items}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
+        rowHeight={rowHeight}
         selectedIndex={selectedIndex}
         suggestBotCommandsUpdateStatus={suggestBotCommandsUpdateStatus}
       />

--- a/shared/chat/conversation/input-area/suggestors/emoji.tsx
+++ b/shared/chat/conversation/input-area/suggestors/emoji.tsx
@@ -15,6 +15,9 @@ export const transformer = (
 
 const keyExtractor = (_item: EmojiData, idx: number) => String(idx) // emojis can have conflicts on the names
 
+const emojiSize = 24
+const rowHeight = Common.desktopRowHeight(emojiSize)
+
 const ItemRenderer = (p: Common.ItemRendererProps<EmojiData>) => {
   const {item, selected} = p
   return (
@@ -27,7 +30,7 @@ const ItemRenderer = (p: Common.ItemRendererProps<EmojiData>) => {
       ])}
       gap="small"
     >
-      <Kb.Emoji emojiData={item} showTooltip={false} size={24} />
+      <Kb.Emoji emojiData={item} showTooltip={false} size={emojiSize} />
       <Kb.Text type="BodySmallSemibold">{item.short_name}</Kb.Text>
     </Kb.Box2>
   )
@@ -81,6 +84,7 @@ export const List = (p: ListProps) => {
       items={items}
       ItemRenderer={ItemRenderer}
       loading={loading}
+      rowHeight={rowHeight}
     />
   )
 }

--- a/shared/chat/conversation/input-area/suggestors/suggestion-list.tsx
+++ b/shared/chat/conversation/input-area/suggestors/suggestion-list.tsx
@@ -9,12 +9,17 @@ type Props<I> = {
   items: Array<I>
   keyExtractor?: (item: I, idx: number) => string
   renderItem: (index: number, item: I) => React.ReactElement
+  // desktop only: height of a single rendered row, so the popup can be sized to
+  // a whole number of rows instead of clipping the last one into a scroll area
+  rowHeight: number
   selectedIndex: number
   style?: Kb.Styles.StylesCrossPlatform
   suggestBotCommandsUpdateStatus?: T.RPCChat.UIBotCommandsUpdateStatusTyp
 }
 import type {LegendListRef} from '@/common-adapters'
 import {FlatList} from 'react-native'
+
+const maxHeight = 224
 
 const SuggestionList = <I,>(props: Props<I>) => {
   const listRef = React.useRef<LegendListRef>(null)
@@ -42,25 +47,27 @@ const SuggestionList = <I,>(props: Props<I>) => {
       return i ? (props.renderItem(index, i) as React.JSX.Element) : <></>
     }
     const itemHeight = {type: 'trueVariable' as const}
-    const maxHeight = 224
-    const estimatedItemHeight = 24
-    const listHeight = Math.min(props.items.length * estimatedItemHeight, maxHeight)
+    const {rowHeight} = props
+    const maxRows = Math.max(1, Math.floor(maxHeight / rowHeight))
+    const listHeight = Math.min(props.items.length, maxRows) * rowHeight
 
     return (
       <Kb.Box2
         direction="vertical"
         fullWidth={true}
-        style={Kb.Styles.collapseStyles([desktopStyles.listContainer, {height: listHeight}, props.style])}
+        style={Kb.Styles.collapseStyles([desktopStyles.listContainer, props.style])}
         testID={TestIDs.CHAT_SUGGESTION_LIST}
       >
-        <Kb.List
-          ref={listRef}
-          renderItem={itemRenderer}
-          items={props.items}
-          itemHeight={itemHeight}
-          estimatedItemHeight={estimatedItemHeight}
-          extraData={selectedIndex}
-        />
+        <Kb.Box2 direction="vertical" fullWidth={true} style={{height: listHeight}}>
+          <Kb.List
+            ref={listRef}
+            renderItem={itemRenderer}
+            items={props.items}
+            itemHeight={itemHeight}
+            estimatedItemHeight={rowHeight}
+            extraData={selectedIndex}
+          />
+        </Kb.Box2>
         {props.suggestBotCommandsUpdateStatus &&
         props.suggestBotCommandsUpdateStatus !== T.RPCChat.UIBotCommandsUpdateStatusTyp.blank ? (
           <Kb.Box2

--- a/shared/chat/conversation/input-area/suggestors/users.tsx
+++ b/shared/chat/conversation/input-area/suggestors/users.tsx
@@ -234,7 +234,7 @@ const ItemRenderer = (p: Common.ItemRendererProps<ListItem>) => {
           <Kb.Icon type="iconfont-people" color={Kb.Styles.globalColors.blueDark} fontSize={16} />
         </Kb.Box2>
       ) : (
-        <Kb.Avatar username={username} size={32} />
+        <Kb.Avatar username={username} size={Common.avatarSize} />
       )}
       <Kb.ConnectedUsernames
         type="BodyBold"
@@ -265,6 +265,7 @@ export const UsersList = (p: ListProps) => {
       items={items}
       ItemRenderer={ItemRenderer}
       loading={false}
+      rowHeight={Common.avatarRowHeight}
     />
   )
 }


### PR DESCRIPTION
The desktop popup height came from a hardcoded estimate of 24px per row, but no suggestor renders a 24px row. A single @user match produced a 24px container around a 40px row, so the popup scrolled instead of fitting.

Each suggestor now declares its own desktop row height, derived from its tallest child plus the padding suggestionBase adds, and the container is sized to a whole number of those rows. itemHeight stays trueVariable so wrapping command descriptions still render at their true height.

The fixed height also moves off the outer Box2 onto a wrapper around the list, so the bot-command status bar adds height below it rather than taking rows away from it.