### PR TITLE
fix(mobile): present anchored popups as bottom sheets by default

### DIFF
--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -443,6 +443,7 @@ const Popup = (p: PopupProps) => {
   return (
     <Kb.Popup
       attachTo={attachRef}
+      mobileAnchored={true}
       matchDimension={true}
       position="top center"
       positionFallbacks={positionFallbacks}

--- a/shared/chat/conversation/messages/reaction-tooltip.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip.tsx
@@ -4,6 +4,7 @@ import * as Kb from '@/common-adapters'
 import * as React from 'react'
 import ReactButton from './react-button'
 import * as T from '@/constants/types'
+import {BottomSheetScrollView} from '@/common-adapters/popup/bottom-sheet'
 import {MessageContext} from './ids-context'
 import {useUsersState} from '@/stores/users'
 import {useConversationThreadID, useConversationThreadMessage, useConversationThreadMessageActions} from '../thread-context'
@@ -130,6 +131,46 @@ const ReactionTooltip = (p: OwnProps) => {
     </Kb.Box2>
   )
 
+  if (isMobile) {
+    return (
+      <Kb.Popup onHidden={onHidden}>
+        <MessageContext value={messageContext}>
+          <BottomSheetScrollView>
+            <Kb.Box2
+              direction="vertical"
+              fullWidth={true}
+              style={Kb.Styles.collapseStyles([styles.sheetContainer, {paddingBottom: insets.bottom}])}
+            >
+              {sections.map(section => (
+                <React.Fragment key={section.key}>
+                  {renderSectionHeader({section})}
+                  {section.data.map(item => (
+                    <React.Fragment key={item.key}>{renderItem({item})}</React.Fragment>
+                  ))}
+                </React.Fragment>
+              ))}
+              <Kb.ButtonBar style={styles.addReactionButtonBar}>
+                <Kb.Button
+                  disabled={!hasMessageID}
+                  mode="Secondary"
+                  fullWidth={true}
+                  onClick={hasMessageID ? onAddReaction : undefined}
+                  label="Add a reaction"
+                >
+                  <Kb.Icon
+                    type="iconfont-reacji"
+                    color={Kb.Styles.globalColors.blue}
+                    style={styles.addReactionButtonIcon}
+                  />
+                </Kb.Button>
+              </Kb.ButtonBar>
+            </Kb.Box2>
+          </BottomSheetScrollView>
+        </MessageContext>
+      </Kb.Popup>
+    )
+  }
+
   return (
     <Kb.Popup
       attachTo={attachmentRef}
@@ -145,42 +186,17 @@ const ReactionTooltip = (p: OwnProps) => {
           onMouseOver={onMouseOver}
           direction="vertical"
           gap="tiny"
-          style={Kb.Styles.collapseStyles([styles.listContainer, {paddingBottom: insets.bottom}])}
+          style={styles.listContainer}
         >
-          {isMobile && (
-            <Kb.Box2 direction="horizontal">
-              <Kb.Text type="BodySemiboldLink" onClick={onHidden} style={styles.closeButton}>
-                Close
-              </Kb.Text>
-              <Kb.Box2 direction="horizontal" flex={1} />
-            </Kb.Box2>
-          )}
           <Kb.SectionList
             alwaysBounceVertical={false}
-            initialNumToRender={19} // Keeps height from trashing on mobile
+            initialNumToRender={19}
             sections={sections}
             stickySectionHeadersEnabled={true}
             contentContainerStyle={styles.list}
             renderItem={renderItem}
             renderSectionHeader={renderSectionHeader}
           />
-          {isMobile && (
-            <Kb.ButtonBar style={styles.addReactionButtonBar}>
-              <Kb.Button
-                disabled={!hasMessageID}
-                mode="Secondary"
-                fullWidth={true}
-                onClick={hasMessageID ? onAddReaction : undefined}
-                label="Add a reaction"
-              >
-                <Kb.Icon
-                  type="iconfont-reacji"
-                  color={Kb.Styles.globalColors.blue}
-                  style={styles.addReactionButtonIcon}
-                />
-              </Kb.Button>
-            </Kb.ButtonBar>
-          )}
         </Kb.Box2>
       </MessageContext>
     </Kb.Popup>
@@ -210,7 +226,6 @@ const styles = Kb.Styles.styleSheetCreate(
         borderTopRightRadius: 3,
         ...Kb.Styles.paddingV(Kb.Styles.globalMargins.tiny),
       },
-      closeButton: {padding: Kb.Styles.globalMargins.small},
       emojiText: {
         color: Kb.Styles.globalColors.black_50,
         flex: -1,
@@ -222,14 +237,10 @@ const styles = Kb.Styles.styleSheetCreate(
         },
       }),
       listContainer: Kb.Styles.platformStyles({
-        common: {backgroundColor: Kb.Styles.globalColors.white},
         isElectron: {
+          backgroundColor: Kb.Styles.globalColors.white,
           maxHeight: 320,
           width: 240,
-        },
-        isMobile: {
-          maxHeight: '90%',
-          width: '100%',
         },
       }),
       overlay: Kb.Styles.platformStyles({
@@ -238,6 +249,10 @@ const styles = Kb.Styles.styleSheetCreate(
           margin: Kb.Styles.globalMargins.tiny,
         },
       }),
+      sheetContainer: {
+        backgroundColor: Kb.Styles.globalColors.white,
+        borderRadius: Kb.Styles.borderRadius,
+      },
       userContainer: {
         alignSelf: 'stretch',
         backgroundColor: Kb.Styles.globalColors.white,

--- a/shared/chat/conversation/pinned-message.tsx
+++ b/shared/chat/conversation/pinned-message.tsx
@@ -122,7 +122,7 @@ const PinnedMessage = function PinnedMessage() {
   )
   const popup = (
     <UnpinPrompt
-      attachTo={isMobile ? undefined : closeref}
+      attachTo={closeref}
       onHidden={() => setShowPopup(false)}
       onUnpin={onDismiss}
       visible={showPopup}
@@ -157,6 +157,7 @@ const UnpinPrompt = (props: UnpinProps) => {
     <Kb.FloatingMenu
       attachTo={props.attachTo}
       closeOnSelect={false}
+      mode="bottomsheet"
       onHidden={props.onHidden}
       visible={props.visible}
       propagateOutsideClicks={true}

--- a/shared/common-adapters/dropdown.tsx
+++ b/shared/common-adapters/dropdown.tsx
@@ -97,6 +97,7 @@ function Dropdown<N extends React.ReactNode>(p: Props<N>) {
       <Kb.Popup
         style={Styles.collapseStyles([styles.overlay, overlayStyle])}
         attachTo={attachTo}
+        mobileAnchored={true}
         visible={true}
         onHidden={hidePopup}
         position={position || 'center center'}

--- a/shared/common-adapters/floating-menu/index.tsx
+++ b/shared/common-adapters/floating-menu/index.tsx
@@ -50,7 +50,9 @@ function FloatingMenu(props: Props) {
     return unsub
   }, [navigation, onHidden])
 
-  if (!visible && !mode) {
+  // modal mode callers control mounting themselves; sheets present on mount so
+  // they must unmount when not visible
+  if (!visible && mode !== 'modal') {
     return null
   }
 
@@ -75,7 +77,9 @@ function FloatingMenu(props: Props) {
 
   return (
     <Popup
-      attachTo={mode === 'bottomsheet' && isMobile ? undefined : props.attachTo}
+      attachTo={props.attachTo}
+      // legacy fullscreen menus (no mode) still use the anchored portal on mobile
+      mobileAnchored={mode !== 'bottomsheet'}
       onHidden={onHidden}
       visible={props.visible}
       position={props.position}

--- a/shared/common-adapters/markdown/maybe-mention/team.tsx
+++ b/shared/common-adapters/markdown/maybe-mention/team.tsx
@@ -89,7 +89,7 @@ const TeamMention = (ownProps: OwnProps) => {
 
   const popups = (
     <TeamInfo
-      attachTo={isMobile ? undefined : mentionRef}
+      attachTo={mentionRef}
       description={description}
       inTeam={inTeam}
       isOpen={isOpen}

--- a/shared/common-adapters/markdown/maybe-mention/unknown.tsx
+++ b/shared/common-adapters/markdown/maybe-mention/unknown.tsx
@@ -35,6 +35,7 @@ const UnknownMentionPopup = (props: PopupProps) => {
       closeOnSelect={true}
       header={header}
       items={items}
+      mode="bottomsheet"
       onHidden={props.onHidden}
       visible={props.visible}
     />
@@ -82,7 +83,7 @@ const UnknownMention = (props: Props) => {
 
   const popups = (
     <UnknownMentionPopup
-      attachTo={isMobile ? undefined : mentionRef}
+      attachTo={mentionRef}
       onHidden={handleMouseLeave}
       onResolve={onResolve}
       text={text}

--- a/shared/common-adapters/popup/index.shared.tsx
+++ b/shared/common-adapters/popup/index.shared.tsx
@@ -6,6 +6,9 @@ export type PopupProps = {
   children: React.ReactNode
   onHidden?: () => void
   attachTo?: React.RefObject<MeasureRef | null>
+  // mobile ignores attachTo and presents a bottom sheet by default; set this
+  // to keep the raw anchored portal on mobile (e.g. positioned over an input)
+  mobileAnchored?: boolean
   position?: Styles.Position
   positionFallbacks?: ReadonlyArray<Styles.Position>
   propagateOutsideClicks?: boolean

--- a/shared/common-adapters/popup/index.tsx
+++ b/shared/common-adapters/popup/index.tsx
@@ -134,7 +134,7 @@ function PopupSheet(props: PopupProps) {
 }
 
 function Popup(props: PopupProps) {
-  if (props.attachTo) {
+  if (props.attachTo && (!isMobile || props.mobileAnchored)) {
     return <PopupPositioned {...props} />
   }
   if (isMobile) {

--- a/shared/common-adapters/popup/index.tsx
+++ b/shared/common-adapters/popup/index.tsx
@@ -25,9 +25,6 @@ const FullWindow = ({children}: {children?: React.ReactNode}): React.ReactNode =
 }
 
 function DesktopPopupPositioned(props: PopupProps) {
-  if (Object.hasOwn(props, 'visible') && !props.visible) {
-    return null
-  }
   return (
     <FloatingBox
       attachTo={props.attachTo}
@@ -134,6 +131,10 @@ function PopupSheet(props: PopupProps) {
 }
 
 function Popup(props: PopupProps) {
+  // sheets present on mount, so an explicitly hidden popup must not render
+  if (Object.hasOwn(props, 'visible') && !props.visible) {
+    return null
+  }
   if (props.attachTo && (!isMobile || props.mobileAnchored)) {
     return <PopupPositioned {...props} />
   }

--- a/shared/common-adapters/profile-card.tsx
+++ b/shared/common-adapters/profile-card.tsx
@@ -268,8 +268,9 @@ export const WithProfileCardPopup = ({username, children, ellipsisStyle}: WithPr
   const popup = showing && (
     <DelayedMounting delay={isMobile ? 0 : 300}>
       <Kb.FloatingMenu
-        attachTo={isMobile ? undefined : popupAnchor}
+        attachTo={popupAnchor}
         closeOnSelect={true}
+        mode="bottomsheet"
         onHidden={onHide}
         position="top center"
         offset={isMobile ? 0 : 10}

--- a/shared/profile/user/teams/teaminfo.tsx
+++ b/shared/profile/user/teams/teaminfo.tsx
@@ -33,6 +33,7 @@ const TeamInfo = (props: Props) => {
     <Kb.FloatingMenu
       attachTo={props.attachTo}
       closeOnSelect={false}
+      mode="bottomsheet"
       onHidden={props.onHidden}
       visible={props.visible}
       propagateOutsideClicks={true}

--- a/shared/teams/role-picker.tsx
+++ b/shared/teams/role-picker.tsx
@@ -398,6 +398,7 @@ export function FloatingRolePicker<IncludeSetIndividually extends boolean = fals
       {open && (
         <Kb.Popup
           attachTo={popupAnchor}
+          mobileAnchored={true}
           position={position || 'top center'}
           onHidden={onCancel ?? (() => {})}
           hideKeyboard={true}

--- a/shared/teams/team/rows/bot-row/bot-menu.tsx
+++ b/shared/teams/team/rows/bot-row/bot-menu.tsx
@@ -26,6 +26,7 @@ const BotMenu = (props: Props) => {
       attachTo={props.attachTo}
       closeOnSelect={true}
       items={items}
+      mode="bottomsheet"
       onHidden={props.onHidden}
       visible={props.visible}
     />

--- a/shared/teams/team/rows/bot-row/bot.tsx
+++ b/shared/teams/team/rows/bot-row/bot.tsx
@@ -105,7 +105,7 @@ const TeamBotRow = (props: Props) => {
             />
           )}
           <BotMenu
-            attachTo={isMobile ? undefined : popupAnchor}
+            attachTo={popupAnchor}
             canManageBots={props.canManageBots}
             visible={showMenu}
             onEdit={props.onEdit}


### PR DESCRIPTION
## Problem

Longpressing a reaction on mobile showed the reactions popup pinned to the top of the screen, clipped, with no backdrop (regression vs 6.6.0). Root cause: 6.6.0 used `Kb.Overlay`, whose native implementation rendered a dimmed bottom-anchored overlay. The rewrite swapped it for `Kb.Popup` with `attachTo`, which on mobile falls into a bare portal (`FloatingBox`) that does no positioning at all.

This was a whole class of bugs: any `Kb.Popup` caller passing `attachTo` had to remember to strip it on mobile (`attachTo={isMobile ? undefined : ref}`), repeated at 7 call sites.

## Fix

- **`Kb.Popup`** now owns the decision: on mobile, `attachTo` is ignored and the popup presents as a gorhom bottom sheet (when `onHidden` is set). New `mobileAnchored` prop opts back into the raw anchored portal for the few callers that need it: suggestors (positioned over the input), role-picker (fullscreen custom layout), dropdown.
- **`FloatingMenu`** passes `attachTo` straight through with `mobileAnchored={mode !== 'bottomsheet'}`, preserving legacy fullscreen menus. Its visibility gate changed from `!visible && !mode` to `!visible && mode !== 'modal'` — sheets present on mount, so always-mounted visible-toggled menus must unmount when hidden.
- **Reaction tooltip** renders its sections statically inside `BottomSheetScrollView` on mobile (menu-layout pattern); desktop anchored popup unchanged.
- The manual `isMobile` strips are removed. `UnpinPrompt`, `TeamInfo`, `UnknownMentionPopup`, profile-card menu, and `BotMenu` switch to `mode="bottomsheet"`, so mobile now gets the proper sheet layout instead of the accidental hybrid (legacy fullscreen layout inside a sheet). Desktop is unaffected — MenuLayout ignores `isModal` on desktop.

## Verify (mobile)

- Longpress a reaction → sheet with reaction sections + Add a reaction
- Longpress pinned message unpin, team mention tap, bot row menu, profile card, role picker, dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)