### PR TITLE
fix(mobile): use legacy expo-media-library/file-system imports

### DIFF
--- a/shared/util/platform-specific/index.tsx
+++ b/shared/util/platform-specific/index.tsx
@@ -1,8 +1,8 @@
 import * as T from '@/constants/types'
 import logger from '@/logger'
-import * as MediaLibrary from 'expo-media-library'
+import * as MediaLibrary from 'expo-media-library/legacy'
 import * as ExpoLocation from 'expo-location'
-import * as FileSystem from 'expo-file-system'
+import * as FileSystem from 'expo-file-system/legacy'
 import {addNotificationRequest, androidShare, androidShareText} from 'react-native-kb'
 import {ActionSheetIOS} from 'react-native'
 


### PR DESCRIPTION
## Problem
Saving images from chat on iOS broke after the expo 57 bump: the download bar fills, then nothing happens and the transfer indicator stays stuck.

## Root cause
expo 57 replaced the root-export legacy methods of `expo-media-library` and `expo-file-system` with deprecation shims that **throw at runtime** while keeping their TypeScript types, so `tsc` stayed green. `MediaLibrary.saveToLibraryAsync` threw immediately after download, which skipped `setAttachmentMobileSaving(ordinal, false)` and left the UI stuck. `FileSystem.deleteAsync` was also throwing (swallowed by a try/catch, leaking the temp file).

## Fix
Import both modules from their `/legacy` subpaths, which keep the real implementations. The new class-based APIs (`Asset.create()`, `File`) are the eventual migration path, but `Asset.create` may require broader photo permissions than the add-only `saveToLibraryAsync`, so this keeps exact prior behavior.

## Validation
- `yarn lint` / `yarn tsc` pass
- Manual: save image in chat on iOS → progress completes, toast shows, photo lands in camera roll

🤖 Generated with [Claude Code](https://claude.com/claude-code)