### PR TITLE
fix(teams): icon-only Activity no longer fills row on mobile

### DIFF
--- a/shared/teams/common/activity.tsx
+++ b/shared/teams/common/activity.tsx
@@ -114,7 +114,8 @@ const Activity = (p: Props) => {
       direction="horizontal"
       gap="xtiny"
       alignItems="center"
-      fullWidth={isMobile}
+      // iconOnly renders inline in horizontal rows; fullWidth would starve siblings
+      fullWidth={isMobile && !iconOnly}
       style={style}
     >
       <Kb.Icon


### PR DESCRIPTION
The Activity component's container was `fullWidth` on mobile. In the browse-all-channels modal row, the icon-only Activity sits inline in a horizontal row, so `width: 100%` starved its siblings: the channel title collapsed to zero width and the member count / join button were pushed off-screen. Rows without activity rendered fine since Activity returns null for `none`.

Fix: only apply `fullWidth` when not `iconOnly`. Other call sites use the labeled variant in vertical containers and are unchanged.

| before | after |
|---|---|
| broken row: only campfire icon visible | title, activity icon, member count, In button all visible |

🤖 Generated with [Claude Code](https://claude.com/claude-code)