### PR TITLE
fix(chat): lock unguarded shared maps

### DIFF
--- a/go/chat/commands/giphy.go
+++ b/go/chat/commands/giphy.go
@@ -30,6 +30,7 @@ func (d defaultGiphySearcher) Search(mctx libkb.MetaContext, apiKeySource types.
 type Giphy struct {
 	sync.Mutex
 	*baseCommand
+	shownMu           sync.Mutex
 	shownResults      map[chat1.ConvIDStr]*string
 	shownWindow       map[chat1.ConvIDStr]bool
 	currentOpCancelFn context.CancelFunc
@@ -119,19 +120,27 @@ func (s *Giphy) Preview(ctx context.Context, uid gregor1.UID, convID chat1.Conve
 	defer close(s.currentOpDoneCb)
 
 	if !s.Match(ctx, text) {
-		if _, ok := s.shownWindow[convID.ConvIDStr()]; ok {
+		s.shownMu.Lock()
+		_, shownOK := s.shownWindow[convID.ConvIDStr()]
+		if shownOK {
+			delete(s.shownResults, convID.ConvIDStr())
+			delete(s.shownWindow, convID.ConvIDStr())
+		}
+		s.shownMu.Unlock()
+		if shownOK {
 			// tell UI to clear
 			err := s.getChatUI().ChatGiphyToggleResultWindow(ctx, convID, false, false)
 			if err != nil {
 				s.Debug(ctx, "Preview: error on toggle result: %+v", err)
 			}
-			delete(s.shownResults, convID.ConvIDStr())
-			delete(s.shownWindow, convID.ConvIDStr())
 		}
 		return
 	}
 	query := s.getQuery(text)
-	if shown, ok := s.shownResults[convID.ConvIDStr()]; ok && s.queryEqual(query, shown) {
+	s.shownMu.Lock()
+	shown, shownOK := s.shownResults[convID.ConvIDStr()]
+	s.shownMu.Unlock()
+	if shownOK && s.queryEqual(query, shown) {
 		s.Debug(ctx, "Preview: same query given, skipping")
 		return
 	}
@@ -140,7 +149,9 @@ func (s *Giphy) Preview(ctx context.Context, uid gregor1.UID, convID chat1.Conve
 		s.Debug(ctx, "Preview: error on toggle result: %+v", err)
 	}
 
+	s.shownMu.Lock()
 	s.shownWindow[convID.ConvIDStr()] = true
+	s.shownMu.Unlock()
 
 	results, err := s.searcher.Search(libkb.NewMetaContext(ctx, s.G().ExternalG()),
 		s.G().ExternalAPIKeySource, query, s.getLimit(), s.G().AttachmentURLSrv)
@@ -157,5 +168,7 @@ func (s *Giphy) Preview(ctx context.Context, uid gregor1.UID, convID chat1.Conve
 		return
 	}
 
+	s.shownMu.Lock()
 	s.shownResults[convID.ConvIDStr()] = query
+	s.shownMu.Unlock()
 }

--- a/go/chat/convsource.go
+++ b/go/chat/convsource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/keybase/client/go/chat/attachments"
@@ -452,7 +453,8 @@ type HybridConversationSource struct {
 	lockTab          *utils.ConversationLockTab
 	// It is sufficient to clear caches once per conversation. Track what
 	// conversations we've already cleared for.
-	deleteConvErrCache map[chat1.ConvIDStr]bool
+	deleteConvErrCacheMu sync.Mutex
+	deleteConvErrCache   map[chat1.ConvIDStr]bool
 }
 
 var _ types.ConversationSource = (*HybridConversationSource)(nil)
@@ -518,13 +520,23 @@ func (s *HybridConversationSource) completeUnfurl(ctx context.Context, msg chat1
 	}
 }
 
+// markDeleteConvErr records that convID's caches were purged; returns false if already recorded.
+func (s *HybridConversationSource) markDeleteConvErr(cid chat1.ConvIDStr) bool {
+	s.deleteConvErrCacheMu.Lock()
+	defer s.deleteConvErrCacheMu.Unlock()
+	if s.deleteConvErrCache[cid] {
+		return false
+	}
+	s.deleteConvErrCache[cid] = true
+	return true
+}
+
 func (s *HybridConversationSource) maybeNuke(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, err *error) {
 	if err != nil && utils.IsDeletedConvError(*err) {
-		if s.deleteConvErrCache[convID.ConvIDStr()] {
+		if !s.markDeleteConvErr(convID.ConvIDStr()) {
 			s.Debug(ctx, "skipping cache purge on: %v for convID: %v, uid: %v", *err, convID, uid)
 			return
 		}
-		s.deleteConvErrCache[convID.ConvIDStr()] = true
 
 		s.Debug(ctx, "purging caches on: %v for convID: %v, uid: %v", *err, convID, uid)
 		if ierr := s.Clear(ctx, convID, uid, &types.ClearOpts{

--- a/go/chat/identify.go
+++ b/go/chat/identify.go
@@ -76,6 +76,8 @@ func (i *CachingIdentifyNotifier) ResetOnGUIConnect() {
 }
 
 func (i *CachingIdentifyNotifier) Reset() {
+	i.Lock()
+	defer i.Unlock()
 	i.identCache = make(map[string]keybase1.CanonicalTLFNameAndIDWithBreaks)
 }
 

--- a/go/chat/inboxsource.go
+++ b/go/chat/inboxsource.go
@@ -536,7 +536,8 @@ type HybridInboxSource struct {
 	searchStatusMap       map[chat1.ConversationStatus]bool
 	searchMemberStatusMap map[chat1.ConversationMemberStatus]bool
 	// It is sufficient to clear caches once per conversation. Track what conversations we've already cleared for.
-	deleteConvErrCache map[chat1.ConvIDStr]bool
+	deleteConvErrCacheMu sync.Mutex
+	deleteConvErrCache   map[chat1.ConvIDStr]bool
 }
 
 var _ types.InboxSource = (*HybridInboxSource)(nil)
@@ -579,6 +580,17 @@ func extractConvIDFromError(err error) *chat1.ConversationID {
 	return nil
 }
 
+// markDeleteConvErr records that convID's caches were purged; returns false if already recorded.
+func (s *HybridInboxSource) markDeleteConvErr(cid chat1.ConvIDStr) bool {
+	s.deleteConvErrCacheMu.Lock()
+	defer s.deleteConvErrCacheMu.Unlock()
+	if s.deleteConvErrCache[cid] {
+		return false
+	}
+	s.deleteConvErrCache[cid] = true
+	return true
+}
+
 func (s *HybridInboxSource) maybeNuke(ctx context.Context, uid gregor1.UID, convID *chat1.ConversationID, err *error) {
 	if err != nil && utils.IsDeletedConvError(*err) {
 		cid := convID
@@ -589,11 +601,10 @@ func (s *HybridInboxSource) maybeNuke(ctx context.Context, uid gregor1.UID, conv
 			cid = extractConvIDFromError(*err)
 		}
 		if cid != nil {
-			if s.deleteConvErrCache[cid.ConvIDStr()] {
+			if !s.markDeleteConvErr(cid.ConvIDStr()) {
 				s.Debug(ctx, "skipping cache purge on: %v for convID: %v, uid: %v", *err, cid, uid)
 				return
 			}
-			s.deleteConvErrCache[cid.ConvIDStr()] = true
 		}
 		s.Debug(ctx, "purging caches on: %v for convID: %v, uid: %v", *err, convID, uid)
 		if ierr := s.G().InboxSource.Clear(ctx, uid, &types.ClearOpts{

--- a/go/chat/uithreadloader.go
+++ b/go/chat/uithreadloader.go
@@ -26,13 +26,14 @@ type UIThreadLoader struct {
 	utils.DebugLabeler
 	sync.Mutex
 
-	clock          clockwork.Clock
-	convPageStatus map[chat1.ConvIDStr]chat1.Pagination
-	validatedDelay time.Duration
-	offlineMu      sync.Mutex
-	offline        bool
-	connectedCh    chan struct{}
-	ri             func() chat1.RemoteInterface
+	clock            clockwork.Clock
+	convPageStatusMu sync.Mutex
+	convPageStatus   map[chat1.ConvIDStr]chat1.Pagination
+	validatedDelay   time.Duration
+	offlineMu        sync.Mutex
+	offline          bool
+	connectedCh      chan struct{}
+	ri               func() chat1.RemoteInterface
 
 	activeConvLoadsMu sync.Mutex
 	activeConvLoads   map[chat1.ConvIDStr]context.CancelFunc
@@ -116,6 +117,8 @@ func (t *UIThreadLoader) applyPagerModeIncoming(ctx context.Context, convID chat
 		if pagination == nil {
 			return nil
 		}
+		t.convPageStatusMu.Lock()
+		defer t.convPageStatusMu.Unlock()
 		oldStored := t.convPageStatus[convID.ConvIDStr()]
 		if len(pagination.Next) > 0 {
 			return &chat1.Pagination{
@@ -143,6 +146,8 @@ func (t *UIThreadLoader) applyPagerModeOutgoing(ctx context.Context, convID chat
 		if pagination == nil {
 			return
 		}
+		t.convPageStatusMu.Lock()
+		defer t.convPageStatusMu.Unlock()
 		if incoming.FirstPage() {
 			t.Debug(ctx, "applyPagerModeOutgoing: resetting pagination: convID: %s p: %s", convID, pagination)
 			t.convPageStatus[convID.ConvIDStr()] = *pagination

--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -351,6 +351,8 @@ func (m *MemEngine) ConsumeMessage(ctx context.Context, msg gregor.Message) (gre
 }
 
 func (m *MemEngine) ConsumeLocalDismissal(ctx context.Context, u gregor.UID, msgID gregor.MsgID) error {
+	m.Lock()
+	defer m.Unlock()
 	user := m.getUser(u)
 	user.removeLocalDismissal(msgID)
 	user.localDismissals = append(user.localDismissals, msgID)
@@ -358,12 +360,16 @@ func (m *MemEngine) ConsumeLocalDismissal(ctx context.Context, u gregor.UID, msg
 }
 
 func (m *MemEngine) InitLocalDismissals(ctx context.Context, u gregor.UID, msgIDs []gregor.MsgID) error {
+	m.Lock()
+	defer m.Unlock()
 	user := m.getUser(u)
 	user.localDismissals = msgIDs
 	return nil
 }
 
 func (m *MemEngine) LocalDismissals(ctx context.Context, u gregor.UID) (res []gregor.MsgID, err error) {
+	m.Lock()
+	defer m.Unlock()
 	user := m.getUser(u)
 	return user.localDismissals, nil
 }
@@ -436,6 +442,8 @@ func (m *MemEngine) StateByCategoryPrefix(ctx context.Context, u gregor.UID, d g
 }
 
 func (m *MemEngine) Clear() error {
+	m.Lock()
+	defer m.Unlock()
 	m.users = make(map[string](*user))
 	return nil
 }

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -414,6 +414,26 @@ func (j *JournalManager) MakeFBOsForExistingJournals(
 		wg.Add(1)
 		tlfID := tlfID
 		tj := tj
+		// Compute the branch here while j.lock is still held; the
+		// goroutine below outlives it.
+		branch := data.MasterBranch
+		if tj.overrideTlfID != tlf.NullID {
+			// Find the conflict key.
+			for k, v := range j.clearedConflictTlfs {
+				if tj.overrideTlfID != v.fakeTlfID {
+					continue
+				}
+
+				ext, err := tlf.NewHandleExtension(
+					tlf.HandleExtensionLocalConflict, k.num, "", k.date)
+				if err != nil {
+					j.log.CWarningf(ctx, "Error making extension: %+v", err)
+					continue
+				}
+
+				branch = data.MakeConflictBranchNameFromExtension(ext)
+			}
+		}
 		go func() {
 			ctx := CtxWithRandomIDReplayable(
 				context.Background(), CtxFBOIDKey, CtxFBOOpID, j.log)
@@ -428,25 +448,6 @@ func (j *JournalManager) MakeFBOsForExistingJournals(
 			defer wg.Done()
 			j.log.CDebugf(ctx,
 				"Initializing FBO for non-empty journal: %s", tlfID)
-
-			branch := data.MasterBranch
-			if tj.overrideTlfID != tlf.NullID {
-				// Find the conflict key.
-				for k, v := range j.clearedConflictTlfs {
-					if tj.overrideTlfID != v.fakeTlfID {
-						continue
-					}
-
-					ext, err := tlf.NewHandleExtension(
-						tlf.HandleExtensionLocalConflict, k.num, "", k.date)
-					if err != nil {
-						j.log.CWarningf(ctx, "Error making extension: %+v", err)
-						continue
-					}
-
-					branch = data.MakeConflictBranchNameFromExtension(ext)
-				}
-			}
 
 			err = j.makeFBOForJournal(ctx, tj, tlfID, branch)
 			if err != nil {

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -180,7 +180,13 @@ func (fs *KBFSOpsStandard) Shutdown(ctx context.Context) error {
 	if err := fs.favs.Shutdown(); err != nil {
 		errors = append(errors, err)
 	}
+	fs.opsLock.RLock()
+	opsList := make([]*folderBranchOps, 0, len(fs.ops))
 	for _, ops := range fs.ops {
+		opsList = append(opsList, ops)
+	}
+	fs.opsLock.RUnlock()
+	for _, ops := range opsList {
 		if err := ops.Shutdown(ctx); err != nil {
 			errors = append(errors, err)
 			// Continue on and try to shut down the other FBOs.


### PR DESCRIPTION
iOS crashed at startup with "fatal error: concurrent map writes" in HybridInboxSource.maybeNuke: parallel unbox goroutines hit a deleted conv and raced on deleteConvErrCache. Audit found the same shape in convsource (deleteConvErrCache), uithreadloader (convPageStatus), giphy (shownResults/shownWindow), and identify (Reset vs Send).