### PR TITLE
fix(chat): make push notification decryption less flaky

### DIFF
--- a/go/bind/notifications.go
+++ b/go/bind/notifications.go
@@ -155,7 +155,9 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 	displayPlaintext bool, intMessageID int, pushID string, badgeCount, unixTime int, soundName string,
 	pusher PushNotifier, showIfStale bool, targetUID string,
 ) (err error) {
-	if err := waitForInit(10 * time.Second); err != nil {
+	// iOS gives roughly 30 seconds of background time for a remote
+	// notification; leave enough of that budget for unboxing and acking.
+	if err := waitForInit(15 * time.Second); err != nil {
 		return err
 	}
 	gc := globals.NewContext(kbCtx, kbChatCtx)
@@ -210,8 +212,21 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 		kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: invalid convID: %s msg: %s", strConvID, err)
 		return err
 	}
+	// Pre-dial the gregor connection used to ack this push: the connection
+	// starts its TLS/auth handshake at construction, so it connects in
+	// parallel with the conversation fetch and unbox below. The ack races the
+	// server's fallback timeout, after which it delivers the generic
+	// notification.
+	var ack *chat.PushAck
+	if len(pushID) > 0 {
+		ack = chat.NewPushAck(ctx, gc)
+		defer ack.Shutdown()
+	}
 	membersType := chat1.ConversationMembersType(intMembersType)
-	conv, err := utils.GetVerifiedConv(ctx, gc, uid, convID, types.InboxSourceDataSourceLocalOnly)
+	// DataSourceAll: fall back to a remote inbox fetch when the conversation
+	// is not in the local cache (first message in a new conversation, fresh
+	// install), instead of failing and letting the generic notification show.
+	conv, err := utils.GetVerifiedConv(ctx, gc, uid, convID, types.InboxSourceDataSourceAll)
 	if err != nil {
 		kbCtx.Log.CDebugf(ctx, "Failed to get conversation info", err)
 		return err
@@ -306,8 +321,8 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 		defer seenNotificationsMtx.Unlock()
 		if _, ok := getSeenNotificationsCache().Get(dupKey); ok {
 			// Cancel any duplicate visible notifications
-			if len(pushID) > 0 {
-				mp.AckNotificationSuccess(ctx, []string{pushID})
+			if ack != nil {
+				ack.Ack(ctx, []string{pushID})
 			}
 			kbCtx.Log.CDebugf(ctx, "HandleBackgroundNotification: duplicate notification convID=%s msgID=%d", strConvID, intMessageID)
 			// Return nil (not an error) so Android does not treat this as failure and show a fallback notification.
@@ -318,8 +333,8 @@ func HandleBackgroundNotification(strConvID, body, serverMessageBody, sender str
 		// see the entry and bail out rather than displaying a duplicate.
 		getSeenNotificationsCache().Add(dupKey, struct{}{})
 		pusher.DisplayChatNotification(&chatNotification)
-		if len(pushID) > 0 {
-			mp.AckNotificationSuccess(ctx, []string{pushID})
+		if ack != nil {
+			ack.Ack(ctx, []string{pushID})
 		}
 	}
 	return nil

--- a/go/chat/mobilepush.go
+++ b/go/chat/mobilepush.go
@@ -55,23 +55,67 @@ func NewMobilePush(g *globals.Context) *MobilePush {
 
 func (h *MobilePush) AckNotificationSuccess(ctx context.Context, pushIDs []string) {
 	defer h.Trace(ctx, nil, "AckNotificationSuccess: pushID: %v", pushIDs)()
-	conn, token, err := utils.GetGregorConn(ctx, h.G(), h.DebugLabeler,
+	ack := NewPushAck(ctx, h.G())
+	defer ack.Shutdown()
+	ack.Ack(ctx, pushIDs)
+}
+
+// PushAck acks push notifications over an ad hoc gregor connection. The ack
+// is what stops the server from delivering its generic fallback notification,
+// so it races the server's timeout: rpc.Connection dials eagerly at
+// construction, so create the PushAck as early as possible to overlap the
+// TLS/auth handshake with unboxing work, then call Ack once the notification
+// has actually been displayed. Always Shutdown when done.
+type PushAck struct {
+	globals.Contextified
+	utils.DebugLabeler
+	conn  *rpc.Connection
+	token gregor1.SessionToken
+	err   error
+}
+
+func NewPushAck(ctx context.Context, g *globals.Context) *PushAck {
+	a := &PushAck{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.ExternalG(), "PushAck", false),
+	}
+	a.conn, a.token, a.err = utils.GetGregorConn(ctx, g, a.DebugLabeler,
 		func(nist *libkb.NIST) rpc.ConnectionHandler {
 			return &remoteNotificationSuccessHandler{}
 		})
-	if err != nil {
+	return a
+}
+
+func (a *PushAck) Ack(ctx context.Context, pushIDs []string) {
+	defer a.Trace(ctx, nil, "Ack: pushID: %v", pushIDs)()
+	if a.err != nil {
+		a.Debug(ctx, "Ack: no gregor connection: %s", a.err)
 		return
 	}
-	defer conn.Shutdown()
+	cli := chat1.RemoteClient{Cli: NewRemoteClient(a.G(), a.conn.GetClient())}
+	arg := chat1.RemoteNotificationSuccessfulArg{
+		AuthToken:        a.token,
+		CompanionPushIDs: pushIDs,
+	}
+	// Acking is idempotent server-side; retry since a lost ack means the user
+	// gets a duplicate generic notification.
+	for attempt := 0; attempt < 3; attempt++ {
+		err := cli.RemoteNotificationSuccessful(ctx, arg)
+		if err == nil {
+			return
+		}
+		a.Debug(ctx, "Ack: attempt %d failed: %s", attempt, err)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
 
-	// Make remote successful call on our ad hoc conn
-	cli := chat1.RemoteClient{Cli: NewRemoteClient(h.G(), conn.GetClient())}
-	if err = cli.RemoteNotificationSuccessful(ctx,
-		chat1.RemoteNotificationSuccessfulArg{
-			AuthToken:        token,
-			CompanionPushIDs: pushIDs,
-		}); err != nil {
-		h.Debug(ctx, "AckNotificationSuccess: failed to invoke remote notification success: %s", err)
+func (a *PushAck) Shutdown() {
+	if a.conn != nil {
+		a.conn.Shutdown()
 	}
 }
 

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.kt
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/KeybasePushNotificationListenerService.kt
@@ -16,7 +16,6 @@ import io.keybase.ossifrage.MainActivity.Companion.setupKBRuntime
 import io.keybase.ossifrage.modules.NativeLogger
 import keybase.Keybase
 import com.reactnativekb.KbModule
-import org.json.JSONArray
 import org.json.JSONObject
 
 class KeybasePushNotificationListenerService : FirebaseMessagingService() {
@@ -379,11 +378,11 @@ internal class NotificationData(type: String, bundle: Bundle) {
         } else if (type == "chat.newmessageSilent_2") {
             messageId = bundle.getString("d", "").toIntOrNull() ?: 0
             convID = bundle.getString("c")
-            val pushId: String = try {
-                bundle.getString("p")?.let { JSONArray(it).getString(0) } ?: ""
-            } catch (e: Exception) {
-                ""
-            }
+            // Deliberately don't extract the companion pushId ("p") here: Android
+            // never displays from the silent push (it waits for the visible
+            // chat.newmessage), and acking the pushId would tell the server to
+            // cancel that visible push, so nothing would ever be shown.
+            pushId = ""
         } else {
             throw Error("Tried to parse notification of unhandled type: $type")
         }

--- a/shared/ios/Keybase/Pusher.swift
+++ b/shared/ios/Keybase/Pusher.swift
@@ -34,6 +34,25 @@ class PushNotifier: NSObject, Keybasego.KeybasePushNotifierProtocol {
     }
   }
 
+  // If we lost the race against the server's fallback timeout, the generic
+  // "you have a new message" push for this message is already in Notification
+  // Center. The local plaintext notification supersedes it, so remove it.
+  private func removeDeliveredGenericNotification(convID: String, msgID: Int) {
+    let center = UNUserNotificationCenter.current()
+    center.getDeliveredNotifications { delivered in
+      let ids = delivered.filter { note in
+        let info = note.request.content.userInfo
+        guard let type = info["type"] as? String, type == "chat.newmessage" else { return false }
+        guard let c = info["convID"] as? String, c == convID else { return false }
+        let m = (info["msgID"] as? NSNumber)?.intValue ?? Int(info["msgID"] as? String ?? "")
+        return m == msgID
+      }.map { $0.request.identifier }
+      if !ids.isEmpty {
+        center.removeDeliveredNotifications(withIdentifiers: ids)
+      }
+    }
+  }
+
   func display(_ n: KeybaseChatNotification?) {
     guard let notification = n else { return }
     guard let message = notification.message else { return }
@@ -61,5 +80,6 @@ class PushNotifier: NSObject, Keybasego.KeybasePushNotifierProtocol {
       typ: "chat.newmessage",
       uid: uid
     )
+    removeDeliveredGenericNotification(convID: notification.convID, msgID: Int(message.id_))
   }
 }


### PR DESCRIPTION
Plaintext pushes race the server's fallback timeout; losing shows the generic notification. Shrink the losers:

- pre-dial the ack gregor conn in parallel with unbox, retry ack 3x
- conv lookup falls back to remote fetch when not in local cache
- remove delivered generic notification once plaintext posts (iOS)
- waitForInit 10s -> 15s of the ~30s iOS background budget
- remove shadowed pushId local in Android silent-push parsing