### PR TITLE
refactor(rn): replace deprecated TextInput blurOnSubmit with submitBe…

### DIFF
--- a/shared/chat/conversation/input-area/normal/input.tsx
+++ b/shared/chat/conversation/input-area/normal/input.tsx
@@ -420,7 +420,6 @@ function NativeInput(p: InputLowLevelProps) {
       autoCapitalize={autoCapitalize}
       autoCorrect={autoCorrect}
       autoFocus={autoFocus}
-      blurOnSubmit={false}
       multiline={multiline}
       onBlur={onBlur as ((e: unknown) => void) | undefined}
       onChangeText={onChangeText}
@@ -431,6 +430,7 @@ function NativeInput(p: InputLowLevelProps) {
       ref={setInputRef}
       selection={selection}
       style={style as object | null | undefined}
+      submitBehavior={multiline ? 'newline' : 'submit'}
       testID={TestIDs.CHAT_INPUT}
       value={value}
     />

--- a/shared/common-adapters/input3.tsx
+++ b/shared/common-adapters/input3.tsx
@@ -5,7 +5,7 @@ import IconAuto from './icon-auto'
 import Text from './text'
 import {getTextStyle} from './text.styles'
 import {useColorScheme, TextInput as _TextInputReal} from 'react-native'
-const NativeTextInput = _TextInputReal as unknown as React.ComponentType<{autoCapitalize?: string; autoCorrect?: boolean; autoFocus?: boolean; blurOnSubmit?: boolean; editable?: boolean; keyboardType?: string; maxLength?: number; multiline?: boolean; onBlur?: () => void; onChangeText?: (text: string) => void; onFocus?: () => void; onSubmitEditing?: () => void; placeholder?: string; placeholderTextColor?: string; ref?: React.Ref<InputLikeRef>; returnKeyType?: string; secureTextEntry?: boolean; selectTextOnFocus?: boolean; style?: Styles.StylesCrossPlatform; textContentType?: string; underlineColorAndroid?: string; value?: string}>
+const NativeTextInput = _TextInputReal as unknown as React.ComponentType<{autoCapitalize?: string; autoCorrect?: boolean; autoFocus?: boolean; editable?: boolean; keyboardType?: string; maxLength?: number; multiline?: boolean; onBlur?: () => void; onChangeText?: (text: string) => void; onFocus?: () => void; onSubmitEditing?: () => void; placeholder?: string; placeholderTextColor?: string; ref?: React.Ref<InputLikeRef>; returnKeyType?: string; secureTextEntry?: boolean; selectTextOnFocus?: boolean; style?: Styles.StylesCrossPlatform; submitBehavior?: 'submit' | 'blurAndSubmit' | 'newline'; textContentType?: string; underlineColorAndroid?: string; value?: string}>
 import type {Input3Props, Input3Ref} from './input3.shared'
 export type {Input3Props, Input3Ref} from './input3.shared'
 
@@ -241,7 +241,6 @@ const NativeInput3 = (props: Input3Props & {ref?: React.Ref<Input3Ref>}) => {
         autoCapitalize={autoCapitalize ?? 'none'}
         autoCorrect={autoCorrect ?? false}
         autoFocus={autoFocus}
-        blurOnSubmit={!multiline}
         editable={!disabled}
         keyboardType={keyboardType ?? 'default'}
         maxLength={maxLength}
@@ -264,6 +263,7 @@ const NativeInput3 = (props: Input3Props & {ref?: React.Ref<Input3Ref>}) => {
           multiline && rowsMax && {maxHeight: rowsMax * lineHeight},
           inputStyle,
         ])}
+        submitBehavior={multiline ? 'newline' : 'blurAndSubmit'}
         textContentType={textContentType}
         underlineColorAndroid="transparent"
         value={value}


### PR DESCRIPTION
…havior

RN is removing blurOnSubmit (react/react-native#57384). Map both call sites to the equivalent submitBehavior value:

- chat input passed blurOnSubmit={false}, meaning "fire onSubmitEditing, never blur" -> 'newline' when multiline, 'submit' otherwise.
- input3 passed blurOnSubmit={!multiline} -> 'blurAndSubmit' when single-line, 'newline' when multiline.

Also swaps the prop in input3's hand-written NativeTextInput cast.