### PR TITLE
fix(settings): chat settings screen can't scroll fully on iOS

### DIFF
--- a/shared/chat/conversation/info-panel/settings/index.tsx
+++ b/shared/chat/conversation/info-panel/settings/index.tsx
@@ -72,15 +72,16 @@ const SettingsPanel = (props: SettingsPanelProps) => {
   }
 
   const showDangerZone = canDeleteHistory || entityType === 'adhoc' || entityType !== 'channel'
+  // No ScrollView here: this renders as a row inside the tab's SectionList, which
+  // owns scrolling; a nested bounded ScrollView would capture the pan gesture on iOS.
   return (
-    <Kb.ScrollView>
-      <Kb.Box2
-        direction="vertical"
-        fullWidth={true}
-        alignItems="flex-start"
-        padding="small"
-        gap="small"
-      >
+    <Kb.Box2
+      direction="vertical"
+      fullWidth={true}
+      alignItems="flex-start"
+      padding="small"
+      gap="small"
+    >
         {isPreview ? (
           <>
             <Kb.Text type="BodySmallSemibold">You are not in this channel.</Kb.Text>
@@ -158,8 +159,7 @@ const SettingsPanel = (props: SettingsPanelProps) => {
             )}
           </>
         ) : null}
-      </Kb.Box2>
-    </Kb.ScrollView>
+    </Kb.Box2>
   )
 }
 

--- a/shared/settings/chat.tsx
+++ b/shared/settings/chat.tsx
@@ -469,7 +469,7 @@ const Misc = ({allowEdit, groups, toggle}: NotificationSettingsState) => {
   return (
     <>
       <Kb.Divider style={styles.divider} />
-      <Kb.Box2 direction="vertical" fullHeight={true} gap="tiny" style={styles.innerContainer}>
+      <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny" style={styles.innerContainer}>
         <Kb.Text type="Header">Misc</Kb.Text>
         {!!groups.get('misc')?.settings && (
           <Group
@@ -489,7 +489,8 @@ const Chat = () => {
   const notificationSettings = useNotificationSettings()
   return (
     <Kb.ScrollView testID={TestIDs.SETTINGS_CHAT}>
-      <Kb.Box2 direction="vertical" fullHeight={true} gap="tiny" style={styles.container}>
+      {/* fullHeight would cap the ScrollView's contentSize at the viewport, cutting off scrolling */}
+      <Kb.Box2 direction="vertical" fullWidth={true} gap="tiny" style={styles.container}>
         <Security {...notificationSettings} />
         <Kb.Divider style={styles.divider} />
         <Links />


### PR DESCRIPTION
## Problem
On iOS the Settings → Chat screen couldn't scroll its full content: the scrollbar looked right but the Misc section sat below the safe area, unreachable.

## Cause
The content `Kb.Box2` inside the screen's `Kb.ScrollView` had `fullHeight={true}` (height: 100%), capping the ScrollView's contentSize at the viewport. Children overflow visibly (RN doesn't clip) but the scroll range excluded them.

## Fix
- `settings/chat.tsx`: `fullHeight` → `fullWidth` on the screen container and the Misc section Box2.
- `chat/conversation/info-panel/settings/index.tsx`: remove the inert nested `Kb.ScrollView` inside the tab's SectionList row. Harmless today (it shrink-wraps, so its pan gesture fails through to the list) but becomes a gesture-stealing bug if it ever gets bounded height. The SectionList owns scrolling, matching the members tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)