### PR TITLE
fix: Input3 default textType Body, pin BodySemibold where 6.6.0 used it

### DIFF
--- a/shared/chat/blocking/block-modal.tsx
+++ b/shared/chat/blocking/block-modal.tsx
@@ -113,6 +113,7 @@ const ReportOptions = (props: ReportOptionsProps) => {
           We will review this report within 24 hours and take an action
         </Kb.Text>
         <Kb.Input3
+          textType="BodySemibold"
           multiline={true}
           placeholder="Extra notes"
           onChangeText={props.setExtraNotes}

--- a/shared/chat/create-channel/index.tsx
+++ b/shared/chat/create-channel/index.tsx
@@ -35,6 +35,7 @@ const CreateChannel = (p: Props) => {
           </Kb.ClickableBox>
           <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny" gapEnd={true} gapStart={true}>
             <Kb.Input3
+              textType="BodySemibold"
               autoFocus={true}
               placeholder="Channel name"
               value={props.channelname}
@@ -42,6 +43,7 @@ const CreateChannel = (p: Props) => {
               onChangeText={props.onChannelnameChange}
             />
             <Kb.Input3
+              textType="BodySemibold"
               autoFocus={false}
               autoCorrect={true}
               autoCapitalize="sentences"
@@ -76,12 +78,14 @@ const CreateChannel = (p: Props) => {
       <Kb.Box2 direction="vertical" fullWidth={true} style={nativeStyles.box}>
         <Kb.Box2 direction="vertical" fullWidth={true} gap="small">
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             placeholder="Channel name"
             value={props.channelname}
             onChangeText={props.onChannelnameChange}
           />
           <Kb.Input3
+            textType="BodySemibold"
             autoCorrect={true}
             autoFocus={false}
             autoCapitalize="sentences"

--- a/shared/chat/send-to-chat/index.tsx
+++ b/shared/chat/send-to-chat/index.tsx
@@ -128,6 +128,7 @@ export const DesktopSendToChatRender = (props: DesktopSendToChatRenderProps) => 
           onSelect={props.onSelect}
         />
         <Kb.Input3
+          textType="BodySemibold"
           placeholder="Title"
           value={props.title}
           onChangeText={props.setTitle}

--- a/shared/common-adapters/input3.tsx
+++ b/shared/common-adapters/input3.tsx
@@ -69,7 +69,7 @@ const DesktopInput3 = (props: Input3Props & {ref?: React.Ref<Input3Ref>}) => {
     growAndScroll, inputStyle, maxLength, multiline, selectTextOnFocus,
     onBlur: onBlurProp, onChangeText, onClick, onEnterKeyDown, onFocus: onFocusProp,
     onKeyDown: onKeyDownProp, placeholder, ref, rowsMax, rowsMin,
-    secureTextEntry, spellCheck, textType = 'BodySemibold', value,
+    secureTextEntry, spellCheck, textType = 'Body', value,
   } = props
 
   const [focused, setFocused] = React.useState(false)
@@ -193,7 +193,7 @@ const NativeInput3 = (props: Input3Props & {ref?: React.Ref<Input3Ref>}) => {
     inputStyle, keyboardType, maxLength, multiline, onEnterKeyDown,
     onBlur: onBlurProp, onChangeText, onFocus: onFocusProp, placeholder, ref,
     returnKeyType, rowsMax, rowsMin, secureTextEntry, selectTextOnFocus,
-    textContentType, textType = 'BodySemibold', value,
+    textContentType, textType = 'Body', value,
   } = props
 
   const [focused, setFocused] = React.useState(false)

--- a/shared/common-adapters/search-filter.tsx
+++ b/shared/common-adapters/search-filter.tsx
@@ -177,6 +177,7 @@ function SearchFilter(props: Props & {ref?: React.Ref<SearchFilterRef>}) {
         : ''
     return (
       <Kb.Input3
+        textType="BodySemibold"
         autoFocus={props.focusOnMount}
         value={currentText()}
         placeholder={props.placeholderText + hotkeyText}

--- a/shared/git/delete-repo.tsx
+++ b/shared/git/delete-repo.tsx
@@ -78,6 +78,7 @@ const DeleteRepo = (ownProps: OwnProps) => {
         <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny">
           <Kb.Text type="BodySemibold">Enter the name of the repository to&nbsp;confirm:</Kb.Text>
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             value={name}
             onChangeText={setName}

--- a/shared/git/new-repo.tsx
+++ b/shared/git/new-repo.tsx
@@ -116,6 +116,7 @@ const NewRepo = (ownProps: OwnProps) => {
           />
         )}
         <Kb.Input3
+          textType="BodySemibold"
           value={name}
           autoFocus={true}
           onChangeText={setName}

--- a/shared/login/relogin/index.tsx
+++ b/shared/login/relogin/index.tsx
@@ -95,6 +95,7 @@ const DesktopLogin = (props: Props) => {
           {props.needPassword && (
             <Kb.Box2 direction="horizontal" fullWidth={true} flex={1} style={desktopStyles.inputRow}>
               <Kb.Input3
+                textType="BodySemibold"
                 autoFocus={true}
                 placeholder="Password"
                 onChangeText={props.passwordChange}
@@ -212,7 +213,7 @@ const NativeLoginRender = (props: Props) => {
         />
         {props.needPassword && (
           <Kb.Box2 direction="vertical" gap="tiny" gapEnd={true} gapStart={true} fullWidth={true}>
-            <Kb.Input3 {...inputProps} />
+            <Kb.Input3 textType="BodySemibold" {...inputProps} />
             <Kb.Checkbox
               checked={props.showTyping}
               label="Show typing"

--- a/shared/login/reset/password-enter.tsx
+++ b/shared/login/reset/password-enter.tsx
@@ -33,6 +33,7 @@ const EnterPassword = ({route}: Props) => {
       buttons={[{label: 'Continue', onClick: onContinue, waiting}]}
     >
       <Kb.Input3
+        textType="BodySemibold"
         placeholder="Enter your password"
         containerStyle={styles.input}
         secureTextEntry={true}

--- a/shared/pinentry/index.desktop.tsx
+++ b/shared/pinentry/index.desktop.tsx
@@ -51,6 +51,7 @@ const Pinentry = (props: Props) => {
           style={styles.inputContainer}
         >
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             error={!!props.retryLabel}
             onChangeText={setPassword}

--- a/shared/profile/pgp/choice.tsx
+++ b/shared/profile/pgp/choice.tsx
@@ -230,12 +230,14 @@ export default function Choice() {
                 Fill in your public info.
               </Kb.Text>
               <Kb.Input3
+                textType="BodySemibold"
                 autoFocus={true}
                 placeholder="Your full name"
                 value={data.pgpFullName}
                 onChangeText={pgpFullName => onUpdate({pgpFullName})}
               />
               <Kb.Input3
+                textType="BodySemibold"
                 placeholder="Email 1"
                 onChangeText={pgpEmail1 => onUpdate({pgpEmail1})}
                 onEnterKeyDown={onGenerate}
@@ -243,6 +245,7 @@ export default function Choice() {
                 error={data.pgpErrorEmail1}
               />
               <Kb.Input3
+                textType="BodySemibold"
                 placeholder="Email 2 (optional)"
                 onChangeText={pgpEmail2 => onUpdate({pgpEmail2})}
                 onEnterKeyDown={onGenerate}
@@ -250,6 +253,7 @@ export default function Choice() {
                 error={data.pgpErrorEmail2}
               />
               <Kb.Input3
+                textType="BodySemibold"
                 placeholder="Email 3 (optional)"
                 onChangeText={pgpEmail3 => onUpdate({pgpEmail3})}
                 onEnterKeyDown={onGenerate}

--- a/shared/provision/forgot-username.tsx
+++ b/shared/provision/forgot-username.tsx
@@ -85,6 +85,7 @@ const ForgotUsername = () => {
         />
         {emailSelected && (
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             placeholder="Email address"
             onEnterKeyDown={onSubmit}

--- a/shared/provision/set-public-name.tsx
+++ b/shared/provision/set-public-name.tsx
@@ -77,6 +77,7 @@ const SetPublicName = ({route}: Props) => {
         <Kb.ImageIcon type={Kb.isValidIconType(maybeIcon) ? maybeIcon : defaultIcon} />
         <Kb.Box2 direction="vertical" style={styles.wrapper} gap="xsmall">
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             error={showDisabled}
             maxLength={64}

--- a/shared/settings/feedback/index.tsx
+++ b/shared/settings/feedback/index.tsx
@@ -65,6 +65,7 @@ const Feedback = (props: Props) => {
         )}
         <Kb.Box2 direction="vertical" padding="small" style={styles.mainBox} gap="xsmall">
           <Kb.Input3
+            textType="BodySemibold"
             autoCapitalize="sentences"
             autoCorrect={true}
             autoFocus={true}
@@ -92,6 +93,7 @@ const Feedback = (props: Props) => {
           </Kb.ClickableBox>
           {props.loggedOut && (
             <Kb.Input3
+              textType="BodySemibold"
               containerStyle={styles.input}
               placeholder="Your email address"
               onChangeText={setEmail}

--- a/shared/settings/proxy.tsx
+++ b/shared/settings/proxy.tsx
@@ -216,6 +216,7 @@ const ProxySettingsComponent = (props: Props) => {
         <>
           <Kb.Text type="BodySmall">Proxy Address</Kb.Text>
           <Kb.Input3
+            textType="BodySemibold"
             placeholder="127.0.0.1"
             onChangeText={address =>
               setProxyForm(
@@ -228,6 +229,7 @@ const ProxySettingsComponent = (props: Props) => {
           />
           <Kb.Text type="BodySmall">Proxy Port</Kb.Text>
           <Kb.Input3
+            textType="BodySemibold"
             placeholder="8080"
             onChangeText={port =>
               setProxyForm(

--- a/shared/signup/device-name.tsx
+++ b/shared/signup/device-name.tsx
@@ -164,6 +164,7 @@ const EnterDevicename = (props: EnterDevicenameProps) => {
         />
         <Kb.Box2 direction="vertical" fullWidth={Kb.Styles.isPhone} gap="tiny">
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             selectTextOnFocus={true}
             containerStyle={styles.input}

--- a/shared/signup/email.tsx
+++ b/shared/signup/email.tsx
@@ -92,6 +92,7 @@ export const EnterEmailBody = (props: BodyProps) => (
       <Kb.ImageIcon type={props.iconType} />
       <Kb.Box2 direction="vertical" gap="tiny" style={styles.inputBox}>
         <Kb.Input3
+          textType="BodySemibold"
           autoFocus={true}
           containerStyle={styles.input}
           keyboardType="email-address"

--- a/shared/signup/username.tsx
+++ b/shared/signup/username.tsx
@@ -157,6 +157,7 @@ const EnterUsername = (props: EnterUsernameProps) => {
           <Kb.Avatar size={C.isLargeScreen ? 96 : 64} />
           <Kb.Box2 direction="vertical" fullWidth={Kb.Styles.isPhone} gap="tiny">
             <Kb.Input3
+              textType="BodySemibold"
               autoFocus={true}
               containerStyle={styles.input}
               placeholder="Pick a username"

--- a/shared/team-building/email-search.tsx
+++ b/shared/team-building/email-search.tsx
@@ -49,6 +49,7 @@ const EmailSearch = ({continueLabel, namespace, search}: EmailSearchProps) => {
     <Kb.Box2 direction="vertical" fullWidth={true} padding="small" style={styles.background}>
       <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny" flex={1}>
         <Kb.Input3
+          textType="BodySemibold"
           autoFocus={true}
           containerStyle={styles.input}
           keyboardType="email-address"

--- a/shared/teams/add-members-wizard/add-email.tsx
+++ b/shared/teams/add-members-wizard/add-email.tsx
@@ -51,6 +51,7 @@ const AddEmail = (props: Props) => {
         <Kb.Text type="Body">Enter one or multiple email addresses:</Kb.Text>
         <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true} alignItems="flex-start">
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             error={!!props.errorMessage}
             multiline={true}

--- a/shared/teams/add-members-wizard/confirm.tsx
+++ b/shared/teams/add-members-wizard/confirm.tsx
@@ -160,6 +160,7 @@ const AddMembersConfirm = ({wizard: initialWizard}: Props) => {
               </Kb.Text>
             ) : (
               <Kb.Input3
+                textType="BodySemibold"
                 autoFocus={true}
                 maxLength={250}
                 multiline={true}

--- a/shared/teams/edit-team-description.tsx
+++ b/shared/teams/edit-team-description.tsx
@@ -50,6 +50,7 @@ const EditTeamDescription = (props: Props) => {
       <Kb.ScrollView alwaysBounceVertical={false} style={Kb.Styles.globalStyles.flexOne}>
         <Kb.Box2 alignItems="center" direction="vertical" fullWidth={true} padding="small">
           <Kb.Input3
+            textType="BodySemibold"
             placeholder="Team description"
             onChangeText={value => {
               userEditedRef.current = true

--- a/shared/teams/invite-by-email.tsx
+++ b/shared/teams/invite-by-email.tsx
@@ -94,6 +94,7 @@ const InviteByEmail = (ownProps: OwnProps) => {
         </Kb.Box2>
         <Kb.Box2 direction="vertical" gap="xtiny" fullWidth={true} alignItems="flex-start">
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             error={!!errorMessage}
             multiline={true}

--- a/shared/teams/new-team/index.tsx
+++ b/shared/teams/new-team/index.tsx
@@ -56,6 +56,7 @@ export const CreateNewTeam = (props: Props) => {
       <Kb.ScrollView alwaysBounceVertical={false} style={Kb.Styles.globalStyles.flexOne}>
         <Kb.Box2 direction="vertical" fullWidth={true} padding="small" gap="tiny">
           <Kb.Input3
+            textType="BodySemibold"
             placeholder="Name your team"
             value={name}
             onChangeText={setName}

--- a/shared/teams/new-team/wizard/create-channels.tsx
+++ b/shared/teams/new-team/wizard/create-channels.tsx
@@ -111,11 +111,12 @@ type ChannelInputProps =
 
 const ChannelInput = (props: ChannelInputProps) => {
   if (props.isGeneral) {
-    return <Kb.Input3 value="#general" disabled={true} containerStyle={styles.inputGeneral} />
+    return <Kb.Input3 textType="BodySemibold" value="#general" disabled={true} containerStyle={styles.inputGeneral} />
   }
   const {value, onChange, onClear} = props
   return (
     <Kb.Input3
+      textType="BodySemibold"
       value={value}
       onChangeText={(text: string) => onChange(cleanChannelname(text))}
       decoration={<Kb.Icon type="iconfont-remove" onClick={onClear} />}

--- a/shared/teams/new-team/wizard/create-subteams.tsx
+++ b/shared/teams/new-team/wizard/create-subteams.tsx
@@ -48,6 +48,7 @@ const CreateSubteams = ({wizard: wizardState}: Props) => {
         </Kb.Text>
         {subteams.map((value, idx) => (
           <Kb.Input3
+            textType="BodySemibold"
             value={value}
             onChangeText={(text: string) => setSubteam(idx, cleanSubteamName(text))}
             decoration={<Kb.Icon type="iconfont-remove" onClick={() => onClear(idx)} />}

--- a/shared/teams/new-team/wizard/new-team-info.tsx
+++ b/shared/teams/new-team/wizard/new-team-info.tsx
@@ -122,6 +122,7 @@ const NewTeamInfo = ({wizard: teamWizardState}: Props) => {
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.body} gap="tiny">
         {parentName ? (
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             disabled={waitingOnParentTeam}
             maxLength={16}
@@ -133,6 +134,7 @@ const NewTeamInfo = ({wizard: teamWizardState}: Props) => {
           />
         ) : (
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             disabled={waitingOnParentTeam}
             maxLength={16}
@@ -157,6 +159,7 @@ const NewTeamInfo = ({wizard: teamWizardState}: Props) => {
           )}
         </Kb.Box2>
         <Kb.Input3
+          textType="BodySemibold"
           disabled={waitingOnParentTeam}
           placeholder="Description"
           value={description}

--- a/shared/teams/team/member/edit-channel.tsx
+++ b/shared/teams/team/member/edit-channel.tsx
@@ -83,6 +83,7 @@ const EditChannel = (props: Props) => {
     <>
       <Kb.Box2 direction="vertical" fullWidth={true} fullHeight={true} style={styles.body} gap="tiny">
         <Kb.Input3
+          textType="BodySemibold"
           autoFocus={true}
           maxLength={16}
           onChangeText={setName}
@@ -96,6 +97,7 @@ const EditChannel = (props: Props) => {
           <Kb.Text type="BodySmall">{"You can't edit the #general channel's name."}</Kb.Text>
         )}
         <Kb.Input3
+          textType="BodySemibold"
           placeholder="Description"
           value={description}
           rowsMin={3}

--- a/shared/teams/team/team-info.tsx
+++ b/shared/teams/team/team-info.tsx
@@ -111,6 +111,7 @@ const TeamInfo = (props: Props) => {
         </Kb.Avatar>
         {isSubteam ? (
           <Kb.Input3
+            textType="BodySemibold"
             autoFocus={true}
             maxLength={16}
             onChangeText={setName}
@@ -121,6 +122,7 @@ const TeamInfo = (props: Props) => {
           />
         ) : (
           <Kb.Input3
+            textType="BodySemibold"
             containerStyle={styles.faded}
             maxLength={16}
             onChangeText={setName}
@@ -133,6 +135,7 @@ const TeamInfo = (props: Props) => {
           {isSubteam ? `Subteam names are private.` : `Team names can't be changed.`}
         </Kb.Text>
         <Kb.Input3
+          textType="BodySemibold"
           placeholder="Description"
           value={description}
           autoFocus={!isSubteam}

--- a/shared/unlock-folders/paper-key-input.desktop.tsx
+++ b/shared/unlock-folders/paper-key-input.desktop.tsx
@@ -17,6 +17,7 @@ const PaperKeyInput = (props: Props) => {
       <Kb.BackButton onClick={props.onBack} style={styles.back} />
       <Kb.ImageIcon style={styles.icon} type="icon-paper-key-48" />
       <Kb.Input3
+        textType="BodySemibold"
         multiline={true}
         rowsMax={3}
         onChangeText={setPaperkey}


### PR DESCRIPTION
Input3 merged PlainInput (Body default) and LabeledInput/NewInput (BodySemibold default) but kept the semibold default, silently bolding every ex-PlainInput input (attachment caption, chat search, edit profile, etc). Flip the default to Body and add explicit textType="BodySemibold" at the call sites whose v6.6.0 ancestor rendered semibold.