### PR TITLE
fix(chat): new-chat stale selection + blank thread header entering created conversations

### DIFF
--- a/shared/chat/conversation/container.tsx
+++ b/shared/chat/conversation/container.tsx
@@ -17,11 +17,18 @@ type Props = ThreadSearchRouteProps & {
 
 const Conversation = function Conversation(props: Props) {
   const conversationIDKey = props.conversationIDKey ?? Chat.noConversationIDKey
+  // BadgeHeaderUpdater stays outside the keyed provider: the pendingWaiting →
+  // real-conv switch is a setParams on this same screen, and the updater's
+  // title-was-empty tracking must survive that switch to repaint the native
+  // header (a remounted instance would see the title content as already
+  // present and never fire).
   return (
-    <LiveConversationThreadProvider key={conversationIDKey} id={conversationIDKey}>
+    <>
       <BadgeHeaderUpdater conversationIDKey={conversationIDKey} />
-      <ConversationInner />
-    </LiveConversationThreadProvider>
+      <LiveConversationThreadProvider key={conversationIDKey} id={conversationIDKey}>
+        <ConversationInner />
+      </LiveConversationThreadProvider>
+    </>
   )
 }
 

--- a/shared/chat/conversation/header-area/index.tsx
+++ b/shared/chat/conversation/header-area/index.tsx
@@ -111,12 +111,6 @@ const HeaderBranchContainerInner = function HeaderBranchContainerInner(props: He
           .map(username => username.trim())
           .filter(Boolean)
       : emptyArray
-  console.log('[HDR] title render', {
-    conversationIDKey,
-    fallbackSmallName: fallback.smallName,
-    participantCount: participants.length,
-    teamname,
-  })
   const isPhoneOrEmail = participants.some(
     participant => participant.endsWith('@phone') || participant.endsWith('@email')
   )
@@ -322,24 +316,8 @@ export const BadgeHeaderUpdater = isIOS
       const hasTitleContent = hasTitleFromMetadata || hasTitleFromLayout
       const titleWasEmptyRef = React.useRef(!hasTitleContent)
       React.useEffect(() => {
-        console.log('[HDR] updater mount', {
-          conversationIDKey,
-          hasTitleFromLayout,
-          hasTitleFromMetadata,
-          titleWasEmpty: titleWasEmptyRef.current,
-        })
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [])
-      React.useEffect(() => {
-        console.log('[HDR] one-shot check', {
-          conversationIDKey,
-          hasTitleContent,
-          titleWasEmpty: titleWasEmptyRef.current,
-          transitionDone,
-        })
         if (!transitionDone || !titleWasEmptyRef.current || !hasTitleContent) return
         titleWasEmptyRef.current = false
-        console.log('[HDR] one-shot FIRING setOptions headerTitle', {conversationIDKey})
         navigation.setOptions({
           headerTitle: () => <HeaderBranchContainerInner conversationIDKey={conversationIDKey} />,
         })
@@ -399,13 +377,7 @@ const ChannelHeader = (props: HeaderConversationProps & {teamname: string; chann
   const maxWidthStyle = useMaxWidthStyle(conversationIDKey)
 
   return (
-    <Kb.Box2
-      direction="vertical"
-      style={maxWidthStyle}
-      onLayout={e => {
-        console.log('[HDR] channel title onLayout', {conversationIDKey, ...e.nativeEvent.layout})
-      }}
-    >
+    <Kb.Box2 direction="vertical" style={maxWidthStyle}>
       <Kb.Box2 direction="horizontal" alignItems="center" alignSelf="center" style={styles.channelHeaderContainer}>
         <Kb.Avatar
           teamname={teamname || undefined}
@@ -454,9 +426,6 @@ const UsernameHeader = (props: HeaderParticipantsProps) => {
     <Kb.Box2
       direction="vertical"
       style={Kb.Styles.collapseStyles([styles.usernameHeaderContainer, maxWidthStyle])}
-      onLayout={e => {
-        console.log('[HDR] username title onLayout', {conversationIDKey, ...e.nativeEvent.layout})
-      }}
     >
       {!!theirFullname && (
         <Kb.Text lineClamp={1} type="BodyBig">

--- a/shared/chat/conversation/header-area/index.tsx
+++ b/shared/chat/conversation/header-area/index.tsx
@@ -18,7 +18,7 @@ import {navToProfile} from '@/constants/router'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import {showConversationInfoPanel, toggleConversationThreadSearch} from '../thread-context'
 import {useConversationMetaSelector, useConversationParticipantsSelector} from '../data-hooks'
-import {useInboxMetadataState} from '@/chat/inbox/metadata'
+import {ensureConversationMetaLoaded, useInboxMetadataState} from '@/chat/inbox/metadata'
 import {muteConversation} from '../status-actions'
 import {getBigLayoutChannelRow, getSmallLayoutRow, useInboxLayoutState} from '@/chat/inbox/layout-state'
 
@@ -75,6 +75,16 @@ const useLayoutFallbackNames = (conversationIDKey: T.Chat.ConversationIDKey) =>
 
 const HeaderBranchContainerInner = function HeaderBranchContainerInner(props: HeaderConversationProps) {
   const {conversationIDKey} = props
+  // self-heal: the header lives in the navigation bar, outside ConversationInner's
+  // data ownership, and can render for a conv whose meta never loaded (e.g. a conv
+  // reached without going through the inbox). The ensure call dedups and no-ops
+  // when the meta is already complete.
+  const loggedIn = useConfigState(s => s.loggedIn)
+  React.useEffect(() => {
+    if (loggedIn) {
+      ensureConversationMetaLoaded(conversationIDKey)
+    }
+  }, [conversationIDKey, loggedIn])
   const meta = useConversationMetaSelector(
     conversationIDKey,
     C.useShallow(m => ({channelname: m.channelname, teamname: m.teamname}))

--- a/shared/chat/conversation/header-area/index.tsx
+++ b/shared/chat/conversation/header-area/index.tsx
@@ -111,6 +111,12 @@ const HeaderBranchContainerInner = function HeaderBranchContainerInner(props: He
           .map(username => username.trim())
           .filter(Boolean)
       : emptyArray
+  console.log('[HDR] title render', {
+    conversationIDKey,
+    fallbackSmallName: fallback.smallName,
+    participantCount: participants.length,
+    teamname,
+  })
   const isPhoneOrEmail = participants.some(
     participant => participant.endsWith('@phone') || participant.endsWith('@email')
   )
@@ -316,8 +322,24 @@ export const BadgeHeaderUpdater = isIOS
       const hasTitleContent = hasTitleFromMetadata || hasTitleFromLayout
       const titleWasEmptyRef = React.useRef(!hasTitleContent)
       React.useEffect(() => {
+        console.log('[HDR] updater mount', {
+          conversationIDKey,
+          hasTitleFromLayout,
+          hasTitleFromMetadata,
+          titleWasEmpty: titleWasEmptyRef.current,
+        })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [])
+      React.useEffect(() => {
+        console.log('[HDR] one-shot check', {
+          conversationIDKey,
+          hasTitleContent,
+          titleWasEmpty: titleWasEmptyRef.current,
+          transitionDone,
+        })
         if (!transitionDone || !titleWasEmptyRef.current || !hasTitleContent) return
         titleWasEmptyRef.current = false
+        console.log('[HDR] one-shot FIRING setOptions headerTitle', {conversationIDKey})
         navigation.setOptions({
           headerTitle: () => <HeaderBranchContainerInner conversationIDKey={conversationIDKey} />,
         })
@@ -377,7 +399,13 @@ const ChannelHeader = (props: HeaderConversationProps & {teamname: string; chann
   const maxWidthStyle = useMaxWidthStyle(conversationIDKey)
 
   return (
-    <Kb.Box2 direction="vertical" style={maxWidthStyle}>
+    <Kb.Box2
+      direction="vertical"
+      style={maxWidthStyle}
+      onLayout={e => {
+        console.log('[HDR] channel title onLayout', {conversationIDKey, ...e.nativeEvent.layout})
+      }}
+    >
       <Kb.Box2 direction="horizontal" alignItems="center" alignSelf="center" style={styles.channelHeaderContainer}>
         <Kb.Avatar
           teamname={teamname || undefined}
@@ -426,6 +454,9 @@ const UsernameHeader = (props: HeaderParticipantsProps) => {
     <Kb.Box2
       direction="vertical"
       style={Kb.Styles.collapseStyles([styles.usernameHeaderContainer, maxWidthStyle])}
+      onLayout={e => {
+        console.log('[HDR] username title onLayout', {conversationIDKey, ...e.nativeEvent.layout})
+      }}
     >
       {!!theirFullname && (
         <Kb.Text lineClamp={1} type="BodyBig">

--- a/shared/constants/router.tsx
+++ b/shared/constants/router.tsx
@@ -975,19 +975,24 @@ export const navigateToThread = (
       clearModals()
     }
 
-    navigateAppend(
-      {
-        name: threadRouteName,
-        params: {
-          conversationIDKey,
-          createConversationError,
-          highlightMessageID,
-          inputAction,
-          threadSearch,
-        },
-      },
-      replace
-    )
+    const params = {
+      conversationIDKey,
+      createConversationError,
+      highlightMessageID,
+      inputAction,
+      threadSearch,
+    }
+    if (replace) {
+      // pendingWaiting -> real conversation. Must be a real replace, not
+      // navigateAppend's replace (which degrades to setParams for the same route
+      // name): setParams keeps the native screen alive, and its header title was
+      // measured while pendingWaiting rendered it empty — iOS never re-measures
+      // an initially-empty title subview, leaving the header blank. A fresh
+      // screen measures the title with its content already present.
+      _getNavigator()?.dispatch(StackActions.replace(threadRouteName, params))
+    } else {
+      navigateAppend({name: threadRouteName, params})
+    }
   }
 }
 

--- a/shared/stores/team-building.tsx
+++ b/shared/stores/team-building.tsx
@@ -326,7 +326,16 @@ const createSlice: Z.ImmerStateCreator<State> = (set, get) => {
       ignorePromise(f())
     },
     finishedTeamBuilding: () => {
-      resetStatePreservingSelection()
+      // teams keeps the selection: its onComplete re-opens the builder with the
+      // chips intact when adding to the wizard fails. Other namespaces are done
+      // with the selection once finished; the store outlives the screen
+      // (per-namespace singleton), so leaving it would show stale chips on the
+      // next open.
+      if (get().namespace === 'teams') {
+        resetStatePreservingSelection()
+      } else {
+        get().dispatch.resetState()
+      }
     },
     removeUsersFromTeamSoFar: users => {
       set(s => {

--- a/shared/stores/tests/team-building.test.ts
+++ b/shared/stores/tests/team-building.test.ts
@@ -45,6 +45,20 @@ test('local setters update role, notifications, and error state', () => {
   expect(store.getState().error).toBe('boom')
 })
 
+test('finishedTeamBuilding clears the selection outside the teams namespace', () => {
+  const store = createTBStore('chat')
+  const alice = makeUser('alice')
+
+  store.getState().dispatch.addUsersToTeamSoFar([alice])
+  store.getState().dispatch.setError('boom')
+
+  store.getState().dispatch.finishedTeamBuilding()
+
+  expect(store.getState().namespace).toBe('chat')
+  expect(store.getState().teamSoFar.size).toBe(0)
+  expect(store.getState().error).toBe('')
+})
+
 test('finishedTeamBuilding clears transient state but preserves namespace and selections', () => {
   const store = createTBStore('teams')
   const alice = makeUser('alice')

--- a/shared/team-building/page.tsx
+++ b/shared/team-building/page.tsx
@@ -167,6 +167,17 @@ const ScreenBody = ({
   const closeTeamBuilding = useTBContext(s => s.dispatch.closeTeamBuilding)
   const finishedTeamBuilding = useTBContext(s => s.dispatch.finishedTeamBuilding)
   const setError = useTBContext(s => s.dispatch.setError)
+  const resetState = useTBContext(s => s.dispatch.resetState)
+
+  // The store is a per-namespace singleton that outlives this screen; a
+  // selection left behind by a previous session (blur can miss when the modal
+  // is removed) would show stale chips. teams intentionally carries the
+  // selection across re-opens for the add-members error path.
+  C.useOnMountOnce(() => {
+    if (namespace !== 'teams') {
+      resetState()
+    }
+  })
 
   React.useEffect(() => {
     if (initialError) {


### PR DESCRIPTION
## Problem

Two bugs in the new-chat flow:

1. **Stale selection**: open new chat → pick a user → Start → reopen new chat: the previous user is still selected.
2. **Blank header**: entering the conversation created by this flow often leaves the navigation header blank until you press back.

## Root causes / fixes

**Stale selection** — the team-building store is a per-namespace singleton that outlives the modal. `finishedTeamBuilding` deliberately preserved `teamSoFar`, and the blur-listener cleanup (`CancelOnBlur`) doesn't fire when the modal is removed, so the selection leaked into the next session.
- `finishedTeamBuilding` now clears the selection for every namespace except `teams` (whose add-members error path re-opens the builder and relies on the chips being intact; every `onComplete` handler receives a copied set, so nothing else reads the store after finish).
- The builder screen also resets stale non-teams selections on mount, covering the back-out path.

**Blank header** — the pendingWaiting → real-conversation switch went through `navigateAppend`'s replace, which degrades to `setParams` for the same route name. That keeps the native screen alive, and its header title was measured while pendingWaiting rendered it empty — iOS never re-measures an initially-empty title subview. Instrumentation confirmed the JS side was fully healthy (title rendered and laid out at 105pt) and the existing one-shot `setOptions` reconfigure fired, yet the bar stayed blank.
- `navigateToThread` now dispatches a real `StackActions.replace` for this case, so the fresh screen measures the title with its content already present.
- `BadgeHeaderUpdater` moved outside the conversation-keyed provider so its title-was-empty tracking survives same-screen conversation swaps.
- The header title component now arms `ensureConversationMetaLoaded` itself, so the header self-heals for any conversation whose meta never loaded.

## Tests

- New store test: chat-namespace finish clears the selection; existing teams-preservation test unchanged.
- `yarn lint`, `yarn tsc`, `yarn jest stores/tests/team-building.test.ts` all green.