### PR TITLE
fix(mobile): land share-to-chat on chat tab instead of people tab

### DIFF
--- a/shared/fs/browser/destination-picker.tsx
+++ b/shared/fs/browser/destination-picker.tsx
@@ -103,6 +103,11 @@ const ConnectedDestinationPicker = (ownProps: OwnProps) => {
     ? () => {
         moveOrCopy('copy')
         clearModals()
+        if (isShare) {
+          // Share flow parks the chat tab beneath its modal (see router-v2/linking.tsx);
+          // saving into Files should land on the Files tab instead.
+          C.Router2.switchTab(C.Tabs.fsTab)
+        }
         nav.safeNavigateAppend({name: 'fsBrowse', params: {path: parentPath}})
       }
     : undefined

--- a/shared/router-v2/linking.tsx
+++ b/shared/router-v2/linking.tsx
@@ -70,10 +70,20 @@ export const makeChatConversationState = (conversationIDKey: string): PartialNav
   }
 }
 
-// Build state for a modal screen at root level
-const makeModalState = (modalName: string, params?: Record<string, unknown>): PartialNavState => ({
+// Build state for a modal screen at root level. underTab selects which tab sits
+// beneath the modal; without it loggedIn falls back to the initial (people) tab.
+const makeModalState = (
+  modalName: string,
+  params?: Record<string, unknown>,
+  underTab?: string
+): PartialNavState => ({
   index: 1,
-  routes: [{name: 'loggedIn'}, {name: modalName, ...(params ? {params} : {})}],
+  routes: [
+    underTab
+      ? {name: 'loggedIn', state: {index: 0, routes: [{name: underTab}]}}
+      : {name: 'loggedIn'},
+    {name: modalName, ...(params ? {params} : {})},
+  ],
 })
 
 // ---- URL pattern handling ----
@@ -148,9 +158,12 @@ const customGetStateFromPath = (
     // keybase://incoming-share/{conversationIDKey?} — convID present when the user
     // picked a donated conversation directly in the share sheet
     case 'incoming-share':
+      // Share always ends in chat, so park the chat tab (inbox) beneath the modal;
+      // otherwise dismissing/back lands on the initial people tab.
       return makeModalState(
         'incomingShareNew',
-        parts[1] ? {selectedConversationIDKey: stringToConversationIDKey(parts[1])} : undefined
+        parts[1] ? {selectedConversationIDKey: stringToConversationIDKey(parts[1])} : undefined,
+        Tabs.chatTab
       )
 
     // keybase://settingsPushPrompt

--- a/shared/router-v2/linking.tsx
+++ b/shared/router-v2/linking.tsx
@@ -75,7 +75,7 @@ export const makeChatConversationState = (conversationIDKey: string): PartialNav
 const makeModalState = (
   modalName: string,
   params?: Record<string, unknown>,
-  underTab?: string
+  underTab?: Tabs.AppTab
 ): PartialNavState => ({
   index: 1,
   routes: [


### PR DESCRIPTION
## Problem
Sharing into the app via the iOS share extension worked, but the view beneath the conversation (and beneath the incoming-share modal) was the people tab instead of the chat inbox.

## Cause
The `keybase://incoming-share` deep link built root navigation state as `[loggedIn, incomingShareNew]` with no tab state inside `loggedIn`, so the tab navigator fell back to its initial tab (people). After sending, the conversation is pushed above the tabs, so backing out revealed the people tab.

## Fix
- `makeModalState` takes an optional `underTab` that seeds `loggedIn` with that tab selected.
- The `incoming-share` case passes `chatTab` (chat is the share flow's default destination), so the inbox sits beneath the modal and the conversation.
- Shares can also go to Files: when the user picks "Save in Files" and commits in the destination picker, we jump to the Files tab before pushing the folder view, so backing out lands in Files rather than under the chat tab.

`settingsPushPrompt` is unchanged (still defaults).

## Validation
- `yarn lint` and `yarn tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)