### PR TITLE
implement packrefs for empty kbfs repos

### DIFF
--- a/go/kbfs/kbfsgit/runner.go
+++ b/go/kbfs/kbfsgit/runner.go
@@ -1787,10 +1787,17 @@ func (r *runner) pushSome(
 			RemoteName: localRepoRemoteName,
 			RefSpecs:   refspecs,
 			StatusChan: statusChan,
-			PackRefs:   kbfsRepoEmpty,
 		})
 		if err == gogit.NoErrAlreadyUpToDate {
 			err = nil
+		}
+
+		// Pack refs for empty repos (KBFS performance optimization)
+		if err == nil && kbfsRepoEmpty {
+			if packErr := repo.Storer.PackRefs(); packErr != nil {
+				r.log.CDebugf(ctx, "PackRefs failed (non-fatal): %+v", packErr)
+				// Don't fail the fetch - loose refs work fine
+			}
 		}
 
 		// All non-deleted refspecs in the batch get the same error.


### PR DESCRIPTION
@songgao 

https://github.com/keybase/go-git/commit/db9b45f2f32748bfea74e36e5b84b47170b1726f i cleaned up the custom option in favor of minimizing changes in our fork since it's a simple direct impl here