### PR TITLE
fix(mobile): retry localhost images on foreground

### DIFF
--- a/shared/common-adapters/image.tsx
+++ b/shared/common-adapters/image.tsx
@@ -4,6 +4,8 @@ import type {ImageLoadEventData, ImageErrorEventData} from 'expo-image'
 import {Image as ExpoImage} from 'expo-image'
 import LoadingStateView from './loading-state-view'
 import type {StylesCrossPlatform} from '@/styles'
+import {useConfigState} from '@/stores/config'
+import {useShellState} from '@/stores/shell'
 
 type Props = {
   contentFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down'
@@ -45,11 +47,27 @@ const DesktopImage = (p: Props) => {
   )
 }
 
+// Srcs served by the local service http server can fail transiently: iOS stops that server
+// on background/inactive and restarts it (new token, possibly new port) on foreground, so a
+// load racing the restart gets connection refused. Those are worth retrying; remote srcs keep
+// the old fail-once behavior.
+const isLocalhostSrc = (src: Props['src']): src is string =>
+  typeof src === 'string' && src.startsWith('http://127.0.0.1:')
+
+const maxRetries = 3
+
 const NativeImage = (p: Props) => {
   const {showLoadingStateUntilLoaded, src, onLoad, onError, style, contentFit = 'contain', allowDownscaling} = p
   const [loading, setLoading] = React.useState(!showLoadingStateUntilLoaded)
   const [lastSrc, setLastSrc] = React.useState(src)
+  const [attempt, setAttempt] = React.useState(0)
+  const retryable = isLocalhostSrc(src)
+  const failedRef = React.useRef(false)
+  const triesRef = React.useRef(0)
+  const timerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
   const _onLoad = (e?: ImageLoadEventData) => {
+    triesRef.current = 0
+    failedRef.current = false
     setLoading(false)
     onLoad?.(e ?? {})
   }
@@ -57,20 +75,68 @@ const NativeImage = (p: Props) => {
   if (lastSrc !== src) {
     setLastSrc(src)
     setLoading(true)
+    setAttempt(0)
   }
 
+  React.useEffect(() => {
+    triesRef.current = 0
+    failedRef.current = false
+    clearTimeout(timerRef.current)
+  }, [src])
+
   const _onError = (e?: ImageErrorEventData) => {
-    setLoading(false)
     console.log('Image load error', e?.error)
+    if (retryable && triesRef.current < maxRetries) {
+      triesRef.current++
+      clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        setAttempt(a => a + 1)
+      }, 1000 * 2 ** (triesRef.current - 1))
+      return
+    }
+    setLoading(false)
+    failedRef.current = true
     onError?.()
   }
 
+  // after retries are exhausted, a server restart (new address/token) or returning to the
+  // foreground means the server is likely back: start the retry cycle over
+  React.useEffect(() => {
+    const maybeHeal = () => {
+      if (!failedRef.current) return
+      // server is stopped while inactive/backgrounded; the active flip will land here again
+      if (useShellState.getState().mobileAppState !== 'active') return
+      failedRef.current = false
+      triesRef.current = 0
+      setLoading(true)
+      setAttempt(a => a + 1)
+    }
+    const unsubConfig = useConfigState.subscribe((s, prev) => {
+      if (s.httpSrv.address !== prev.httpSrv.address || s.httpSrv.token !== prev.httpSrv.token) {
+        maybeHeal()
+      }
+    })
+    const unsubShell = useShellState.subscribe((s, prev) => {
+      if (s.mobileAppState === 'active' && prev.mobileAppState !== 'active') {
+        maybeHeal()
+      }
+    })
+    return () => {
+      unsubConfig()
+      unsubShell()
+      clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  // cache-buster forces expo-image to actually refetch; recyclingKey stays on the original
+  // src so the view isn't blanked by retries
+  const srcToUse = retryable && attempt > 0 ? `${src}${src.includes('?') ? '&' : '?'}kbRetry=${attempt}` : src
   const recyclingKey = typeof src === 'string' ? src : Array.isArray(src) ? src[0]?.uri : String(src)
 
   return (
     <>
       <ExpoImage
-        source={src}
+        source={srcToUse}
         style={style}
         onLoad={_onLoad}
         contentFit={contentFit}

--- a/shared/common-adapters/image.tsx
+++ b/shared/common-adapters/image.tsx
@@ -102,6 +102,7 @@ const NativeImage = (p: Props) => {
   // after retries are exhausted, a server restart (new address/token) or returning to the
   // foreground means the server is likely back: start the retry cycle over
   React.useEffect(() => {
+    if (!retryable) return
     const maybeHeal = () => {
       if (!failedRef.current) return
       // server is stopped while inactive/backgrounded; the active flip will land here again
@@ -126,7 +127,7 @@ const NativeImage = (p: Props) => {
       unsubShell()
       clearTimeout(timerRef.current)
     }
-  }, [])
+  }, [retryable])
 
   // cache-buster forces expo-image to actually refetch; recyclingKey stays on the original
   // src so the view isn't blanked by retries

--- a/shared/ios/Keybase/AppDelegate.swift
+++ b/shared/ios/Keybase/AppDelegate.swift
@@ -479,6 +479,11 @@ class AppDelegate: ExpoAppDelegate, UNUserNotificationCenterDelegate, UIDropInte
     log.info("applicationWillEnterForeground: hiding keyz screen.")
     PerfFPSMonitor.appWillEnterForeground()
     hideCover()
+    // Tell Go we're foregrounding now instead of waiting for didBecomeActive: the service's
+    // local http server restarts on this signal, and doing it here gives it a head start
+    // before React Native resumes and image loads race the restart. Can't use
+    // notifyAppState here since applicationState is still .background at this point.
+    Keybasego.KeybaseSetAppStateForeground()
     NSLog("applicationWillEnterForeground: done")
   }
 


### PR DESCRIPTION
## Problem

User report: iOS app can lose images after foregrounding. Root cause: the service's local http server is stopped on background/inactive and restarted on foreground (with a new token each time). Two JS-visible symptoms:

- expo-image refetches evicted images on resume; loads racing the server restart get connection refused, and `Kb.Image` never retried a failed src → image stays blank until the row remounts.
- Same failure on any inactive window (control center, app switcher, Face ID, share sheet) since those also stop the server.

## Fix (JS + iOS native only, Go untouched)

- `common-adapters/image.tsx`: srcs pointing at `http://127.0.0.1:` now retry on error (3 attempts, 1s/2s/4s backoff, cache-buster param so expo-image actually refetches; `recyclingKey` stays on the original src so the view isn't blanked). After retries are exhausted, a zustand subscription re-arms the cycle when `httpSrv` address/token changes or the app returns to active. `onError` is only forwarded to consumers on final failure. Store subscriptions instead of hooks so images don't re-render on the every-foreground token rotation.
- `ios/Keybase/AppDelegate.swift`: signal FOREGROUND to Go from `applicationWillEnterForeground` (fires before `didBecomeActive`) so the server restart gets a head start before React Native resumes rendering. `notifyAppState` can't be used there since `applicationState` is still `.background` at that point; duplicate FOREGROUND from `didBecomeActive` is a no-op.

All localhost image consumers funnel through `Kb.Image` (attachments, unfurls, giphy, custom emoji, video posters, zoomable); avatars already rebuild URLs reactively from the store and are unaffected.

Not addressed (known, deliberate): messages unboxed while the server is down get empty attachment URLs baked in service-side and only heal on re-unbox — needs a Go fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)