### PR TITLE
build(ios): stamp sigh's actual profile into the build

### DIFF
--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -98,6 +98,17 @@ if [ -n "$clean" ]; then
 	xcodebuild clean -workspace "Keybase.xcworkspace" -scheme "Keybase"
 fi
 
+# Stale cached profiles shadow the fresh ones sigh downloads when Xcode
+# matches profiles by name (e.g. after annual renewal); park them so only
+# freshly-downloaded profiles are visible.
+profile_backup="$HOME/old-provisioning-profiles/$(date +%Y%m%d-%H%M%S)"
+for profile_dir in "$HOME/Library/MobileDevice/Provisioning Profiles" "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"; do
+	if compgen -G "$profile_dir/*.mobileprovision" >/dev/null; then
+		mkdir -p "$profile_backup"
+		mv "$profile_dir"/*.mobileprovision "$profile_backup/"
+	fi
+done
+
 # fastlane wants these set
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8

--- a/shared/ios/fastlane/Fastfile
+++ b/shared/ios/fastlane/Fastfile
@@ -36,27 +36,43 @@ platform :ios do
       in_house: false # optional but may be required if using match/sigh
     )
 
-    # Profile names must match PROVISIONING_PROFILE_SPECIFIER in
-    # Keybase.xcodeproj: Release archives use manual distribution signing,
-    # so nothing here depends on development profiles or a signed-in Xcode.
-    sigh(
-      app_identifier: "keybase.ios",
-      provisioning_name: "keybase.ios AppStore",
-      ignore_profiles_with_different_name: true
+    # Release archives use manual distribution signing. Portal profile
+    # names aren't stable (sigh appends a timestamp when it has to create
+    # one), so stamp whatever valid App Store profile sigh installs into
+    # the project before building. The checked-in PROVISIONING_PROFILE_SPECIFIER
+    # values are only local-archive defaults; this overwrites them.
+    sigh(app_identifier: "keybase.ios")
+    main_profile = lane_context[SharedValues::SIGH_NAME]
+    update_code_signing_settings(
+      path: "Keybase.xcodeproj",
+      targets: ["Keybase"],
+      build_configurations: ["Release"],
+      use_automatic_signing: false,
+      code_sign_identity: "iPhone Distribution",
+      sdk: "iphoneos*",
+      profile_name: main_profile
     )
-    sigh(
-      app_identifier: "keybase.ios.KeybaseShare",
-      provisioning_name: "keybase.ios.KeybaseShare AppStore",
-      ignore_profiles_with_different_name: true
+
+    sigh(app_identifier: "keybase.ios.KeybaseShare")
+    share_profile = lane_context[SharedValues::SIGH_NAME]
+    update_code_signing_settings(
+      path: "Keybase.xcodeproj",
+      targets: ["KeybaseShare"],
+      build_configurations: ["Release"],
+      use_automatic_signing: false,
+      code_sign_identity: "iPhone Distribution",
+      sdk: "iphoneos*",
+      profile_name: share_profile
     )
+
     gym(
       scheme: "Keybase",
       export_method: "app-store",
       export_options: {
         signingStyle: "manual",
         provisioningProfiles: {
-          "keybase.ios" => "keybase.ios AppStore",
-          "keybase.ios.KeybaseShare" => "keybase.ios.KeybaseShare AppStore"
+          "keybase.ios" => main_profile,
+          "keybase.ios.KeybaseShare" => share_profile
         }
       }
     )


### PR DESCRIPTION
Pinning profile names broke: when the portal's existing profile isn't reusable, sigh creates one with a timestamp suffix, so the name baked into the project never matches what got installed.

Take whatever valid App Store profile sigh installs and write it into the Release configs via update_code_signing_settings before gym, and pass the same names in the export mapping. Also park cached profiles before each run — stale expired copies shadow fresh ones during Xcode's by-name matching.