### PR TITLE
Store-derived mobile build numbers; play-publisher 3.12.1

### DIFF
--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -6,15 +6,15 @@ apply plugin: 'com.github.triplet.play'
 // KB: app version
 def VERSION_NAME = "6.7.0"
 
-// KB: Number of commits, like ios
-Integer getVersionCode() {
-    def result = providers.exec {
-        commandLine 'git', 'rev-list', 'HEAD', '--count'
-    }
-    return Integer.parseInt(result.standardOutput.asText.get().trim()) + 10517785 // plus bump it so its above the old version code
-}
+// KB: Number of commits, like ios.
+// Computed into a script-level variable: inside the defaultConfig closure a
+// getVersionCode() call resolves to ProductFlavor's own getter (delegate-first),
+// which returns null and silently drops versionCode from the manifest.
+def kbVersionCode = Integer.parseInt(providers.exec {
+    commandLine 'git', 'rev-list', 'HEAD', '--count'
+}.standardOutput.asText.get().trim()) + 10517785 // plus bump it so its above the old version code
 
-project.logger.lifecycle('Version code: ' + getVersionCode().toString())
+project.logger.lifecycle('Version code: ' + kbVersionCode.toString())
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -101,7 +101,7 @@ android {
         applicationId "io.keybase.ossifrage"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode getVersionCode()
+        versionCode kbVersionCode
         versionName VERSION_NAME
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
         // KB added

--- a/shared/android/app/build.gradle
+++ b/shared/android/app/build.gradle
@@ -1,3 +1,5 @@
+import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
+
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
@@ -6,15 +8,9 @@ apply plugin: 'com.github.triplet.play'
 // KB: app version
 def VERSION_NAME = "6.7.0"
 
-// KB: Number of commits, like ios.
-// Computed into a script-level variable: inside the defaultConfig closure a
-// getVersionCode() call resolves to ProductFlavor's own getter (delegate-first),
-// which returns null and silently drops versionCode from the manifest.
-def kbVersionCode = Integer.parseInt(providers.exec {
-    commandLine 'git', 'rev-list', 'HEAD', '--count'
-}.standardOutput.asText.get().trim()) + 10517785 // plus bump it so its above the old version code
-
-project.logger.lifecycle('Version code: ' + kbVersionCode.toString())
+// KB: local-build fallback only. Publishing via the play plugin (ResolutionStrategy.AUTO)
+// fetches the live version code from Play and increments it.
+def kbVersionCode = 10555519
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -152,6 +148,7 @@ android {
    play {
        track = 'internal'
        serviceAccountCredentials = file(KB_SERVICE_ACCT_JSON)
+       resolutionStrategy = ResolutionStrategy.AUTO
    }
 }
 

--- a/shared/android/build.gradle
+++ b/shared/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
 
-        classpath("com.github.triplet.gradle:play-publisher:3.7.0") // To publish from gradle
+        classpath("com.github.triplet.gradle:play-publisher:3.12.1") // To publish from gradle
         classpath("com.google.gms:google-services:4.4.4")
     }
 }

--- a/shared/ios/fastlane/Fastfile
+++ b/shared/ios/fastlane/Fastfile
@@ -25,9 +25,6 @@ platform :ios do
   desc "Submit a new Beta Build to Apple TestFlight"
   desc "This will also make sure the profile is up to date"
   lane :beta do
-    version = get_version_number(xcodeproj: ENV['XCODEPROJ_NAME'], target: 'Keybase')
-    increment_build_number(build_number: number_of_commits)
-
     api_key = app_store_connect_api_key(
       key_id: "C783PA5XUX",
       issuer_id: "69a6de85-d809-47e3-e053-5b8c7c11a4d1",
@@ -35,6 +32,8 @@ platform :ios do
       duration: 1200, # optional (maximum 1200)
       in_house: false # optional but may be required if using match/sigh
     )
+
+    increment_build_number(build_number: latest_testflight_build_number(api_key: api_key) + 1)
 
     # Release archives use manual distribution signing. Portal profile
     # names aren't stable (sigh appends a timestamp when it has to create


### PR DESCRIPTION
## What

- Restore Android `versionCode` lost in the 670 cleanup (was silently dropped from the manifest — `getVersionCode()` inside `defaultConfig` resolved to ProductFlavor's own getter).
- Bump gradle-play-publisher 3.7.0 → 3.12.1.
- Replace git-commit-count build numbers on both platforms with store-derived ones:
  - Android: `play { resolutionStrategy = ResolutionStrategy.AUTO }` — publish fetches the live version code from Play and increments. Static `versionCode` remains as a local-build fallback.
  - iOS: beta lane uses `latest_testflight_build_number(api_key:) + 1` instead of `number_of_commits`.

## Why

`git rev-list HEAD --count` is branch-dependent, breaks on shallow clones, and can go backwards across branches — store-side resolution is monotonic by construction.

## Notes

- `packaging/android/build_and_publish.sh` unchanged; `publishReleaseBundle` still the entry point.
- Verified: Gradle 9.3.1/AGP 8.12 configure cleanly with GPP 3.12.1, `publishReleaseBundle` registered. iOS lane is syntax-checked; real verification happens on the next `fastlane ios beta` from the build machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)