### PR TITLE
fix(chat): restore iOS video compression on attach

### DIFF
--- a/shared/util/expo-image-picker.tsx
+++ b/shared/util/expo-image-picker.tsx
@@ -4,6 +4,11 @@ const defaultOptions = {
   allowsEditing: false,
   exif: false,
   quality: 0.4,
+  // marked deprecated but still the only thing that compresses library video picks on iOS;
+  // default is Passthrough which uploads the original file untouched
+  videoExportPreset: ImagePicker.VideoExportPreset.H264_1280x720,
+  // camera recordings + legacy editing picker only
+  videoQuality: ImagePicker.UIImagePickerControllerQualityType.Medium,
 } as const
 
 const mediaTypeToImagePickerMediaType = (


### PR DESCRIPTION
Video attachments picked from the library on iOS were uploading the original file untranscoded. #29122 removed `videoExportPreset`/`videoQuality` from the shared picker defaults, which left expo-image-picker's `Passthrough` default in place — no compression at all.

`videoExportPreset` is marked deprecated in the expo docs, but it is still the only option that drives the PHPicker transcode path (`MediaHandler.swift` → `VideoUtils.transcodeVideoAsync`), so the old patch-based workaround is no longer needed. Restores:

- `videoExportPreset: H264_1280x720` — compresses library picks (deterministic 720p H.264 + AAC, roughly matching the old flow's output)
- `videoQuality: Medium` — camera recordings and the legacy editing picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)