### PR TITLE
fix hovered chat row z-index after legendapp list 3.3.3

### DIFF
--- a/shared/chat/conversation/conversation.css
+++ b/shared/chat/conversation/conversation.css
@@ -57,7 +57,9 @@
   }
 }
 
-.chat-message-list [data-index]:has(.WrapperMessage-hoverBox:hover) {
+/* LegendList 3.3.3 dropped the data-index attribute from its item containers, so target the
+   container as the div whose direct child is the WrapperMessage instead */
+.chat-message-list div:has(> .WrapperMessage-hoverBox:hover) {
   contain: layout style !important;
   overflow: visible !important;
   z-index: 1;


### PR DESCRIPTION
3.3.3 removed the data-index attribute from item containers, so the hover rule matched nothing and the reactions row painted behind neighboring rows. Select the container structurally instead.