### PR TITLE
fix(chat): reactions sheet empty area matches row background

### DIFF
--- a/shared/chat/conversation/messages/reaction-tooltip.tsx
+++ b/shared/chat/conversation/messages/reaction-tooltip.tsx
@@ -135,6 +135,7 @@ const ReactionTooltip = (p: OwnProps) => {
     return (
       <Kb.Popup
         onHidden={onHidden}
+        style={styles.sheet}
         footer={
           <Kb.ButtonBar
             style={Kb.Styles.collapseStyles([
@@ -258,6 +259,8 @@ const styles = Kb.Styles.styleSheetCreate(
           margin: Kb.Styles.globalMargins.tiny,
         },
       }),
+      // fills the sheet's empty area below the reactions so it matches the rows
+      sheet: {backgroundColor: Kb.Styles.globalColors.white},
       sheetContainer: {
         backgroundColor: Kb.Styles.globalColors.white,
         borderRadius: Kb.Styles.borderRadius,

--- a/shared/common-adapters/popup/bottom-sheet.tsx
+++ b/shared/common-adapters/popup/bottom-sheet.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react'
+import type {StylesCrossPlatform} from '@/styles'
 import type {BottomSheetModalProps, BottomSheetBackdropProps, BottomSheetFooterProps} from '@gorhom/bottom-sheet'
 import * as _gorhomRaw from '@gorhom/bottom-sheet'
 
 type NativeMethods = {present: () => void; forceClose: () => void}
 type BackdropProps = BottomSheetBackdropProps & {disappearsOnIndex?: number; appearsOnIndex?: number; opacity?: number}
-type ScrollViewProps = {style?: object; children?: React.ReactNode; enableFooterMarginAdjustment?: boolean}
+type ScrollViewProps = {
+  style?: StylesCrossPlatform
+  children?: React.ReactNode
+  enableFooterMarginAdjustment?: boolean
+}
 type FooterProps = BottomSheetFooterProps & {bottomInset?: number; children?: React.ReactNode}
 type GorhomModule = {
   BottomSheetModal: React.ForwardRefExoticComponent<BottomSheetModalProps & React.RefAttributes<NativeMethods>>

--- a/shared/common-adapters/popup/index.tsx
+++ b/shared/common-adapters/popup/index.tsx
@@ -100,7 +100,7 @@ function stopBubbling(ev: React.MouseEvent<HTMLDivElement>) {
 }
 
 function PopupSheet(props: PopupProps) {
-  const {children, footer, onHidden, snapPoints} = props
+  const {children, footer, onHidden, snapPoints, style} = props
   const {top: safeTop} = useSafeAreaInsets()
   const bottomRef = React.useRef<BottomSheetModal | null>(null)
 
@@ -142,7 +142,9 @@ function PopupSheet(props: PopupProps) {
     >
       {/* a scrollable must be the sheet's direct child: nesting one inside
           BottomSheetView measures unbounded, so tall content clips instead of scrolling */}
-      <BottomSheetScrollView enableFooterMarginAdjustment={!!footer}>{children}</BottomSheetScrollView>
+      <BottomSheetScrollView enableFooterMarginAdjustment={!!footer} style={style}>
+        {children}
+      </BottomSheetScrollView>
     </BottomSheetModal>
   )
 }


### PR DESCRIPTION
On mobile, the reactions bottom sheet's own background (`black_05_on_white`, near-black in dark mode) showed through the empty area between the reaction rows and the pinned "Add a reaction" footer. The rows and footer both use `globalColors.white`, so the gap read as a black hole.

- `Popup`'s mobile sheet now forwards `style` (previously unused there) to the `BottomSheetScrollView`, letting callers style the sheet's scroll area.
- Widened `ScrollViewProps.style` in the bottom-sheet wrapper to `StylesCrossPlatform`.
- The reaction tooltip passes a `globalColors.white` background so the empty area matches the rows and footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)