### PR TITLE
fix(chat): reactions bottom sheet scrolling, pinned footer, compact rows

### DIFF
--- a/shared/chat/conversation/messages/reaction-tooltip.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip.tsx
@@ -84,10 +84,11 @@ const ReactionTooltip = (p: OwnProps) => {
   const renderItem = React.useCallback(
     ({item}: {item: ListItem}) => (
       <Kb.NameWithIcon
+        avatarSize={isMobile ? 32 : undefined}
         colorFollowing={true}
         containerStyle={styles.userContainer}
         horizontal={true}
-        metaOne={item.fullName}
+        metaOne={isMobile ? undefined : item.fullName}
         onClick={onClickUser}
         clickType="onClick"
         withProfileCardPopup={false}
@@ -223,12 +224,17 @@ const styles = Kb.Styles.styleSheetCreate(
         ),
       },
       addReactionButtonIcon: {marginRight: Kb.Styles.globalMargins.tiny},
-      buttonContainer: {
-        backgroundColor: Kb.Styles.globalColors.white,
-        borderTopLeftRadius: 3,
-        borderTopRightRadius: 3,
-        ...Kb.Styles.paddingV(Kb.Styles.globalMargins.tiny),
-      },
+      buttonContainer: Kb.Styles.platformStyles({
+        common: {
+          ...Kb.Styles.paddingV(Kb.Styles.globalMargins.tiny),
+        },
+        isElectron: {
+          backgroundColor: Kb.Styles.globalColors.white,
+          borderTopLeftRadius: 3,
+          borderTopRightRadius: 3,
+        },
+        isMobile: {backgroundColor: Kb.Styles.globalColors.blueGrey},
+      }),
       emojiText: {
         color: Kb.Styles.globalColors.black_50,
         flex: -1,
@@ -256,13 +262,16 @@ const styles = Kb.Styles.styleSheetCreate(
         backgroundColor: Kb.Styles.globalColors.white,
         borderRadius: Kb.Styles.borderRadius,
       },
-      userContainer: {
-        alignSelf: 'stretch',
-        backgroundColor: Kb.Styles.globalColors.white,
-        ...Kb.Styles.paddingH(Kb.Styles.globalMargins.small),
-        ...Kb.Styles.paddingV(Kb.Styles.globalMargins.xtiny),
-        width: '100%',
-      },
+      userContainer: Kb.Styles.platformStyles({
+        common: {
+          alignSelf: 'stretch',
+          backgroundColor: Kb.Styles.globalColors.white,
+          ...Kb.Styles.paddingH(Kb.Styles.globalMargins.small),
+          ...Kb.Styles.paddingV(Kb.Styles.globalMargins.xtiny),
+          width: '100%',
+        },
+        isMobile: {paddingLeft: Kb.Styles.globalMargins.small + 8},
+      }),
     }) as const
 )
 

--- a/shared/chat/conversation/messages/reaction-tooltip.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip.tsx
@@ -4,7 +4,6 @@ import * as Kb from '@/common-adapters'
 import * as React from 'react'
 import ReactButton from './react-button'
 import * as T from '@/constants/types'
-import {BottomSheetScrollView} from '@/common-adapters/popup/bottom-sheet'
 import {MessageContext} from './ids-context'
 import {useUsersState} from '@/stores/users'
 import {useConversationThreadID, useConversationThreadMessage, useConversationThreadMessageActions} from '../thread-context'
@@ -116,7 +115,7 @@ const ReactionTooltip = (p: OwnProps) => {
       gapStart={true}
       gapEnd={true}
       fullWidth={true}
-      centerChildren={true}
+      alignItems="center"
       noShrink={true}
       style={styles.buttonContainer}
     >
@@ -133,39 +132,42 @@ const ReactionTooltip = (p: OwnProps) => {
 
   if (isMobile) {
     return (
-      <Kb.Popup onHidden={onHidden}>
-        <MessageContext value={messageContext}>
-          <BottomSheetScrollView>
-            <Kb.Box2
-              direction="vertical"
+      <Kb.Popup
+        onHidden={onHidden}
+        footer={
+          <Kb.ButtonBar
+            style={Kb.Styles.collapseStyles([
+              styles.addReactionButtonBar,
+              {paddingBottom: Kb.Styles.globalMargins.medium + insets.bottom},
+            ])}
+          >
+            <Kb.Button
+              disabled={!hasMessageID}
+              mode="Secondary"
               fullWidth={true}
-              style={Kb.Styles.collapseStyles([styles.sheetContainer, {paddingBottom: insets.bottom}])}
+              onClick={hasMessageID ? onAddReaction : undefined}
+              label="Add a reaction"
             >
-              {sections.map(section => (
-                <React.Fragment key={section.key}>
-                  {renderSectionHeader({section})}
-                  {section.data.map(item => (
-                    <React.Fragment key={item.key}>{renderItem({item})}</React.Fragment>
-                  ))}
-                </React.Fragment>
-              ))}
-              <Kb.ButtonBar style={styles.addReactionButtonBar}>
-                <Kb.Button
-                  disabled={!hasMessageID}
-                  mode="Secondary"
-                  fullWidth={true}
-                  onClick={hasMessageID ? onAddReaction : undefined}
-                  label="Add a reaction"
-                >
-                  <Kb.Icon
-                    type="iconfont-reacji"
-                    color={Kb.Styles.globalColors.blue}
-                    style={styles.addReactionButtonIcon}
-                  />
-                </Kb.Button>
-              </Kb.ButtonBar>
-            </Kb.Box2>
-          </BottomSheetScrollView>
+              <Kb.Icon
+                type="iconfont-reacji"
+                color={Kb.Styles.globalColors.blue}
+                style={styles.addReactionButtonIcon}
+              />
+            </Kb.Button>
+          </Kb.ButtonBar>
+        }
+      >
+        <MessageContext value={messageContext}>
+          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.sheetContainer}>
+            {sections.map(section => (
+              <React.Fragment key={section.key}>
+                {renderSectionHeader({section})}
+                {section.data.map(item => (
+                  <React.Fragment key={item.key}>{renderItem({item})}</React.Fragment>
+                ))}
+              </React.Fragment>
+            ))}
+          </Kb.Box2>
         </MessageContext>
       </Kb.Popup>
     )
@@ -213,6 +215,7 @@ const styles = Kb.Styles.styleSheetCreate(
   () =>
     ({
       addReactionButtonBar: {
+        backgroundColor: Kb.Styles.globalColors.white,
         ...Kb.Styles.padding(
           Kb.Styles.globalMargins.small,
           Kb.Styles.globalMargins.small,

--- a/shared/common-adapters/floating-menu/menu-layout/index.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.tsx
@@ -12,7 +12,6 @@ import Badge from '@/common-adapters/badge'
 import ProgressIndicator from '@/common-adapters/progress-indicator'
 import SafeAreaView, {useSafeAreaInsets} from '@/common-adapters/safe-area-view'
 import ScrollView from '@/common-adapters/scroll-view'
-import {BottomSheetScrollView} from '@/common-adapters/popup/bottom-sheet'
 import {TouchableOpacity, Keyboard} from 'react-native'
 import {SafeAreaProvider, initialWindowMetrics} from 'react-native-safe-area-context'
 import {useOnMountOnce} from '@/constants/react'
@@ -288,12 +287,15 @@ const NativeMenuLayout = (props: MenuLayoutProps & {safeBottom: number}) => {
   )
 
   if (isModal === 'bottomsheet') {
+    // Popup's sheet provides the scroll view; this is just the content
     return (
-      <BottomSheetScrollView
-        style={[
+      <Box2
+        direction="vertical"
+        fullWidth={true}
+        style={Styles.collapseStyles([
           {backgroundColor: Styles.undynamicColor(Styles.globalColors.black_05OrBlack)},
-          nativeStyles.bottomSheetScrollView,
-        ]}
+          nativeStyles.bottomSheetOuter,
+        ])}
       >
         <Box2
           style={Styles.collapseStyles([nativeStyles.bottomSheetContainer, {marginBottom: 20 + safeBottom}])}
@@ -304,7 +306,7 @@ const NativeMenuLayout = (props: MenuLayoutProps & {safeBottom: number}) => {
           {items}
           {close}
         </Box2>
-      </BottomSheetScrollView>
+      </Box2>
     )
   }
 
@@ -419,7 +421,7 @@ const nativeStyles = Styles.styleSheetCreate(
         borderRadius: Styles.borderRadius,
         marginBottom: 20,
       },
-      bottomSheetScrollView: {
+      bottomSheetOuter: {
         padding: 8,
       },
       divider: {marginBottom: Styles.globalMargins.tiny},

--- a/shared/common-adapters/popup/bottom-sheet.tsx
+++ b/shared/common-adapters/popup/bottom-sheet.tsx
@@ -1,24 +1,19 @@
 import * as React from 'react'
-import type {BottomSheetModalProps, BottomSheetBackdropProps} from '@gorhom/bottom-sheet'
+import type {BottomSheetModalProps, BottomSheetBackdropProps, BottomSheetFooterProps} from '@gorhom/bottom-sheet'
 import * as _gorhomRaw from '@gorhom/bottom-sheet'
 
 type NativeMethods = {present: () => void; forceClose: () => void}
 type BackdropProps = BottomSheetBackdropProps & {disappearsOnIndex?: number; appearsOnIndex?: number; opacity?: number}
-type ScrollViewProps = {style?: object; children?: React.ReactNode}
+type ScrollViewProps = {style?: object; children?: React.ReactNode; enableFooterMarginAdjustment?: boolean}
+type FooterProps = BottomSheetFooterProps & {bottomInset?: number; children?: React.ReactNode}
 type GorhomModule = {
   BottomSheetModal: React.ForwardRefExoticComponent<BottomSheetModalProps & React.RefAttributes<NativeMethods>>
-  BottomSheetView: React.ComponentType<{children?: React.ReactNode}>
   BottomSheetBackdrop: React.ComponentType<BackdropProps>
   BottomSheetScrollView: React.ComponentType<ScrollViewProps>
+  BottomSheetFooter: React.ComponentType<FooterProps>
 }
 
 const _gorhom: GorhomModule | null = isMobile ? (_gorhomRaw as unknown as GorhomModule) : null
-
-export const BottomSheetView = (_p: {children?: React.ReactNode}) => {
-  if (!isMobile) return null
-  const {BottomSheetView: NativeView} = _gorhom!
-  return <NativeView>{_p.children}</NativeView>
-}
 
 export class BottomSheetModal extends React.Component<BottomSheetModalProps> {
   private _native: NativeMethods | null = null
@@ -57,4 +52,10 @@ export const BottomSheetScrollView = (_p: ScrollViewProps) => {
   return <NativeScrollView {..._p} />
 }
 
-export type {BottomSheetBackdropProps} from '@gorhom/bottom-sheet'
+export const BottomSheetFooter = (_p: FooterProps) => {
+  if (!isMobile) return null
+  const {BottomSheetFooter: NativeFooter} = _gorhom!
+  return <NativeFooter {..._p} />
+}
+
+export type {BottomSheetBackdropProps, BottomSheetFooterProps} from '@gorhom/bottom-sheet'

--- a/shared/common-adapters/popup/index.shared.tsx
+++ b/shared/common-adapters/popup/index.shared.tsx
@@ -20,4 +20,6 @@ export type PopupProps = {
   visible?: boolean
   hideKeyboard?: boolean
   snapPoints?: Array<string | number>
+  // mobile sheet only: pinned below the scrolling content, always visible
+  footer?: React.ReactNode
 }

--- a/shared/common-adapters/popup/index.tsx
+++ b/shared/common-adapters/popup/index.tsx
@@ -6,10 +6,13 @@ import {EscapeHandler} from '../key-event-handler'
 import {Portal} from '../portal'
 import {
   BottomSheetModal,
-  BottomSheetView,
+  BottomSheetScrollView,
   BottomSheetBackdrop,
+  BottomSheetFooter,
   type BottomSheetBackdropProps,
+  type BottomSheetFooterProps,
 } from './bottom-sheet'
+import {useSafeAreaInsets} from '../safe-area-view'
 import {FullWindowOverlay} from 'react-native-screens'
 import type {PopupProps} from './index.shared'
 export type {PopupProps} from './index.shared'
@@ -97,8 +100,16 @@ function stopBubbling(ev: React.MouseEvent<HTMLDivElement>) {
 }
 
 function PopupSheet(props: PopupProps) {
-  const {children, onHidden, snapPoints} = props
+  const {children, footer, onHidden, snapPoints} = props
+  const {top: safeTop} = useSafeAreaInsets()
   const bottomRef = React.useRef<BottomSheetModal | null>(null)
+
+  // the footer floats over the scrolled content down to the screen edge, so the
+  // caller's node must bring its own background and bottom safe-area padding
+  const renderFooter = React.useCallback(
+    (fp: BottomSheetFooterProps) => <BottomSheetFooter {...fp}>{footer}</BottomSheetFooter>,
+    [footer]
+  )
 
   React.useEffect(() => {
     bottomRef.current?.present()
@@ -124,8 +135,14 @@ function PopupSheet(props: PopupProps) {
       style={nativeStyles.modalStyle}
       backdropComponent={Backdrop}
       onDismiss={onHidden}
+      // dynamic sizing clamps to the container (full window via FullWindowOverlay),
+      // so without this tall sheets cover the status bar
+      topInset={safeTop}
+      footerComponent={footer ? renderFooter : undefined}
     >
-      <BottomSheetView>{children}</BottomSheetView>
+      {/* a scrollable must be the sheet's direct child: nesting one inside
+          BottomSheetView measures unbounded, so tall content clips instead of scrolling */}
+      <BottomSheetScrollView enableFooterMarginAdjustment={!!footer}>{children}</BottomSheetScrollView>
     </BottomSheetModal>
   )
 }


### PR DESCRIPTION
Long-press reaction sheet was broken with many reactions: it grew past the status bar, clipped at the bottom, and never scrolled — the "Add a reaction" button could be entirely off screen.

- \`PopupSheet\` now owns the \`BottomSheetScrollView\` as the sheet's direct child (nesting a scrollable inside \`BottomSheetView\` measures unbounded, so tall content clipped instead of scrolling), and clamps below the status bar via \`topInset\`.
- New \`Kb.Popup\` \`footer\` prop backed by gorhom \`BottomSheetFooter\` + \`enableFooterMarginAdjustment\`: the "Add a reaction" button stays pinned and visible while content scrolls under it.
- Reaction rows restyled on mobile: left-aligned section headers with blueGrey background, 32px avatars indented 8px, username only (no full name).
- \`menu-layout\` de-nested its own scrollview; dead \`BottomSheetView\` wrapper removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)