### PR TITLE
build(desktop): stop pruning optional deps in yarn modules

### DIFF
--- a/shared/desktop/yarn-helper/electron.mts
+++ b/shared/desktop/yarn-helper/electron.mts
@@ -79,9 +79,9 @@ async function startHotLoop() {
   process.env['HOT'] = 'true'
 
   // Imported lazily: pulling vite in at module load would load its rolldown
-  // native binding, which CI (jenkins_test.sh) skips via `yarn --ignore-optional`.
-  // This module is imported by the postinstall helper, so an eager import breaks
-  // `yarn install` on CI. Only the hot dev loop actually needs the bundler.
+  // native binding, which may be absent (installs that prune optional deps).
+  // This module is imported by the postinstall helper, so an eager import would
+  // break `yarn install` there. Only the hot dev loop actually needs the bundler.
   const {createServer, build} = await import('vite')
   const {makeNodeConfig} = await import('../vite.node.mts')
 

--- a/shared/jenkins_test.sh
+++ b/shared/jenkins_test.sh
@@ -51,8 +51,7 @@ js_tests() {
 	rm -rf node_modules
 
 	echo 'yarn install'
-	# no `yarn modules` here: its --ignore-optional prunes the platform-specific
-	# @typescript/typescript-* binaries that typescript-native (tsc) needs
+	# no `yarn modules` here: CI wants its own network/engine flags
 	yarn install --network-concurrency 1 --prefer-offline --pure-lockfile --ignore-engines
 	check_rc $? 'yarn install fail' 1
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -54,7 +54,7 @@
     "lint:daemon": "eslint_d --cache .",
     "lint:specific": "eslint --cache --quiet ",
     "lint:warn": "eslint .",
-    "modules": "yarn install --pure-lockfile --ignore-optional --ignore-scripts && yarn postinstall",
+    "modules": "yarn install --pure-lockfile --ignore-scripts && yarn postinstall",
     "perf:compare": "node perf/compare-perf.js",
     "perf:inbox:desktop": "node perf/run-desktop-perf.js --flow inbox",
     "perf:inbox:ios": "MAESTRO_CLI_NO_ANALYTICS=1 ./perf/run-maestro.sh --flow performance/perf-inbox-scroll.yaml",


### PR DESCRIPTION
--ignore-optional dropped rolldown's platform binding, breaking the vite package step on the darwin build bot.