### PR TITLE
build(ios): restore automatic dev signing for local archives

### DIFF
--- a/shared/ios/Keybase.xcodeproj/project.pbxproj
+++ b/shared/ios/Keybase.xcodeproj/project.pbxproj
@@ -690,8 +690,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Keybase/Keybase.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 114;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_BITCODE = NO;
@@ -727,7 +728,6 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios;
 				PRODUCT_NAME = Keybase;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "keybase.ios AppStore";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "Keybase/Keybase-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -806,8 +806,9 @@
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = KeybaseShare/KeybaseShare.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_BITCODE = NO;
@@ -831,7 +832,6 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = keybase.ios.KeybaseShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "keybase.ios.KeybaseShare AppStore";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "KeybaseShare/KeybaseShare-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/shared/ios/fastlane/Fastfile
+++ b/shared/ios/fastlane/Fastfile
@@ -35,11 +35,11 @@ platform :ios do
 
     increment_build_number(build_number: latest_testflight_build_number(api_key: api_key) + 1)
 
-    # Release archives use manual distribution signing. Portal profile
-    # names aren't stable (sigh appends a timestamp when it has to create
-    # one), so stamp whatever valid App Store profile sigh installs into
-    # the project before building. The checked-in PROVISIONING_PROFILE_SPECIFIER
-    # values are only local-archive defaults; this overwrites them.
+    # The checked-in project uses automatic development signing so local
+    # archives work; bot archives need manual distribution signing, so this
+    # lane flips the Release configs before building. Portal profile names
+    # aren't stable (sigh appends a timestamp when it has to create one),
+    # so stamp whatever valid App Store profile sigh installs.
     sigh(app_identifier: "keybase.ios")
     main_profile = lane_context[SharedValues::SIGH_NAME]
     update_code_signing_settings(


### PR DESCRIPTION
#29415 checked manual "iPhone Distribution" signing into `project.pbxproj`, which broke local Xcode archives: dev machines have only an Apple Development cert — no distribution private key and no App Store profiles — so the Release configs couldn't sign.

The `beta` lane already converts Release to manual distribution signing at build time (`update_code_signing_settings` with the sigh-fetched profile names, plus explicit `export_options.provisioningProfiles`), so the checked-in Manual values were redundant for the bot and only affected local builds.

- `project.pbxproj`: Release configs (Keybase + KeybaseShare) back to `CODE_SIGN_STYLE = Automatic` + `iPhone Developer`; pinned `PROVISIONING_PROFILE_SPECIFIER` lines removed
- `Fastfile`: comment updated to describe the split (checked-in project = local dev signing, lane flips to manual distribution before gym)

Verified: local device archive succeeds again with automatic dev signing. Bot flow untouched — the lane stamps everything it needs before gym.

🤖 Generated with [Claude Code](https://claude.com/claude-code)