### PR TITLE
fix(mobile): menus present as self-sizing bottom sheets

### DIFF
--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -1070,7 +1070,10 @@ const styles = Kb.Styles.styleSheetCreate(
       fail: {color: Kb.Styles.globalColors.redDark},
       failExploding: {color: Kb.Styles.globalColors.black_50},
       failUnderline: {color: Kb.Styles.globalColors.redDark, textDecorationLine: 'underline'},
-      messagePopupContainer: {marginRight: Kb.Styles.globalMargins.small},
+      // desktop anchored menu offset; on mobile this would shift the bottom sheet's content left
+      messagePopupContainer: Kb.Styles.platformStyles({
+        isElectron: {marginRight: Kb.Styles.globalMargins.small},
+      }),
       middle: {
         flexShrink: 1,
         paddingLeft: isMobile ? 48 : 56,

--- a/shared/common-adapters/floating-menu/index.tsx
+++ b/shared/common-adapters/floating-menu/index.tsx
@@ -78,8 +78,6 @@ function FloatingMenu(props: Props) {
   return (
     <Popup
       attachTo={props.attachTo}
-      // legacy fullscreen menus (no mode) still use the anchored portal on mobile
-      mobileAnchored={mode !== 'bottomsheet'}
       onHidden={onHidden}
       visible={props.visible}
       position={props.position}

--- a/shared/common-adapters/floating-menu/menu-layout/index.tsx
+++ b/shared/common-adapters/floating-menu/menu-layout/index.tsx
@@ -286,8 +286,10 @@ const NativeMenuLayout = (props: MenuLayoutProps & {safeBottom: number}) => {
     </>
   )
 
-  if (isModal === 'bottomsheet') {
-    // Popup's sheet provides the scroll view; this is just the content
+  if (isModal !== 'modal') {
+    // every mobile menu presents as Popup's bottom sheet; the sheet provides the
+    // scroll view, this is just the content. Only 'modal' (a nav modal screen)
+    // still uses the fullscreen layout below.
     return (
       <Box2
         direction="vertical"

--- a/shared/common-adapters/popup/bottom-sheet.tsx
+++ b/shared/common-adapters/popup/bottom-sheet.tsx
@@ -9,6 +9,8 @@ type ScrollViewProps = {
   style?: StylesCrossPlatform
   children?: React.ReactNode
   enableFooterMarginAdjustment?: boolean
+  alwaysBounceVertical?: boolean
+  overScrollMode?: 'auto' | 'always' | 'never'
 }
 type FooterProps = BottomSheetFooterProps & {bottomInset?: number; children?: React.ReactNode}
 type GorhomModule = {

--- a/shared/common-adapters/popup/index.tsx
+++ b/shared/common-adapters/popup/index.tsx
@@ -17,8 +17,6 @@ import {FullWindowOverlay} from 'react-native-screens'
 import type {PopupProps} from './index.shared'
 export type {PopupProps} from './index.shared'
 
-const defaultSnapPoints = ['75%']
-
 function Backdrop(props: BottomSheetBackdropProps) {
   return <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
 }
@@ -127,7 +125,8 @@ function PopupSheet(props: PopupProps) {
     <BottomSheetModal
       ref={setBottomSheetRef}
       enableDynamicSizing={true}
-      snapPoints={snapPoints ?? defaultSnapPoints}
+      // no snapPoints -> dynamic sizing only: sheet hugs content and can't be dragged taller
+      snapPoints={snapPoints}
       backgroundStyle={nativeStyles.modalBackground}
       containerComponent={FullWindow}
       handleStyle={nativeStyles.handleStyle}
@@ -142,7 +141,12 @@ function PopupSheet(props: PopupProps) {
     >
       {/* a scrollable must be the sheet's direct child: nesting one inside
           BottomSheetView measures unbounded, so tall content clips instead of scrolling */}
-      <BottomSheetScrollView enableFooterMarginAdjustment={!!footer} style={style}>
+      <BottomSheetScrollView
+        alwaysBounceVertical={false}
+        overScrollMode="never"
+        enableFooterMarginAdjustment={!!footer}
+        style={style}
+      >
         {children}
       </BottomSheetScrollView>
     </BottomSheetModal>

--- a/shared/fs/common/error-state.tsx
+++ b/shared/fs/common/error-state.tsx
@@ -148,6 +148,20 @@ export const FsErrorProvider = ({children}: {children: React.ReactNode}) => {
   )
 }
 
+// The mobile bottom sheet teleports popup children to the app root (gorhom
+// portal), outside this per-screen provider. Content rendered inside a sheet
+// must capture the value in the source tree with useFsErrorContextValue and
+// re-provide it across the portal with FsErrorContextBridge.
+export const useFsErrorContextValue = () => React.useContext(FsErrorContext)
+
+export const FsErrorContextBridge = ({
+  children,
+  value,
+}: {
+  children: React.ReactNode
+  value: FsErrorContextType | null
+}) => <FsErrorContext.Provider value={value}>{children}</FsErrorContext.Provider>
+
 export const useFsErrors = () => {
   const routeErrors = React.useContext(FsErrorContext)
   return routeErrors?.errors ?? emptyErrors

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -990,14 +990,17 @@ export const useFsLoadPathItemInfoOnMount = (path: T.FS.Path) => {
   const routeData = React.useContext(FsDataContext)
   const pathItem = useFsPathItem(path)
   const pathIsItem = isPathItem(path)
-  const isMaybeFolder = pathItem.type !== T.FS.PathType.File
+  // Only load children once the item is known to be a folder (TLF-level paths
+  // are always folders); the metadata load above flips the type and re-enables
+  // this. Loading eagerly on Unknown would fire a bogus list RPC on files.
+  const isFolder = FS.isFolder(path, pathItem)
   useFsLoadOnMountAndFocus({
     enabled: pathIsItem && !!routeData,
     load: () => routeData?.loadPathMetadata(path),
     reloadKey: path,
   })
   useFsLoadOnMountAndFocus({
-    enabled: pathIsItem && isMaybeFolder && !!routeData,
+    enabled: pathIsItem && isFolder && !!routeData,
     load: () => routeData?.loadFolderChildren(path, false),
     reloadKey: path,
   })

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -95,6 +95,20 @@ type FsDataContextType = {
 
 const FsDataContext = React.createContext<FsDataContextType | null>(null)
 
+// The mobile bottom sheet teleports popup children to the app root (gorhom
+// portal), outside this per-screen provider. Content rendered inside a sheet
+// must capture the value in the source tree with useFsDataContextValue and
+// re-provide it across the portal with FsDataContextBridge.
+export const useFsDataContextValue = () => React.useContext(FsDataContext)
+
+export const FsDataContextBridge = ({
+  children,
+  value,
+}: {
+  children: React.ReactNode
+  value: FsDataContextType | null
+}) => <FsDataContext.Provider value={value}>{children}</FsDataContext.Provider>
+
 type DownloadStartType = 'download' | 'share' | 'saveMedia'
 
 const downloadIntentFromStartType = (type: DownloadStartType): T.FS.DownloadIntent | undefined =>
@@ -965,6 +979,26 @@ export const useFsScreenCoordinator = (path: T.FS.Path) => {
   useFsLoadOnMountAndFocus({
     enabled: pathIsItem && !!routeData,
     load: () => routeData?.loadPathMetadata(path),
+    reloadKey: path,
+  })
+}
+
+// The path-item-action menu shows stat info and children counts for its target
+// path, which the screen coordinator may never load (e.g. a TLF row at the
+// Files tab root), so the menu triggers its own loads while open.
+export const useFsLoadPathItemInfoOnMount = (path: T.FS.Path) => {
+  const routeData = React.useContext(FsDataContext)
+  const pathItem = useFsPathItem(path)
+  const pathIsItem = isPathItem(path)
+  const isMaybeFolder = pathItem.type !== T.FS.PathType.File
+  useFsLoadOnMountAndFocus({
+    enabled: pathIsItem && !!routeData,
+    load: () => routeData?.loadPathMetadata(path),
+    reloadKey: path,
+  })
+  useFsLoadOnMountAndFocus({
+    enabled: pathIsItem && isMaybeFolder && !!routeData,
+    load: () => routeData?.loadFolderChildren(path, false),
     reloadKey: path,
   })
 }

--- a/shared/fs/common/path-item-action/menu-container.tsx
+++ b/shared/fs/common/path-item-action/menu-container.tsx
@@ -7,12 +7,15 @@ import Header from './header'
 import type {FloatingMenuProps, OnDownloadStarted} from './types'
 import {useFsBrowserEdits} from '@/fs/browser/edit-state'
 import {getRootLayout, getShareLayout} from './layout'
-import {useFsErrorActionOrThrow} from '../error-state'
+import {FsErrorContextBridge, useFsErrorActionOrThrow, useFsErrorContextValue} from '../error-state'
 import {
+  FsDataContextBridge,
   useFsCancelDownload,
+  useFsDataContextValue,
   useFsDismissDownload,
   useFsDownload,
   useFsFileContext,
+  useFsLoadPathItemInfoOnMount,
   useFsReloadTlfs,
   useFsWatchDownloadForMobile,
 } from '../hooks'
@@ -61,6 +64,9 @@ const Container = (op: OwnProps) => {
   const {downloadID, downloadIntent, path, mode, floatingMenuProps, onDownloadStarted, setView, view} = op
   const {hide, containerStyle, attachTo, visible} = floatingMenuProps
   const {fileContext, pathItem} = useFsFileContext(path)
+  useFsLoadPathItemInfoOnMount(path)
+  const fsData = useFsDataContextValue()
+  const fsErrors = useFsErrorContextValue()
   const errorToActionOrThrow = useFsErrorActionOrThrow()
   const reloadTlfs = useFsReloadTlfs()
   const browserEdits = useFsBrowserEdits()
@@ -367,7 +373,16 @@ const Container = (op: OwnProps) => {
       visible={visible}
       onHidden={userInitiatedHide}
       position="left center"
-      header={<Header path={path} />}
+      header={
+        // on mobile the sheet portals the header out of the fs providers'
+        // subtree; bridge the captured context values across so the header's
+        // path info and children counts can read them
+        <FsDataContextBridge value={fsData}>
+          <FsErrorContextBridge value={fsErrors}>
+            <Header path={path} />
+          </FsErrorContextBridge>
+        </FsDataContextBridge>
+      }
       items={items.length ? ['Divider' as const, ...items] : items}
       safeProviderStyle={safeProviderStyle}
     />


### PR DESCRIPTION
Every mobile FloatingMenu now renders as a self-sizing bottom sheet:

- `MenuLayout` renders the sheet content branch for all mobile menus; only `mode="modal"` (the nav-modal message popup route) keeps the legacy fullscreen layout. Previously un-converted menus (teams row `...`, inbox gear, fs path-item, etc.) rendered the fullscreen layout *inside* the gorhom sheet, producing a fixed-size sheet with the close button outside the safe-area-aware container.
- Removed `Popup`'s default `['75%']` snap point. With `enableDynamicSizing` and no snap points, the sheet hugs its content and can't be dragged taller. Callers that want bigger sheets (channel picker `90%`, message popups) still pass explicit `snapPoints`.
- `alwaysBounceVertical={false}` / `overScrollMode="never"` on the sheet scroll view: no rubber-band drag when content fits; tall content still scrolls. Drag-down-to-dismiss unaffected.
- Message popup's `marginRight` is now desktop-only; on mobile it shifted the sheet content left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)