### PR TITLE
perf: stop identity churn and oversubscription across chat/inbox stores

### DIFF
--- a/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
+++ b/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
@@ -102,7 +102,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         val versionName: String,
         val cacheDir: String,
         val downloadDir: String,
-        val guiConfig: String?,
         val serverConfig: String,
         val uses24HourClock: Boolean,
         val version: String,
@@ -132,7 +131,6 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
             versionName = getBuildConfigValue("VERSION_NAME").toString(),
             cacheDir = reactContext.cacheDir?.absolutePath ?: "",
             downloadDir = reactContext.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)?.absolutePath ?: "",
-            guiConfig = readGuiConfig(),
             serverConfig = serverConfig,
             uses24HourClock = DateFormat.is24HourFormat(reactContext),
             version = version(),
@@ -150,7 +148,10 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         constants.putBoolean("darkModeSupported", false)
         constants.putString("fsCacheDir", c.cacheDir)
         constants.putString("fsDownloadDir", c.downloadDir)
-        constants.putString("guiConfig", c.guiConfig)
+        // gui_config.json changes at runtime (route persistence), and JS re-reads
+        // these constants on a dev reload; read it fresh so a reload doesn't
+        // restore a stale launch-time route.
+        constants.putString("guiConfig", readGuiConfig())
         constants.putString("serverConfig", c.serverConfig)
         constants.putBoolean("uses24HourClock", c.uses24HourClock)
         constants.putString("version", c.version)

--- a/rnmodules/react-native-kb/ios/Kb.mm
+++ b/rnmodules/react-native-kb/ios/Kb.mm
@@ -79,13 +79,14 @@ static NSString *kbSetupGuiConfig(void) {
 }
 
 // Built once; safe because fsPaths and KeybaseInit are set up in the app
-// delegate before React Native creates this module.
+// delegate before React Native creates this module. guiConfig is NOT cached
+// here: it changes at runtime (route persistence), so getTypedConstants
+// re-reads it per call.
 static NSDictionary *kbConstants(void) {
   static NSDictionary *constants = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     NSString *serverConfig = kbSetupServerConfig();
-    NSString *guiConfig = kbSetupGuiConfig();
 
     NSString *appVersionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     if (appVersionString == nil) {
@@ -111,7 +112,6 @@ static NSDictionary *kbConstants(void) {
       @"darkModeSupported" : @YES,
       @"fsCacheDir" : cacheDir,
       @"fsDownloadDir" : downloadDir,
-      @"guiConfig" : guiConfig,
       @"serverConfig" : serverConfig,
       @"uses24HourClock" : @(kbUses24HourClockForLocale(currentLocale)),
       @"version" : kbVersion
@@ -265,7 +265,12 @@ RCT_EXPORT_METHOD(setEnablePasteImage:(BOOL)enabled) {
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getTypedConstants) {
-  return kbConstants();
+  // gui_config.json changes at runtime (route persistence), and JS re-reads
+  // these constants on a dev reload; a launch-time snapshot would restore a
+  // stale route, so read it fresh on every call.
+  NSMutableDictionary *constants = [kbConstants() mutableCopy];
+  constants[@"guiConfig"] = kbSetupGuiConfig();
+  return constants;
 }
 
 RCT_EXPORT_METHOD(shareListenersRegistered) {

--- a/shared/chat/blocking/invitation-to-block.tsx
+++ b/shared/chat/blocking/invitation-to-block.tsx
@@ -13,7 +13,7 @@ import {
   useConversationThreadSelector,
   useThreadMeta,
 } from '../conversation/thread-context'
-import {useConversationParticipants} from '../conversation/data-hooks'
+import {useConversationParticipantsSelector} from '../conversation/data-hooks'
 
 const dismissBlockButtons = (teamID: T.RPCGen.TeamID) => {
   const f = async () => {
@@ -31,21 +31,23 @@ const dismissBlockButtons = (teamID: T.RPCGen.TeamID) => {
 const BlockButtons = () => {
   const navigateAppend = C.Router2.navigateAppend
   const conversationIDKey = useConversationThreadID()
-  const {messageMap, messageOrdinals} = useConversationThreadSelector(
-    C.useShallow(s => ({
-      messageMap: s.messageMap,
-      messageOrdinals: s.messageOrdinals,
-    }))
-  )
   const {team, teamID, tlfname} = useThreadMeta(
     C.useShallow(m => ({team: m.teamname, teamID: m.teamID, tlfname: m.tlfname}))
   )
-  const participantInfo = useConversationParticipants(conversationIDKey)
+  const participantInfo = useConversationParticipantsSelector(
+    conversationIDKey,
+    C.useShallow(p => ({all: p.all, name: p.name}))
+  )
   const blockButtonInfo = useBlockButtonsInfo(teamID)
   const currentUser = useCurrentUserState(s => s.username)
-  const hasOwnMessage =
-    !!currentUser &&
-    [...(messageOrdinals ?? [])].some(ordinal => messageMap.get(ordinal)?.author === currentUser)
+  // Derive the boolean in the selector so thread churn only re-renders this when the
+  // answer flips; skip the scan entirely for the common no-block-buttons case.
+  const hasOwnMessage = useConversationThreadSelector(
+    s =>
+      !!blockButtonInfo &&
+      !!currentUser &&
+      (s.messageOrdinals ?? []).some(ordinal => s.messageMap.get(ordinal)?.author === currentUser)
+  )
 
   React.useEffect(() => {
     if (hasOwnMessage && blockButtonInfo && teamID) {

--- a/shared/chat/conversation/attachment-actions.tsx
+++ b/shared/chat/conversation/attachment-actions.tsx
@@ -1,4 +1,3 @@
-import * as C from '@/constants'
 import * as Common from '@/constants/chat/common'
 import * as Message from '@/constants/chat/message'
 import * as T from '@/constants/types'
@@ -14,7 +13,7 @@ import {useCurrentUserState} from '@/stores/current-user'
 import {
   useConversationThreadActions,
   useConversationThreadID,
-  useConversationThreadSelector,
+  useConversationThreadStore,
 } from './thread-context'
 
 const {darwinCopyToChatTempUploadFile} = KB2.functions
@@ -314,16 +313,13 @@ export const loadNextAttachmentMessage = async (
 export const useConversationAttachmentActions = () => {
   const conversationIDKey = useConversationThreadID()
   const actions = useConversationThreadActions()
-  const {messageMap, messageOrdinals, pendingOutboxToOrdinal} = useConversationThreadSelector(
-    C.useShallow(s => ({
-      messageMap: s.messageMap,
-      messageOrdinals: s.messageOrdinals,
-      pendingOutboxToOrdinal: s.pendingOutboxToOrdinal,
-    }))
-  )
+  // Read thread state lazily at call time. Callers (TransferIcon etc) render per
+  // message row, so subscribing to messageMap here would re-render every one of
+  // them on every thread change.
+  const threadStore = useConversationThreadStore()
 
   const downloadAttachment = async (downloadToCache: boolean, ordinal: T.Chat.Ordinal) => {
-    const messageID = messageMap.get(ordinal)?.id
+    const messageID = threadStore.getState().messageMap.get(ordinal)?.id
     if (!messageID) {
       return false
     }
@@ -352,7 +348,7 @@ export const useConversationAttachmentActions = () => {
   }
 
   const attachmentDownload = (ordinal: T.Chat.Ordinal) => {
-    const old = messageMap.get(ordinal)
+    const old = threadStore.getState().messageMap.get(ordinal)
     if (!old) {
       return
     }
@@ -378,7 +374,7 @@ export const useConversationAttachmentActions = () => {
     if (!isMobile) {
       return
     }
-    const existing = messageMap.get(ordinal)
+    const existing = threadStore.getState().messageMap.get(ordinal)
     if (existing?.type !== 'attachment') {
       throw new Error('Invalid share message')
     }
@@ -405,7 +401,7 @@ export const useConversationAttachmentActions = () => {
   }
 
   const messageAttachmentNativeShare = (ordinal: T.Chat.Ordinal, fromDownload = false) => {
-    const message = messageMap.get(ordinal)
+    const message = threadStore.getState().messageMap.get(ordinal)
     if (message?.type !== 'attachment') {
       throw new Error('Invalid share message')
     }
@@ -432,12 +428,12 @@ export const useConversationAttachmentActions = () => {
   }
 
   const loadNextAttachment = async (from: T.Chat.Ordinal, backInTime: boolean) => {
-    const fromMsg = messageMap.get(from)
+    const fromMsg = threadStore.getState().messageMap.get(from)
     if (!fromMsg) {
       return Promise.reject(new Error('Incorrect from'))
     }
     const {deviceName, username} = useCurrentUserState.getState()
-    const getLastOrdinal = () => messageOrdinals?.at(-1) ?? T.Chat.numberToOrdinal(0)
+    const getLastOrdinal = () => threadStore.getState().messageOrdinals?.at(-1) ?? T.Chat.numberToOrdinal(0)
     const result = await T.RPCChat.localGetNextAttachmentMessageLocalRpcPromise({
       assetTypes: [T.RPCChat.AssetMetadataType.image, T.RPCChat.AssetMetadataType.video],
       backInTime,
@@ -457,8 +453,8 @@ export const useConversationAttachmentActions = () => {
       if (goodMessage?.type === 'attachment') {
         actions.addMessages([goodMessage])
         let ordinal = goodMessage.ordinal
-        if (goodMessage.outboxID && !messageMap.get(ordinal)) {
-          const pendingOrdinal = pendingOutboxToOrdinal.get(goodMessage.outboxID)
+        if (goodMessage.outboxID && !threadStore.getState().messageMap.get(ordinal)) {
+          const pendingOrdinal = threadStore.getState().pendingOutboxToOrdinal.get(goodMessage.outboxID)
           if (pendingOrdinal) {
             ordinal = pendingOrdinal
           }
@@ -475,7 +471,7 @@ export const useConversationAttachmentActions = () => {
     messageAttachmentNativeSave,
     messageAttachmentNativeShare,
     showAttachmentPreview: (ordinal: T.Chat.Ordinal, message?: T.Chat.MessageAttachment) => {
-      const existing = messageMap.get(ordinal)
+      const existing = threadStore.getState().messageMap.get(ordinal)
       const initialMessage = message ?? (existing?.type === 'attachment' ? existing : undefined)
       if (initialMessage) {
         showAttachmentPreview(conversationIDKey, initialMessage)

--- a/shared/chat/conversation/bottom-banner.tsx
+++ b/shared/chat/conversation/bottom-banner.tsx
@@ -9,7 +9,7 @@ import {useUsersState} from '@/stores/users'
 import {useFollowerState} from '@/stores/followers'
 import {showShareActionSheet} from '@/util/platform-specific'
 import {useConversationThreadID, useThreadMeta} from './thread-context'
-import {useConversationParticipants} from './data-hooks'
+import {useConversationParticipantsSelector} from './data-hooks'
 
 type Store = T.Immutable<{
   inviteBannerDismissed: Set<T.Chat.ConversationIDKey>
@@ -47,8 +47,10 @@ const installMessage = `I sent you encrypted messages on Keybase. You can instal
 const Invite = (props: {onDismiss: () => void}) => {
   const linkUrlProps = Kb.useClickURL('https://keybase.io/app')
   const conversationIDKey = useConversationThreadID()
-  const participantInfo = useConversationParticipants(conversationIDKey)
-  const participantInfoAll = participantInfo.all
+  const {all: participantInfoAll, contactName: usernameToContactName} = useConversationParticipantsSelector(
+    conversationIDKey,
+    C.useShallow(p => ({all: p.all, contactName: p.contactName}))
+  )
   const users = participantInfoAll.filter(p => p.includes('@'))
 
   const openShareSheet = () => {
@@ -65,8 +67,6 @@ const Invite = (props: {onDismiss: () => void}) => {
       .then(() => {})
       .catch(() => {})
   }
-
-  const usernameToContactName = participantInfo.contactName
 
   const theirName =
     users.length === 1
@@ -145,11 +145,10 @@ const BannerContainerInner = function BannerContainerInner(props: {
     }))
   )
   const meta = useThreadMeta(C.useShallow(m => ({isEmpty: m.isEmpty, teamType: m.teamType})))
-  const participantInfo = useConversationParticipants(conversationIDKey)
+  const participantInfoAll = useConversationParticipantsSelector(conversationIDKey, p => p.all)
   if (meta.teamType !== 'adhoc') {
     return null
   }
-  const participantInfoAll = participantInfo.all
   const brokenUsers = participantInfoAll.filter(p => following.has(p) && infoMap.get(p)?.broken)
   if (brokenUsers.length > 0) {
     return <Kb.ProofBrokenBanner users={brokenUsers} />

--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -8,6 +8,7 @@ import Rekey from './rekey/container'
 import type {ThreadSearchRouteProps} from './thread-search-route'
 import type * as T from '@/constants/types'
 import {BadgeHeaderUpdater} from './header-area'
+import {useConversationMetadataReload} from './data-hooks'
 import {LiveConversationThreadProvider, useConversationThreadID, useThreadMeta} from './thread-context'
 
 type Props = ThreadSearchRouteProps & {
@@ -26,6 +27,9 @@ const Conversation = function Conversation(props: Props) {
 
 const ConversationInner = function ConversationInner() {
   const conversationIDKey = useConversationThreadID()
+  // Single owner of the meta/participants reload listeners for this screen; the
+  // header/banner/input consumers read via the reload-free selector hooks.
+  useConversationMetadataReload(conversationIDKey)
   const meta = useThreadMeta(
     C.useShallow(m => ({
       membershipType: m.membershipType,

--- a/shared/chat/conversation/data-hooks.tsx
+++ b/shared/chat/conversation/data-hooks.tsx
@@ -64,7 +64,10 @@ const activityConversationIDKey = (activity: T.RPCChat.ChatActivity) => {
   }
 }
 
-const useConversationMetadataReload = (conversationIDKey: T.Chat.ConversationIDKey) => {
+// Arms the meta/participants reload listeners for a conversation. The conversation
+// screen root (ConversationInner) owns this; narrow readers should use the reload-free
+// selector hooks below instead of useConversationMetadata.
+export const useConversationMetadataReload = (conversationIDKey: T.Chat.ConversationIDKey) => {
   const reload = React.useEffectEvent(() => {
     reloadConversationMetadata(conversationIDKey)
   })
@@ -137,6 +140,20 @@ export const useConversationMeta = (conversationIDKey: T.Chat.ConversationIDKey)
 
 export const useConversationParticipants = (conversationIDKey: T.Chat.ConversationIDKey) =>
   useConversationMetadata(conversationIDKey).participants
+
+// Reload-free narrow reads. Unlike useConversationMetadata these neither subscribe to
+// the whole meta/participants objects (whose identity changes on every send) nor arm
+// a per-mount copy of the reload listeners. Wrap object results in C.useShallow.
+export const useConversationMetaSelector = <TValue,>(
+  conversationIDKey: T.Chat.ConversationIDKey,
+  selector: (meta: T.Immutable<T.Chat.ConversationMeta>) => TValue
+): TValue => useInboxMetadataState(s => selector(s.metas.get(conversationIDKey) ?? emptyConversationMeta))
+
+export const useConversationParticipantsSelector = <TValue,>(
+  conversationIDKey: T.Chat.ConversationIDKey,
+  selector: (participants: T.Chat.ParticipantInfo) => TValue
+): TValue =>
+  useInboxMetadataState(s => selector(s.participants.get(conversationIDKey) ?? emptyParticipantInfo))
 
 export const useConversationExplodingMode = (conversationIDKey: T.Chat.ConversationIDKey) =>
   useConfigState(state => getExplodingModeFromGregorItems(conversationIDKey, state.gregorPushState) ?? 0)

--- a/shared/chat/conversation/header-area/index.tsx
+++ b/shared/chat/conversation/header-area/index.tsx
@@ -17,7 +17,7 @@ import {useConfigState} from '@/stores/config'
 import {navToProfile} from '@/constants/router'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import {showConversationInfoPanel, toggleConversationThreadSearch} from '../thread-context'
-import {useConversationMetadata} from '../data-hooks'
+import {useConversationMetaSelector, useConversationParticipantsSelector} from '../data-hooks'
 import {useInboxMetadataState} from '@/chat/inbox/metadata'
 import {muteConversation} from '../status-actions'
 import {getBigLayoutChannelRow, getSmallLayoutRow, useInboxLayoutState} from '@/chat/inbox/layout-state'
@@ -75,7 +75,11 @@ const useLayoutFallbackNames = (conversationIDKey: T.Chat.ConversationIDKey) =>
 
 const HeaderBranchContainerInner = function HeaderBranchContainerInner(props: HeaderConversationProps) {
   const {conversationIDKey} = props
-  const {meta, participants: participantInfo} = useConversationMetadata(conversationIDKey)
+  const meta = useConversationMetaSelector(
+    conversationIDKey,
+    C.useShallow(m => ({channelname: m.channelname, teamname: m.teamname}))
+  )
+  const participantNames = useConversationParticipantsSelector(conversationIDKey, p => p.name)
   const fallback = useLayoutFallbackNames(conversationIDKey)
   const teamname = meta.teamname || fallback.bigTeamname || (fallback.smallIsTeam ? fallback.smallName : '')
   if (teamname) {
@@ -89,8 +93,8 @@ const HeaderBranchContainerInner = function HeaderBranchContainerInner(props: He
   }
   // the small-row name is the tlf name (comma-joined usernames, includes you), matching
   // participants.name semantics
-  const participants = participantInfo.name.length
-    ? participantInfo.name
+  const participants = participantNames.length
+    ? participantNames
     : fallback.smallName
       ? fallback.smallName
           .split(',')
@@ -317,7 +321,7 @@ const shhIconFontSize = 24
 
 const ShhIcon = function ShhIcon(props: HeaderConversationProps) {
   const {conversationIDKey} = props
-  const isMuted = useConversationMetadata(conversationIDKey).meta.isMuted
+  const isMuted = useConversationMetaSelector(conversationIDKey, m => m.isMuted)
   const unMuteConversation = () => {
     muteConversation(conversationIDKey, false)
   }
@@ -346,7 +350,10 @@ const useMaxWidthStyle = (conversationIDKey: T.Chat.ConversationIDKey) => {
 
 const ChannelHeader = (props: HeaderConversationProps & {teamname: string; channelname: string}) => {
   const {conversationIDKey, teamname, channelname} = props
-  const {teamType, teamID} = useConversationMetadata(conversationIDKey).meta
+  const {teamType, teamID} = useConversationMetaSelector(
+    conversationIDKey,
+    C.useShallow(m => ({teamID: m.teamID, teamType: m.teamType}))
+  )
   // teamType is 'adhoc' when the meta hasn't loaded yet (we only render on layout-fallback
   // names then); a big-team layout row is the only fallback that carries a channelname
   const smallTeam = teamType !== 'adhoc' ? teamType !== 'big' : !channelname
@@ -395,11 +402,10 @@ type HeaderParticipantsProps = HeaderConversationProps & {participants: Readonly
 const UsernameHeader = (props: HeaderParticipantsProps) => {
   const {conversationIDKey, participants} = props
   const you = useCurrentUserState(s => s.username)
-  const infoMap = useUsersState(s => s.infoMap)
-  const theirFullname =
-    participants.length === 2
-      ? participants.filter(username => username !== you).map(username => infoMap.get(username)?.fullname)[0]
-      : undefined
+  const theirUsername = participants.length === 2 ? participants.find(username => username !== you) : undefined
+  const theirFullname = useUsersState(s =>
+    theirUsername ? s.infoMap.get(theirUsername)?.fullname : undefined
+  )
   const onShowProfile = (username: string) => {
     navToProfile(username)
   }
@@ -436,10 +442,9 @@ const UsernameHeader = (props: HeaderParticipantsProps) => {
 
 const PhoneOrEmailHeader = (props: HeaderParticipantsProps) => {
   const {conversationIDKey, participants} = props
-  const {participants: participantInfo} = useConversationMetadata(conversationIDKey)
   const phoneOrEmail = participants.find(s => s.endsWith('@phone') || s.endsWith('@email')) || ''
   const formattedPhoneOrEmail = assertionToDisplay(phoneOrEmail)
-  const name = participantInfo.contactName.get(phoneOrEmail)
+  const name = useConversationParticipantsSelector(conversationIDKey, p => p.contactName.get(phoneOrEmail))
   const maxWidthStyle = useMaxWidthStyle(conversationIDKey)
   return (
     <Kb.Box2

--- a/shared/chat/conversation/input-area/input-state.tsx
+++ b/shared/chat/conversation/input-area/input-state.tsx
@@ -1,4 +1,3 @@
-import * as C from '@/constants'
 import * as React from 'react'
 import * as T from '@/constants/types'
 import {clearThreadInputAction} from '@/constants/router'
@@ -6,7 +5,7 @@ import {findLast} from '@/util/arrays'
 import {useChatThreadRouteParams, type ThreadInputAction} from '../thread-search-route'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useEngineActionListener} from '@/engine/action-listener'
-import {useConversationThreadSelector} from '../thread-context'
+import {useConversationThreadStore} from '../thread-context'
 import {useConversationSendActions} from '../send-actions'
 
 type ConversationInputStore = T.Immutable<{
@@ -114,9 +113,9 @@ export const ConversationInputProvider = (p: React.PropsWithChildren<{id: T.Chat
   const {children, id} = p
   const routeInputAction = useChatThreadRouteParams()?.inputAction
   const [state, dispatchState] = React.useReducer(inputReducer, initialConversationInputStore)
-  const {messageMap, messageOrdinals} = useConversationThreadSelector(
-    C.useShallow(s => ({messageMap: s.messageMap, messageOrdinals: s.messageOrdinals}))
-  )
+  // Only setEditing reads thread state, so read it lazily instead of subscribing —
+  // a subscription here re-renders the whole input subtree on every thread change.
+  const threadStore = useConversationThreadStore()
   const {sendGiphyResult: sendGiphyResultAction, sendMessage} = useConversationSendActions()
 
   const injectIntoInput = React.useEffectEvent((text?: string, focus?: boolean) => {
@@ -146,6 +145,7 @@ export const ConversationInputProvider = (p: React.PropsWithChildren<{id: T.Chat
       return
     }
 
+    const {messageMap, messageOrdinals} = threadStore.getState()
     let ordinal: T.Chat.Ordinal | undefined
     if (e === 'last') {
       const editLastUser = useCurrentUserState.getState().username

--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -1,5 +1,4 @@
 import * as C from '@/constants'
-import * as Chat from '@/constants/chat'
 import * as Kb from '@/common-adapters'
 import * as React from 'react'
 import CommandMarkdown from '../../command-markdown'
@@ -26,7 +25,7 @@ import {
 import {useConversationParticipantsSelector} from '../../data-hooks'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useRoute} from '@react-navigation/native'
-import {metasReceived, unboxRows} from '@/chat/inbox/metadata'
+import {metasReceived, unboxRows, useInboxMetadataState} from '@/chat/inbox/metadata'
 
 const useHintText = (p: {
   isExploding: boolean
@@ -143,7 +142,17 @@ const ConnectedPlatformInput = function ConnectedPlatformInput() {
   const replyToMessage = useConversationThreadMessage(uiData.replyTo)
   const conversationIDKey = useConversationThreadID()
   const explodingMode = useConversationThreadSelector(s => s.explodingMode)
-  const meta = useThreadMeta(m => m)
+  const meta = useThreadMeta(
+    C.useShallow(m => ({
+      cannotWrite: m.cannotWrite,
+      conversationIDKey: m.conversationIDKey,
+      draft: m.draft,
+      minWriterRole: m.minWriterRole,
+      retentionPolicy: m.retentionPolicy,
+      teamRetentionPolicy: m.teamRetentionPolicy,
+      tlfname: m.tlfname,
+    }))
+  )
   const setExplodingModeRaw = useConversationThreadSetExplodingMode()
   const {cannotWrite, minWriterRole, tlfname} = meta
   const convoID = T.Chat.isValidConversationIDKey(conversationIDKey)
@@ -151,7 +160,8 @@ const ConnectedPlatformInput = function ConnectedPlatformInput() {
     : new Uint8Array(0)
   const metaGood = meta.conversationIDKey === conversationIDKey
   const storeDraft = metaGood ? meta.draft : undefined
-  const convRetention = Chat.getEffectiveRetentionPolicy(meta)
+  const convRetention =
+    meta.retentionPolicy.type === 'inherit' ? meta.teamRetentionPolicy : meta.retentionPolicy
   const explodingModeSecondsRaw =
     convRetention.type === 'explode' ? Math.min(explodingMode || Infinity, convRetention.seconds) : explodingMode
   const showReplyPreview = !!replyToMessage?.id
@@ -208,7 +218,10 @@ const ConnectedPlatformInput = function ConnectedPlatformInput() {
     // Immediately update local meta.draft so switching back to this thread
     // before the async unbox completes won't re-inject the old stale draft.
     // Merges from the current meta (same inbox version), so force past gating.
-    metasReceived([{...meta, draft: text}], undefined, {force: true})
+    const currentMeta = useInboxMetadataState.getState().metas.get(conversationIDKey)
+    if (currentMeta) {
+      metasReceived([{...currentMeta, draft: text}], undefined, {force: true})
+    }
     const f = async () => {
       await T.RPCChat.localUpdateUnsentTextRpcPromise({
         conversationID: convoID,

--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -23,7 +23,7 @@ import {
   useConversationThreadToggleSearch,
   useThreadMeta,
 } from '../../thread-context'
-import {useConversationParticipants} from '../../data-hooks'
+import {useConversationParticipantsSelector} from '../../data-hooks'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useRoute} from '@react-navigation/native'
 import {metasReceived, unboxRows} from '@/chat/inbox/metadata'
@@ -44,7 +44,7 @@ const useHintText = (p: {
       teamname: m.teamname,
     }))
   )
-  const participantInfoName = useConversationParticipants(conversationIDKey).name
+  const participantInfoName = useConversationParticipantsSelector(conversationIDKey, p => p.name)
   if (isMobile && isExploding) {
     return C.isLargeScreen ? `Write an exploding message` : 'Exploding message'
   }

--- a/shared/chat/conversation/messages/account-payment/container.tsx
+++ b/shared/chat/conversation/messages/account-payment/container.tsx
@@ -65,13 +65,19 @@ const getRequestMessageInfo = (
 
 const ConnectedAccountPayment = (ownProps: OwnProps) => {
   const you = useCurrentUserState(s => s.username)
-  const accountsInfoMap = useConversationThreadSelector(s => s.accountsInfoMap)
+  // Derive this message's info inside the selector so the row only re-renders when
+  // its own entry changes, not on any accountsInfoMap identity churn.
+  const messageInfo = useConversationThreadSelector(s =>
+    ownProps.message.type === 'sendPayment'
+      ? Chat.getPaymentMessageInfo(s.accountsInfoMap, ownProps.message)
+      : getRequestMessageInfo(s.accountsInfoMap, ownProps.message)
+  )
 
   const stateProps = (() => {
     const youAreSender = ownProps.message.author === you
     switch (ownProps.message.type) {
       case 'sendPayment': {
-        const paymentInfo = Chat.getPaymentMessageInfo(accountsInfoMap, ownProps.message)
+        const paymentInfo = messageInfo as T.Chat.ChatPaymentInfo | undefined
         if (!paymentInfo) {
           // waiting for service to load it (missed service cache on loading thread)
           return loadingProps
@@ -103,7 +109,7 @@ const ConnectedAccountPayment = (ownProps: OwnProps) => {
       }
       case 'requestPayment': {
         const message = ownProps.message
-        const requestInfo = getRequestMessageInfo(accountsInfoMap, message)
+        const requestInfo = messageInfo as T.Chat.ChatRequestInfo | undefined
         if (!requestInfo) {
           // waiting for service to load it
           return loadingProps

--- a/shared/chat/conversation/messages/special-top-message.tsx
+++ b/shared/chat/conversation/messages/special-top-message.tsx
@@ -12,7 +12,7 @@ import {
   useConversationThreadSelector,
   useThreadMeta,
 } from '../thread-context'
-import {useConversationParticipants} from '../data-hooks'
+import {useConversationParticipantsSelector} from '../data-hooks'
 import * as FS from '@/constants/fs'
 import {useCurrentUserState} from '@/stores/current-user'
 
@@ -126,7 +126,7 @@ function SpecialTopMessage() {
       teamType: m.teamType,
     }))
   )
-  const participants = useConversationParticipants(conversationIDKey)
+  const partAll = useConversationParticipantsSelector(conversationIDKey, p => p.all)
   const loadMoreType = moreToLoadBack ? 'moreToLoad' : 'noMoreToLoad'
   const pendingState =
     conversationIDKey === T.Chat.pendingWaitingConversationIDKey
@@ -135,7 +135,6 @@ function SpecialTopMessage() {
         ? 'error'
         : 'done'
 
-  const partAll = participants.all
   const partNum = partAll.length
   const isHelloBotConversation = teamType === 'adhoc' && partNum === 2 && partAll.includes('hellobot')
   const isSelfConversation = teamType === 'adhoc' && partNum === 1 && partAll.includes(username)

--- a/shared/chat/conversation/send-actions.tsx
+++ b/shared/chat/conversation/send-actions.tsx
@@ -1,15 +1,14 @@
-import * as C from '@/constants'
 import * as Common from '@/constants/chat/common'
 import * as T from '@/constants/types'
 import logger from '@/logger'
 import {RPCError} from '@/util/errors'
 import {ignorePromise} from '@/constants/utils'
 import {getClientPrevFromThread} from './attachment-actions'
+import {useInboxMetadataState} from '../inbox/metadata-store'
 import {
   useConversationThreadActions,
   useConversationThreadID,
-  useConversationThreadSelector,
-  useThreadMeta,
+  useConversationThreadStore,
 } from './thread-context'
 
 type SendTextParams = {
@@ -83,18 +82,17 @@ export const sendTextToConversation = (
 export const useConversationSendActions = () => {
   const conversationIDKey = useConversationThreadID()
   const actions = useConversationThreadActions()
-  const {explodingMode, messageMap, messageOrdinals} = useConversationThreadSelector(
-    C.useShallow(s => ({
-      explodingMode: s.explodingMode,
-      messageMap: s.messageMap,
-      messageOrdinals: s.messageOrdinals,
-    }))
-  )
-  const meta = useThreadMeta(C.useShallow(m => ({tlfname: m.tlfname})))
-  const clientPrev = getClientPrevFromThread(messageMap, messageOrdinals)
+  // Callbacks-only hook: read thread/meta state lazily so per-row callers
+  // (coinflip rows, the input provider) don't re-render on thread churn.
+  const threadStore = useConversationThreadStore()
+  const getTlfName = () => useInboxMetadataState.getState().metas.get(conversationIDKey)?.tlfname ?? ''
+  const getClientPrev = () => {
+    const {messageMap, messageOrdinals} = threadStore.getState()
+    return getClientPrevFromThread(messageMap, messageOrdinals)
+  }
 
   const editMessage = (ordinal: T.Chat.Ordinal, text: string) => {
-    const message = messageMap.get(ordinal)
+    const message = threadStore.getState().messageMap.get(ordinal)
     if (message?.type !== 'text' && message?.type !== 'attachment') {
       return
     }
@@ -108,7 +106,7 @@ export const useConversationSendActions = () => {
     const f = async () => {
       await T.RPCChat.localPostEditNonblockRpcPromise({
         body: text,
-        clientPrev,
+        clientPrev: getClientPrev(),
         conversationID: T.Chat.keyToConversationID(conversationIDKey),
         identifyBehavior: T.RPCGen.TLFIdentifyBehavior.chatGui,
         outboxID: Common.generateOutboxID(),
@@ -116,7 +114,7 @@ export const useConversationSendActions = () => {
           messageID: message.id,
           outboxID: message.outboxID ? T.Chat.outboxIDToRpcOutboxID(message.outboxID) : undefined,
         },
-        tlfName: meta.tlfname,
+        tlfName: getTlfName(),
         tlfPublic: false,
       })
     }
@@ -137,15 +135,15 @@ export const useConversationSendActions = () => {
       return
     }
     const replyToOrdinal = context?.replyToOrdinal
-    const replyTo = messageMap.get(replyToOrdinal ?? T.Chat.numberToOrdinal(0))?.id
+    const replyTo = threadStore.getState().messageMap.get(replyToOrdinal ?? T.Chat.numberToOrdinal(0))?.id
     sendTextMessageStoreless({
-      clientPrev,
+      clientPrev: getClientPrev(),
       conversationIDKey,
-      ephemeralLifetime: explodingMode,
+      ephemeralLifetime: threadStore.getState().explodingMode,
       onRestoreText: context?.onRestoreText,
       replyTo,
       text,
-      tlfName: meta.tlfname,
+      tlfName: getTlfName(),
     })
   }
 
@@ -154,14 +152,14 @@ export const useConversationSendActions = () => {
       try {
         await T.RPCChat.localTrackGiphySelectRpcPromise({result})
       } catch {}
-      const replyTo = messageMap.get(replyToOrdinal ?? T.Chat.numberToOrdinal(0))?.id
+      const replyTo = threadStore.getState().messageMap.get(replyToOrdinal ?? T.Chat.numberToOrdinal(0))?.id
       sendTextMessageStoreless({
-        clientPrev,
+        clientPrev: getClientPrev(),
         conversationIDKey,
-        ephemeralLifetime: explodingMode,
+        ephemeralLifetime: threadStore.getState().explodingMode,
         replyTo,
         text: result.targetUrl,
-        tlfName: meta.tlfname,
+        tlfName: getTlfName(),
       })
     }
     ignorePromise(f())
@@ -169,12 +167,14 @@ export const useConversationSendActions = () => {
 
   const sendAudioRecording = async (path: string, duration: number, amps: ReadonlyArray<number>) => {
     const outboxID = Common.generateOutboxID()
-    if (!meta.tlfname) {
+    const tlfName = getTlfName()
+    if (!tlfName) {
       logger.warn('sendAudioRecording: no meta for send')
       return
     }
 
     const callerPreview = await T.RPCChat.localMakeAudioPreviewRpcPromise({amps, duration})
+    const explodingMode = threadStore.getState().explodingMode
     const ephemeralData = explodingMode !== 0 ? {ephemeralLifetime: explodingMode} : {}
     try {
       await T.RPCChat.localPostFileAttachmentLocalNonblockRpcPromise({
@@ -187,10 +187,10 @@ export const useConversationSendActions = () => {
           metadata: new Uint8Array(),
           outboxID,
           title: '',
-          tlfName: meta.tlfname,
+          tlfName,
           visibility: T.RPCGen.TLFVisibility.private,
         },
-        clientPrev,
+        clientPrev: getClientPrev(),
       })
     } catch (error) {
       if (error instanceof RPCError) {

--- a/shared/chat/inbox/layout-state.tsx
+++ b/shared/chat/inbox/layout-state.tsx
@@ -37,6 +37,32 @@ const hasInboxRows = (layout: T.RPCChat.UIInboxLayout) =>
 export const isEmptyInboxLayout = (layout: T.RPCChat.UIInboxLayout | undefined) =>
   !!layout && (layout.smallTeams || []).length === 0 && (layout.bigTeams || []).length === 0
 
+// A fresh layout arrives on every incoming message, usually with most rows unchanged.
+// Reuse the prior row objects that deep-equal their replacements so per-row selectors
+// (getSmallLayoutRow / getBigLayoutChannelRow) keep identity and visible rows can bail.
+const bigRowKey = (r: T.Immutable<T.RPCChat.UIInboxBigTeamRow>) =>
+  r.state === T.RPCChat.UIInboxBigTeamRowTyp.channel ? `c:${r.channel.convID}` : `l:${r.label.id}`
+
+const recycleLayoutRows = (
+  old: T.Immutable<T.RPCChat.UIInboxLayout> | undefined,
+  next: T.RPCChat.UIInboxLayout
+): T.RPCChat.UIInboxLayout => {
+  if (!old) {
+    return next
+  }
+  const oldSmall = new Map(old.smallTeams?.map(r => [r.convID, r]) ?? [])
+  const smallTeams = next.smallTeams?.map(r => {
+    const o = oldSmall.get(r.convID)
+    return o && isEqual(o, r) ? (o as T.RPCChat.UIInboxSmallTeamRow) : r
+  })
+  const oldBig = new Map(old.bigTeams?.map(r => [bigRowKey(r), r]) ?? [])
+  const bigTeams = next.bigTeams?.map(r => {
+    const o = oldBig.get(bigRowKey(r))
+    return o && isEqual(o, r) ? (o as T.RPCChat.UIInboxBigTeamRow) : r
+  })
+  return {...next, bigTeams, smallTeams}
+}
+
 export const useInboxLayoutState = Z.createZustand<State>('chat-inbox-layout', (set, get) => {
   const requestInboxLayout = async (reason: T.Chat.RefreshReason) => {
     const {username} = useCurrentUserState.getState()
@@ -68,30 +94,32 @@ export const useInboxLayoutState = Z.createZustand<State>('chat-inbox-layout', (
       })
     },
     updateLayout: str => {
-      set(s => {
-        try {
-          const _layout = JSON.parse(str) as unknown
-          if (!_layout || typeof _layout !== 'object') {
-            logger.warn(
-              `Invalid inbox layout JSON: expected object, got ${_layout === null ? 'null' : typeof _layout}`
-            )
-            return
-          }
-          const layout = _layout as T.RPCChat.UIInboxLayout
-          // Compare against committed state, not the draft: immer 11.1.9 sanitizes
-          // constructor/prototype access on drafts (prototype-pollution fix),
-          // making lodash isEqual throw a proxy-invariant TypeError.
-          if (!isEqual(get().layout, layout)) {
-            s.layout = T.castDraft(layout)
+      try {
+        const _layout = JSON.parse(str) as unknown
+        if (!_layout || typeof _layout !== 'object') {
+          logger.warn(
+            `Invalid inbox layout JSON: expected object, got ${_layout === null ? 'null' : typeof _layout}`
+          )
+          return
+        }
+        const layout = _layout as T.RPCChat.UIInboxLayout
+        // Compare against committed state, not the draft: immer 11.1.9 sanitizes
+        // constructor/prototype access on drafts (prototype-pollution fix),
+        // making lodash isEqual throw a proxy-invariant TypeError.
+        const prev = get().layout
+        const changed = !isEqual(prev, layout)
+        set(s => {
+          if (changed) {
+            s.layout = T.castDraft(recycleLayoutRows(prev, layout))
           }
           s.hasLoaded = !!layout
           if (hasInboxRows(layout)) {
             s.retriedOnCurrentEmpty = false
           }
-        } catch (e) {
-          logger.warn('failed to JSON parse inbox layout', e)
-        }
-      })
+        })
+      } catch (e) {
+        logger.warn('failed to JSON parse inbox layout', e)
+      }
     },
   }
   return {

--- a/shared/chat/inbox/metadata-store.tsx
+++ b/shared/chat/inbox/metadata-store.tsx
@@ -40,16 +40,23 @@ export const metasReceived = (
   // can't clobber newer data (previously done by the thread store). Compute
   // against getState() (not the immer draft) so updateMeta never sees a proxy.
   const current = useInboxMetadataState.getState().metas
-  const nextMetas = metas.map(m => {
-    const old = force ? undefined : current.get(m.conversationIDKey)
-    return old ? Meta.updateMeta(old, m) : m
-  })
+  // Drop metas updateMeta resolved to the existing object so we don't wake
+  // subscribers when nothing changed.
+  const changedMetas = metas
+    .map(m => {
+      const old = force ? undefined : current.get(m.conversationIDKey)
+      return old ? Meta.updateMeta(old, m) : m
+    })
+    .filter(next => current.get(next.conversationIDKey) !== next)
+  if (!changedMetas.length && !removals?.length) {
+    return
+  }
   useInboxMetadataState.setState(s => {
     removals?.forEach(r => {
       s.metas.delete(r)
       s.participants.delete(r)
     })
-    nextMetas.forEach(next => {
+    changedMetas.forEach(next => {
       s.metas.set(next.conversationIDKey, T.castDraft(next))
     })
   })

--- a/shared/chat/inbox/row/small-team/swipe-conv-actions/index.tsx
+++ b/shared/chat/inbox/row/small-team/swipe-conv-actions/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 import Swipeable, {type SwipeableMethods} from '@/common-adapters/swipeable-row'
 import {useOpenedRowState} from '../../opened-row-state'
-import {useInboxRowSmall} from '@/chat/inbox/rows-state'
+import {useInboxRowIsMuted} from '@/chat/inbox/rows-state'
 import {hideConversation, markConversationUnread, muteConversation} from '@/chat/conversation/status-actions'
 
 const actionWidth = 64
@@ -52,7 +52,7 @@ function SwipeConvActions(p: Props) {
   const wasOpenRef = React.useRef(isOpened)
   const setOpenedRow = useOpenedRowState(s => s.dispatch.setOpenRow)
   const swipeableRef = React.useRef<SwipeableMethods | null>(null)
-  const isMuted = useInboxRowSmall(conversationIDKey).isMuted
+  const isMuted = useInboxRowIsMuted(conversationIDKey)
 
   React.useLayoutEffect(() => {
     swipeableRef.current?.reset()

--- a/shared/chat/inbox/rows-state.tsx
+++ b/shared/chat/inbox/rows-state.tsx
@@ -186,6 +186,17 @@ export const useInboxRowSmall = (id: string): InboxRowSmall => {
   )
 }
 
+// Narrow muted read for callers (swipe actions) that don't need the full row —
+// three primitive subscriptions instead of the six-slice computeSmallRow.
+export const useInboxRowIsMuted = (id: string): boolean => {
+  const metaIsMuted = useInboxMetadataState(s => s.metas.get(id)?.isMuted ?? false)
+  const metaTrusted = useInboxMetadataState(s =>
+    isMetaTrusted(s.metas.get(id)?.trustedState ?? 'untrusted')
+  )
+  const layoutIsMuted = useInboxLayoutState(s => getSmallLayoutRow(s, id)?.isMuted)
+  return !metaTrusted && layoutIsMuted !== undefined ? layoutIsMuted : metaIsMuted
+}
+
 export const useInboxRowBig = (id: string): InboxRowBig => {
   const meta = useInboxMetadataState(s => s.metas.get(id))
   const layoutChannel = useInboxLayoutState(s => getBigLayoutChannelRow(s, id))

--- a/shared/chat/inbox/rows-state.tsx
+++ b/shared/chat/inbox/rows-state.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as T from '@/constants/types'
+import {useShallow} from '@/util/zustand'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useInboxMetadataState} from '@/chat/inbox/metadata'
 import {
@@ -52,6 +53,40 @@ export type InboxRowSmall = {
 type Meta = T.Immutable<T.Chat.ConversationMeta> | undefined
 type ParticipantInfo = T.Immutable<T.Chat.ParticipantInfo> | undefined
 
+// The row computations read a subset of meta. Subscribing to just these fields (not
+// the meta object, whose identity changes on every version bump / send) lets visible
+// rows bail unless something they show actually changed.
+type SmallRowMeta =
+  | Pick<
+      NonNullable<Meta>,
+      | 'draft'
+      | 'isMuted'
+      | 'membershipType'
+      | 'rekeyers'
+      | 'resetParticipants'
+      | 'snippet'
+      | 'snippetDecorated'
+      | 'snippetDecoration'
+      | 'teamname'
+      | 'timestamp'
+      | 'trustedState'
+      | 'wasFinalizedBy'
+    >
+  | undefined
+type BigRowMeta =
+  | Pick<
+      NonNullable<Meta>,
+      | 'channelname'
+      | 'draft'
+      | 'isMuted'
+      | 'snippet'
+      | 'snippetDecorated'
+      | 'snippetDecoration'
+      | 'teamname'
+      | 'trustedState'
+    >
+  | undefined
+
 const buildTypingSnippet = (typing?: ReadonlySet<string>): string => {
   if (!typing?.size) {
     return ''
@@ -82,7 +117,7 @@ const isMetaTrusted = (trustedState: T.Chat.MetaTrustedState) =>
 const computeSmallRow = (
   id: string,
   you: string,
-  meta: Meta,
+  meta: SmallRowMeta,
   participantInfo: ParticipantInfo,
   layoutRow: SmallLayoutRow | undefined,
   counts: BadgeCounts | undefined,
@@ -147,7 +182,7 @@ const computeSmallRow = (
 }
 
 const computeBigRow = (
-  meta: Meta,
+  meta: BigRowMeta,
   layoutChannel: BigLayoutChannelRow | undefined,
   counts: BadgeCounts | undefined
 ): InboxRowBig => {
@@ -175,7 +210,27 @@ const computeBigRow = (
 
 export const useInboxRowSmall = (id: string): InboxRowSmall => {
   const you = useCurrentUserState(s => s.username)
-  const meta = useInboxMetadataState(s => s.metas.get(id))
+  const meta = useInboxMetadataState(
+    useShallow((s): SmallRowMeta => {
+      const m = s.metas.get(id)
+      return (
+        m && {
+          draft: m.draft,
+          isMuted: m.isMuted,
+          membershipType: m.membershipType,
+          rekeyers: m.rekeyers,
+          resetParticipants: m.resetParticipants,
+          snippet: m.snippet,
+          snippetDecorated: m.snippetDecorated,
+          snippetDecoration: m.snippetDecoration,
+          teamname: m.teamname,
+          timestamp: m.timestamp,
+          trustedState: m.trustedState,
+          wasFinalizedBy: m.wasFinalizedBy,
+        }
+      )
+    })
+  )
   const participantInfo = useInboxMetadataState(s => s.participants.get(id))
   const layoutRow = useInboxLayoutState(s => getSmallLayoutRow(s, id))
   const counts = useInboxBadgeState(s => s.counts.get(id))
@@ -198,7 +253,23 @@ export const useInboxRowIsMuted = (id: string): boolean => {
 }
 
 export const useInboxRowBig = (id: string): InboxRowBig => {
-  const meta = useInboxMetadataState(s => s.metas.get(id))
+  const meta = useInboxMetadataState(
+    useShallow((s): BigRowMeta => {
+      const m = s.metas.get(id)
+      return (
+        m && {
+          channelname: m.channelname,
+          draft: m.draft,
+          isMuted: m.isMuted,
+          snippet: m.snippet,
+          snippetDecorated: m.snippetDecorated,
+          snippetDecoration: m.snippetDecoration,
+          teamname: m.teamname,
+          trustedState: m.trustedState,
+        }
+      )
+    })
+  )
   const layoutChannel = useInboxLayoutState(s => getBigLayoutChannelRow(s, id))
   const counts = useInboxBadgeState(s => s.counts.get(id))
   return React.useMemo(() => computeBigRow(meta, layoutChannel, counts), [meta, layoutChannel, counts])

--- a/shared/constants/chat/meta.tsx
+++ b/shared/constants/chat/meta.tsx
@@ -1,5 +1,5 @@
 // Meta manages the metadata about a conversation. Participants, isMuted, reset people, etc. Things that drive the inbox
-import {shallowEqual} from '../utils'
+import isEqual from 'lodash/isEqual'
 import * as T from '@/constants/types'
 import * as Teams from '@/constants/teams'
 import * as Message from './message'
@@ -186,24 +186,23 @@ export const getEffectiveRetentionPolicy = (meta: T.Immutable<T.Chat.Conversatio
   return meta.retentionPolicy.type === 'inherit' ? meta.teamRetentionPolicy : meta.retentionPolicy
 }
 
+// Incoming metas are freshly unmarshaled from RPC data, so fields with unchanged
+// content still arrive with new identities (botAliases, commands, pinnedMsg, ...).
+// Reuse the old value for any deep-equal field so subscriber selectors can bail on
+// reference checks instead of re-rendering.
 const copyOverOldValuesIfEqual = (
   oldMeta: T.Immutable<T.Chat.ConversationMeta>,
   newMeta: T.Immutable<T.Chat.ConversationMeta>
-) => {
-  const merged = {...newMeta}
-  if (shallowEqual([...merged.rekeyers], [...oldMeta.rekeyers])) {
-    merged.rekeyers = oldMeta.rekeyers
+): T.Immutable<T.Chat.ConversationMeta> => {
+  const merged: Record<string, unknown> = {...newMeta}
+  for (const key of Object.keys(merged)) {
+    const oldValue = (oldMeta as Record<string, unknown>)[key]
+    const newValue = merged[key]
+    if (newValue !== oldValue && isEqual(newValue, oldValue)) {
+      merged[key] = oldValue
+    }
   }
-  if (shallowEqual([...merged.resetParticipants], [...oldMeta.resetParticipants])) {
-    merged.resetParticipants = oldMeta.resetParticipants
-  }
-  if (shallowEqual(merged.retentionPolicy, oldMeta.retentionPolicy)) {
-    merged.retentionPolicy = oldMeta.retentionPolicy
-  }
-  if (shallowEqual(merged.teamRetentionPolicy, oldMeta.teamRetentionPolicy)) {
-    merged.teamRetentionPolicy = oldMeta.teamRetentionPolicy
-  }
-  return merged
+  return merged as T.Immutable<T.Chat.ConversationMeta>
 }
 
 // Upgrade a meta, try and keep existing values if possible to reduce render thrashing in components

--- a/shared/people/container.tsx
+++ b/shared/people/container.tsx
@@ -309,12 +309,6 @@ const usePeoplePageState = () => {
   const [newItems, setNewItems] = React.useState<Array<T.People.PeopleScreenItem>>([])
   const [oldItems, setOldItems] = React.useState<Array<T.People.PeopleScreenItem>>([])
   const [resentEmail, setResentEmail] = React.useState('')
-  const {followers, following} = useFollowerState(
-    C.useShallow(s => ({
-      followers: s.followers,
-      following: s.following,
-    }))
-  )
   const dismissAnnouncementRPC = C.useRPC(T.RPCGen.homeHomeDismissAnnouncementRpcPromise)
   const skipTodoRPC = C.useRPC(T.RPCGen.homeHomeSkipTodoTypeRpcPromise)
   const mountedRef = React.useRef(true)
@@ -334,6 +328,7 @@ const usePeoplePageState = () => {
             return
           }
 
+          const {followers, following} = useFollowerState.getState()
           const nextState = reducePeopleScreenData(data, followers, following)
           setFollowSuggestions(s =>
             isEqual(s, nextState.followSuggestions) ? s : nextState.followSuggestions

--- a/shared/profile/showcase-team-offer.tsx
+++ b/shared/profile/showcase-team-offer.tsx
@@ -5,7 +5,6 @@ import {useTeamsList} from '@/teams/use-teams-list'
 import {useConfigState} from '@/stores/config'
 
 const ShowcaseTeamOffer = () => {
-  const waiting = C.useWaitingState(s => s.counts)
   const {reload, teams} = useTeamsList()
   const setGlobalError = useConfigState(s => s.dispatch.setGlobalError)
   const setMemberPublicity = C.useRPC(T.RPCGen.teamsSetTeamMemberShowcaseRpcPromise)
@@ -38,7 +37,7 @@ const ShowcaseTeamOffer = () => {
             membercount={teamMeta.memberCount}
             onPromote={promoted => onPromote(teamMeta.id, promoted)}
             showcased={teamMeta.showcasing}
-            waiting={!!waiting.get(C.waitingKeyTeamsTeam(teamMeta.id))}
+            teamID={teamMeta.id}
           />
         ))}
       </Kb.ScrollView>
@@ -53,12 +52,13 @@ type RowProps = {
   membercount: number
   onPromote: (promote: boolean) => void
   showcased: boolean
-  waiting: boolean
+  teamID: T.Teams.TeamID
   isExplicitMember: boolean
 }
 
 const TeamRow = (p: RowProps) => {
-  const {canShowcase, name, isOpen, membercount, onPromote, showcased, waiting, isExplicitMember} = p
+  const {canShowcase, name, isOpen, membercount, onPromote, showcased, teamID, isExplicitMember} = p
+  const waiting = C.Waiting.useAnyWaiting(C.waitingKeyTeamsTeam(teamID))
   return (
     <Kb.Box2 direction="vertical" fullWidth={true}>
       <Kb.Box2 direction="horizontal" fullWidth={true} gap="small" style={styles.teamRowShowcaseTeamOffer}>

--- a/shared/router-v2/tab-bar.desktop.tsx
+++ b/shared/router-v2/tab-bar.desktop.tsx
@@ -215,9 +215,9 @@ type TabProps = {
 
 const TabBadge = (p: {name: Tabs.Tab}) => {
   const {name} = p
-  const badgeNumbers = useNotifState(s => s.navBadges)
+  const badgeNumber = useNotifState(s => s.navBadges.get(name) ?? 0)
   const fsCriticalUpdate = useShellState(s => s.fsCriticalUpdate)
-  const badge = (badgeNumbers.get(name) ?? 0) + (name === Tabs.fsTab && fsCriticalUpdate ? 1 : 0)
+  const badge = badgeNumber + (name === Tabs.fsTab && fsCriticalUpdate ? 1 : 0)
   return badge ? <Kb.Badge className="tab-badge" badgeNumber={badge} /> : null
 }
 

--- a/shared/settings/root-phone.tsx
+++ b/shared/settings/root-phone.tsx
@@ -58,7 +58,14 @@ type Item = {
 type Section = {title: string; data: ReadonlyArray<Item>}
 
 function SettingsNav() {
-  const badgeNumbers = useNotifState(s => s.navBadges)
+  // Narrow to the three tabs shown here so chat/team badge churn doesn't re-render settings
+  const badgeNumbers = useNotifState(
+    C.useShallow(s => ({
+      devices: s.navBadges.get(C.Tabs.devicesTab),
+      git: s.navBadges.get(C.Tabs.gitTab),
+      settings: s.navBadges.get(C.Tabs.settingsTab),
+    }))
+  )
   const badgeNotifications = usePushState(s => !s.hasPermissions)
   const statsShown = useConfigState(s => !!s.runtimeStats)
   const navigateAppend = C.Router2.navigateAppend
@@ -78,7 +85,7 @@ function SettingsNav() {
           text: 'Crypto',
         },
         {
-          badgeNumber: badgeNumbers.get(C.Tabs.devicesTab),
+          badgeNumber: badgeNumbers.devices,
           icon: 'iconfont-nav-2-devices',
           onClick: () => {
             navigateAppend({name: Settings.settingsDevicesTab, params: {}})
@@ -86,7 +93,7 @@ function SettingsNav() {
           text: 'Devices',
         },
         {
-          badgeNumber: badgeNumbers.get(C.Tabs.gitTab),
+          badgeNumber: badgeNumbers.git,
           icon: 'iconfont-nav-2-git',
           onClick: () => {
             navigateAppend({name: Settings.settingsGitTab, params: {}})
@@ -106,7 +113,7 @@ function SettingsNav() {
     {
       data: [
         {
-          badgeNumber: badgeNumbers.get(C.Tabs.settingsTab),
+          badgeNumber: badgeNumbers.settings,
           onClick: () => {
             navigateAppend({name: Settings.settingsAccountTab, params: {}})
           },

--- a/shared/stores/notifications.test.tsx
+++ b/shared/stores/notifications.test.tsx
@@ -1,0 +1,106 @@
+/// <reference types="jest" />
+import type * as T from '@/constants/types'
+import {resetAllStores} from '@/util/zustand'
+import {useNotifState} from './notifications'
+import type * as EngineGen from '@/constants/rpc'
+
+const makeBadgeState = (p: Partial<T.RPCGen.BadgeState>): T.RPCGen.BadgeState =>
+  ({
+    bigTeamBadgeCount: 0,
+    conversations: [],
+    deletedTeams: [],
+    homeTodoItems: 0,
+    inboxVers: 1,
+    newDevices: [],
+    newGitRepoGlobalUniqueIDs: [],
+    newTeamAccessRequestCount: 0,
+    newTeams: [],
+    resetState: {active: false, endTime: 0},
+    revokedDevices: [],
+    smallTeamBadgeCount: 0,
+    teamsWithResetUsers: [],
+    unreadWalletAccounts: [],
+    unverifiedEmails: 0,
+    unverifiedPhones: 0,
+    ...p,
+  }) as unknown as T.RPCGen.BadgeState
+
+const badgeAction = (badgeState: T.RPCGen.BadgeState) =>
+  ({
+    payload: {params: {badgeState}},
+    type: 'keybase.1.NotifyBadges.badgeState',
+  }) as unknown as EngineGen.Actions
+
+const gregorAction = (items: Array<{category: string; body: string}>) =>
+  ({
+    payload: {
+      params: {
+        state: {
+          items: items.map(({category, body}) => ({
+            item: {body: new TextEncoder().encode(body), category},
+            md: {},
+          })),
+        },
+      },
+    },
+    type: 'keybase.1.gregorUI.pushState',
+  }) as unknown as EngineGen.Actions
+
+describe('notifications store identity stability', () => {
+  beforeEach(() => {
+    resetAllStores()
+  })
+
+  it('keeps team map identities stable across badgeStates with unchanged team data', () => {
+    const dispatch = useNotifState.getState().dispatch
+    dispatch.onEngineIncomingImpl(
+      badgeAction(
+        makeBadgeState({
+          inboxVers: 10,
+          newTeams: ['teamA'],
+          smallTeamBadgeCount: 1,
+          teamsWithResetUsers: [{teamID: 'teamA', username: 'testuser'}] as never,
+        })
+      )
+    )
+    const before = useNotifState.getState()
+    expect(before.newTeams.has('teamA')).toBe(true)
+    expect(before.navBadges.get('tabs.chatTab' as never) ?? 0).toBeGreaterThanOrEqual(0)
+
+    // same team data, only chat badge count moved (an incoming message)
+    dispatch.onEngineIncomingImpl(
+      badgeAction(
+        makeBadgeState({
+          inboxVers: 11,
+          newTeams: ['teamA'],
+          smallTeamBadgeCount: 2,
+          teamsWithResetUsers: [{teamID: 'teamA', username: 'testuser'}] as never,
+        })
+      )
+    )
+    const after = useNotifState.getState()
+    expect(after.newTeams).toBe(before.newTeams)
+    expect(after.deletedTeams).toBe(before.deletedTeams)
+    expect(after.teamIDToResetUsers).toBe(before.teamIDToResetUsers)
+    // navBadges legitimately changed
+    expect(after.navBadges).not.toBe(before.navBadges)
+  })
+
+  it('keeps newTeamRequests identity stable across equal gregor pushStates', () => {
+    const dispatch = useNotifState.getState().dispatch
+    dispatch.onEngineIncomingImpl(
+      gregorAction([
+        {body: JSON.stringify({id: 'teamA', username: 'testuser'}), category: 'team.request_access:teamA'},
+      ])
+    )
+    const before = useNotifState.getState().newTeamRequests
+    expect(before.get('teamA' as never)?.has('testuser')).toBe(true)
+
+    dispatch.onEngineIncomingImpl(
+      gregorAction([
+        {body: JSON.stringify({id: 'teamA', username: 'testuser'}), category: 'team.request_access:teamA'},
+      ])
+    )
+    expect(useNotifState.getState().newTeamRequests).toBe(before)
+  })
+})

--- a/shared/stores/notifications.tsx
+++ b/shared/stores/notifications.tsx
@@ -156,11 +156,26 @@ export const useNotifState = Z.createZustand<State>('notifications', (set, get) 
           if (currentBadgeVersion > badgeState.inboxVers) {
             break
           }
-          set(s => {
-            s.deletedTeams = T.castDraft(badgeState.deletedTeams ?? [])
-            s.newTeams = new Set(badgeState.newTeams ?? [])
-            s.teamIDToResetUsers = badgeStateToTeamIDToResetUsers(badgeState)
-          })
+          // badgeState fires on every incoming message; keep identities stable when the
+          // team data didn't change so subscribers (TeamsRoot etc) can bail. Compare
+          // against committed state, not the draft (immer 11 breaks lodash isEqual on drafts).
+          {
+            const prev = get()
+            const deletedTeams = badgeState.deletedTeams ?? []
+            const newTeams = new Set(badgeState.newTeams ?? [])
+            const teamIDToResetUsers = badgeStateToTeamIDToResetUsers(badgeState)
+            set(s => {
+              if (!isEqual(prev.deletedTeams, deletedTeams)) {
+                s.deletedTeams = T.castDraft(deletedTeams)
+              }
+              if (!isEqual(prev.newTeams, newTeams)) {
+                s.newTeams = newTeams
+              }
+              if (!isEqual(prev.teamIDToResetUsers, teamIDToResetUsers)) {
+                s.teamIDToResetUsers = teamIDToResetUsers
+              }
+            })
+          }
           if (currentBadgeVersion === badgeState.inboxVers) {
             // Teams badge detail can change without advancing inboxVers, so keep the
             // Teams tab badge in sync with the latest server-owned badge state.
@@ -191,9 +206,14 @@ export const useNotifState = Z.createZustand<State>('notifications', (set, get) 
           if (goodState.length !== items.length) {
             logger.warn('Lost some messages in filtering out nonNull gregor items')
           }
-          set(s => {
-            s.newTeamRequests = gregorItemsToNewTeamRequests(goodState)
-          })
+          {
+            const newTeamRequests = gregorItemsToNewTeamRequests(goodState)
+            if (!isEqual(get().newTeamRequests, newTeamRequests)) {
+              set(s => {
+                s.newTeamRequests = newTeamRequests
+              })
+            }
+          }
           break
         }
         default:

--- a/shared/teams/channel/rows.tsx
+++ b/shared/teams/channel/rows.tsx
@@ -33,13 +33,13 @@ type Props = {
 
 const ChannelMemberRow = (props: Props) => {
   const {conversationIDKey, participantInfo, teamID, username} = props
-  const infoMap = useUsersState(s => s.infoMap)
+  const userFullname = useUsersState(s => s.infoMap.get(username)?.fullname)
   const {selectedMembers: channelSelectedMembers, setMemberSelected: channelSetMemberSelected} =
     useChannelSelectionState()
   const {teamDetails, teamMeta, yourOperations} = useLoadedTeam(teamID)
   const teamMemberInfo = teamDetails.members.get(username) ?? Teams.initialMemberInfo
   const you = useCurrentUserState(s => s.username)
-  const fullname = infoMap.get(username)?.fullname ?? participantInfo.contactName.get(username) ?? ''
+  const fullname = userFullname ?? participantInfo.contactName.get(username) ?? ''
   const active = teamMemberInfo.status === 'active'
   const roleType = teamMemberInfo.type
   const disabledReasons = getRolePickerDisabledReasons({

--- a/shared/teams/team/rows/subteam-row/team.tsx
+++ b/shared/teams/team/rows/subteam-row/team.tsx
@@ -15,18 +15,17 @@ const SubteamTeamRow = ({teamID, teamMeta: providedTeamMeta}: Props) => {
   const teamMetaByID = useTeamsListMap()
   const teamMeta = providedTeamMeta ?? teamMetaByID.get(teamID) ?? Teams.makeTeamMeta({id: teamID})
   const {teams: activityByTeam} = useActivityLevels()
-  const {isNew, newTeamRequests, teamIDToResetUsers} = useNotifState(
+  const {badgeCount, isNew} = useNotifState(
     C.useShallow(s => ({
+      badgeCount: Teams.getTeamRowBadgeCount(s.newTeamRequests, s.teamIDToResetUsers, teamID),
       isNew: s.newTeams.has(teamID),
-      newTeamRequests: s.newTeamRequests,
-      teamIDToResetUsers: s.teamIDToResetUsers,
     }))
   )
 
   return (
     <TeamRow
       activityLevel={activityByTeam.get(teamID) || 'none'}
-      badgeCount={Teams.getTeamRowBadgeCount(newTeamRequests, teamIDToResetUsers, teamID)}
+      badgeCount={badgeCount}
       id={teamID}
       isNew={isNew}
       teamMeta={teamMeta}

--- a/shared/teams/use-teams-list.tsx
+++ b/shared/teams/use-teams-list.tsx
@@ -1,4 +1,5 @@
 import * as C from '@/constants'
+import isEqual from 'lodash/isEqual'
 import logger from '@/logger'
 import {useConfigState} from '@/stores/config'
 import {useCurrentUserState} from '@/stores/current-user'
@@ -43,6 +44,23 @@ const teamsRoleMapCache = createCachedResourceCache<T.RPCGen.TeamRoleMapAndVersi
 
 const teamListToArray = (list: ReadonlyArray<T.RPCGen.AnnotatedMemberInfo>) => {
   return [...Teams.teamListToMeta(list).values()]
+}
+
+// Incoming team chat messages fire teamMetadataUpdate, which reloads this list; the
+// result is usually deep-equal to what we have. Reuse prior identities (the whole
+// array when nothing changed) so context consumers like TeamsRoot can bail.
+const recycleTeamList = (
+  old: ReadonlyArray<T.Teams.TeamMeta>,
+  next: Array<T.Teams.TeamMeta>
+): ReadonlyArray<T.Teams.TeamMeta> => {
+  if (old.length === next.length && next.every((t, i) => isEqual(t, old[i]))) {
+    return old
+  }
+  const oldByID = new Map(old.map(t => [t.id, t]))
+  return next.map(t => {
+    const o = oldByID.get(t.id)
+    return o && isEqual(o, t) ? o : t
+  })
 }
 
 const invalidateCachedResource = <T, K>(cache: CachedResourceCache<T, K>, nextKey: K) => {
@@ -110,7 +128,7 @@ const useTeamsListRaw = (enabled = true): TeamsList => {
       new Promise<ReadonlyArray<T.Teams.TeamMeta>>((resolve, reject) => {
         loadTeamsRPC(
           [{includeImplicitTeams: false, userAssertion: username}, C.waitingKeyTeamsLoaded],
-          result => resolve(teamListToArray(result.teams ?? [])),
+          result => resolve(recycleTeamList(teamsListCache.getData(), teamListToArray(result.teams ?? []))),
           error => reject(ensureError(error))
         )
       }),

--- a/skill/react-devtools-profile/SKILL.md
+++ b/skill/react-devtools-profile/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: react-devtools-profile
+description: Use when analyzing a React DevTools Profiler export (.json with "dataForRoots"/"commitData") — re-render storms, commit fan-out, "why did this component render", send/interaction render cost. NOT for Chrome Performance traces (those have "traceEvents" — use electron-profile).
+---
+
+# React DevTools Profiler Export Analysis
+
+Parse React DevTools Profiler exports (version 4/5 JSON, top-level `dataForRoots`) with Python scripts in `scripts/` — no DevTools UI needed. Works for React Native and web/Electron profiles alike.
+
+Distinguish from a Chrome Performance trace: profiler export has `{"version": N, "dataForRoots": [...]}`; a trace has `traceEvents` (use the electron-profile skill for those).
+
+## Workflow
+
+1. **Overview** — commit totals, top commits with updaters, component ranking by aggregate self duration, timeline buckets:
+   ```bash
+   python3 scripts/profile-overview.py <profile.json> [--top 25] [--bucket-ms 500]
+   ```
+2. **Per-commit detail** — full updater list, fiber counts, top fibers with ancestor paths, changeDescriptions if recorded:
+   ```bash
+   python3 scripts/profile-commits.py <profile.json> [--commit N] [--top 10] [--root 0]
+   ```
+
+Run from the skill directory (or use absolute script paths); both scripts need `scripts/rdtlib.py` alongside. The overview's top-commit list prints `#N` — that is the index to pass as `--commit N` (commits are chronological).
+
+## Interpreting results
+
+| Signal | Meaning |
+|---|---|
+| `updaters` on a commit | Fibers that *scheduled* the update — setState / store subscription (useSyncExternalStore) firing. The render entry point, not necessarily where time went. |
+| Same broad updater set repeated across several commits | Shared-store fan-out: many components' selectors woke for one logical change. Find the common denominator subscription (here it was conversation meta) and fix identity churn there. |
+| Unnamed fibers `#1234` | Fiber absent from the end-of-profiling snapshot = unmounted before profiling stopped (virtualized-list churn, pending rows replaced on server ack). Cross-reference the same id in `updaters`, which carries displayName. |
+| `prio=Immediate` | Sync flush — store setState outside a React event (zustand, RPC callbacks). Each one blocks the frame; many small Immediate commits = stacked sync flushes worth batching. |
+| High `x<count>` in component ranking | Component rendered in many commits — subscription too broad or unstable selector output (fresh object/closure identity per run defeats useShallow). |
+| Large single-fiber self time in a big-fiber-count commit | Usually a subtree mount (new list row). Mount cost is mostly inherent; look at whether it mounts twice (key churn). |
+| `changeDescriptions: null` | Profile recorded without "Record why each component rendered". Re-record with it enabled to get props/state/hooks/context attribution per fiber. |
+
+**Scope caveat:** durations are React render/effect time only. Store selector runs, native layout, bridge, and app JS outside render are invisible here — a small total does NOT mean no perf problem; it means the problem isn't React commits.
+
+**Fan-out diagnosis recipe:** overview → spot repeated updater sets → per-commit to list exact updater components → read their store selectors → find the shared subscription whose selected values change identity without changing content → preserve identity at the producer (deep-equal reuse on store write), not with deeper memo at consumers.
+
+## Gotchas
+
+- Timestamps are ms relative to profiling start; scripts print t= relative to first commit.
+- `fiberActualDurations` = inclusive per fiber; `fiberSelfDurations` = self. Ranking uses self.
+- Multiple roots possible (`dataForRoots`); overview iterates all, per-commit takes `--root`.
+- Updater lists carry displayNames even for fibers missing from the snapshot — best way to name unmounted fibers.

--- a/skill/react-devtools-profile/scripts/profile-commits.py
+++ b/skill/react-devtools-profile/scripts/profile-commits.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Per-commit detail of a React DevTools Profiler export: full updater list, fiber
+count, top fibers by self duration with ancestor paths, changeDescriptions when the
+profile was recorded with 'Record why each component rendered'."""
+
+import argparse
+
+from rdtlib import load, root_info, fiber_path, updater_names
+
+ap = argparse.ArgumentParser()
+ap.add_argument("profile")
+ap.add_argument("--root", type=int, default=0, help="index into dataForRoots")
+ap.add_argument("--commit", type=int, help="only this commit index")
+ap.add_argument("--top", type=int, default=10, help="fibers shown per commit")
+args = ap.parse_args()
+
+data = load(args.profile)
+r = data["dataForRoots"][args.root]
+commits = r["commitData"]
+names, parents = root_info(r)
+
+ts0 = commits[0]["timestamp"]
+for i, c in enumerate(commits):
+    if args.commit is not None and i != args.commit:
+        continue
+    print(f"\n--- commit {i} t={c['timestamp'] - ts0:.0f}ms dur={c['duration']:.2f}ms prio={c.get('priorityLevel')}")
+    print("  updaters:", ", ".join(updater_names(c)))
+    rendered = c.get("fiberActualDurations", [])
+    print(f"  fibers rendered: {len(rendered)}")
+    for fid, d in sorted(c.get("fiberSelfDurations", []), key=lambda kv: -kv[1])[: args.top]:
+        print(f"    {d:6.2f}ms  {fiber_path(fid, names, parents)}")
+    cds = c.get("changeDescriptions")
+    if not cds:
+        print("  changeDescriptions: not recorded (enable 'Record why each component rendered')")
+    else:
+        print("  why (changeDescriptions):")
+        for fid, cd in cds:
+            bits = []
+            if cd.get("isFirstMount"):
+                bits.append("mount")
+            if cd.get("props"):
+                bits.append("props:" + ",".join(map(str, cd["props"])))
+            if cd.get("state"):
+                bits.append("state:" + ",".join(map(str, cd["state"])))
+            if cd.get("hooks"):
+                bits.append("hooks:" + ",".join(map(str, cd["hooks"])))
+            if cd.get("context"):
+                bits.append("context")
+            print(f"    {names.get(fid, f'#{fid}')}#{fid}: {' '.join(bits) or cd}")

--- a/skill/react-devtools-profile/scripts/profile-overview.py
+++ b/skill/react-devtools-profile/scripts/profile-overview.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Overview of a React DevTools Profiler export: commit totals, top commits with
+their updaters, top components by aggregate self duration, commit timeline."""
+
+import argparse
+from collections import defaultdict
+
+from rdtlib import load, root_info, updater_names
+
+ap = argparse.ArgumentParser()
+ap.add_argument("profile")
+ap.add_argument("--top", type=int, default=25, help="rows in component ranking")
+ap.add_argument("--bucket-ms", type=int, default=500, help="timeline bucket size")
+args = ap.parse_args()
+
+data = load(args.profile)
+print("version:", data.get("version"))
+roots = data["dataForRoots"]
+print("roots:", len(roots))
+
+for r in roots:
+    commits = r["commitData"]
+    if not commits:
+        continue
+    print(f"\n=== root {r.get('rootID')} displayName={r.get('displayName')} commits={len(commits)} ===")
+    names, _ = root_info(r)
+
+    total = sum(c["duration"] for c in commits)
+    eff = sum(c.get("effectDuration") or 0 for c in commits)
+    passive = sum(c.get("passiveEffectDuration") or 0 for c in commits)
+    ts0 = commits[0]["timestamp"]
+    print(f"total commit render time: {total:.1f}ms  effects:{eff:.1f}ms passive:{passive:.1f}ms")
+    print(f"span: {commits[-1]['timestamp'] - ts0:.0f}ms")
+
+    print("\ntop 15 commits by duration (#N = index for profile-commits.py --commit):")
+    for i, c in sorted(enumerate(commits), key=lambda ic: -ic[1]["duration"])[:15]:
+        ups = ",".join(n.split("#")[0] for n in updater_names(c))[:60]
+        print(
+            f"  #{i:<3d} t={c['timestamp'] - ts0:7.0f}ms dur={c['duration']:7.2f}ms"
+            f" eff={(c.get('effectDuration') or 0):6.2f} passive={(c.get('passiveEffectDuration') or 0):6.2f}"
+            f" prio={c.get('priorityLevel')} updaters={ups}"
+        )
+
+    self_tot = defaultdict(float)
+    self_cnt = defaultdict(int)
+    for c in commits:
+        for fid, d in c.get("fiberSelfDurations", []):
+            n = names.get(fid, f"fiber{fid}")
+            self_tot[n] += d
+            self_cnt[n] += 1
+    print(f"\ntop {args.top} components by total self duration (all commits):")
+    for n, d in sorted(self_tot.items(), key=lambda kv: -kv[1])[: args.top]:
+        print(f"  {d:8.1f}ms  x{self_cnt[n]:4d}  {n}")
+
+    print(f"\ncommit timeline (per {args.bucket_ms}ms bucket: count / total ms):")
+    buckets = defaultdict(lambda: [0, 0.0])
+    for c in commits:
+        b = int((c["timestamp"] - ts0) // args.bucket_ms)
+        buckets[b][0] += 1
+        buckets[b][1] += c["duration"]
+    for b in sorted(buckets):
+        cnt, d = buckets[b]
+        print(f"  {b * args.bucket_ms:6d}-{(b + 1) * args.bucket_ms:6d}ms: {cnt:3d} commits {d:7.1f}ms")

--- a/skill/react-devtools-profile/scripts/rdtlib.py
+++ b/skill/react-devtools-profile/scripts/rdtlib.py
@@ -1,0 +1,36 @@
+"""Shared helpers for parsing React DevTools Profiler exports (version 4/5 JSON)."""
+
+import json
+
+
+def load(path):
+    data = json.load(open(path))
+    return data
+
+
+def root_info(root):
+    """Build fiber id -> displayName and id -> parent id maps from the root's snapshot.
+
+    The snapshot describes the tree at the END of profiling. Fibers rendered during
+    profiling but unmounted before it stopped are absent — they show up as '#<id>'.
+    """
+    names = {}
+    parents = {}
+    for fid, info in root.get("snapshots") or []:
+        names[int(fid)] = info.get("displayName") or "?"
+        for ch in info.get("children", []):
+            parents[int(ch)] = int(fid)
+    return names, parents
+
+
+def fiber_path(fid, names, parents, depth=6):
+    out = []
+    while fid is not None and depth > 0:
+        out.append(names.get(fid, f"#{fid}"))
+        fid = parents.get(fid)
+        depth -= 1
+    return " < ".join(out)
+
+
+def updater_names(commit):
+    return [f"{u.get('displayName') or '?'}#{u.get('id')}" for u in commit.get("updaters") or []]


### PR DESCRIPTION
Profiling chat send, message receive (sitting in inbox), and thread scrollback with the React DevTools profiler surfaced a systemic pattern: stores handing out fresh object identities for unchanged data, and components subscribing to whole objects/maps when they read one field. Each store write then woke large subscriber sets that re-rendered for nothing.

### Results (dev-build React commit time, same flows before/after)

| Flow | Before | After |
|---|---|---|
| Send a message | 52ms, 5 whole-screen fan-outs (every visible row + header + banner + input + inbox row, ~5x each) | 40ms, only legit renders (new row mount, inbox row snippet, input clear) |
| Receive while in inbox | 98ms (every visible inbox row, Teams root, Settings nav, tab bar) | ~25ms (receiving row, badge divider, tab badge — all real changes) |
| Scrollback in thread | — | all remaining cost is FlatList internals; zero app subscription wakes during a 100-message ingest |

### Producer-side fixes (keep identities stable when content didn't change)

- `updateMeta`/`copyOverOldValuesIfEqual`: generic deep-equal field reuse for incoming conversation metas (was a hand-picked 4-field list; `botAliases`/`commands`/`pinnedMsg` leaked new identities on every send)
- `metasReceived`: drop metas that resolved to the existing object; skip the store write when nothing changed
- inbox layout: recycle deep-equal layout rows per conversation (a fresh `UIInboxLayout` arrives on every incoming message; previously any change gave every row a new identity)
- notifications store: `isEqual`-guard `deletedTeams`/`newTeams`/`teamIDToResetUsers`/`newTeamRequests`, which were rebuilt on every `badgeState`/gregor push (fires per message) — with regression tests
- teams list: reuse the prior `TeamMeta` array when a `teamMetadataUpdate`-triggered reload returns deep-equal data (fires per incoming team message)

### Consumer-side fixes (subscribe to what's read)

- new reload-free `useConversationMetaSelector`/`useConversationParticipantsSelector`; `useConversationMetadata` (whole meta+participants pair + arms 7 engine reload listeners per mount) now only backs surfaces that want that; `ConversationInner` is the single reload owner for the thread screen
- migrated the hot always-mounted thread surfaces to narrow reads: header (ShhIcon/ChannelHeader/branch container/phone-email/username), bottom banner, BlockButtons, SpecialTopMessage, input placeholder, ConnectedPlatformInput (was `useThreadMeta(m => m)`)
- `useInboxRowSmall`/`useInboxRowBig` subscribe to typed field picks instead of the whole meta object, so version-only meta bumps don't wake visible inbox rows
- callbacks-only hooks (`useConversationAttachmentActions`, `useConversationSendActions`, `ConversationInputProvider.setEditing`, People page loader) read the store lazily at call time instead of subscribing to `messageMap`/`messageOrdinals`/follower sets
- per-row/whole-map narrowings from a repo-wide subscription sweep: channel member rows, subteam rows, desktop tab badges, showcase-team-offer rows, swipe actions (new `useInboxRowIsMuted`), SettingsNav badges, account-payment rows, UsernameHeader fullname
- `BlockButtons` derives its has-own-message boolean inside the selector, gated on block-button info, instead of rescanning every ordinal per thread change

### Also

- `fix(native)`: re-read guiConfig per `getTypedConstants` call
- new `skill/react-devtools-profile`: scripts to analyze React DevTools profiler exports headlessly (commit overview, per-commit updater/fiber breakdown, changeDescriptions) — used for all of the above

Scrollback profile confirms the list itself (FlatList windowing + the 100-message batch mount) is now the only remaining cost there; that's the LegendList migration's territory, deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
