### PR TITLE
fix(teams): show team page avatar instantly, no placeholder flash

### DIFF
--- a/shared/common-adapters/avatar/index.tsx
+++ b/shared/common-adapters/avatar/index.tsx
@@ -141,6 +141,7 @@ for (const size of allSizes) {
 
 const bgColor = Styles.globalColors.greyLight
 const errorUnderlay = {backgroundColor: bgColor, position: 'absolute'} as const
+const blankBg = {backgroundColor: bgColor} as const
 
 // ── Desktop-only ─────────────────────────────────────────────────────────────
 
@@ -262,9 +263,14 @@ function Avatar(p: Props) {
             onLoad={() => setErrorUri(undefined)}
           />
         </>
-      ) : // no source yet (name/httpSrv not loaded): keep the sized box blank instead of
-      // flashing a placeholder that may be the wrong type (user vs team)
-      null}
+      ) : name ? (
+        // name known, just waiting on httpSrv address: the placeholder type is correct
+        <Image source={placeholderSource} style={cached.image} />
+      ) : (
+        // no name yet (e.g. team meta still loading): a placeholder could be the wrong
+        // type (user vs team), so hold the shape with a blank background instead
+        <View style={[cached.image, blankBg]} />
+      )}
       {children}
     </>
   )

--- a/shared/common-adapters/avatar/index.tsx
+++ b/shared/common-adapters/avatar/index.tsx
@@ -262,9 +262,9 @@ function Avatar(p: Props) {
             onLoad={() => setErrorUri(undefined)}
           />
         </>
-      ) : (
-        <Image source={placeholderSource} style={cached.image} />
-      )}
+      ) : // no source yet (name/httpSrv not loaded): keep the sized box blank instead of
+      // flashing a placeholder that may be the wrong type (user vs team)
+      null}
       {children}
     </>
   )

--- a/shared/teams/team/new-header.tsx
+++ b/shared/teams/team/new-header.tsx
@@ -112,7 +112,7 @@ const HeaderTitle = (props: HeaderTitleProps) => {
         onEditAvatar && styles.clickable,
       ])}
     >
-      {!!onEditAvatar && <Kb.Icon type="iconfont-edit" style={styles.editTeamAvatar} />}
+      {!!onEditAvatar && !!meta.teamname && <Kb.Icon type="iconfont-edit" style={styles.editTeamAvatar} />}
     </Kb.Avatar>
   )
 

--- a/shared/teams/team/team-info.tsx
+++ b/shared/teams/team/team-info.tsx
@@ -107,7 +107,7 @@ const TeamInfo = (props: Props) => {
           size={96}
           style={styles.avatar}
         >
-          <Kb.Icon type="iconfont-edit" style={styles.editTeamAvatar} />
+          {!!teamname && <Kb.Icon type="iconfont-edit" style={styles.editTeamAvatar} />}
         </Kb.Avatar>
         {isSubteam ? (
           <Kb.Input3

--- a/shared/teams/team/use-loaded-team.tsx
+++ b/shared/teams/team/use-loaded-team.tsx
@@ -3,7 +3,7 @@ import {useEngineActionListener} from '@/engine/action-listener'
 import logger from '@/logger'
 import * as Teams from '@/constants/teams'
 import * as React from 'react'
-import {useTeamsRoleMap} from '../use-teams-list'
+import {useTeamsListMap, useTeamsRoleMap} from '../use-teams-list'
 import {type CachedResourceCache, getCachedResourceCache, useCachedResource} from '../use-cached-resource'
 
 type LoadedTeam = {
@@ -94,7 +94,14 @@ const useLoadedTeamRaw = (
     () => getCachedResourceCache(cacheMap, emptyLoadedTeamData(validTeamID), validTeamID),
     [cacheMap, validTeamID]
   )
-  const initialData = React.useMemo(() => emptyLoadedTeamData(validTeamID), [validTeamID])
+  // Seed from the teams-list cache so the header (teamname, avatar, member count)
+  // renders immediately instead of waiting for getAnnotatedTeam to round-trip.
+  const teamsListMap = useTeamsListMap()
+  const initialData = React.useMemo(() => {
+    const data = emptyLoadedTeamData(validTeamID)
+    const listMeta = validTeamID ? teamsListMap.get(validTeamID) : undefined
+    return listMeta ? {...data, teamMeta: listMeta} : data
+  }, [validTeamID, teamsListMap])
   const {data, loaded, loading, reload, clear} = useCachedResource({
     cache,
     cacheKey: validTeamID,


### PR DESCRIPTION
Entering a team page on mobile briefly showed the generic **user** placeholder before switching to the team avatar, and the avatar felt slow even when the image was cached.

Root causes:
- The team header renders `Avatar` with `meta.teamname` before team meta loads; an empty teamname makes Avatar treat it as a user and show the user placeholder.
- `LoadedTeamProvider`'s cache map is created per mount, so every team-page entry waited on the `getAnnotatedTeam` RPC before teamname existed — the avatar request couldn't even start.

Changes:
- **Avatar (mobile)**: when there's no source yet, render a blank box that retains the avatar's size instead of a placeholder (which could be the wrong type). The generic placeholder now only shows when a load actually fails, via the existing error underlay path.
- **useLoadedTeam**: seed initial `teamMeta` from the teams-list module cache (same `TeamMeta` shape, already populated by the screen you navigated from) so teamname/avatar/member count render on the first frame. The RPC still runs and refreshes with full details.
- **new-header / team-info**: gate the edit-pencil overlay on `teamname` so it doesn't float over a blank avatar box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)