### PR TITLE
fix: lock unguarded shared maps outside chat

### DIFF
--- a/go/gregor/storage/mem_sm.go
+++ b/go/gregor/storage/mem_sm.go
@@ -351,6 +351,8 @@ func (m *MemEngine) ConsumeMessage(ctx context.Context, msg gregor.Message) (gre
 }
 
 func (m *MemEngine) ConsumeLocalDismissal(ctx context.Context, u gregor.UID, msgID gregor.MsgID) error {
+	m.Lock()
+	defer m.Unlock()
 	user := m.getUser(u)
 	user.removeLocalDismissal(msgID)
 	user.localDismissals = append(user.localDismissals, msgID)
@@ -358,12 +360,16 @@ func (m *MemEngine) ConsumeLocalDismissal(ctx context.Context, u gregor.UID, msg
 }
 
 func (m *MemEngine) InitLocalDismissals(ctx context.Context, u gregor.UID, msgIDs []gregor.MsgID) error {
+	m.Lock()
+	defer m.Unlock()
 	user := m.getUser(u)
 	user.localDismissals = msgIDs
 	return nil
 }
 
 func (m *MemEngine) LocalDismissals(ctx context.Context, u gregor.UID) (res []gregor.MsgID, err error) {
+	m.Lock()
+	defer m.Unlock()
 	user := m.getUser(u)
 	return user.localDismissals, nil
 }
@@ -436,6 +442,8 @@ func (m *MemEngine) StateByCategoryPrefix(ctx context.Context, u gregor.UID, d g
 }
 
 func (m *MemEngine) Clear() error {
+	m.Lock()
+	defer m.Unlock()
 	m.users = make(map[string](*user))
 	return nil
 }

--- a/go/kbfs/libkbfs/journal_manager.go
+++ b/go/kbfs/libkbfs/journal_manager.go
@@ -414,6 +414,26 @@ func (j *JournalManager) MakeFBOsForExistingJournals(
 		wg.Add(1)
 		tlfID := tlfID
 		tj := tj
+		// Compute the branch here while j.lock is still held; the
+		// goroutine below outlives it.
+		branch := data.MasterBranch
+		if tj.overrideTlfID != tlf.NullID {
+			// Find the conflict key.
+			for k, v := range j.clearedConflictTlfs {
+				if tj.overrideTlfID != v.fakeTlfID {
+					continue
+				}
+
+				ext, err := tlf.NewHandleExtension(
+					tlf.HandleExtensionLocalConflict, k.num, "", k.date)
+				if err != nil {
+					j.log.CWarningf(ctx, "Error making extension: %+v", err)
+					continue
+				}
+
+				branch = data.MakeConflictBranchNameFromExtension(ext)
+			}
+		}
 		go func() {
 			ctx := CtxWithRandomIDReplayable(
 				context.Background(), CtxFBOIDKey, CtxFBOOpID, j.log)
@@ -428,25 +448,6 @@ func (j *JournalManager) MakeFBOsForExistingJournals(
 			defer wg.Done()
 			j.log.CDebugf(ctx,
 				"Initializing FBO for non-empty journal: %s", tlfID)
-
-			branch := data.MasterBranch
-			if tj.overrideTlfID != tlf.NullID {
-				// Find the conflict key.
-				for k, v := range j.clearedConflictTlfs {
-					if tj.overrideTlfID != v.fakeTlfID {
-						continue
-					}
-
-					ext, err := tlf.NewHandleExtension(
-						tlf.HandleExtensionLocalConflict, k.num, "", k.date)
-					if err != nil {
-						j.log.CWarningf(ctx, "Error making extension: %+v", err)
-						continue
-					}
-
-					branch = data.MakeConflictBranchNameFromExtension(ext)
-				}
-			}
 
 			err = j.makeFBOForJournal(ctx, tj, tlfID, branch)
 			if err != nil {

--- a/go/kbfs/libkbfs/kbfs_ops.go
+++ b/go/kbfs/libkbfs/kbfs_ops.go
@@ -180,7 +180,13 @@ func (fs *KBFSOpsStandard) Shutdown(ctx context.Context) error {
 	if err := fs.favs.Shutdown(); err != nil {
 		errors = append(errors, err)
 	}
+	fs.opsLock.RLock()
+	opsList := make([]*folderBranchOps, 0, len(fs.ops))
 	for _, ops := range fs.ops {
+		opsList = append(opsList, ops)
+	}
+	fs.opsLock.RUnlock()
+	for _, ops := range opsList {
 		if err := ops.Shutdown(ctx); err != nil {
 			errors = append(errors, err)
 			// Continue on and try to shut down the other FBOs.


### PR DESCRIPTION
Same audit as adf86f6, rest of go/ tree: gregor MemEngine skipped its lock in four methods (users map), kbfs journal FBO goroutines read clearedConflictTlfs after journal lock released, KBFSOps Shutdown ranged fs.ops without opsLock.