### PR TITLE
fix(chat): hide profile hover card when username is clicked

### DIFF
--- a/shared/common-adapters/profile-card.tsx
+++ b/shared/common-adapters/profile-card.tsx
@@ -302,6 +302,14 @@ export const WithProfileCardPopup = ({username, children, ellipsisStyle}: WithPr
       style={Styles.collapseStyles([styles.popupTextContainer, ellipsisStyle])}
       onMouseOver={onShow}
       onMouseLeave={onHide}
+      onMouseDown={e => {
+        // clicking the username navigates to the profile; cancel any pending/visible popup.
+        // portal children bubble through the React tree, so only hide when the click is on
+        // the anchor itself and not inside the floating card (follow/chat buttons).
+        // loose typing since tsconfig.native compiles this file without DOM lib
+        const anchor = e.currentTarget as unknown as {contains?: (t: unknown) => boolean}
+        if (anchor.contains?.(e.target)) onHide()
+      }}
       ref={popupAnchor}
     >
       {children()}


### PR DESCRIPTION
## Problem
On desktop, hovering a username in chat shows the profile hover card. Clicking the username navigates to the profile page, but the card could still appear on top of the profile afterwards.

Two timers race with navigation: the debounced show (200ms) plus `DelayedMounting` (300ms). Clicking never cancelled them or hid the card, and the chat screen stays mounted behind the profile screen, so the FloatingMenu portal rendered above the new page. `onMouseLeave` never fires either since the pointer doesn't move.

## Fix
In `WithProfileCardPopup` (desktop branch), hide + cancel the pending show on `mousedown` on the anchor text. A `contains` check keeps clicks inside the portaled card (follow/chat buttons) from closing it, since portal events bubble through the React tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)