### PR TITLE
build(ios): manual distribution signing for Release archives

### DIFF
--- a/shared/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/ios/Keybase.xcodeproj/project.pbxproj
@@ -675,7 +675,6 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
-				PROVISIONING_PROFILE = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -691,8 +690,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keybase/Keybase.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Keybase, Inc. (99229SGT5K)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 114;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_BITCODE = NO;
@@ -728,7 +727,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
-				PROVISIONING_PROFILE = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "keybase.ios AppStore";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -807,9 +806,8 @@
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = KeybaseShare/KeybaseShare.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Keybase, Inc. (99229SGT5K)";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_BITCODE = NO;
@@ -833,6 +831,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios.KeybaseShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "keybase.ios.KeybaseShare AppStore";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "KeybaseShare/KeybaseShare-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -999,7 +998,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				CXX = "";
 				DEVELOPMENT_TEAM = 99229SGT5K;

--- a/shared/ios/fastlane/Fastfile
+++ b/shared/ios/fastlane/Fastfile
@@ -36,9 +36,30 @@ platform :ios do
       in_house: false # optional but may be required if using match/sigh
     )
 
-    sigh(app_identifier: "keybase.ios")
-    sigh(app_identifier: "keybase.ios.KeybaseShare")
-    gym(scheme: "Keybase") # Build your app - more options available
+    # Profile names must match PROVISIONING_PROFILE_SPECIFIER in
+    # Keybase.xcodeproj: Release archives use manual distribution signing,
+    # so nothing here depends on development profiles or a signed-in Xcode.
+    sigh(
+      app_identifier: "keybase.ios",
+      provisioning_name: "keybase.ios AppStore",
+      ignore_profiles_with_different_name: true
+    )
+    sigh(
+      app_identifier: "keybase.ios.KeybaseShare",
+      provisioning_name: "keybase.ios.KeybaseShare AppStore",
+      ignore_profiles_with_different_name: true
+    )
+    gym(
+      scheme: "Keybase",
+      export_method: "app-store",
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: {
+          "keybase.ios" => "keybase.ios AppStore",
+          "keybase.ios.KeybaseShare" => "keybase.ios.KeybaseShare AppStore"
+        }
+      }
+    )
     pilot(
         api_key: api_key,
         changelog: changelog_from_git_commits(


### PR DESCRIPTION
Release device builds signed with the "iPhone Developer" identity, so archiving required development profiles the beta lane never refreshed; they expired, and headless xcodebuild cannot auto-provision without -allowProvisioningUpdates.

Pin manual "iPhone Distribution" signing with named App Store profiles per target, fetch those exact profiles via sigh, and pass an explicit export mapping to gym. Development profiles are no longer needed.