### PR TITLE
perf: cut the client-side RPC floods, and repair four desktop e2e tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 - No `Co-Authored-By` in commits. Ever.
 - Never interact with the Electron app or iOS simulator (screenshots, driving UI, debug ports) without asking first. The user drives and takes screenshots.
 - Use `--no-ext-diff` with `git diff` (and `git show`/`git log -p`) so external diff tools don't hijack output.
-- "Was working before" = base branch, not previous commit. Base branch is almost always `nojima/HOTPOT-next-670-clean-2` (not `master`). Always run `gh pr view --json baseRefName` to confirm before any `git diff` or `git log` comparison.
+- "Was working before" = base branch, not previous commit. Base is normally `master`. Always run `gh pr view --json baseRefName` to confirm before any `git diff` or `git log` comparison.
 - Never use `npm`. Always `yarn`.
 - Never silently drop features/behavior — ask first, present options.
 - In tests/stories, use `testuser` / `testuser-mac` as placeholder usernames — never real usernames like `chrisnojima`.
@@ -23,4 +23,4 @@ Repo root is `client/`. TS source lives in `shared/`. Always use absolute paths 
 - Plans created by superpowers skills go into `plans/` at the repo root.
 
 ## Validation
-After TS changes (from `shared/`): `yarn lint` then `yarn tsc`. When debugging visually, skip until fix is confirmed. Never delete the ESLint cache.
+After TS changes (from `shared/`): `yarn lint:all` (= `yarn lint` && `yarn lint:bailouts` && `yarn tsc`). Plain `yarn lint` is eslint only and does NOT catch react-compiler bailouts — no compiler rule is wired into `eslint.config.mjs`, so bailouts only surface via `lint:bailouts`. Repo baseline is 0 bailouts; keep it there. When debugging visually, skip until fix is confirmed. Never delete the ESLint cache.

--- a/shared/chat/conversation/attachment-actions.tsx
+++ b/shared/chat/conversation/attachment-actions.tsx
@@ -15,6 +15,7 @@ import {
   useConversationThreadID,
   useConversationThreadStore,
 } from './thread-context'
+import {registerExternalResetter} from '@/util/zustand'
 
 const {darwinCopyToChatTempUploadFile} = KB2.functions
 
@@ -92,6 +93,12 @@ export const showAttachmentPreview = (
 }
 
 const pdfMessageHandoff = new Map<string, T.Chat.MessageAttachment>()
+
+// module scope outlives sign-out; both hold attachment messages keyed by conversation
+registerExternalResetter('chat-attachment-message-handoff', () => {
+  attachmentPreviewMessageHandoff.clear()
+  pdfMessageHandoff.clear()
+})
 
 export const takePDFMessage = (
   conversationIDKey: T.Chat.ConversationIDKey,

--- a/shared/chat/conversation/attachment-fullscreen/hooks.tsx
+++ b/shared/chat/conversation/attachment-fullscreen/hooks.tsx
@@ -12,6 +12,7 @@ import {
 } from '../attachment-actions'
 import {showConversationInfoPanel} from '../thread-context'
 import {useConversationMessage} from '../data-hooks'
+import {registerExternalResetter} from '@/util/zustand'
 
 const blankMessage = Chat.makeMessageAttachment({})
 export const useData = (
@@ -116,6 +117,11 @@ export const useData = (
 
 // if we've seen it its likely cached so lets just always just show it and never fallback
 const seenPaths = new Set<string>()
+
+// module scope outlives sign-out; holds the previous user's attachment cache paths
+registerExternalResetter('chat-attachment-seen-paths', () => {
+  seenPaths.clear()
+})
 // preload full and return ''. If too much time passes show preview. Show full when loaded
 export const usePreviewFallback = (
   path: string,

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -4,7 +4,7 @@ import type * as T from '@/constants/types'
 import {makeInsertMatcher} from '@/util/string'
 
 type Props = {
-  channelMetas: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
+  channelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
   installInConvs: ReadonlyArray<string>
   setChannelPickerScreen: (show: boolean) => void
   setInstallInConvs: (convs: ReadonlyArray<string>) => void
@@ -14,7 +14,7 @@ type Props = {
 }
 
 const getChannels = (
-  channelMetas: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>,
+  channelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>,
   searchText: string
 ) => {
   const matcher = makeInsertMatcher(searchText)

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -1,6 +1,5 @@
 import * as C from '@/constants'
 import * as ChatCommon from '@/constants/chat/common'
-import * as Meta from '@/constants/chat/meta'
 import * as Teams from '@/constants/teams'
 import * as Kb from '@/common-adapters'
 import * as React from 'react'
@@ -9,13 +8,15 @@ import ChannelPicker from './channel-picker'
 import {useChatTeam} from '../team-hooks'
 import {openURL} from '@/util/misc'
 import * as T from '@/constants/types'
+import * as TestIDs from '@/tests/e2e/shared/test-ids'
 import {useAllChannelMetas} from '@/teams/common/channel-hooks'
+import {useGeneralConvIDKey} from '@/teams/common/general-conv'
 import {useFeaturedBot} from '@/util/featured-bots'
 import {useRPCLoad} from '@/util/use-rpc-load'
 import {RPCError} from '@/util/errors'
 import logger from '@/logger'
 import {useBotSettings} from './settings'
-import {metasReceived, participantInfoReceived} from '@/chat/inbox/metadata'
+import {participantInfoReceived} from '@/chat/inbox/metadata'
 import {useConversationMeta} from '../data-hooks'
 
 const RestrictedItem = '---RESTRICTED---'
@@ -66,22 +67,7 @@ export const useRefreshBotMembershipOnSuccess = (
 
 export const useBotConversationIDKey = (inConvIDKey?: T.Chat.ConversationIDKey, teamID?: T.Teams.TeamID) => {
   const cleanInConvIDKey = T.Chat.isValidConversationIDKey(inConvIDKey ?? '') ? inConvIDKey : undefined
-  const {data: generalConvIDKey} = useRPCLoad(
-    T.RPCChat.localFindGeneralConvFromTeamIDRpcPromise,
-    [{teamID: teamID ?? T.Teams.noTeamID}],
-    {
-      enabled: !cleanInConvIDKey && !!teamID,
-      key: teamID ?? T.Teams.noTeamID,
-      map: conv => {
-        const meta = Meta.inboxUIItemToConversationMeta(conv)
-        if (!meta) {
-          return undefined
-        }
-        metasReceived([meta])
-        return meta.conversationIDKey
-      },
-    }
-  )
+  const generalConvIDKey = useGeneralConvIDKey(teamID, !cleanInConvIDKey)
   return cleanInConvIDKey ?? generalConvIDKey
 }
 
@@ -622,7 +608,13 @@ const InstallBotPopup = (props: Props) => {
     )
   return (
     <>
-      <Kb.Box2 direction="vertical" flex={1} style={styles.outerContainer} fullWidth={true}>
+      <Kb.Box2
+        direction="vertical"
+        flex={1}
+        style={styles.outerContainer}
+        fullWidth={true}
+        testID={TestIDs.CHAT_BOT_INSTALL}
+      >
         {bodyContent}
       </Kb.Box2>
       {enabled && (!readOnly || showReviewButton) ? (

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -701,7 +701,7 @@ const CommandsLabel = (props: CommandsLabelProps) => {
 }
 
 type PermsListProps = {
-  channelMetas?: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
+  channelMetas?: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
   commands: T.Chat.BotPublicCommands | undefined
   settings?: T.RPCGen.TeamBotSettings
   username: string

--- a/shared/chat/conversation/fwd-msg.tsx
+++ b/shared/chat/conversation/fwd-msg.tsx
@@ -7,6 +7,7 @@ import {useNavigation} from '@react-navigation/native'
 import {Avatars, TeamAvatar} from '@/chat/avatars'
 import logger from '@/logger'
 import {useConversationMessage} from './data-hooks'
+import {registerExternalResetter} from '@/util/zustand'
 
 type Props = {conversationIDKey?: T.Chat.ConversationIDKey; messageID: T.Chat.MessageID}
 
@@ -15,6 +16,11 @@ type PickerState = 'picker' | 'title'
 const forwardMessageHandoff = new Map<string, T.Chat.Message>()
 const forwardMessageKey = (conversationIDKey: T.Chat.ConversationIDKey, messageID: T.Chat.MessageID) =>
   `${conversationIDKey}:${T.Chat.messageIDToNumber(messageID)}`
+
+// module scope outlives sign-out; holds message bodies keyed by conversation
+registerExternalResetter('chat-forward-message-handoff', () => {
+  forwardMessageHandoff.clear()
+})
 
 const getForwardMessage = (conversationIDKey: T.Chat.ConversationIDKey, messageID: T.Chat.MessageID) => {
   const key = forwardMessageKey(conversationIDKey, messageID)

--- a/shared/chat/conversation/input-area/suggestors/channels.tsx
+++ b/shared/chat/conversation/input-area/suggestors/channels.tsx
@@ -7,6 +7,7 @@ import {useInboxLayoutState} from '@/chat/inbox/layout-state'
 import {useCurrentUserState} from '@/stores/current-user'
 import * as React from 'react'
 import {useConversationMetadata} from '../../data-hooks'
+import {useMutualTeams} from '@/util/use-mutual-teams'
 
 export const transformer = (
   {channelname, teamname}: {channelname: string; teamname?: string},
@@ -48,56 +49,25 @@ const ItemRenderer = (p: Common.ItemRendererProps<ChannelType>) => {
 
 const noChannel: Array<{channelname: string}> = []
 const noMutualTeams: ReadonlyArray<T.RPCChat.SharedTeam> = []
+const noParticipants: ReadonlyArray<string> = []
 
-const useMutualTeams = (
+const useConversationMutualTeams = (
   conversationIDKey: T.Chat.ConversationIDKey,
   meta: T.Immutable<T.Chat.ConversationMeta>,
   participants: T.Immutable<T.Chat.ParticipantInfo>
 ) => {
   const username = useCurrentUserState(s => s.username)
-  const [loaded, setLoaded] = React.useState<
-    | {
-        conversationIDKey: T.Chat.ConversationIDKey
-        teams: ReadonlyArray<T.RPCChat.SharedTeam>
-      }
-    | undefined
-  >()
-  const loadMutualTeams = C.useRPC(T.RPCChat.localGetMutualTeamsLocalRpcPromise)
-  const requestIDRef = React.useRef(0)
   const shouldLoad = !meta.teamname
-
-  React.useEffect(() => {
-    requestIDRef.current += 1
-    if (!shouldLoad) {
-      return undefined
-    }
-    const requestID = requestIDRef.current
-    const otherParticipants = Meta.getRowParticipants(participants, username || '')
-    loadMutualTeams(
-      [{usernames: otherParticipants}, C.waitingKeyChatMutualTeams(conversationIDKey)],
-      results => {
-        if (requestIDRef.current !== requestID) {
-          return
-        }
-        setLoaded({conversationIDKey, teams: results.teams ?? noMutualTeams})
-      },
-      () => {
-        if (requestIDRef.current !== requestID) {
-          return
-        }
-        setLoaded({conversationIDKey, teams: noMutualTeams})
-      }
-    )
-    return () => {
-      if (requestIDRef.current === requestID) {
-        requestIDRef.current += 1
-      }
-    }
-  }, [conversationIDKey, loadMutualTeams, participants, shouldLoad, username])
-
-  return shouldLoad && loaded?.conversationIDKey === conversationIDKey
-    ? loaded.teams
-    : noMutualTeams
+  const otherParticipants = React.useMemo(
+    () => (shouldLoad ? Meta.getRowParticipants(participants, username || '') : noParticipants),
+    [participants, shouldLoad, username]
+  )
+  const {teams} = useMutualTeams(
+    otherParticipants,
+    C.waitingKeyChatMutualTeams(conversationIDKey),
+    shouldLoad
+  )
+  return shouldLoad ? teams : noMutualTeams
 }
 
 const getChannelSuggestions = (teamname: string, mutualTeams: ReadonlyArray<T.RPCChat.SharedTeam>) => {
@@ -134,7 +104,7 @@ const getChannelSuggestions = (teamname: string, mutualTeams: ReadonlyArray<T.RP
 
 const useDataSource = (conversationIDKey: T.Chat.ConversationIDKey, filter: string) => {
   const {meta, participants} = useConversationMetadata(conversationIDKey)
-  const mutualTeams = useMutualTeams(conversationIDKey, meta, participants)
+  const mutualTeams = useConversationMutualTeams(conversationIDKey, meta, participants)
   const {teamID} = meta
 
   const suggestChannelsLoading = C.Waiting.useAnyWaiting([

--- a/shared/chat/conversation/input-area/suggestors/emoji.tsx
+++ b/shared/chat/conversation/input-area/suggestors/emoji.tsx
@@ -53,9 +53,15 @@ const cachedEmojiData = (emoji: T.RPCChat.Emoji) => {
 }
 
 const useDataSource = (conversationIDKey: T.Chat.ConversationIDKey, filter: string) => {
-  const {emojis: userEmojis, loading: userEmojisLoading} = useUserEmoji({conversationIDKey})
+  // a filter the prepass rejects discards the result below, so don't pay for the
+  // fetch — userEmojis is expensive to resolve service-side
+  const matchesPrepass = emojiPrepass.test(filter)
+  const {emojis: userEmojis, loading: userEmojisLoading} = useUserEmoji({
+    conversationIDKey,
+    disabled: !matchesPrepass,
+  })
 
-  if (!emojiPrepass.test(filter)) {
+  if (!matchesPrepass) {
     return {
       items: empty,
       loading: false,

--- a/shared/chat/conversation/input-area/suggestors/users.tsx
+++ b/shared/chat/conversation/input-area/suggestors/users.tsx
@@ -6,6 +6,7 @@ import {useUsersState} from '@/stores/users'
 import {useChatTeamMembers} from '../../team-hooks'
 import {useInboxLayoutState} from '@/chat/inbox/layout-state'
 import {useConversationMetadata} from '../../data-hooks'
+import {registerExternalResetter} from '@/util/zustand'
 
 export const transformer = (
   input: {
@@ -259,6 +260,11 @@ const keyExtractor = (item: ListItem) => {
 // the memoized suggestion rows can bail. Bounded by users/channels ever
 // suggested; the size guard is a backstop for pathological accounts.
 const listItemCache = new Map<string, ListItem>()
+
+// module scope outlives sign-out; keyed by username / team#channel
+registerExternalResetter('chat-user-suggestor-item-cache', () => {
+  listItemCache.clear()
+})
 const canonicalizeItems = (items: Array<ListItem>) => {
   if (listItemCache.size > 8192) {
     listItemCache.clear()

--- a/shared/chat/conversation/messages/attachment/shared.tsx
+++ b/shared/chat/conversation/messages/attachment/shared.tsx
@@ -53,12 +53,14 @@ export const ShowToastAfterSaving = ({transferState, toastTargetRef}: Props) => 
   const [allowToast, setAllowToast] = React.useState(true)
 
   // since this uses portals we need to hide if we're hidden else we can get stuck showing if our render is frozen
-  C.Router2.useSafeFocusEffect(() => {
-    setAllowToast(true)
-    return () => {
-      setAllowToast(false)
-    }
-  })
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      setAllowToast(true)
+      return () => {
+        setAllowToast(false)
+      }
+    }, [])
+  )
 
   return allowToast && showingToast ? (
     <Kb.SimpleToast iconType="iconfont-check" text="Saved" visible={true} toastTargetRef={toastTargetRef} />

--- a/shared/chat/conversation/messages/wrapper/send-indicator.tsx
+++ b/shared/chat/conversation/messages/wrapper/send-indicator.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as Kb from '@/common-adapters'
 import {produce} from 'immer'
 import {useColorScheme} from 'react-native'
+import {registerExternalResetter} from '@/util/zustand'
 
 type AnimationStatus =
   | 'encrypting'
@@ -45,6 +46,11 @@ const statusToIconDarkExploding = {
 } as const
 
 const shownEncryptingSet = new Set()
+
+// module scope outlives sign-out; holds the previous user's outbox ids
+registerExternalResetter('chat-send-indicator-shown', () => {
+  shownEncryptingSet.clear()
+})
 
 type OwnProps = {
   failed: boolean

--- a/shared/chat/conversation/team-hooks.tsx
+++ b/shared/chat/conversation/team-hooks.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/teams/use-cached-resource'
 import {updateChosenChannelsTeamnames, useChosenChannelsTeamnames} from './manage-channels-badge'
 import {useThreadMeta} from './thread-context'
+import {registerExternalResetter} from '@/util/zustand'
 
 type ChatTeamState = {
   allowPromote: boolean
@@ -66,6 +67,13 @@ const emptyChatTeamMembersData: ChatTeamMembersData = new Map<string, T.Teams.Me
 const chatTeamCacheMap: TeamCacheMap<ChatTeamData> = new Map()
 const chatTeamMembersCacheMap: TeamCacheMap<ChatTeamMembersData> = new Map()
 const chatTeamReloadStaleMs = 5 * 60_000
+
+// module scope outlives sign-out, so the next user would be served the previous
+// user's team data and member lists
+registerExternalResetter('chat-team-hooks-caches', () => {
+  chatTeamCacheMap.clear()
+  chatTeamMembersCacheMap.clear()
+})
 
 // A disabled "shadow" instance (one that returns the context value instead of
 // its own) must NOT share the loader's cache: with enabled=false

--- a/shared/chat/create-channel/hooks.tsx
+++ b/shared/chat/create-channel/hooks.tsx
@@ -4,6 +4,7 @@ import * as T from '@/constants/types'
 import {RPCError} from '@/util/errors'
 import upperFirst from 'lodash/upperFirst'
 import type {Props} from './index.shared'
+import {invalidateTeamChannels} from '@/teams/common/team-channels-invalidation'
 import {useChatTeam} from '../conversation/team-hooks'
 
 export default (p: Props) => {
@@ -57,6 +58,7 @@ export default (p: Props) => {
             C.waitingKeyTeamsCreateChannel(teamID)
           )
         }
+        invalidateTeamChannels(teamID)
         onBack()
         if (navToChatOnSuccess) {
           previewConversation({channelname, conversationIDKey, reason: 'newChannel', teamname})

--- a/shared/chat/inbox-search/index.tsx
+++ b/shared/chat/inbox-search/index.tsx
@@ -16,6 +16,7 @@ import {
   type InboxSearchVisibleResultCounts,
 } from '../inbox/use-inbox-search'
 import {showTeamByName} from '@/teams/team-page-actions'
+import {registerExternalResetter} from '@/util/zustand'
 
 type OwnProps = {
   header?: React.ReactElement | null
@@ -56,6 +57,12 @@ const nameResultCache = new Map<string, NameResult>()
 const textResultCache = new Map<string, TextResult>()
 const openTeamItemCache = new WeakMap<T.Chat.InboxSearchOpenTeamHit, OpenTeamResult>()
 const botItemCache = new WeakMap<T.RPCGen.FeaturedBot, BotResult>()
+
+// module scope outlives sign-out; these hold conversation and username hits
+registerExternalResetter('chat-inbox-search-item-caches', () => {
+  nameResultCache.clear()
+  textResultCache.clear()
+})
 
 const canonNameResult = (next: NameResult) => {
   if (nameResultCache.size > 4096) {
@@ -258,7 +265,7 @@ export default function InboxSearchContainer(ownProps: OwnProps) {
     renderHeaderWithMore(section, _botsResults.length, botsCollapsed, botsAll, toggleBotsAll)
 
   const renderTextHeader = (section: Section) => {
-    const ratio = indexPercent / 100.0
+    const ratio = (indexPercent ?? 0) / 100.0
     return (
       <Kb.Box2 direction="vertical" fullWidth={true} style={styles.textHeader}>
         <Kb.SectionDivider
@@ -273,7 +280,7 @@ export default function InboxSearchContainer(ownProps: OwnProps) {
               Search failed, please try again, or contact Keybase describing the problem.
             </Kb.Text>
           </Kb.Box2>
-        ) : indexPercent > 0 && indexPercent < 100 ? (
+        ) : indexPercent !== undefined && indexPercent < 100 ? (
           <Kb.Box2 direction="horizontal" gap="xtiny" style={styles.percentContainer} fullWidth={true}>
             <Kb.Text type="BodyTiny">Indexing...</Kb.Text>
             {isMobile ? (

--- a/shared/chat/inbox/index.tsx
+++ b/shared/chat/inbox/index.tsx
@@ -510,9 +510,11 @@ function NativeInboxBody(p: ControlledInboxProps) {
 
   const setOpenRow = useOpenedRowState(s => s.dispatch.setOpenRow)
 
-  C.Router2.useSafeFocusEffect(() => {
-    setOpenRow(Chat.noConversationIDKey)
-  })
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      setOpenRow(Chat.noConversationIDKey)
+    }, [setOpenRow])
+  )
 
   const promptSmallTeamsNum = React.useCallback(() => {
     if (isIOS) {

--- a/shared/chat/inbox/use-inbox-search.tsx
+++ b/shared/chat/inbox/use-inbox-search.tsx
@@ -25,7 +25,7 @@ export const makeInboxSearchInfo = (): T.Chat.InboxSearchInfo => ({
   botsResults: [],
   botsResultsSuggested: false,
   botsStatus: 'initial',
-  indexPercent: 0,
+  indexPercent: undefined,
   nameResults: [],
   nameResultsUnread: false,
   nameStatus: 'initial',
@@ -311,6 +311,9 @@ export function useInboxSearch(): InboxSearchController {
           updateIfActive(prev => ({
             ...prev,
             botsStatus: 'inprogress',
+            // unknown again until this search reports one, rather than carrying
+            // the previous search's number
+            indexPercent: undefined,
             nameStatus: 'inprogress',
             openTeamsStatus: 'inprogress',
             selectedIndex: 0,

--- a/shared/chat/inbox/use-inbox-state.tsx
+++ b/shared/chat/inbox/use-inbox-state.tsx
@@ -139,11 +139,13 @@ export function useInboxState(
     C.Router2.setChatRootParams({refreshInbox: undefined})
   }, [inboxRefresh, isFocused, loggedIn, refreshInbox, username])
 
-  C.Router2.useSafeFocusEffect(() => {
-    if (!inboxHasLoaded) {
-      C.ignorePromise(inboxRefresh('componentNeverLoaded'))
-    }
-  })
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      if (!inboxHasLoaded) {
+        C.ignorePromise(inboxRefresh('componentNeverLoaded'))
+      }
+    }, [inboxHasLoaded, inboxRefresh])
+  )
 
   React.useEffect(() => {
     const ready = loggedIn && !!username

--- a/shared/chat/user-emoji.tsx
+++ b/shared/chat/user-emoji.tsx
@@ -1,8 +1,36 @@
+import * as React from 'react'
 import * as T from '@/constants/types'
-import {useRPCLoad} from '@/util/use-rpc-load'
+import {useEmojiState} from '@/teams/emojis/use-emoji'
+import {
+  type CachedResourceCache,
+  createCachedResourceCache,
+  getCachedResourceCache,
+  useCachedResource,
+} from '@/teams/use-cached-resource'
+import {registerExternalResetter} from '@/util/zustand'
 
 const emptyEmojiGroups: ReadonlyArray<T.RPCChat.EmojiGroup> = []
 const emptyEmojis: ReadonlyArray<T.RPCChat.Emoji> = []
+
+type UserEmojiData = {
+  emojiGroups: ReadonlyArray<T.RPCChat.EmojiGroup>
+  emojis: ReadonlyArray<T.RPCChat.Emoji>
+}
+
+const emptyUserEmojiData: UserEmojiData = {emojiGroups: emptyEmojiGroups, emojis: emptyEmojis}
+
+// One cache per request key, shared by every consumer. userEmojis is expensive on
+// the service side - it resolves two attachment URLs per custom emoji - so the
+// suggestor remounting on each ':' trigger used to refetch the entire set. The
+// shared cache also collapses concurrent mounts onto a single in-flight request.
+const userEmojiCaches = new Map<string, CachedResourceCache<UserEmojiData, string>>()
+const userEmojiStaleMs = 60_000
+
+// module scope outlives sign-out, so the next user would be served the previous
+// user's custom emoji until the entries went stale
+registerExternalResetter('chat-user-emoji-caches', () => {
+  userEmojiCaches.clear()
+})
 
 const flattenUserEmojis = (groups: ReadonlyArray<T.RPCChat.EmojiGroup>) => {
   const emojis = new Array<T.RPCChat.Emoji>()
@@ -25,33 +53,59 @@ export const useUserEmoji = ({
   const requestKey = `${conversationIDKey ?? T.Chat.noConversationIDKey}:${
     requestOnlyInTeam ? 'team' : 'all'
   }`
-  const {data, loading} = useRPCLoad(
-    T.RPCChat.localUserEmojisRpcPromise,
-    [
-      {
-        convID:
-          conversationIDKey && conversationIDKey !== T.Chat.noConversationIDKey
-            ? T.Chat.keyToConversationID(conversationIDKey)
-            : null,
-        opts: {
-          getAliases: true,
-          getCreationInfo: false,
-          onlyInTeam: requestOnlyInTeam,
-        },
-      },
-    ],
-    {
-      enabled: !disabled,
-      key: requestKey,
-      map: results => {
-        const nextGroups = results.emojis.emojis ?? emptyEmojiGroups
-        return {emojiGroups: nextGroups, emojis: flattenUserEmojis(nextGroups)}
-      },
-    }
+  // adding, aliasing or removing an emoji bumps this; it busts the cache so the
+  // picker and the suggestor pick the change up instead of serving a stale set
+  const emojiUpdatedTrigger = useEmojiState(s => s.emojiUpdatedTrigger)
+  // a disabled instance resets the cache it holds, so keep those off the shared one
+  const [localCache] = React.useState<CachedResourceCache<UserEmojiData, string>>(() =>
+    createCachedResourceCache(emptyUserEmojiData, requestKey)
   )
+  const sharedCache = React.useMemo(
+    () => getCachedResourceCache(userEmojiCaches, emptyUserEmojiData, requestKey),
+    [requestKey]
+  )
+  const load = React.useCallback(async () => {
+    const results = await T.RPCChat.localUserEmojisRpcPromise({
+      convID:
+        conversationIDKey && conversationIDKey !== T.Chat.noConversationIDKey
+          ? T.Chat.keyToConversationID(conversationIDKey)
+          : null,
+      opts: {
+        getAliases: true,
+        getCreationInfo: false,
+        onlyInTeam: requestOnlyInTeam,
+      },
+    })
+    const emojiGroups = results.emojis.emojis ?? emptyEmojiGroups
+    return {emojiGroups, emojis: flattenUserEmojis(emojiGroups)}
+  }, [conversationIDKey, requestOnlyInTeam])
+
+  const {data, loading, reload} = useCachedResource({
+    cache: disabled ? localCache : sharedCache,
+    cacheKey: requestKey,
+    enabled: !disabled,
+    initialData: emptyUserEmojiData,
+    load,
+    refreshKey: emojiUpdatedTrigger,
+    staleMs: userEmojiStaleMs,
+  })
+
+  // refreshKey alone only re-checks staleness, and an edit we just made is never
+  // stale — force past the cache when the emoji set actually changed
+  const lastEmojiUpdatedTriggerRef = React.useRef(emojiUpdatedTrigger)
+  React.useEffect(() => {
+    if (lastEmojiUpdatedTriggerRef.current === emojiUpdatedTrigger) {
+      return
+    }
+    lastEmojiUpdatedTriggerRef.current = emojiUpdatedTrigger
+    if (!disabled) {
+      void reload()
+    }
+  }, [disabled, emojiUpdatedTrigger, reload])
+
   return {
-    emojiGroups: disabled ? undefined : (data?.emojiGroups ?? emptyEmojiGroups),
-    emojis: data?.emojis ?? emptyEmojis,
+    emojiGroups: disabled ? undefined : data.emojiGroups,
+    emojis: data.emojis,
     loading,
   }
 }

--- a/shared/chat/user-emoji.tsx
+++ b/shared/chat/user-emoji.tsx
@@ -82,8 +82,23 @@ export const useUserEmoji = ({
     if (disabled) {
       return undefined
     }
-    if (userEmojiCaches.size > userEmojiCacheMax) {
-      userEmojiCaches.clear()
+    // drop the least recently asked for entries rather than the whole map: a
+    // wholesale clear at the cap makes the conversation you switch back to
+    // re-issue localUserEmojis even though its entry was still fresh. Map
+    // iterates in insertion order, and re-inserting on use below keeps that
+    // order meaningful.
+    if (userEmojiCaches.has(requestKey)) {
+      const existing = userEmojiCaches.get(requestKey)!
+      userEmojiCaches.delete(requestKey)
+      userEmojiCaches.set(requestKey, existing)
+    } else {
+      while (userEmojiCaches.size >= userEmojiCacheMax) {
+        const oldest = userEmojiCaches.keys().next()
+        if (oldest.done) {
+          break
+        }
+        userEmojiCaches.delete(oldest.value)
+      }
     }
     return getCachedResourceCache(userEmojiCaches, emptyUserEmojiData, requestKey)
   }, [disabled, requestKey])

--- a/shared/chat/user-emoji.tsx
+++ b/shared/chat/user-emoji.tsx
@@ -25,11 +25,27 @@ const emptyUserEmojiData: UserEmojiData = {emojiGroups: emptyEmojiGroups, emojis
 // shared cache also collapses concurrent mounts onto a single in-flight request.
 const userEmojiCaches = new Map<string, CachedResourceCache<UserEmojiData, string>>()
 const userEmojiStaleMs = 60_000
+// an entry holds every custom emoji the conv can see, with two resolved
+// attachment URLs each, and every channel of a team keeps its own copy, so this
+// is capped by size rather than left to grow for the life of the session
+const userEmojiCacheMax = 32
 
 // module scope outlives sign-out, so the next user would be served the previous
 // user's custom emoji until the entries went stale
 registerExternalResetter('chat-user-emoji-caches', () => {
   userEmojiCaches.clear()
+})
+
+// Adding, aliasing or removing an emoji has to drop the shared entries from the
+// store, not from a mounted consumer: the edit happens on the team emoji page,
+// where nothing is using useUserEmoji, so by the time the picker or the
+// suggestor mounts there is no trigger change left for it to notice and the
+// entry is still inside its stale window.
+useEmojiState.subscribe((state, prev) => {
+  if (state.emojiUpdatedTrigger === prev.emojiUpdatedTrigger) {
+    return
+  }
+  userEmojiCaches.forEach((cache, key) => cache.invalidate(key))
 })
 
 const flattenUserEmojis = (groups: ReadonlyArray<T.RPCChat.EmojiGroup>) => {
@@ -53,17 +69,24 @@ export const useUserEmoji = ({
   const requestKey = `${conversationIDKey ?? T.Chat.noConversationIDKey}:${
     requestOnlyInTeam ? 'team' : 'all'
   }`
-  // adding, aliasing or removing an emoji bumps this; it busts the cache so the
-  // picker and the suggestor pick the change up instead of serving a stale set
+  // the store subscription above already dropped the shared entries; this makes
+  // the mounted consumers re-run their load and pick the new set up
   const emojiUpdatedTrigger = useEmojiState(s => s.emojiUpdatedTrigger)
   // a disabled instance resets the cache it holds, so keep those off the shared one
   const [localCache] = React.useState<CachedResourceCache<UserEmojiData, string>>(() =>
     createCachedResourceCache(emptyUserEmojiData, requestKey)
   )
-  const sharedCache = React.useMemo(
-    () => getCachedResourceCache(userEmojiCaches, emptyUserEmojiData, requestKey),
-    [requestKey]
-  )
+  // a disabled instance must not seed the shared map: it never loads, so the
+  // entry it created would sit there empty for the life of the session
+  const sharedCache = React.useMemo(() => {
+    if (disabled) {
+      return undefined
+    }
+    if (userEmojiCaches.size > userEmojiCacheMax) {
+      userEmojiCaches.clear()
+    }
+    return getCachedResourceCache(userEmojiCaches, emptyUserEmojiData, requestKey)
+  }, [disabled, requestKey])
   const load = React.useCallback(async () => {
     const results = await T.RPCChat.localUserEmojisRpcPromise({
       convID:
@@ -80,8 +103,8 @@ export const useUserEmoji = ({
     return {emojiGroups, emojis: flattenUserEmojis(emojiGroups)}
   }, [conversationIDKey, requestOnlyInTeam])
 
-  const {data, loading, reload} = useCachedResource({
-    cache: disabled ? localCache : sharedCache,
+  const {data, loading} = useCachedResource({
+    cache: sharedCache ?? localCache,
     cacheKey: requestKey,
     enabled: !disabled,
     initialData: emptyUserEmojiData,
@@ -89,19 +112,6 @@ export const useUserEmoji = ({
     refreshKey: emojiUpdatedTrigger,
     staleMs: userEmojiStaleMs,
   })
-
-  // refreshKey alone only re-checks staleness, and an edit we just made is never
-  // stale — force past the cache when the emoji set actually changed
-  const lastEmojiUpdatedTriggerRef = React.useRef(emojiUpdatedTrigger)
-  React.useEffect(() => {
-    if (lastEmojiUpdatedTriggerRef.current === emojiUpdatedTrigger) {
-      return
-    }
-    lastEmojiUpdatedTriggerRef.current = emojiUpdatedTrigger
-    if (!disabled) {
-      void reload()
-    }
-  }, [disabled, emojiUpdatedTrigger, reload])
 
   return {
     emojiGroups: disabled ? undefined : data.emojiGroups,

--- a/shared/common-adapters/hot-key.tsx
+++ b/shared/common-adapters/hot-key.tsx
@@ -202,20 +202,31 @@ const unregisterKeys = (keysArr: Array<string>, cb: (key: string) => void) => {
 }
 
 export function useHotKey(keys: Array<string> | string, cb: (key: string) => void) {
-  const keysArr = (() => {
-    const arr = typeof keys === 'string' ? [keys] : keys
-    return arr.filter(k => k.length > 0)
-  })()
+  // callers pass inline arrays/closures, so derive stable identities for both:
+  // otherwise every render unregisters and re-registers, which also re-orders the
+  // LIFO stack and lets a re-rendering background screen steal the key
+  const keysKey = typeof keys === 'string' ? keys : keys.join(',')
+  const keysArr = React.useMemo(() => keysKey.split(',').filter(k => k.length > 0), [keysKey])
 
-  C.Router2.useSafeFocusEffect(() => {
-    if (isMobile || keysArr.length === 0) return
-    registerKeys(keysArr, cb)
-    return () => unregisterKeys(keysArr, cb)
+  const cbRef = React.useRef(cb)
+  React.useEffect(() => {
+    cbRef.current = cb
   })
+  const [stableCB] = React.useState(() => (key: string) => cbRef.current(key))
+
+  // registering again on focus re-pushes us to the top of the stack so the
+  // focused screen wins the key over screens that merely stayed mounted
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      if (isMobile || keysArr.length === 0) return
+      registerKeys(keysArr, stableCB)
+      return () => unregisterKeys(keysArr, stableCB)
+    }, [keysArr, stableCB])
+  )
 
   React.useEffect(() => {
     if (isMobile || keysArr.length === 0) return
-    registerKeys(keysArr, cb)
-    return () => unregisterKeys(keysArr, cb)
-  }, [keysArr, cb])
+    registerKeys(keysArr, stableCB)
+    return () => unregisterKeys(keysArr, stableCB)
+  }, [keysArr, stableCB])
 }

--- a/shared/common-adapters/markdown/spoiler.tsx
+++ b/shared/common-adapters/markdown/spoiler.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as Styles from '@/styles'
 import Text from '@/common-adapters/text'
+import {registerExternalResetter} from '@/util/zustand'
 
 type Props = {
   children: React.ReactNode
@@ -9,6 +10,12 @@ type Props = {
 }
 
 const spoilerState = new Map<string, boolean>()
+
+// module scope outlives sign-out; keyed by message content, and a spoiler the
+// previous user revealed must not come up already revealed for the next one
+registerExternalResetter('markdown-spoiler-state', () => {
+  spoilerState.clear()
+})
 
 const Spoiler = (p: Props) => {
   const {children, content, context} = p

--- a/shared/common-adapters/profile-card.tsx
+++ b/shared/common-adapters/profile-card.tsx
@@ -140,7 +140,10 @@ const ProfileCard = ({
   onLayoutChange,
   username,
 }: Props) => {
-  const {details: userDetails, loadProfile} = useTrackerProfile(username)
+  // a hover card is incidental, not "check this identity now" - the cached proof
+  // results are what it should show, and forcing a check re-fetches every proof
+  // from its third-party host
+  const {details: userDetails, loadProfile} = useTrackerProfile(username, {cachedOnMount: true})
   const followThem = useFollowerState(s => s.following.has(username))
   const followsYou = useFollowerState(s => s.followers.has(username))
   const isSelf = useCurrentUserState(s => s.username === username)

--- a/shared/common-adapters/with-tooltip.tsx
+++ b/shared/common-adapters/with-tooltip.tsx
@@ -62,11 +62,16 @@ function WithTooltip(p: Props) {
   }, 3000)
   const {width: screenWidth, height: screenHeight} = useSafeAreaFrame()
 
-  C.Router2.useSafeFocusEffect(() => {
-    return () => {
-      setNativeVisible(false)
-    }
-  })
+  // must be stable: an unstable callback re-runs the focus effect (and so its
+  // cleanup) on every render, which would hide the tooltip as soon as showing it
+  // re-renders us
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      return () => {
+        setNativeVisible(false)
+      }
+    }, [])
+  )
 
   if (!isMobile) {
     const onMouseEnter = () => setDesktopVisible(true)

--- a/shared/constants/types/chat/index.tsx
+++ b/shared/constants/types/chat/index.tsx
@@ -50,7 +50,9 @@ export type InboxSearchOpenTeamHit = {
 }
 
 export type InboxSearchInfo = {
-  indexPercent: number
+  // undefined until the service reports one; 0 is a real value meaning nothing
+  // is indexed yet, which is what an index rebuild looks like
+  indexPercent?: number
   botsResults: ReadonlyArray<RPCTypes.FeaturedBot>
   botsResultsSuggested: boolean
   botsStatus: InboxSearchStatus

--- a/shared/crypto/recipients.tsx
+++ b/shared/crypto/recipients.tsx
@@ -1,4 +1,5 @@
 import * as Kb from '@/common-adapters'
+import * as TestIDs from '@/tests/e2e/shared/test-ids'
 
 type Props = {
   inProgress: boolean
@@ -22,6 +23,7 @@ const Recipients = ({inProgress, onAddRecipients, onClearRecipients, recipients}
           <Kb.ClickableBox
             direction="horizontal"
             style={styles.input}
+            testID={TestIDs.CRYPTO_RECIPIENTS}
             onClick={inProgress ? undefined : onAddRecipients}
           >
             {/* Display-only input; block it from taking focus so opening the

--- a/shared/engine/action-listener.test.ts
+++ b/shared/engine/action-listener.test.ts
@@ -64,3 +64,23 @@ test('clearAll removes all registered listeners', () => {
 
   expect(homeListener).not.toHaveBeenCalled()
 })
+
+test('a stale unsubscribe from before a reset leaves later subscribers alone', () => {
+  const before = jest.fn()
+  const staleUnsubscribe = subscribeToEngineAction('keybase.1.homeUI.homeUIRefresh', before)
+
+  clearAllEngineActionListeners()
+
+  const after = jest.fn()
+  subscribeToEngineAction('keybase.1.homeUI.homeUIRefresh', after)
+
+  // the component that subscribed before the reset unmounts late
+  staleUnsubscribe()
+
+  notifyEngineActionListeners({
+    payload: {params: {}},
+    type: 'keybase.1.homeUI.homeUIRefresh',
+  } as never)
+  expect(after).toHaveBeenCalledTimes(1)
+  expect(before).not.toHaveBeenCalled()
+})

--- a/shared/engine/action-listener.tsx
+++ b/shared/engine/action-listener.tsx
@@ -31,7 +31,11 @@ export const subscribeToEngineAction = <T extends EngineGen.ActionType>(
   listeners.add(untypedListener)
   return () => {
     listeners.delete(untypedListener)
-    if (!listeners.size) {
+    // Only drop the entry if the map still holds THIS set. A reset replaces the
+    // set for a type, so an unsubscribe left over from before the reset would
+    // otherwise see its own detached, now-empty set and delete the live one,
+    // silently unsubscribing everybody who registered after the reset.
+    if (!listeners.size && listenersByType.get(type) === listeners) {
       listenersByType.delete(type)
     }
   }

--- a/shared/fs/browser/root.tsx
+++ b/shared/fs/browser/root.tsx
@@ -7,6 +7,7 @@ import SfmiBanner from '../banner/system-file-manager-integration-banner/contain
 import {WrapRow} from './rows/rows'
 import * as FS from '@/constants/fs'
 import {useCurrentUserState} from '@/stores/current-user'
+import {registerExternalResetter} from '@/util/zustand'
 
 type Props = {
   destinationPickerSource?: T.FS.MoveOrCopySource | T.FS.IncomingShareSource
@@ -57,6 +58,11 @@ const renderSectionHeader = ({section}: {section: {key: string; title: string}})
 // recents are re-derived on every FsDataContext write; reuse item identities
 // so the memoized rows can bail
 const recentItemCache = new Map<string, SectionListItem>()
+
+// module scope outlives sign-out; keyed by TLF name
+registerExternalResetter('fs-browser-recent-item-cache', () => {
+  recentItemCache.clear()
+})
 const canonRecentItem = (name: string, tlfType: T.FS.TlfType): SectionListItem => {
   const key = `${tlfType}-${name}`
   let item = recentItemCache.get(key)

--- a/shared/git/index.tsx
+++ b/shared/git/index.tsx
@@ -101,13 +101,14 @@ const GitRoot = (ownProps: OwnProps) => {
   // errors from row actions (toggling chat), load errors come from the hook
   const [rowError, setRowError] = React.useState<Error | undefined>()
   const isNew = useConfigState(s => s.badgeState?.newGitRepoGlobalUniqueIDs)
-  const {badged} = useLocalBadging(new Set(isNew ?? []), () => {
+  const clearBadges = React.useCallback(() => {
     clearGitBadges(
       [{category: 'new_git_repo'}],
       () => {},
       () => {}
     )
-  })
+  }, [clearGitBadges])
+  const {badged} = useLocalBadging(new Set(isNew ?? []), clearBadges)
   const {
     data,
     error: loadError,

--- a/shared/login/join-or-login.tsx
+++ b/shared/login/join-or-login.tsx
@@ -26,10 +26,12 @@ const Intro = () => {
   const [showing, setShowing] = React.useState(true)
   Kb.useInterval(loadIsOnline, showing ? 5000 : undefined)
 
-  C.Router2.useSafeFocusEffect(() => {
-    setShowing(true)
-    return () => setShowing(false)
-  })
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      setShowing(true)
+      return () => setShowing(false)
+    }, [])
+  )
 
   return (
     <Kb.Box2

--- a/shared/package.json
+++ b/shared/package.json
@@ -71,6 +71,8 @@
     "sync:kb-modules": "yarn run _helper sync-local-rnmodules",
     "test:e2e:desktop": "playwright test --config tests/e2e/electron/playwright.config.ts",
     "test:e2e:desktop:branch": "playwright test --config tests/e2e/electron/playwright.config.ts tests/e2e/electron/flows/team-member.test.ts && yarn test:e2e:desktop:report",
+    "test:e2e:desktop:flows": "playwright test --config tests/e2e/electron/playwright.config.ts --project=electron-flows",
+    "test:e2e:desktop:rpc": "yarn test:e2e:desktop:flows tests/e2e/electron/flows/teams-browse.test.ts tests/e2e/electron/flows/teams-inner.test.ts tests/e2e/electron/flows/teams-modals.test.ts tests/e2e/electron/flows/team-member.test.ts tests/e2e/electron/flows/team-wizard-channel.test.ts tests/e2e/electron/flows/chat-interactions.test.ts",
     "test:e2e:desktop:report": "node tests/e2e/generate-electron-report.mts && open tests/results/electron-report.html",
     "test:e2e:desktop:save-baseline": "node tests/e2e/generate-electron-report.mts --save-baseline",
     "test:e2e:ios": "bash tests/e2e/run-ios-appium-parallel.sh",

--- a/shared/people/container.tsx
+++ b/shared/people/container.tsx
@@ -435,7 +435,14 @@ const PeopleReloadable = () => {
 
   const onClickUser = (username: string) => navToProfile(username)
 
-  const onReload = (isRetry?: boolean) => getData(false, isRetry === true || !followSuggestions.length)
+  const reload = React.useEffectEvent((isRetry?: boolean) => {
+    getData(false, isRetry === true || !followSuggestions.length)
+  })
+  // frozen wrapper: effect-event identities change every render, and an unstable
+  // fn makes useSafeFocusEffect re-run (so re-reload) on every render while focused
+  const [onReload] = React.useState(() => (isRetry?: boolean) => {
+    reload(isRetry)
+  })
 
   C.Router2.useSafeFocusEffect(onReload)
   useEngineActionListener('keybase.1.homeUI.homeUIRefresh', () => {

--- a/shared/profile/generic/proofs-list.tsx
+++ b/shared/profile/generic/proofs-list.tsx
@@ -349,7 +349,7 @@ const runProofFlow = async (p: {
 const ProofsList = ({platform, reason = 'profile'}: Props) => {
   const currentUsername = useCurrentUserState(s => s.username)
   const {proofSuggestions} = useProofSuggestions()
-  const {loadProfile} = useTrackerProfile(currentUsername)
+  const {loadProfile} = useTrackerProfile(currentUsername, {loadOnMount: false})
   const registerCryptoAddress = C.useRPC(T.RPCGen.cryptocurrencyRegisterAddressRpcPromise)
   const isDarkMode = useColorScheme() === 'dark'
   const {clearModals, navigateAppend, navigateUp} = C.Router2

--- a/shared/profile/user/hooks.tsx
+++ b/shared/profile/user/hooks.tsx
@@ -62,9 +62,7 @@ const useUserData = (username: string) => {
     loadNonUserProfile,
     loadProfile,
     nonUserDetails,
-  } = useTrackerProfile(username, {
-    reloadOnFocus: true,
-  })
+  } = useTrackerProfile(username)
   const requestIDRef = React.useRef(0)
   const [sharedTeamsState, setSharedTeamsState] = React.useState<{
     teams?: ReadonlyArray<T.RPCChat.SharedTeam>

--- a/shared/profile/user/hooks.tsx
+++ b/shared/profile/user/hooks.tsx
@@ -57,6 +57,11 @@ const useUserData = (username: string) => {
   const usernameKey = username.toLowerCase()
   const userIsYou = username === myName
   const {proofSuggestions, reload: reloadProofSuggestions} = useProofSuggestions(userIsYou)
+  // Deliberately no reload on focus. An identify re-checks every proof, and each
+  // check is an outbound request to a third-party host that rate limits us, so
+  // navigating back to a profile screen that never unmounted is not worth a fresh
+  // one. The mount path, an explicit pull-to-refresh, and the tracking /
+  // userChanged notifications are what refresh this.
   const {
     details: d,
     loadNonUserProfile,

--- a/shared/profile/user/hooks.tsx
+++ b/shared/profile/user/hooks.tsx
@@ -1,5 +1,5 @@
 import * as C from '@/constants'
-import * as T from '@/constants/types'
+import type * as T from '@/constants/types'
 import {type BackgroundColorType} from '.'
 import * as React from 'react'
 import {useColorScheme} from 'react-native'
@@ -8,8 +8,7 @@ import {useCurrentUserState} from '@/stores/current-user'
 import {editAvatar} from '@/util/misc'
 import {useProofSuggestions} from '../use-proof-suggestions'
 import {useTrackerProfile} from '@/tracker/use-profile'
-import {RPCError} from '@/util/errors'
-import logger from '@/logger'
+import {useMutualTeams} from '@/util/use-mutual-teams'
 
 const headerBackgroundColorType = (
   state: T.Tracker.DetailsState,
@@ -21,34 +20,6 @@ const headerBackgroundColorType = (
     return 'blue'
   } else {
     return followThem ? 'green' : 'blue'
-  }
-}
-
-const loadSharedTeams = async (
-  requestUsernameKey: string,
-  requestID: number,
-  requestIDRef: {current: number},
-  setSharedTeamsState: (s: {teams?: ReadonlyArray<T.RPCChat.SharedTeam>; usernameKey: string}) => void
-) => {
-  try {
-    const res = await T.RPCChat.localGetMutualTeamsLocalRpcPromise(
-      {usernames: [requestUsernameKey]},
-      C.waitingKeyTrackerSharedTeams(requestUsernameKey)
-    )
-    if (requestIDRef.current !== requestID) {
-      return
-    }
-    const teams = res.teams ?? []
-    setSharedTeamsState({teams, usernameKey: requestUsernameKey})
-  } catch (error) {
-    if (requestIDRef.current !== requestID) {
-      return
-    }
-    if (error instanceof RPCError) {
-      logger.error(`Error loading shared teams: ${error.message}`)
-    } else {
-      logger.error('Error loading shared teams: non-RPC error', error)
-    }
   }
 }
 
@@ -68,29 +39,22 @@ const useUserData = (username: string) => {
     loadProfile,
     nonUserDetails,
   } = useTrackerProfile(username)
-  const requestIDRef = React.useRef(0)
-  const [sharedTeamsState, setSharedTeamsState] = React.useState<{
-    teams?: ReadonlyArray<T.RPCChat.SharedTeam>
-    usernameKey: string
-  }>({teams: undefined, usernameKey})
   const notAUser = d.state === 'notAUserYet'
 
-  React.useEffect(() => {
-    if (!myName || !username || username === myName || notAUser) {
-      return
-    }
-    const requestUsernameKey = usernameKey
-    const requestID = requestIDRef.current + 1
-    requestIDRef.current = requestID
-    C.ignorePromise(loadSharedTeams(requestUsernameKey, requestID, requestIDRef, setSharedTeamsState))
-    return () => {
-      if (requestIDRef.current === requestID) {
-        requestIDRef.current += 1
-      }
-    }
-  }, [d.guiID, myName, notAUser, username, usernameKey])
-
-  const sharedTeams = sharedTeamsState.usernameKey === usernameKey ? sharedTeamsState.teams : undefined
+  // shares one cache with the chat channel suggestor, keyed on the usernames:
+  // getMutualTeamsLocal localizes every conversation these users share and
+  // remotely refreshes each one's participants, so it must not run twice for the
+  // same person just because two surfaces want the answer
+  const sharedTeamsUsernames = React.useMemo(() => [usernameKey], [usernameKey])
+  const {loaded: sharedTeamsLoaded, teams: loadedSharedTeams} = useMutualTeams(
+    sharedTeamsUsernames,
+    C.waitingKeyTrackerSharedTeams(usernameKey),
+    !!myName && !!username && username !== myName && !notAUser,
+    d.guiID
+  )
+  // the shared-teams section distinguishes "not loaded yet" (spinner) from
+  // "loaded, none" (renders nothing), so keep undefined until it has landed
+  const sharedTeams = sharedTeamsLoaded ? loadedSharedTeams : undefined
 
   const commonProps = {
     _assertions: undefined,

--- a/shared/profile/user/index.tsx
+++ b/shared/profile/user/index.tsx
@@ -15,6 +15,7 @@ import {SiteIcon} from '../generic/site-icon'
 import useUserData from './hooks'
 import {LoadedTeamsListProvider} from '@/teams/use-teams-list'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
+import {registerExternalResetter} from '@/util/zustand'
 
 export type BackgroundColorType = 'red' | 'green' | 'blue'
 
@@ -565,6 +566,11 @@ const User = (props: {username: string}) => {
 }
 
 const usernameSelectedTab = new Map<string, Tab>()
+
+// module scope outlives sign-out; keyed by username
+registerExternalResetter('profile-user-selected-tab', () => {
+  usernameSelectedTab.clear()
+})
 
 const avatarSize = 128
 

--- a/shared/profile/user/teams/index.tsx
+++ b/shared/profile/user/teams/index.tsx
@@ -63,6 +63,9 @@ type TeamShowcaseProps = T.Tracker.TeamShowcase & {
 const TeamShowcase = (props: TeamShowcaseProps) => {
   const {name, isOpen} = props
   const {onClick, popup, popupAnchor} = useTeamInfoPopup({
+    // a profile can feature every team its owner is in; annotating them all up
+    // front is one expensive getAnnotatedTeam per row for a popup nobody opened
+    loadOnDemand: true,
     popupInfo: props,
     teamname: name,
   })

--- a/shared/profile/user/teams/use-team-info-popup.tsx
+++ b/shared/profile/user/teams/use-team-info-popup.tsx
@@ -27,11 +27,12 @@ const useTeamInfoPopup = ({loadOnDemand = false, popupInfo, teamID: initialTeamI
   const teamID = initialTeamID ?? teamNameToID.get(teamname) ?? T.Teams.noTeamID
   const teamLoadEnabled = !loadOnDemand || hasRequestedLoad
   const {loaded, loading: loadingTeam, teamDetails, teamMeta} = useLoadedTeam(teamID, teamLoadEnabled)
-  const hasLoadedTeam = teamMeta.teamname.length > 0
+  // `loaded`, not a non-empty teamname: useLoadedTeam seeds teamMeta from the cheap
+  // teams-list, so a team you're in looks named long before its details exist.
   const inTeam = teamMeta.role !== 'none'
-  const description = hasLoadedTeam ? teamDetails.description : (popupInfo?.description ?? '')
-  const isOpen = hasLoadedTeam ? teamDetails.settings.open : (popupInfo?.isOpen ?? false)
-  const membersCount = hasLoadedTeam ? teamDetails.members.size : (popupInfo?.membersCount ?? 0)
+  const description = loaded ? teamDetails.description : (popupInfo?.description ?? '')
+  const isOpen = loaded ? teamDetails.settings.open : (popupInfo?.isOpen ?? false)
+  const membersCount = loaded ? teamDetails.members.size : (popupInfo?.membersCount ?? 0)
 
   const onJoinTeam = React.useCallback(
     (teamname: string) => {
@@ -89,17 +90,23 @@ const useTeamInfoPopup = ({loadOnDemand = false, popupInfo, teamID: initialTeamI
   }, [loaded, loadingTeam, pendingOpen, showPopup])
 
   const onClick = React.useCallback(() => {
-    if (!loadOnDemand || teamID === T.Teams.noTeamID || hasLoadedTeam) {
+    if (!loadOnDemand || teamID === T.Teams.noTeamID || loaded) {
+      showPopup()
+      return
+    }
+    setHasRequestedLoad(true)
+    // popupInfo already carries everything the popup shows (it comes from the
+    // profile's showcase payload), so open now and let the load refine it
+    if (popupInfo) {
       showPopup()
       return
     }
     if (loadingTeam || pendingOpen) {
       return
     }
-    setHasRequestedLoad(true)
     hasSeenPendingLoadRef.current = false
     setPendingOpen(true)
-  }, [hasLoadedTeam, loadOnDemand, loadingTeam, pendingOpen, showPopup, teamID])
+  }, [loaded, loadOnDemand, loadingTeam, pendingOpen, popupInfo, showPopup, teamID])
 
   return {loadingTeam, onClick, pendingOpen, popup, popupAnchor}
 }

--- a/shared/router-v2/screen-layout-modal.desktop.tsx
+++ b/shared/router-v2/screen-layout-modal.desktop.tsx
@@ -86,12 +86,14 @@ export const ModalWrapper = (p: ModalWrapperProps) => {
 
   const [topMostModal, setTopMostModal] = React.useState(true)
 
-  C.Router2.useSafeFocusEffect(() => {
-    setTopMostModal(true)
-    return () => {
-      setTopMostModal(false)
-    }
-  })
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      setTopMostModal(true)
+      return () => {
+        setTopMostModal(false)
+      }
+    }, [])
+  )
 
   React.useEffect(() => {
     if (!topMostModal || overlayNoClose) return

--- a/shared/teams/channel/create-channels.tsx
+++ b/shared/teams/channel/create-channels.tsx
@@ -4,6 +4,7 @@ import * as Kb from '@/common-adapters'
 import * as T from '@/constants/types'
 import {RPCError} from '@/util/errors'
 import {CreateChannelsModal} from '../new-team/wizard/create-channels'
+import {invalidateTeamChannels} from '../common/team-channels-invalidation'
 import {useLoadedTeam} from '../team/use-loaded-team'
 
 type Props = {teamID: T.Teams.TeamID}
@@ -34,6 +35,7 @@ const submitChannels = async (
         C.waitingKeyTeamsCreateChannel(teamID)
       )
     }
+    invalidateTeamChannels(teamID)
     setSuccess(true)
     C.Router2.clearModals()
   } catch (error_) {

--- a/shared/teams/channel/index.tsx
+++ b/shared/teams/channel/index.tsx
@@ -23,6 +23,7 @@ import {LoadedTeamChannelsProvider} from '../common/use-loaded-team-channels'
 import {useUsersState} from '@/stores/users'
 import {LoadedTeamProvider, useLoadedTeam} from '../team/use-loaded-team'
 import {unboxRows, useInboxMetadataState} from '@/chat/inbox/metadata'
+import {registerExternalResetter} from '@/util/zustand'
 
 export type OwnProps = {
   teamID: T.Teams.TeamID
@@ -75,18 +76,24 @@ const useLoadDataForChannelPage = (
 }
 
 // keep track during session
-const lastSelectedTabs: {[T: string]: TabKey} = {}
+const lastSelectedTabs = new Map<T.Chat.ConversationIDKey, TabKey>()
 const defaultTab: TabKey = 'members'
+
+// module scope outlives sign-out; keyed by conversation, so the next user would
+// inherit the previous user's tab choices
+registerExternalResetter('teams-channel-index', () => {
+  lastSelectedTabs.clear()
+})
 
 const useTabsState = (
   conversationIDKey: T.Chat.ConversationIDKey,
   providedTab?: TabKey
 ): [TabKey, (t: TabKey) => void] => {
-  const defaultSelectedTab = lastSelectedTabs[conversationIDKey] ?? providedTab ?? defaultTab
+  const defaultSelectedTab = lastSelectedTabs.get(conversationIDKey) ?? providedTab ?? defaultTab
   const [selectedTab, setSelectedTab] = React.useState<TabKey>(defaultSelectedTab)
 
   React.useEffect(() => {
-    lastSelectedTabs[conversationIDKey] = selectedTab
+    lastSelectedTabs.set(conversationIDKey, selectedTab)
   }, [conversationIDKey, selectedTab])
 
   const prevConvIDRef = React.useRef(conversationIDKey)

--- a/shared/teams/common/channel-hooks.tsx
+++ b/shared/teams/common/channel-hooks.tsx
@@ -45,6 +45,10 @@ const allChannelMetasCaches = new Map<
 // module scope outlives sign-out, so the next user would be served the previous
 // user's channel metas for any team they happen to share
 registerExternalResetter('teams-all-channel-metas-caches', () => {
+  // dropping the map is not enough on its own: a consumer that is still mounted
+  // through the sign-out holds the cache object itself, so each one has to be
+  // emptied as well
+  allChannelMetasCaches.forEach((cache, teamID) => cache.reset(emptyChannelMetasData, teamID))
   allChannelMetasCaches.clear()
 })
 

--- a/shared/teams/common/channel-hooks.tsx
+++ b/shared/teams/common/channel-hooks.tsx
@@ -5,12 +5,19 @@ import * as React from 'react'
 import logger from '@/logger'
 import {ensureError} from '@/util/errors'
 import {useLoadedTeam} from '../team/use-loaded-team'
-import {createCachedResourceCache, type CachedResourceCache, useCachedResource} from '../use-cached-resource'
+import {
+  createCachedResourceCache,
+  type CachedResourceCache,
+  getCachedResourceCache,
+  useCachedResource,
+} from '../use-cached-resource'
 import {
   teamChannelsRPCParams,
   useLoadedTeamChannels,
   useReloadOnTeamChannelChanges,
 } from './use-loaded-team-channels'
+import {registerExternalResetter} from '@/util/zustand'
+import {registerTeamChannelsInvalidator} from './team-channels-invalidation'
 
 type ChannelMetasData = {
   channelMetas: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
@@ -18,6 +25,40 @@ type ChannelMetasData = {
 }
 
 const allChannelMetasReloadStaleMs = 5_000
+
+const emptyChannelMetas = new Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>()
+const emptyChannelParticipants = new Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>()
+const emptyChannelMetasData: ChannelMetasData = {
+  channelMetas: emptyChannelMetas,
+  channelParticipants: emptyChannelParticipants,
+}
+
+// One cache per team, shared by every consumer: getTLFConversations makes the
+// service localize (and remotely refresh participants for) every channel in the
+// team, so a per-instance cache turns each extra mount into a full refetch —
+// enough of them trips the server's chat rate limit on a big team.
+const allChannelMetasCaches = new Map<
+  T.Teams.TeamID,
+  CachedResourceCache<ChannelMetasData, T.Teams.TeamID>
+>()
+
+// module scope outlives sign-out, so the next user would be served the previous
+// user's channel metas for any team they happen to share
+registerExternalResetter('teams-all-channel-metas-caches', () => {
+  allChannelMetasCaches.clear()
+})
+
+const allChannelMetasInvalidationListeners = new Set<(teamID: T.Teams.TeamID) => void>()
+
+// This is the second shared cache of a team's channels, and channel create and
+// delete fire no teamChangedByID, so it needs the same explicit drop as
+// use-loaded-team-channels. Without it a create/delete leaves every
+// useAllChannelMetas consumer - the browse-channels modal, the channels widget,
+// the delete confirm itself - serving the pre-change list for the stale window.
+registerTeamChannelsInvalidator((teamID: T.Teams.TeamID) => {
+  allChannelMetasCaches.get(teamID)?.invalidate(teamID)
+  allChannelMetasInvalidationListeners.forEach(listener => listener(teamID))
+})
 
 // Filter bots out using team role info, isolate to only when related state changes
 export const useChannelParticipants = (
@@ -54,21 +95,20 @@ export const useAllChannelMetas = (
     teamMeta: {teamname},
   } = useLoadedTeam(teamID)
   const enabled = !dontCallRPC && !!teamname
-  const emptyChannelMetas = React.useMemo(
-    () => new Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>(),
-    []
+  const initialData = emptyChannelMetasData
+  // a dontCallRPC instance is disabled, and useCachedResource resets the cache it
+  // holds when disabled — give those their own throwaway cache so they can't wipe
+  // the shared one out from under a real loader
+  const [localCache] = React.useState<CachedResourceCache<ChannelMetasData, T.Teams.TeamID>>(() =>
+    createCachedResourceCache(initialData, teamID)
   )
-  const emptyChannelParticipants = React.useMemo(
-    () => new Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>(),
-    []
+  const sharedCache = React.useMemo(
+    () => getCachedResourceCache(allChannelMetasCaches, initialData, teamID),
+    [initialData, teamID]
   )
-  const initialData = React.useMemo(
-    () => ({channelMetas: emptyChannelMetas, channelParticipants: emptyChannelParticipants}),
-    [emptyChannelMetas, emptyChannelParticipants]
-  )
-  const [channelMetasCache] = React.useState<CachedResourceCache<ChannelMetasData, T.Teams.TeamID>>(
-    () => createCachedResourceCache(initialData, teamID)
-  )
+  // gate on `enabled`, not just dontCallRPC: an instance whose teamname has not
+  // resolved yet is also disabled, and would otherwise reset the shared cache
+  const channelMetasCache = enabled ? sharedCache : localCache
   const {data, loading, reload, clear} = useCachedResource({
     cache: channelMetasCache,
     cacheKey: teamID,
@@ -110,6 +150,22 @@ export const useAllChannelMetas = (
   })
 
   useReloadOnTeamChannelChanges(teamID, enabled, reload, () => clear(teamID))
+
+  // a mounted list must pick up a create/delete too, not just the next mount
+  React.useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    const listener = (invalidatedTeamID: T.Teams.TeamID) => {
+      if (invalidatedTeamID === teamID) {
+        void reload()
+      }
+    }
+    allChannelMetasInvalidationListeners.add(listener)
+    return () => {
+      allChannelMetasInvalidationListeners.delete(listener)
+    }
+  }, [enabled, teamID, reload])
 
   return {
     channelMetas: data.channelMetas,

--- a/shared/teams/common/channel-hooks.tsx
+++ b/shared/teams/common/channel-hooks.tsx
@@ -1,68 +1,6 @@
-import * as T from '@/constants/types'
-import * as C from '@/constants'
-import * as Chat from '@/constants/chat'
-import * as React from 'react'
-import logger from '@/logger'
-import {ensureError} from '@/util/errors'
+import type * as T from '@/constants/types'
 import {useLoadedTeam} from '../team/use-loaded-team'
-import {
-  createCachedResourceCache,
-  type CachedResourceCache,
-  getCachedResourceCache,
-  useCachedResource,
-} from '../use-cached-resource'
-import {
-  teamChannelsRPCParams,
-  useLoadedTeamChannels,
-  useReloadOnTeamChannelChanges,
-} from './use-loaded-team-channels'
-import {registerExternalResetter} from '@/util/zustand'
-import {registerTeamChannelsInvalidator} from './team-channels-invalidation'
-
-type ChannelMetasData = {
-  channelMetas: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
-  channelParticipants: Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>
-}
-
-const allChannelMetasReloadStaleMs = 5_000
-
-const emptyChannelMetas = new Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>()
-const emptyChannelParticipants = new Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>()
-const emptyChannelMetasData: ChannelMetasData = {
-  channelMetas: emptyChannelMetas,
-  channelParticipants: emptyChannelParticipants,
-}
-
-// One cache per team, shared by every consumer: getTLFConversations makes the
-// service localize (and remotely refresh participants for) every channel in the
-// team, so a per-instance cache turns each extra mount into a full refetch —
-// enough of them trips the server's chat rate limit on a big team.
-const allChannelMetasCaches = new Map<
-  T.Teams.TeamID,
-  CachedResourceCache<ChannelMetasData, T.Teams.TeamID>
->()
-
-// module scope outlives sign-out, so the next user would be served the previous
-// user's channel metas for any team they happen to share
-registerExternalResetter('teams-all-channel-metas-caches', () => {
-  // dropping the map is not enough on its own: a consumer that is still mounted
-  // through the sign-out holds the cache object itself, so each one has to be
-  // emptied as well
-  allChannelMetasCaches.forEach((cache, teamID) => cache.reset(emptyChannelMetasData, teamID))
-  allChannelMetasCaches.clear()
-})
-
-const allChannelMetasInvalidationListeners = new Set<(teamID: T.Teams.TeamID) => void>()
-
-// This is the second shared cache of a team's channels, and channel create and
-// delete fire no teamChangedByID, so it needs the same explicit drop as
-// use-loaded-team-channels. Without it a create/delete leaves every
-// useAllChannelMetas consumer - the browse-channels modal, the channels widget,
-// the delete confirm itself - serving the pre-change list for the stale window.
-registerTeamChannelsInvalidator((teamID: T.Teams.TeamID) => {
-  allChannelMetasCaches.get(teamID)?.invalidate(teamID)
-  allChannelMetasInvalidationListeners.forEach(listener => listener(teamID))
-})
+import {useLoadedTeamChannels} from './use-loaded-team-channels'
 
 // Filter bots out using team role info, isolate to only when related state changes
 export const useChannelParticipants = (
@@ -85,95 +23,28 @@ export const useChannelParticipants = (
   })
 }
 
+// The channel metas come from the same getTLFConversations result as the channel
+// list, so this is a view onto that one cache rather than a second loader.
 export const useAllChannelMetas = (
   teamID: T.Teams.TeamID,
   dontCallRPC?: boolean
 ): {
-  channelMetas: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
-  channelParticipants: Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>
+  channelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
+  channelParticipants: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>
   loadingChannels: boolean
   reloadChannels: () => Promise<void>
 } => {
-  const getConversations = C.useRPC(T.RPCChat.localGetTLFConversationsLocalRpcPromise)
   const {
     teamMeta: {teamname},
   } = useLoadedTeam(teamID)
-  const enabled = !dontCallRPC && !!teamname
-  const initialData = emptyChannelMetasData
-  // a dontCallRPC instance is disabled, and useCachedResource resets the cache it
-  // holds when disabled — give those their own throwaway cache so they can't wipe
-  // the shared one out from under a real loader
-  const [localCache] = React.useState<CachedResourceCache<ChannelMetasData, T.Teams.TeamID>>(() =>
-    createCachedResourceCache(initialData, teamID)
+  const {channelMetas, channelParticipants, loading, reload} = useLoadedTeamChannels(
+    teamID,
+    undefined,
+    !dontCallRPC
   )
-  const sharedCache = React.useMemo(
-    () => getCachedResourceCache(allChannelMetasCaches, initialData, teamID),
-    [initialData, teamID]
-  )
-  // gate on `enabled`, not just dontCallRPC: an instance whose teamname has not
-  // resolved yet is also disabled, and would otherwise reset the shared cache
-  const channelMetasCache = enabled ? sharedCache : localCache
-  const {data, loading, reload, clear} = useCachedResource({
-    cache: channelMetasCache,
-    cacheKey: teamID,
-    enabled,
-    initialData,
-    load: async () =>
-      new Promise<ChannelMetasData>((resolve, reject) => {
-        getConversations(
-          [teamChannelsRPCParams(teamname), C.waitingKeyTeamsGetChannels(teamID)],
-          ({convs}) => {
-            const channelMetas = new Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>()
-            const channelParticipants = new Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>()
-            const loadedConvs = convs ?? []
-            loadedConvs.forEach(conv => {
-              const meta = Chat.inboxUIItemToConversationMeta(conv)
-              if (!meta) {
-                return
-              }
-              const conversationIDKey = meta.conversationIDKey
-              channelMetas.set(conversationIDKey, meta)
-              channelParticipants.set(
-                conversationIDKey,
-                Chat.uiParticipantsToParticipantInfo(conv.participants ?? [])
-              )
-            })
-            resolve({
-              channelMetas,
-              channelParticipants,
-            })
-          },
-          error => reject(ensureError(error))
-        )
-      }),
-    onError: error => {
-      logger.warn(`Failed to load all channel metas for ${teamID}`, error)
-    },
-    refreshKey: teamname,
-    staleMs: allChannelMetasReloadStaleMs,
-  })
-
-  useReloadOnTeamChannelChanges(teamID, enabled, reload, () => clear(teamID))
-
-  // a mounted list must pick up a create/delete too, not just the next mount
-  React.useEffect(() => {
-    if (!enabled) {
-      return
-    }
-    const listener = (invalidatedTeamID: T.Teams.TeamID) => {
-      if (invalidatedTeamID === teamID) {
-        void reload()
-      }
-    }
-    allChannelMetasInvalidationListeners.add(listener)
-    return () => {
-      allChannelMetasInvalidationListeners.delete(listener)
-    }
-  }, [enabled, teamID, reload])
-
   return {
-    channelMetas: data.channelMetas,
-    channelParticipants: data.channelParticipants,
+    channelMetas,
+    channelParticipants,
     loadingChannels: (!dontCallRPC && !teamname) || loading,
     reloadChannels: reload,
   }

--- a/shared/teams/common/general-conv.tsx
+++ b/shared/teams/common/general-conv.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import * as T from '@/constants/types'
+import * as Meta from '@/constants/chat/meta'
+import {metasReceived} from '@/chat/inbox/metadata'
+import {registerExternalResetter} from '@/util/zustand'
+import {
+  type CachedResourceCache,
+  createCachedResourceCache,
+  getCachedResourceCache,
+  useCachedResource,
+} from '../use-cached-resource'
+
+type GeneralConvData = T.Chat.ConversationIDKey | undefined
+
+const noGeneralConv: GeneralConvData = undefined
+
+// A team's #general conversation does not move, but two screens ask for it - the
+// team rows and the bot install modal - and each used to hold the answer in its
+// own state, so every mount was another findGeneralConvFromTeamID. Share one
+// cache per team, and let it live a while since the answer is effectively static.
+const generalConvCaches = new Map<T.Teams.TeamID, CachedResourceCache<GeneralConvData, T.Teams.TeamID>>()
+const generalConvStaleMs = 5 * 60_000
+
+registerExternalResetter('teams-general-conv-caches', () => {
+  generalConvCaches.clear()
+})
+
+export const useGeneralConvIDKey = (teamID?: T.Teams.TeamID, enabled = true) => {
+  const validTeamID = teamID && teamID !== T.Teams.noTeamID ? teamID : undefined
+  const on = enabled && !!validTeamID
+  const cacheKey = validTeamID ?? T.Teams.noTeamID
+  // a disabled instance resets whatever cache it holds, so keep it off the shared one
+  const [localCache] = React.useState<CachedResourceCache<GeneralConvData, T.Teams.TeamID>>(() =>
+    createCachedResourceCache<GeneralConvData, T.Teams.TeamID>(noGeneralConv, cacheKey)
+  )
+  const sharedCache = React.useMemo(
+    () => getCachedResourceCache(generalConvCaches, noGeneralConv, cacheKey),
+    [cacheKey]
+  )
+  const {data} = useCachedResource({
+    cache: on ? sharedCache : localCache,
+    cacheKey,
+    enabled: on,
+    initialData: noGeneralConv,
+    load: async () => {
+      const conv = await T.RPCChat.localFindGeneralConvFromTeamIDRpcPromise({
+        teamID: validTeamID ?? T.Teams.noTeamID,
+      })
+      const meta = Meta.inboxUIItemToConversationMeta(conv)
+      if (!meta) {
+        return noGeneralConv
+      }
+      metasReceived([meta])
+      return meta.conversationIDKey
+    },
+    staleMs: generalConvStaleMs,
+  })
+  return data
+}

--- a/shared/teams/common/general-conv.tsx
+++ b/shared/teams/common/general-conv.tsx
@@ -21,7 +21,11 @@ const noGeneralConv: GeneralConvData = undefined
 const generalConvCaches = new Map<T.Teams.TeamID, CachedResourceCache<GeneralConvData, T.Teams.TeamID>>()
 const generalConvStaleMs = 5 * 60_000
 
+// module scope outlives sign-out. Dropping the map is not enough on its own: a
+// consumer that is still mounted through the sign-out holds the cache object
+// itself, so each one has to be emptied as well.
 registerExternalResetter('teams-general-conv-caches', () => {
+  generalConvCaches.forEach((cache, teamID) => cache.reset(noGeneralConv, teamID))
   generalConvCaches.clear()
 })
 
@@ -33,12 +37,14 @@ export const useGeneralConvIDKey = (teamID?: T.Teams.TeamID, enabled = true) => 
   const [localCache] = React.useState<CachedResourceCache<GeneralConvData, T.Teams.TeamID>>(() =>
     createCachedResourceCache<GeneralConvData, T.Teams.TeamID>(noGeneralConv, cacheKey)
   )
+  // an off instance must not seed the shared map: it never loads, so the entry it
+  // created would sit there empty for the life of the session
   const sharedCache = React.useMemo(
-    () => getCachedResourceCache(generalConvCaches, noGeneralConv, cacheKey),
-    [cacheKey]
+    () => (on ? getCachedResourceCache(generalConvCaches, noGeneralConv, cacheKey) : undefined),
+    [cacheKey, on]
   )
   const {data} = useCachedResource({
-    cache: on ? sharedCache : localCache,
+    cache: sharedCache ?? localCache,
     cacheKey,
     enabled: on,
     initialData: noGeneralConv,

--- a/shared/teams/common/team-channels-invalidation.tsx
+++ b/shared/teams/common/team-channels-invalidation.tsx
@@ -1,0 +1,23 @@
+import type * as T from '@/constants/types'
+
+type Invalidator = (teamID: T.Teams.TeamID) => void
+
+// Creating or deleting a channel fires no teamChangedByID, so the team channel
+// cache has to be dropped by hand. This indirection exists so the chat-side
+// create-channel screen can trigger it without importing anything from teams:
+// teams/common sits in a require cycle (channel-hooks -> @/constants ->
+// constants/router -> router-v2/routes -> chat/routes -> teams/common), and a
+// chat -> teams import there has broken team rendering on iOS before. Keep this
+// module a leaf: type-only imports.
+const invalidators = new Set<Invalidator>()
+
+export const registerTeamChannelsInvalidator = (invalidator: Invalidator) => {
+  invalidators.add(invalidator)
+  return () => {
+    invalidators.delete(invalidator)
+  }
+}
+
+export const invalidateTeamChannels = (teamID: T.Teams.TeamID) => {
+  invalidators.forEach(invalidator => invalidator(teamID))
+}

--- a/shared/teams/common/use-loaded-team-channels.tsx
+++ b/shared/teams/common/use-loaded-team-channels.tsx
@@ -4,6 +4,8 @@ import * as T from '@/constants/types'
 import {useEngineActionListener} from '@/engine/action-listener'
 import logger from '@/logger'
 import * as React from 'react'
+import {registerExternalResetter} from '@/util/zustand'
+import {registerTeamChannelsInvalidator} from './team-channels-invalidation'
 import {useLoadedTeam} from '../team/use-loaded-team'
 import {type CachedResourceCache, getCachedResourceCache, useCachedResource} from '../use-cached-resource'
 
@@ -25,7 +27,6 @@ type LoadedTeamChannelsCacheMap = Map<
 >
 
 const LoadedTeamChannelsContext = React.createContext<LoadedTeamChannelsContextValue | null>(null)
-const LoadedTeamChannelsCacheContext = React.createContext<LoadedTeamChannelsCacheMap | null>(null)
 const loadedTeamChannelsReloadStaleMs = 5_000
 
 const emptyChannels: ReadonlyMap<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo> = new Map()
@@ -39,20 +40,37 @@ const emptyLoadedTeamChannelsData: LoadedTeamChannelsData = {
   channels: emptyChannels,
 }
 
+// One map for every consumer. The stale window and the single-flight both live on
+// the cache object, so callers holding separate maps cannot see each other's
+// in-flight request and each issue their own getTLFConversationsLocal - which
+// localizes every channel in the team. Measured at 7 calls for one team inside
+// 1.5s before this was shared.
+const loadedTeamChannelsCache: LoadedTeamChannelsCacheMap = new Map()
+const loadedTeamChannelsInvalidationListeners = new Set<(teamID: T.Teams.TeamID | undefined) => void>()
+
+// module scope outlives sign-out and this is per-user team data
+registerExternalResetter('loaded-team-channels-cache', () => {
+  loadedTeamChannelsCache.forEach(cache => cache.reset(emptyLoadedTeamChannelsData, undefined))
+  loadedTeamChannelsCache.clear()
+})
+
+// While every consumer held a private cache a remount happened to refetch, which
+// is what the channel list relied on after a create. Sharing one cache means a
+// remount inside the stale window serves the pre-change channels instead, so the
+// create/delete screens have to drop this explicitly.
+registerTeamChannelsInvalidator((teamID: T.Teams.TeamID) => {
+  const key = loadableTeamID(teamID)
+  loadedTeamChannelsCache.get(key)?.invalidate(key)
+  loadedTeamChannelsInvalidationListeners.forEach(listener => listener(key))
+})
+
 // forceLocalCache: a disabled "shadow" instance (one that returns the context
 // value instead of its own) must NOT share the loader's cache map. With enabled=false
 // useCachedResource resets the cache (loadedAt=0), which would clobber the loader's
 // loaded data. Give shadows a private throwaway map so their resets are harmless.
-const useLoadedTeamChannelsCacheMap = (
-  providedCacheMap?: LoadedTeamChannelsCacheMap,
-  forceLocalCache = false
-) => {
-  const contextCacheMap = React.useContext(LoadedTeamChannelsCacheContext)
+const useLoadedTeamChannelsCacheMap = (forceLocalCache: boolean) => {
   const [localCacheMap] = React.useState<LoadedTeamChannelsCacheMap>(() => new Map())
-  if (forceLocalCache) {
-    return localCacheMap
-  }
-  return providedCacheMap ?? contextCacheMap ?? localCacheMap
+  return forceLocalCache ? localCacheMap : loadedTeamChannelsCache
 }
 
 export const teamChannelsRPCParams = (teamname: string) => ({
@@ -90,7 +108,6 @@ const useLoadedTeamChannelsRaw = (
   teamID: T.Teams.TeamID,
   providedTeamname?: string,
   enabled = true,
-  providedCacheMap?: LoadedTeamChannelsCacheMap,
   forceLocalCache = false
 ): LoadedTeamChannels => {
   const validTeamID = loadableTeamID(teamID)
@@ -98,7 +115,12 @@ const useLoadedTeamChannelsRaw = (
     teamMeta: {teamname: loadedTeamname},
   } = useLoadedTeam(teamID, enabled)
   const teamnameToLoad = providedTeamname || loadedTeamname
-  const cacheMap = useLoadedTeamChannelsCacheMap(providedCacheMap, forceLocalCache)
+  // useCachedResource resets whatever cache it holds while disabled, so a
+  // disabled instance must never hold the shared one — including the ordinary
+  // consumer whose teamname has not resolved yet, which would otherwise wipe a
+  // real loader's data mid-flight. Gate the cache on exactly the load condition.
+  const canLoad = enabled && !!validTeamID && !!teamnameToLoad
+  const cacheMap = useLoadedTeamChannelsCacheMap(forceLocalCache || !canLoad)
   const cache = React.useMemo(
     () => getCachedResourceCache(cacheMap, emptyLoadedTeamChannelsData, validTeamID),
     [cacheMap, validTeamID]
@@ -106,7 +128,7 @@ const useLoadedTeamChannelsRaw = (
   const {data, loading, reload, clear} = useCachedResource({
     cache,
     cacheKey: validTeamID,
-    enabled: enabled && !!validTeamID && !!teamnameToLoad,
+    enabled: canLoad,
     initialData: emptyLoadedTeamChannelsData,
     load: async () => {
       if (!teamnameToLoad) {
@@ -149,21 +171,39 @@ const useLoadedTeamChannelsRaw = (
 
   useReloadOnTeamChannelChanges(validTeamID, enabled, reload, () => clear(validTeamID))
 
-  return {...data, loading, reload}
+  // a mounted list must pick up an invalidation too, not just the next mount
+  React.useEffect(() => {
+    if (!enabled || !validTeamID) {
+      return
+    }
+    const listener = (invalidatedTeamID: T.Teams.TeamID | undefined) => {
+      if (invalidatedTeamID === validTeamID) {
+        void reload()
+      }
+    }
+    loadedTeamChannelsInvalidationListeners.add(listener)
+    return () => {
+      loadedTeamChannelsInvalidationListeners.delete(listener)
+    }
+  }, [enabled, validTeamID, reload])
+
+  const {channelParticipants, channels} = data
+  return React.useMemo(
+    () => ({channelParticipants, channels, loading, reload}),
+    [channelParticipants, channels, loading, reload]
+  )
 }
 
 export const LoadedTeamChannelsProvider = (
   props: React.PropsWithChildren<{teamID: T.Teams.TeamID; teamname?: string}>
 ) => {
   const {children, teamID, teamname} = props
-  const [cacheMap] = React.useState<LoadedTeamChannelsCacheMap>(() => new Map())
-  const loadedTeamChannels = useLoadedTeamChannelsRaw(teamID, teamname, true, cacheMap)
-  const value = {...loadedTeamChannels, teamID}
-  return (
-    <LoadedTeamChannelsCacheContext.Provider value={cacheMap}>
-      <LoadedTeamChannelsContext.Provider value={value}>{children}</LoadedTeamChannelsContext.Provider>
-    </LoadedTeamChannelsCacheContext.Provider>
+  const loadedTeamChannels = useLoadedTeamChannelsRaw(teamID, teamname, true)
+  const value = React.useMemo(
+    () => ({...loadedTeamChannels, teamID}),
+    [loadedTeamChannels, teamID]
   )
+  return <LoadedTeamChannelsContext.Provider value={value}>{children}</LoadedTeamChannelsContext.Provider>
 }
 
 export const useLoadedTeamChannels = (
@@ -172,7 +212,7 @@ export const useLoadedTeamChannels = (
 ): LoadedTeamChannels => {
   const context = React.useContext(LoadedTeamChannelsContext)
   const useContextValue = context?.teamID === teamID
-  const raw = useLoadedTeamChannelsRaw(teamID, teamname, !useContextValue, undefined, useContextValue)
+  const raw = useLoadedTeamChannelsRaw(teamID, teamname, !useContextValue, useContextValue)
   return useContextValue ? context : raw
 }
 

--- a/shared/teams/common/use-loaded-team-channels.tsx
+++ b/shared/teams/common/use-loaded-team-channels.tsx
@@ -2,6 +2,7 @@ import * as C from '@/constants'
 import * as Chat from '@/constants/chat'
 import * as T from '@/constants/types'
 import {useEngineActionListener} from '@/engine/action-listener'
+import isEqual from 'lodash/isEqual'
 import logger from '@/logger'
 import * as React from 'react'
 import {registerExternalResetter} from '@/util/zustand'
@@ -41,6 +42,27 @@ const loadedTeamChannelsReloadStaleMs = 5_000
 const emptyChannels: ReadonlyMap<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo> = new Map()
 const emptyChannelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta> = new Map()
 const emptyChannelParticipants: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo> = new Map()
+
+// teamChangedByID fires for every incoming message in a team and reloads this,
+// and the result is nearly always identical to what is already cached. A fresh
+// Map each time gives the memo below a new identity, which wakes every consumer
+// of the context value - the cost this shared cache exists to remove. Reuse the
+// previous Map when nothing changed, and the previous entries when only some
+// did, so downstream memos can bail too.
+const recycleMap = <K, V>(old: ReadonlyMap<K, V>, next: Map<K, V>): ReadonlyMap<K, V> => {
+  let unchanged = old.size === next.size
+  for (const [key, value] of next) {
+    const previous = old.get(key)
+    if (previous !== undefined && isEqual(previous, value)) {
+      if (previous !== value) {
+        next.set(key, previous)
+      }
+    } else {
+      unchanged = false
+    }
+  }
+  return unchanged ? old : next
+}
 
 const loadableTeamID = (teamID: T.Teams.TeamID) =>
   teamID && teamID !== T.Teams.noTeamID && teamID !== T.Teams.newTeamWizardTeamID ? teamID : undefined
@@ -171,11 +193,19 @@ const useLoadedTeamChannelsRaw = (
         }
       }
 
-      return {
-        channelMetas,
-        channelParticipants,
-        channels,
+      const previous = cache.getData()
+      const recycled = {
+        channelMetas: recycleMap(previous.channelMetas, channelMetas),
+        channelParticipants: recycleMap(previous.channelParticipants, channelParticipants),
+        channels: recycleMap(previous.channels, channels),
       }
+      // nothing moved at all: hand back the very object the cache already holds,
+      // so useCachedResource settles without a state change
+      return recycled.channelMetas === previous.channelMetas &&
+        recycled.channelParticipants === previous.channelParticipants &&
+        recycled.channels === previous.channels
+        ? previous
+        : recycled
     },
     onError: error => {
       logger.warn(`Failed to load team channels for ${validTeamID}`, error)

--- a/shared/teams/common/use-loaded-team-channels.tsx
+++ b/shared/teams/common/use-loaded-team-channels.tsx
@@ -11,6 +11,12 @@ import {type CachedResourceCache, getCachedResourceCache, useCachedResource} fro
 
 type LoadedTeamChannels = {
   channels: ReadonlyMap<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo>
+  // the full meta for each channel, derived from the same getTLFConversations
+  // result. This used to be a second module cache issuing the same RPC with the
+  // same arguments, which the two caches could not dedupe between - measured as
+  // pairs of identical calls microseconds apart, each fanning out to one remote
+  // participant refresh per channel in the team.
+  channelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
   channelParticipants: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>
   loading: boolean
   reload: () => Promise<void>
@@ -20,7 +26,10 @@ type LoadedTeamChannelsContextValue = LoadedTeamChannels & {
   teamID: T.Teams.TeamID
 }
 
-type LoadedTeamChannelsData = Pick<LoadedTeamChannels, 'channels' | 'channelParticipants'>
+type LoadedTeamChannelsData = Pick<
+  LoadedTeamChannels,
+  'channels' | 'channelMetas' | 'channelParticipants'
+>
 type LoadedTeamChannelsCacheMap = Map<
   T.Teams.TeamID | undefined,
   CachedResourceCache<LoadedTeamChannelsData, T.Teams.TeamID | undefined>
@@ -30,12 +39,14 @@ const LoadedTeamChannelsContext = React.createContext<LoadedTeamChannelsContextV
 const loadedTeamChannelsReloadStaleMs = 5_000
 
 const emptyChannels: ReadonlyMap<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo> = new Map()
+const emptyChannelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta> = new Map()
 const emptyChannelParticipants: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo> = new Map()
 
 const loadableTeamID = (teamID: T.Teams.TeamID) =>
   teamID && teamID !== T.Teams.noTeamID && teamID !== T.Teams.newTeamWizardTeamID ? teamID : undefined
 
 const emptyLoadedTeamChannelsData: LoadedTeamChannelsData = {
+  channelMetas: emptyChannelMetas,
   channelParticipants: emptyChannelParticipants,
   channels: emptyChannels,
 }
@@ -140,24 +151,28 @@ const useLoadedTeamChannelsRaw = (
         teamChannelsRPCParams(teamname),
         C.waitingKeyTeamsGetChannels(teamIDToLoad)
       )
+      const channels = new Map<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo>()
+      const channelMetas = new Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>()
       const channelParticipants = new Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>()
-      const channels =
-        convs?.reduce((res, inboxUIItem) => {
-          const conversationIDKey = T.Chat.stringToConversationIDKey(inboxUIItem.convID)
-          res.set(conversationIDKey, {
-            channelname: inboxUIItem.channel,
-            conversationIDKey,
-            description: inboxUIItem.headline,
-          })
-          channelParticipants.set(
-            conversationIDKey,
-            Chat.uiParticipantsToParticipantInfo(inboxUIItem.participants ?? [])
-          )
-          return res
-        }, new Map<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo>()) ??
-        new Map<T.Chat.ConversationIDKey, T.Teams.TeamChannelInfo>()
+      for (const inboxUIItem of convs ?? []) {
+        const conversationIDKey = T.Chat.stringToConversationIDKey(inboxUIItem.convID)
+        channels.set(conversationIDKey, {
+          channelname: inboxUIItem.channel,
+          conversationIDKey,
+          description: inboxUIItem.headline,
+        })
+        channelParticipants.set(
+          conversationIDKey,
+          Chat.uiParticipantsToParticipantInfo(inboxUIItem.participants ?? [])
+        )
+        const meta = Chat.inboxUIItemToConversationMeta(inboxUIItem)
+        if (meta) {
+          channelMetas.set(meta.conversationIDKey, meta)
+        }
+      }
 
       return {
+        channelMetas,
         channelParticipants,
         channels,
       }
@@ -187,10 +202,10 @@ const useLoadedTeamChannelsRaw = (
     }
   }, [enabled, validTeamID, reload])
 
-  const {channelParticipants, channels} = data
+  const {channelMetas, channelParticipants, channels} = data
   return React.useMemo(
-    () => ({channelParticipants, channels, loading, reload}),
-    [channelParticipants, channels, loading, reload]
+    () => ({channelMetas, channelParticipants, channels, loading, reload}),
+    [channelMetas, channelParticipants, channels, loading, reload]
   )
 }
 
@@ -208,11 +223,14 @@ export const LoadedTeamChannelsProvider = (
 
 export const useLoadedTeamChannels = (
   teamID: T.Teams.TeamID,
-  teamname?: string
+  teamname?: string,
+  enabled = true
 ): LoadedTeamChannels => {
   const context = React.useContext(LoadedTeamChannelsContext)
+  // a disabled consumer still reads a provider's already-loaded value when there
+  // is one - it only must not issue a load of its own
   const useContextValue = context?.teamID === teamID
-  const raw = useLoadedTeamChannelsRaw(teamID, teamname, !useContextValue, useContextValue)
+  const raw = useLoadedTeamChannelsRaw(teamID, teamname, enabled && !useContextValue, useContextValue)
   return useContextValue ? context : raw
 }
 

--- a/shared/teams/confirm-modals/delete-channel.tsx
+++ b/shared/teams/confirm-modals/delete-channel.tsx
@@ -5,6 +5,7 @@ import * as T from '@/constants/types'
 import {useNavigation} from '@react-navigation/native'
 import {pluralize} from '@/util/string'
 import setRouteParamsIfPresent from './set-route-params-if-present'
+import {invalidateTeamChannels} from '@/teams/common/team-channels-invalidation'
 import {useAllChannelMetas} from '@/teams/common/channel-hooks'
 
 type Props = {
@@ -77,11 +78,12 @@ const DeleteChannel = (props: Props) => {
       for (const channelID of channelIDs) {
         await deleteChannel(channelID)
       }
+      invalidateTeamChannels(teamID)
       setRouteParamsIfPresent(navigation, 'team', {selectedChannels: undefined})
       C.Router2.clearModals()
     }
     C.ignorePromise(f())
-  }, [channelIDs, deleteChannel, navigation])
+  }, [channelIDs, deleteChannel, navigation, teamID])
 
   return (
     <Kb.ConfirmModal

--- a/shared/teams/team/index.tsx
+++ b/shared/teams/team/index.tsx
@@ -24,6 +24,7 @@ import {
 } from './rows'
 import {teamSeen} from '@/teams/actions'
 import * as TestIDs from '@/tests/e2e/shared/test-ids'
+import {registerExternalResetter} from '@/util/zustand'
 
 type Props = {
   teamID: T.Teams.TeamID
@@ -36,6 +37,12 @@ type Props = {
 // keep track during session
 const lastSelectedTabs = new Map<string, T.Teams.TabKey>()
 const defaultTab: T.Teams.TabKey = 'members'
+
+// module scope outlives sign-out; keyed by team, so the next user would inherit
+// the previous user's tab choices
+registerExternalResetter('teams-team-index', () => {
+  lastSelectedTabs.clear()
+})
 
 const getSettingsErrorWaitingKeys = (teamID: T.Teams.TeamID) =>
   [
@@ -127,16 +134,24 @@ const TeamBody = (props: Props) => {
 
   const {loading: loadingTeam, teamDetails, teamMeta, yourOperations} = useLoadedTeam(teamID)
 
-  C.Router2.useSafeFocusEffect(() => {
-    return () => teamSeen(teamID)
-  })
-  C.Router2.useSafeFocusEffect(() => {
-    return () => {
-      if (props.justFinishedAddWizard) {
-        clearJustFinishedAddWizard()
+  // useSafeFocusEffect re-runs (and so runs its cleanup) whenever the callback
+  // identity changes, so an inline callback here would fire the gregor dismiss
+  // RPC on every render of this screen
+  const justFinishedAddWizard = props.justFinishedAddWizard
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      return () => teamSeen(teamID)
+    }, [teamID])
+  )
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      return () => {
+        if (justFinishedAddWizard) {
+          clearJustFinishedAddWizard()
+        }
       }
-    }
-  })
+    }, [justFinishedAddWizard, clearJustFinishedAddWizard])
+  )
 
   const {channels, loading: loadingChannels} = useLoadedTeamChannels(teamID, teamMeta.teamname)
 

--- a/shared/teams/team/member/add-to-channels.tsx
+++ b/shared/teams/team/member/add-to-channels.tsx
@@ -42,8 +42,8 @@ const canonChannelItem = (channelMeta: T.Chat.ConversationMeta, participants: Ar
 }
 
 const getChannelsForList = (
-  channels: Map<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>,
-  channelParticipants: Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>,
+  channels: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>,
+  channelParticipants: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>,
   // Team channel participants arrive asynchronously via the ChatParticipantsInfo
   // notification (stored here), not in the getTLFConversations RPC result.
   inboxParticipants: T.Immutable<Map<T.Chat.ConversationIDKey, T.Chat.ParticipantInfo>>,

--- a/shared/teams/team/member/edit-channel.tsx
+++ b/shared/teams/team/member/edit-channel.tsx
@@ -3,6 +3,7 @@ import * as Kb from '@/common-adapters'
 import * as React from 'react'
 import * as T from '@/constants/types'
 import {useSafeNavigation} from '@/util/safe-navigation'
+import {invalidateTeamChannels} from '@/teams/common/team-channels-invalidation'
 import {useLoadedTeam} from '../use-loaded-team'
 
 type Props = {
@@ -73,6 +74,12 @@ const EditChannel = (props: Props) => {
     ]
     Promise.all(ps)
       .then(() => {
+        // renaming a channel or editing its description fires no
+        // teamChangedByID, so the shared channel caches would keep serving the
+        // old name and description for their stale window
+        if (ps.length) {
+          invalidateTeamChannels(teamID)
+        }
         nav.safeNavigateUp()
       })
       .catch(() => {})

--- a/shared/teams/team/rows/index.tsx
+++ b/shared/teams/team/rows/index.tsx
@@ -1,8 +1,8 @@
 import * as C from '@/constants'
-import * as Meta from '@/constants/chat/meta'
 import * as T from '@/constants/types'
 import type * as Kb from '@/common-adapters'
 import * as React from 'react'
+import {useGeneralConvIDKey} from '@/teams/common/general-conv'
 import EmptyRow from './empty-row'
 import LoadingRow from './loading'
 import MemberRow from './member-row'
@@ -23,7 +23,6 @@ import {getOrderedMemberArray, sortInvites, getOrderedBotsArray} from './helpers
 import {useEmojiState} from '../../emojis/use-emoji'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useTeamsListMap} from '@/teams/use-teams-list'
-import {metasReceived} from '@/chat/inbox/metadata'
 
 export type Item =
   | {type: 'members-loading'}
@@ -287,49 +286,8 @@ export const useSubteamsSections = (
   return sections
 }
 
-const useGeneralConversationIDKey = (teamID?: T.Teams.TeamID) => {
-  const [conversationIDKeyResult, setConversationIDKeyResult] = React.useState<
-    {conversationIDKey: T.Chat.ConversationIDKey; teamID: T.Teams.TeamID} | undefined
-  >()
-  const findGeneralConvIDFromTeamID = C.useRPC(T.RPCChat.localFindGeneralConvFromTeamIDRpcPromise)
-  const requestIDRef = React.useRef(0)
-  const conversationIDKey =
-    conversationIDKeyResult && conversationIDKeyResult.teamID === teamID
-      ? conversationIDKeyResult.conversationIDKey
-      : undefined
-
-  React.useEffect(() => {
-    if (conversationIDKey || !teamID) {
-      return
-    }
-    requestIDRef.current += 1
-    const requestID = requestIDRef.current
-    findGeneralConvIDFromTeamID(
-      [{teamID}],
-      conv => {
-        if (requestIDRef.current !== requestID) {
-          return
-        }
-        const meta = Meta.inboxUIItemToConversationMeta(conv)
-        if (!meta) {
-          return
-        }
-        metasReceived([meta])
-        setConversationIDKeyResult({conversationIDKey: meta.conversationIDKey, teamID})
-      },
-      () => {}
-    )
-    return () => {
-      if (requestIDRef.current === requestID) {
-        requestIDRef.current += 1
-      }
-    }
-  }, [conversationIDKey, findGeneralConvIDFromTeamID, teamID])
-  return conversationIDKey
-}
-
 export const useEmojiSections = (teamID: T.Teams.TeamID, shouldActuallyLoad: boolean): Array<Section> => {
-  const convID = useGeneralConversationIDKey(teamID)
+  const convID = useGeneralConvIDKey(teamID)
   const getUserEmoji = C.useRPC(T.RPCChat.localUserEmojisRpcPromise)
   const [customEmoji, setCustomEmoji] = React.useState<T.RPCChat.Emoji[]>([])
   const [filter, setFilter] = React.useState('')

--- a/shared/teams/team/settings-tab/default-channels.tsx
+++ b/shared/teams/team/settings-tab/default-channels.tsx
@@ -2,107 +2,68 @@ import * as C from '@/constants'
 import * as React from 'react'
 import * as Kb from '@/common-adapters'
 import * as T from '@/constants/types'
-import type {RPCError} from '@/util/errors'
-import {produce} from 'immer'
+import logger from '@/logger'
+import {registerExternalResetter} from '@/util/zustand'
 import {ChannelsWidget} from '@/teams/common'
 import {useLoadedTeam} from '../use-loaded-team'
+import {type CachedResourceCache, getCachedResourceCache, useCachedResource} from '../../use-cached-resource'
 
 type Props = {
   teamID: T.Teams.TeamID
 }
 
-export const useDefaultChannels = (teamID: T.Teams.TeamID) => {
-  type DefaultChannelsState = {
-    defaultChannels: Array<T.Teams.ChannelNameID>
-    error?: RPCError
-    loadedTeamID?: T.Teams.TeamID
-    waiting: boolean
+type DefaultChannelsData = ReadonlyArray<T.Teams.ChannelNameID>
+
+const defaultChannelsStaleMs = 5_000
+const emptyDefaultChannels: DefaultChannelsData = []
+
+// One cache per team, shared by every consumer: each load is a remote
+// chat.1.remote.getDefaultTeamChannels round trip, so a per-instance cache turns
+// every extra mount of the settings tab into another hit on the chat rate limit.
+const defaultChannelsCaches = new Map<
+  T.Teams.TeamID,
+  CachedResourceCache<DefaultChannelsData, T.Teams.TeamID>
+>()
+
+// module scope outlives sign-out, so the next user would inherit this user's channels
+registerExternalResetter('teams-default-channels-caches', () => {
+  defaultChannelsCaches.clear()
+})
+
+// resolve rather than reject on failure: consumers render an empty list (and no
+// spinner) on error, and a cached failure keeps a broken team from re-requesting
+// on every render. Module scope, not inline in the hook: a try/catch wrapping a
+// value block is a react-compiler bailout.
+const loadDefaultChannels = async (teamID: T.Teams.TeamID): Promise<DefaultChannelsData> => {
+  try {
+    const {convs} = await T.RPCChat.localGetDefaultTeamChannelsLocalRpcPromise({teamID})
+    return [
+      {channelname: 'general', conversationIDKey: 'unused'},
+      ...(convs ?? []).map(conv => ({channelname: conv.channel, conversationIDKey: conv.convID})),
+    ]
+  } catch (error) {
+    logger.warn(`Failed to load default channels for ${teamID}`, error)
+    return emptyDefaultChannels
   }
+}
 
-  const getDefaultChannelsRPC = C.useRPC(T.RPCChat.localGetDefaultTeamChannelsLocalRpcPromise)
-  const [state, setState] = React.useState<DefaultChannelsState>({
-    defaultChannels: [],
-    error: undefined,
-    loadedTeamID: teamID,
-    waiting: true,
+export const useDefaultChannels = (teamID: T.Teams.TeamID) => {
+  const cache = React.useMemo(
+    () => getCachedResourceCache(defaultChannelsCaches, emptyDefaultChannels, teamID),
+    [teamID]
+  )
+  const {data, loaded, loading, reload} = useCachedResource({
+    cache,
+    cacheKey: teamID,
+    initialData: emptyDefaultChannels,
+    load: async () => await loadDefaultChannels(teamID),
+    staleMs: defaultChannelsStaleMs,
   })
-  const requestVersionRef = React.useRef(0)
-  const requestTeamIDRef = React.useRef(teamID)
-
-  // no synchronous setState here so the mount effect below can call it directly;
-  // initial/mismatched-team state already shows waiting
-  const load = React.useCallback(() => {
-    const requestVersion = ++requestVersionRef.current
-    getDefaultChannelsRPC(
-      [{teamID}],
-      result => {
-        if (requestVersion !== requestVersionRef.current) {
-          return
-        }
-        setState({
-          defaultChannels: [
-            {channelname: 'general', conversationIDKey: 'unused'},
-            ...(result.convs || []).map(conv => ({
-              channelname: conv.channel,
-              conversationIDKey: conv.convID,
-            })),
-          ],
-          error: undefined,
-          loadedTeamID: teamID,
-          waiting: false,
-        })
-      },
-      err => {
-        if (requestVersion !== requestVersionRef.current) {
-          return
-        }
-        setState(
-          produce(draft => {
-            draft.error = err
-            draft.loadedTeamID = teamID
-            draft.waiting = false
-          })
-        )
-      }
-    )
-  }, [getDefaultChannelsRPC, teamID])
-
-  const reloadDefaultChannels = React.useCallback(() => {
-    setState(
-      produce(draft => {
-        draft.error = undefined
-        draft.waiting = true
-      })
-    )
-    load()
-  }, [load])
-
-  React.useEffect(() => {
-    if (requestTeamIDRef.current !== teamID) {
-      requestTeamIDRef.current = teamID
-      requestVersionRef.current++
-    }
-  }, [teamID])
-
-  React.useEffect(() => {
-    load()
-  }, [load])
-
-  const visibleState =
-    state.loadedTeamID === teamID
-      ? state
-      : {
-          defaultChannels: [] as Array<T.Teams.ChannelNameID>,
-          error: undefined,
-          loadedTeamID: teamID,
-          waiting: true,
-        }
 
   return {
-    defaultChannels: visibleState.defaultChannels,
-    defaultChannelsWaiting: visibleState.waiting,
-    error: visibleState.error,
-    reloadDefaultChannels,
+    defaultChannels: data,
+    defaultChannelsWaiting: loading || !loaded,
+    reloadDefaultChannels: reload,
   }
 }
 
@@ -125,7 +86,7 @@ const DefaultChannels = (props: Props) => {
       [{convs, teamID}],
       () => {
         setWaiting(false)
-        reloadDefaultChannels()
+        void reloadDefaultChannels()
       },
       error => {
         setWaiting(false)
@@ -145,7 +106,7 @@ const DefaultChannels = (props: Props) => {
         [{convs, teamID}],
         () => {
           setWaiting(false)
-          reloadDefaultChannels()
+          void reloadDefaultChannels()
         },
         error => {
           setWaiting(false)

--- a/shared/teams/team/settings-tab/index.tsx
+++ b/shared/teams/team/settings-tab/index.tsx
@@ -8,7 +8,6 @@ import {pluralize} from '@/util/string'
 import type {RPCError} from '@/util/errors'
 import RetentionPicker from './retention'
 import DefaultChannels from './default-channels'
-import isEqual from 'lodash/isEqual'
 import {useLoadedTeam} from '../use-loaded-team'
 import {useIsBigTeam} from '../../common/use-loaded-team-channels'
 import {useSettingsTabState} from './use-settings'
@@ -138,7 +137,6 @@ const OpenTeam = (props: {
                 Anyone will be able to join immediately. Users will join as
               </Kb.Text>
               <FloatingRolePicker
-
                 onConfirm={props.onConfirmRolePicker}
                 onCancel={props.onCancelRolePicker}
                 position="bottom center"
@@ -189,45 +187,69 @@ const Settings = (p: Props) => {
   const {error, savePublicity, isBigTeam, teamID, yourOperations, teamname, showOpenTeamWarning} = p
   const {canShowcase, allowOpenTrigger} = p
 
-  const [newPublicityAnyMember, setNewPublicityAnyMember] = React.useState(p.publicityAnyMember)
-  const [newPublicityTeam, setNewPublicityTeam] = React.useState(p.publicityTeam)
-  const [newIgnoreAccessRequests, setNewIgnoreAccessRequests] = React.useState(p.ignoreAccessRequests)
-  const [newPublicityMember, setNewPublicityMember] = React.useState(p.publicityMember)
+  const serverSettings = {
+    ignoreAccessRequests: p.ignoreAccessRequests,
+    openTeam: p.openTeam,
+    openTeamRole: p.openTeamRole,
+    publicityAnyMember: p.publicityAnyMember,
+    publicityMember: p.publicityMember,
+    publicityTeam: p.publicityTeam,
+  }
+  // resync the checkboxes whenever the server-side values change. Doing this in
+  // render instead of with a key on this component matters: a key would remount the
+  // whole subtree, and RetentionPicker / DefaultChannels each load over RPC on mount.
+  const serverKey = `${p.ignoreAccessRequests}:${p.openTeam}:${p.openTeamRole}:${p.publicityAnyMember}:${p.publicityMember}:${p.publicityTeam}`
+  const [local, setLocal] = React.useState({...serverSettings, serverKey})
   const [isRolePickerOpen, setIsRolePickerOpen] = React.useState(false)
-  const [newOpenTeam, setNewOpenTeam] = React.useState(p.openTeam)
-  const [newOpenTeamRole, setNewOpenTeamRole] = React.useState<T.Teams.TeamRoleType>(p.openTeamRole)
 
   const lastAllowOpenTriggerRef = React.useRef(allowOpenTrigger)
 
-  React.useEffect(() => {
-    if (lastAllowOpenTriggerRef.current !== allowOpenTrigger) {
-      lastAllowOpenTriggerRef.current = allowOpenTrigger
-      setNewOpenTeam(o => !o)
-    }
-  }, [allowOpenTrigger])
+  if (local.serverKey !== serverKey) {
+    setLocal({...serverSettings, serverKey})
+  }
 
-  const lastSave = React.useRef({
+  const {
     ignoreAccessRequests: newIgnoreAccessRequests,
     openTeam: newOpenTeam,
     openTeamRole: newOpenTeamRole,
     publicityAnyMember: newPublicityAnyMember,
     publicityMember: newPublicityMember,
     publicityTeam: newPublicityTeam,
-  })
-  React.useEffect(() => {
-    const next = {
-      ignoreAccessRequests: newIgnoreAccessRequests,
-      openTeam: newOpenTeam,
-      openTeamRole: newOpenTeamRole,
-      publicityAnyMember: newPublicityAnyMember,
-      publicityMember: newPublicityMember,
-      publicityTeam: newPublicityTeam,
-    }
-    if (!isEqual(next, lastSave.current)) {
-      lastSave.current = next
+    serverKey: localServerKey,
+  } = local
+
+  const applySettings = React.useCallback(
+    (changes: Partial<T.Teams.PublicitySettings>) => {
+      const next: T.Teams.PublicitySettings = {
+        ignoreAccessRequests: newIgnoreAccessRequests,
+        openTeam: newOpenTeam,
+        openTeamRole: newOpenTeamRole,
+        publicityAnyMember: newPublicityAnyMember,
+        publicityMember: newPublicityMember,
+        publicityTeam: newPublicityTeam,
+        ...changes,
+      }
+      setLocal({...next, serverKey: localServerKey})
       savePublicity(next)
+    },
+    [
+      localServerKey,
+      newIgnoreAccessRequests,
+      newOpenTeam,
+      newOpenTeamRole,
+      newPublicityAnyMember,
+      newPublicityMember,
+      newPublicityTeam,
+      savePublicity,
+    ]
+  )
+
+  React.useEffect(() => {
+    if (lastAllowOpenTriggerRef.current !== allowOpenTrigger) {
+      lastAllowOpenTriggerRef.current = allowOpenTrigger
+      applySettings({openTeam: !newOpenTeam})
     }
-  }, [savePublicity, newIgnoreAccessRequests, newOpenTeam, newOpenTeamRole, newPublicityAnyMember, newPublicityMember, newPublicityTeam])
+  }, [allowOpenTrigger, applySettings, newOpenTeam])
 
   return (
     <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.outerBox}>
@@ -237,7 +259,7 @@ const Settings = (p: Props) => {
           yourOperationsJoinTeam={yourOperations.joinTeam}
           canShowcase={canShowcase}
           newPublicityMember={newPublicityMember}
-          setNewPublicityMember={setNewPublicityMember}
+          setNewPublicityMember={publicityMember => applySettings({publicityMember})}
         />
         {(yourOperations.changeOpenTeam ||
           yourOperations.setTeamShowcase ||
@@ -249,11 +271,14 @@ const Settings = (p: Props) => {
             {yourOperations.setPublicityAny ? (
               <PublicityAnyMember
                 newPublicityAnyMember={newPublicityAnyMember}
-                setNewPublicityAnyMember={setNewPublicityAnyMember}
+                setNewPublicityAnyMember={publicityAnyMember => applySettings({publicityAnyMember})}
               />
             ) : null}
             {yourOperations.setTeamShowcase ? (
-              <PublicityTeam newPublicityTeam={newPublicityTeam} setNewPublicityTeam={setNewPublicityTeam} />
+              <PublicityTeam
+                newPublicityTeam={newPublicityTeam}
+                setNewPublicityTeam={publicityTeam => applySettings({publicityTeam})}
+              />
             ) : null}
             {yourOperations.changeOpenTeam ? (
               <OpenTeam
@@ -264,7 +289,7 @@ const Settings = (p: Props) => {
                 onCancelRolePicker={() => setIsRolePickerOpen(false)}
                 onConfirmRolePicker={(role: T.Teams.TeamRoleType) => {
                   setIsRolePickerOpen(false)
-                  setNewOpenTeamRole(role)
+                  applySettings({openTeamRole: role})
                 }}
                 onOpenRolePicker={() => setIsRolePickerOpen(true)}
               />
@@ -272,7 +297,7 @@ const Settings = (p: Props) => {
             {!newOpenTeam && yourOperations.changeTarsDisabled ? (
               <IgnoreAccessRequests
                 newIgnoreAccessRequests={newIgnoreAccessRequests}
-                setNewIgnoreAccessRequests={setNewIgnoreAccessRequests}
+                setNewIgnoreAccessRequests={ignoreAccessRequests => applySettings({ignoreAccessRequests})}
               />
             ) : null}
           </>
@@ -431,11 +456,8 @@ const SettingsTabContainer = (ownProps: OwnProps) => {
     ]
   )
 
-  const settingsKey = `${ignoreAccessRequests}:${openTeam}:${openTeamRole}:${publicityAnyMember}:${publicityMember}:${publicityTeam}`
-
   return (
     <Settings
-      key={settingsKey}
       allowOpenTrigger={allowOpenTrigger}
       canShowcase={canShowcase}
       error={error}

--- a/shared/teams/team/settings-tab/index.tsx
+++ b/shared/teams/team/settings-tab/index.tsx
@@ -206,6 +206,9 @@ const Settings = (p: Props) => {
 
   if (local.serverKey !== serverKey) {
     setLocal({...serverSettings, serverKey})
+    // the picker edits openTeamRole, so leaving it open after a server-side change
+    // would confirm against values that no longer exist.
+    setIsRolePickerOpen(false)
   }
 
   const {

--- a/shared/teams/team/settings-tab/retention/index.tsx
+++ b/shared/teams/team/settings-tab/retention/index.tsx
@@ -5,7 +5,15 @@ import * as Teams from '@/constants/teams'
 import * as Kb from '@/common-adapters'
 import * as T from '@/constants/types'
 import SaveIndicator from '@/common-adapters/save-indicator'
+import logger from '@/logger'
+import {registerExternalResetter} from '@/util/zustand'
 import {useEngineActionListener} from '@/engine/action-listener'
+import {
+  type CachedResourceCache,
+  createCachedResourceCache,
+  getCachedResourceCache,
+  useCachedResource,
+} from '../../../use-cached-resource'
 import {useLoadedTeam} from '../../use-loaded-team'
 import {useConfirm} from './use-confirm'
 import {ConversationThreadProvider, useThreadMeta} from '@/chat/conversation/thread-context'
@@ -358,99 +366,67 @@ const policyToExplanation = (
   return exp
 }
 
-const loadTeamRetentionPolicy = async (
-  teamID: T.Teams.TeamID,
-  shouldApply: () => boolean,
-  setTeamRetentionPolicy: (policy?: T.RPCChat.RetentionPolicy | null) => void
-) => {
-  try {
-    const servicePolicy = await T.RPCChat.localGetTeamRetentionLocalRpcPromise(
-      {teamID},
-      C.waitingKeyTeamsLoadRetentionPolicy(teamID)
-    )
-    if (!shouldApply()) {
-      return
-    }
-    setTeamRetentionPolicy(servicePolicy)
-  } catch {
-    if (!shouldApply()) {
-      return
-    }
-    setTeamRetentionPolicy(undefined)
-  }
-}
+type TeamRetentionData = T.Retention.RetentionPolicy | undefined
+
+const teamRetentionStaleMs = 5_000
+const noTeamRetentionPolicy: TeamRetentionData = undefined
+
+// One cache per team, shared by every consumer (settings tab and every chat info
+// panel for the team): a burst of remounts would otherwise be a burst of
+// GetTeamRetentionLocal calls with identical arguments.
+const teamRetentionCaches = new Map<T.Teams.TeamID, CachedResourceCache<TeamRetentionData, T.Teams.TeamID>>()
+
+// module scope outlives sign-out, so the next user would inherit this user's policies
+registerExternalResetter('teams-retention-caches', () => {
+  teamRetentionCaches.clear()
+})
 
 const useLoadedTeamRetentionPolicy = (teamID: T.Teams.TeamID) => {
-  type TeamRetentionState = {
-    loadedTeamID?: T.Teams.TeamID
-    teamPolicy?: T.Retention.RetentionPolicy
-  }
-
-  const [state, setState] = React.useState<TeamRetentionState>({loadedTeamID: teamID, teamPolicy: undefined})
-  const requestVersionRef = React.useRef(0)
-  const requestTeamIDRef = React.useRef(teamID)
-
-  const setTeamRetentionPolicy = React.useCallback((policy?: T.RPCChat.RetentionPolicy | null) => {
-    const nextPolicy = Teams.serviceRetentionPolicyToRetentionPolicy(policy)
-    setState({
-      loadedTeamID: teamID,
-      teamPolicy: nextPolicy.type === 'inherit' ? Teams.retentionPolicies.policyRetain : nextPolicy,
-    })
-  }, [teamID])
-
-  const reload = React.useCallback(async () => {
-    const requestVersion = ++requestVersionRef.current
-    await loadTeamRetentionPolicy(
-      teamID,
-      () => requestVersion === requestVersionRef.current,
-      setTeamRetentionPolicy
-    )
-  }, [setTeamRetentionPolicy, teamID])
-
-  React.useEffect(() => {
-    if (requestTeamIDRef.current !== teamID) {
-      requestTeamIDRef.current = teamID
-      requestVersionRef.current++
-    }
-  }, [teamID])
-
-  React.useEffect(() => {
-    let canceled = false
-    const requestVersion = ++requestVersionRef.current
-    void loadTeamRetentionPolicy(
-      teamID,
-      () => !canceled && requestVersion === requestVersionRef.current,
-      setTeamRetentionPolicy
-    )
-    return () => {
-      canceled = true
-    }
-  }, [setTeamRetentionPolicy, teamID])
-
-  C.Router2.useSafeFocusEffect(
-    React.useCallback(() => {
-      void reload()
-    }, [reload])
+  const enabled = !!teamID && teamID !== T.Teams.noTeamID
+  // an adhoc conversation has no team, and useCachedResource resets the cache it
+  // holds when disabled — give those instances their own throwaway cache so they
+  // can't wipe the shared one out from under a real loader
+  const [localCache] = React.useState<CachedResourceCache<TeamRetentionData, T.Teams.TeamID>>(() =>
+    createCachedResourceCache<TeamRetentionData, T.Teams.TeamID>(noTeamRetentionPolicy, teamID)
   )
-
-  useEngineActionListener('chat.1.NotifyChat.ChatSetTeamRetention', action => {
-    if (action.payload.params.teamID !== teamID) {
-      return
-    }
-    const first = action.payload.params.convs?.[0]
-    if (!first?.teamRetention) {
-      void reload()
-      return
-    }
-    setTeamRetentionPolicy(first.teamRetention)
+  const sharedCache = React.useMemo(
+    () => getCachedResourceCache(teamRetentionCaches, noTeamRetentionPolicy, teamID),
+    [teamID]
+  )
+  const {data: teamPolicy, reload} = useCachedResource({
+    cache: enabled ? sharedCache : localCache,
+    cacheKey: teamID,
+    enabled,
+    initialData: noTeamRetentionPolicy,
+    // resolve rather than reject on failure: the picker falls back to the default
+    // "retain" policy on error instead of spinning forever
+    load: async () => {
+      let servicePolicy: T.RPCChat.RetentionPolicy | undefined | null
+      try {
+        servicePolicy = await T.RPCChat.localGetTeamRetentionLocalRpcPromise(
+          {teamID},
+          C.waitingKeyTeamsLoadRetentionPolicy(teamID)
+        )
+      } catch (error) {
+        logger.warn(`Failed to load team retention policy for ${teamID}`, error)
+      }
+      const policy = Teams.serviceRetentionPolicyToRetentionPolicy(servicePolicy)
+      return policy.type === 'inherit' ? Teams.retentionPolicies.policyRetain : policy
+    },
+    staleMs: teamRetentionStaleMs,
   })
 
-  const visibleState =
-    state.loadedTeamID === teamID ? state : {loadedTeamID: teamID, teamPolicy: undefined}
+  // the notification carries the new policy, but reload() is what actually
+  // invalidates the shared cache for the other consumers
+  useEngineActionListener('chat.1.NotifyChat.ChatSetTeamRetention', action => {
+    if (action.payload.params.teamID === teamID) {
+      void reload()
+    }
+  })
 
   return {
-    loading: !visibleState.teamPolicy,
-    teamPolicy: visibleState.teamPolicy,
+    loading: !teamPolicy,
+    teamPolicy,
   }
 }
 

--- a/shared/teams/team/settings-tab/retention/warning.tsx
+++ b/shared/teams/team/settings-tab/retention/warning.tsx
@@ -1,5 +1,6 @@
 import * as Kb from '@/common-adapters'
 import * as C from '@/constants'
+import * as React from 'react'
 import type * as T from '@/constants/types'
 import type {RetentionEntityType} from '.'
 import ConfirmWarning from '../confirm-warning'
@@ -87,12 +88,12 @@ const RetentionWarningContainer = (ownProps: OwnProps) => {
   const updateConfirm = useConfirm(s => s.dispatch.updateConfirm)
 
   C.Router2.useSafeFocusEffect(
-    () => {
+    React.useCallback(() => {
       openModal()
       return () => {
         closeModal()
       }
-    }
+    }, [openModal, closeModal])
   )
 
   const onConfirm = () => {

--- a/shared/teams/team/use-loaded-team.test.tsx
+++ b/shared/teams/team/use-loaded-team.test.tsx
@@ -1,0 +1,101 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import {expect, jest, test} from '@jest/globals'
+import {act, render} from '@testing-library/react'
+import * as T from '@/constants/types'
+import {useCurrentUserState} from '@/stores/current-user'
+import {useConfigState} from '@/stores/config'
+import {LoadedTeamsListProvider} from '../use-teams-list'
+import {LoadedTeamChannelsProvider, useLoadedTeamChannels} from '../common/use-loaded-team-channels'
+import {LoadedTeamProvider, useLoadedTeam} from './use-loaded-team'
+
+const teamID = 'tid1' as T.Teams.TeamID
+
+const annotated = {
+  invites: [],
+  joinRequests: [],
+  members: [],
+  name: 'testteam',
+  settings: {joinAs: T.RPCGen.TeamRole.reader, open: false},
+  showcase: {anyMemberShowcase: false, description: '', isShowcased: false},
+  tarsDisabled: false,
+  transitiveSubteamsUnverified: {entries: []},
+} as unknown as T.RPCGen.AnnotatedTeam
+
+let annotatedCalls = 0
+jest.spyOn(T.RPCGen, 'teamsGetAnnotatedTeamRpcPromise').mockImplementation(async () => {
+  annotatedCalls++
+  await Promise.resolve()
+  return annotated
+})
+jest.spyOn(T.RPCChat, 'localGetTLFConversationsLocalRpcPromise').mockImplementation(async () => {
+  await Promise.resolve()
+  return {convs: [], offline: false} as never
+})
+let listCalls = 0
+jest.spyOn(T.RPCGen, 'teamsTeamListUnverifiedRpcPromise').mockImplementation(async () => {
+  listCalls++
+  await Promise.resolve()
+  return {
+    teams: [
+      {
+        fqName: 'testteam',
+        isOpenTeam: false,
+        memberCount: 1,
+        role: T.RPCGen.TeamRole.owner,
+        teamID,
+        username: 'testuser',
+      },
+    ],
+  } as never
+})
+jest.spyOn(T.RPCGen, 'teamsGetTeamRoleMapRpcPromise').mockImplementation(async () => {
+  await Promise.resolve()
+  return {teams: {}, version: 1} as never
+})
+
+let bodyRenders = 0
+const Body = () => {
+  // counts real renders: compiling this away is exactly what the test measures
+  'use no memo'
+  bodyRenders++
+  const {teamMeta} = useLoadedTeam(teamID)
+  const {channels} = useLoadedTeamChannels(teamID)
+  return (
+    <div>
+      {teamMeta.teamname}
+      {channels.size}
+    </div>
+  )
+}
+
+const WithChannels = () => {
+  const {teamMeta} = useLoadedTeam(teamID)
+  return (
+    <LoadedTeamChannelsProvider teamID={teamID} teamname={teamMeta.teamname}>
+      <Body />
+    </LoadedTeamChannelsProvider>
+  )
+}
+
+// The team screen mounts one real loader plus a shadow instance per consumer;
+// a teams-list load landing must not re-issue getAnnotatedTeam.
+test('team screen loads getAnnotatedTeam once', async () => {
+  useCurrentUserState.setState({username: 'testuser'})
+  useConfigState.setState({loggedIn: true})
+  render(
+    <LoadedTeamsListProvider>
+      <LoadedTeamProvider teamID={teamID}>
+        <WithChannels />
+      </LoadedTeamProvider>
+    </LoadedTeamsListProvider>
+  )
+  for (let i = 0; i < 60; i++) {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+  expect(listCalls).toBe(1)
+  expect(bodyRenders).toBeLessThan(10)
+  expect(annotatedCalls).toBe(1)
+})

--- a/shared/teams/team/use-loaded-team.test.tsx
+++ b/shared/teams/team/use-loaded-team.test.tsx
@@ -5,6 +5,7 @@ import {act, render} from '@testing-library/react'
 import * as T from '@/constants/types'
 import {useCurrentUserState} from '@/stores/current-user'
 import {useConfigState} from '@/stores/config'
+import {resetAllStores} from '@/util/zustand'
 import {LoadedTeamsListProvider} from '../use-teams-list'
 import {LoadedTeamChannelsProvider, useLoadedTeamChannels} from '../common/use-loaded-team-channels'
 import {LoadedTeamProvider, useLoadedTeam} from './use-loaded-team'
@@ -98,4 +99,50 @@ test('team screen loads getAnnotatedTeam once', async () => {
   expect(listCalls).toBe(1)
   expect(bodyRenders).toBeLessThan(10)
   expect(annotatedCalls).toBe(1)
+})
+
+// These caches live at module scope, so they outlive the signed-in session. If
+// sign-out did not clear them the next user would be served the previous user's
+// team inside the stale window - and the entries are keyed on teamID, which
+// says nothing about who loaded them.
+test('signing out drops the shared team caches', async () => {
+  useCurrentUserState.setState({username: 'testuser'})
+  useConfigState.setState({loggedIn: true})
+  const first = render(
+    <LoadedTeamsListProvider>
+      <LoadedTeamProvider teamID={teamID}>
+        <WithChannels />
+      </LoadedTeamProvider>
+    </LoadedTeamsListProvider>
+  )
+  for (let i = 0; i < 60; i++) {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+  const callsWhileSignedIn = annotatedCalls
+  expect(callsWhileSignedIn).toBeGreaterThan(0)
+
+  first.unmount()
+  act(() => {
+    resetAllStores()
+  })
+
+  // a different user mounting the same screen must re-issue the RPC rather than
+  // read the entry the previous one left behind
+  useCurrentUserState.setState({username: 'testuser-mac'})
+  useConfigState.setState({loggedIn: true})
+  render(
+    <LoadedTeamsListProvider>
+      <LoadedTeamProvider teamID={teamID}>
+        <WithChannels />
+      </LoadedTeamProvider>
+    </LoadedTeamsListProvider>
+  )
+  for (let i = 0; i < 60; i++) {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+  expect(annotatedCalls).toBe(callsWhileSignedIn + 1)
 })

--- a/shared/teams/team/use-loaded-team.tsx
+++ b/shared/teams/team/use-loaded-team.tsx
@@ -96,12 +96,15 @@ const useLoadedTeamRaw = (
   )
   // Seed from the teams-list cache so the header (teamname, avatar, member count)
   // renders immediately instead of waiting for getAnnotatedTeam to round-trip.
+  // key the memo on this team's meta, not on the map: the map gets a new
+  // identity on every teams-list reload, and a fresh initialData object churns
+  // the whole useCachedResource state/effect chain for no reason
   const teamsListMap = useTeamsListMap()
+  const listMeta = validTeamID ? teamsListMap.get(validTeamID) : undefined
   const initialData = React.useMemo(() => {
     const data = emptyLoadedTeamData(validTeamID)
-    const listMeta = validTeamID ? teamsListMap.get(validTeamID) : undefined
     return listMeta ? {...data, teamMeta: listMeta} : data
-  }, [validTeamID, teamsListMap])
+  }, [validTeamID, listMeta])
   const {data, loaded, loading, reload, clear} = useCachedResource({
     cache,
     cacheKey: validTeamID,
@@ -123,7 +126,13 @@ const useLoadedTeamRaw = (
     },
     staleMs: loadedTeamReloadStaleMs,
   })
-  const roleAndDetails = roleAndDetailsFromMap(roleMap, validTeamID ?? T.Teams.noTeamID)
+  // builds a fresh object whenever the team is in the map, so without this the
+  // memos below (and the context value built from them) never hit and every
+  // consumer re-renders on every render of the provider
+  const roleAndDetails = React.useMemo(
+    () => roleAndDetailsFromMap(roleMap, validTeamID ?? T.Teams.noTeamID),
+    [roleMap, validTeamID]
+  )
   const teamMeta = React.useMemo(
     () => ({
       ...data.teamMeta,
@@ -160,14 +169,18 @@ const useLoadedTeamRaw = (
     }
   }, subscribeToUpdates)
 
-  return {...data, loaded, loading, reload, teamMeta, yourOperations}
+  const teamDetails = data.teamDetails
+  return React.useMemo(
+    () => ({loaded, loading, reload, teamDetails, teamMeta, yourOperations}),
+    [loaded, loading, reload, teamDetails, teamMeta, yourOperations]
+  )
 }
 
 export const LoadedTeamProvider = (props: React.PropsWithChildren<{teamID: T.Teams.TeamID}>) => {
   const {children, teamID} = props
   const [cacheMap] = React.useState<LoadedTeamCacheMap>(() => new Map())
   const loadedTeam = useLoadedTeamRaw(teamID, true, cacheMap)
-  const value = {...loadedTeam, teamID}
+  const value = React.useMemo(() => ({...loadedTeam, teamID}), [loadedTeam, teamID])
   return (
     <LoadedTeamCacheContext.Provider value={cacheMap}>
       <LoadedTeamContext.Provider value={value}>{children}</LoadedTeamContext.Provider>

--- a/shared/teams/team/use-loaded-team.tsx
+++ b/shared/teams/team/use-loaded-team.tsx
@@ -5,6 +5,7 @@ import * as Teams from '@/constants/teams'
 import * as React from 'react'
 import {useTeamsListMap, useTeamsRoleMap} from '../use-teams-list'
 import {type CachedResourceCache, getCachedResourceCache, useCachedResource} from '../use-cached-resource'
+import {registerExternalResetter} from '@/util/zustand'
 
 type LoadedTeam = {
   loaded: boolean
@@ -26,8 +27,15 @@ type LoadedTeamCacheMap = Map<
 >
 
 const LoadedTeamContext = React.createContext<LoadedTeamContextValue | null>(null)
-const LoadedTeamCacheContext = React.createContext<LoadedTeamCacheMap | null>(null)
 const loadedTeamReloadStaleMs = 5_000
+
+// One map for every consumer, for the same reason as the team channel cache: the
+// stale window and the single-flight live on the cache object, so callers holding
+// separate maps cannot see each other's in-flight request. While each provider
+// and each provider-less consumer held its own map, 81% of getAnnotatedTeam calls
+// in an e2e run landed inside their own 5s stale window - the team screen, the
+// channel screen and any modal above them each paid a full 200ms team load.
+const loadedTeamCache: LoadedTeamCacheMap = new Map()
 
 const loadableTeamID = (teamID: T.Teams.TeamID) =>
   teamID && teamID !== T.Teams.noTeamID && teamID !== T.Teams.newTeamWizardTeamID ? teamID : undefined
@@ -35,6 +43,12 @@ const loadableTeamID = (teamID: T.Teams.TeamID) =>
 const emptyLoadedTeamData = (teamID?: T.Teams.TeamID): LoadedTeamData => ({
   teamDetails: Teams.emptyTeamDetails,
   teamMeta: teamID ? Teams.makeTeamMeta({id: teamID}) : Teams.emptyTeamMeta,
+})
+
+// module scope outlives sign-out and this is per-user team data
+registerExternalResetter('loaded-team-cache', () => {
+  loadedTeamCache.forEach((cache, teamID) => cache.reset(emptyLoadedTeamData(teamID), teamID))
+  loadedTeamCache.clear()
 })
 
 const roleAndDetailsFromMap = (
@@ -71,25 +85,22 @@ const annotatedTeamToMeta = (
 // value instead of its own) must NOT share the loader's cache map. With enabled=false
 // useCachedResource resets the cache (loadedAt=0), which would clobber the loader's
 // loaded data. Give shadows a private throwaway map so their resets are harmless.
-const useLoadedTeamCacheMap = (providedCacheMap?: LoadedTeamCacheMap, forceLocalCache = false) => {
-  const contextCacheMap = React.useContext(LoadedTeamCacheContext)
+const useLoadedTeamCacheMap = (forceLocalCache: boolean) => {
   const [localCacheMap] = React.useState<LoadedTeamCacheMap>(() => new Map())
-  if (forceLocalCache) {
-    return localCacheMap
-  }
-  return providedCacheMap ?? contextCacheMap ?? localCacheMap
+  return forceLocalCache ? localCacheMap : loadedTeamCache
 }
 
 const useLoadedTeamRaw = (
   teamID: T.Teams.TeamID,
   enabled = true,
-  providedCacheMap?: LoadedTeamCacheMap,
   subscribeToUpdates = enabled,
   forceLocalCache = false
 ): LoadedTeam => {
   const validTeamID = loadableTeamID(teamID)
   const {loadIfStale: loadRoleMapIfStale, roleMap} = useTeamsRoleMap()
-  const cacheMap = useLoadedTeamCacheMap(providedCacheMap, forceLocalCache)
+  // a disabled instance resets whatever cache it holds, so it must never hold the
+  // shared one - gate on exactly the load condition, not just forceLocalCache
+  const cacheMap = useLoadedTeamCacheMap(forceLocalCache || !enabled || !validTeamID)
   const cache = React.useMemo(
     () => getCachedResourceCache(cacheMap, emptyLoadedTeamData(validTeamID), validTeamID),
     [cacheMap, validTeamID]
@@ -178,14 +189,9 @@ const useLoadedTeamRaw = (
 
 export const LoadedTeamProvider = (props: React.PropsWithChildren<{teamID: T.Teams.TeamID}>) => {
   const {children, teamID} = props
-  const [cacheMap] = React.useState<LoadedTeamCacheMap>(() => new Map())
-  const loadedTeam = useLoadedTeamRaw(teamID, true, cacheMap)
+  const loadedTeam = useLoadedTeamRaw(teamID)
   const value = React.useMemo(() => ({...loadedTeam, teamID}), [loadedTeam, teamID])
-  return (
-    <LoadedTeamCacheContext.Provider value={cacheMap}>
-      <LoadedTeamContext.Provider value={value}>{children}</LoadedTeamContext.Provider>
-    </LoadedTeamCacheContext.Provider>
-  )
+  return <LoadedTeamContext.Provider value={value}>{children}</LoadedTeamContext.Provider>
 }
 
 export const useLoadedTeam = (teamID: T.Teams.TeamID, enabled = true): LoadedTeam => {
@@ -194,7 +200,6 @@ export const useLoadedTeam = (teamID: T.Teams.TeamID, enabled = true): LoadedTea
   const raw = useLoadedTeamRaw(
     teamID,
     enabled && !useContextValue,
-    undefined,
     enabled && !useContextValue,
     useContextValue
   )

--- a/shared/teams/use-cached-resource.test.tsx
+++ b/shared/teams/use-cached-resource.test.tsx
@@ -4,10 +4,14 @@ import {expect, jest, test} from '@jest/globals'
 import {act, render} from '@testing-library/react'
 import {createCachedResourceCache, useCachedResource} from './use-cached-resource'
 
+// A setState that lands outside act() - every load settling on its own - is
+// scheduled on React's MessageChannel, i.e. a macrotask. A flush built only from
+// awaited microtasks never lets the event loop reach it, so the commit lands (or
+// not) depending on how the runtime happens to interleave: use a real timer.
 const flush = async (turns = 40) => {
   for (let i = 0; i < turns; i++) {
     await act(async () => {
-      await Promise.resolve()
+      await new Promise(resolve => setTimeout(resolve, 0))
     })
   }
 }
@@ -198,6 +202,43 @@ test('a forced reload supersedes a request that predates it', async () => {
   await flush()
   expect(view.getAllByText('v2')).toHaveLength(1)
   expect(cache.getData()).toEqual({v: 2})
+})
+
+// The mutation and the reload it triggers routinely fall inside one millisecond,
+// so ordering the two by Date.now() compares them equal and the forced load
+// joins the very request it exists to supersede.
+test('a forced reload supersedes a same-millisecond request', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  const releases: Array<(v: Data) => void> = []
+  const load = jest.fn(async () => {
+    calls++
+    return await new Promise<Data>(resolve => {
+      releases.push(resolve)
+    })
+  })
+  let reload: (() => Promise<void>) | undefined
+  const Comp = () => {
+    'use no memo'
+    const resource = useCachedResource({cache, cacheKey: 'k', initialData: {v: 0}, load, staleMs: 5000})
+    reload = resource.reload
+    return <div>{resource.loaded ? `v${resource.data.v}` : 'pending'}</div>
+  }
+  const realNow = Date.now
+  const frozen = realNow()
+  Date.now = () => frozen
+  try {
+    render(<Comp />)
+    await flush()
+    expect(calls).toBe(1)
+    act(() => {
+      void reload?.()
+    })
+    await flush()
+    expect(calls).toBe(2)
+  } finally {
+    Date.now = realNow
+  }
 })
 
 // Two consumers mounting together must share one request, not race two. This is

--- a/shared/teams/use-cached-resource.test.tsx
+++ b/shared/teams/use-cached-resource.test.tsx
@@ -1,0 +1,236 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import {expect, jest, test} from '@jest/globals'
+import {act, render} from '@testing-library/react'
+import {createCachedResourceCache, useCachedResource} from './use-cached-resource'
+
+const flush = async (turns = 40) => {
+  for (let i = 0; i < turns; i++) {
+    await act(async () => {
+      await Promise.resolve()
+    })
+  }
+}
+
+type Data = {v: number}
+
+// A caller that rebuilds initialData every render (seeding it from another
+// store) must not put useCachedResource into a render loop.
+test('unstable initialData does not loop', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  let renders = 0
+  const load = jest.fn(async () => {
+    calls++
+    await Promise.resolve()
+    return {v: calls}
+  })
+  const Comp = () => {
+    // counts real renders: compiling this away is exactly what the test measures
+    'use no memo'
+    renders++
+    const {data} = useCachedResource({cache, cacheKey: 'k', initialData: {v: 0}, load, staleMs: 5000})
+    return <div>{data.v}</div>
+  }
+  render(<Comp />)
+  await flush()
+  expect(calls).toBe(1)
+  expect(renders).toBeLessThan(10)
+})
+
+// A load that rejects leaves loadedAt at 0, i.e. permanently stale. Without a
+// backoff every re-render re-issued the request the instant the previous one
+// settled, which hammered both the service and the server.
+test('a failed load backs off instead of retrying on every render', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  let loadIfStale: (() => Promise<void>) | undefined
+  const load = jest.fn(async () => {
+    calls++
+    await Promise.resolve()
+    throw new Error('nope')
+  })
+  const Comp = () => {
+    // drives loadIfStale from the test; the mount effect only ever fires once,
+    // so without this the assertion below holds even with no backoff at all
+    'use no memo'
+    const resource = useCachedResource({
+      cache,
+      cacheKey: 'k',
+      initialData: {v: 0},
+      load,
+      onError: () => {},
+      staleMs: 5000,
+    })
+    loadIfStale = resource.loadIfStale
+    return <div>{resource.data.v}</div>
+  }
+  render(<Comp />)
+  await flush()
+  expect(calls).toBe(1)
+
+  // inside the backoff window: further attempts must not reach `load`
+  await act(async () => {
+    await loadIfStale?.()
+    await loadIfStale?.()
+  })
+  await flush()
+  expect(calls).toBe(1)
+
+  // past it: the next attempt goes through
+  const realNow = Date.now
+  Date.now = () => realNow() + 5_001
+  try {
+    await act(async () => {
+      await loadIfStale?.()
+    })
+    await flush()
+  } finally {
+    Date.now = realNow
+  }
+  expect(calls).toBe(2)
+})
+
+test('reload bypasses the failure backoff', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  let reload: (() => Promise<void>) | undefined
+  const load = jest.fn(async () => {
+    calls++
+    await Promise.resolve()
+    throw new Error('nope')
+  })
+  const Comp = () => {
+    // hoists reload out to the test body; the compiler rejects the assignment
+    'use no memo'
+    const resource = useCachedResource({
+      cache,
+      cacheKey: 'k',
+      initialData: {v: 0},
+      load,
+      onError: () => {},
+      staleMs: 5000,
+    })
+    reload = resource.reload
+    return <div>{resource.data.v}</div>
+  }
+  render(<Comp />)
+  await flush()
+  expect(calls).toBe(1)
+  await act(async () => {
+    await reload?.()
+  })
+  expect(calls).toBe(2)
+})
+
+test('a successful load is served from cache while fresh', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  const load = jest.fn(async () => {
+    calls++
+    await Promise.resolve()
+    return {v: calls}
+  })
+  const Comp = ({staleMs}: {staleMs: number}) => {
+    const {data, loaded} = useCachedResource({cache, cacheKey: 'k', initialData: {v: 0}, load, staleMs})
+    return <div>{loaded ? data.v : 'x'}</div>
+  }
+  const first = render(<Comp staleMs={5000} />)
+  await flush()
+  expect(calls).toBe(1)
+
+  // a re-render of the same fiber proves nothing: the effect deps are stable so
+  // it never re-runs. The window only matters to a NEW consumer of this cache.
+  first.unmount()
+  const second = render(<Comp staleMs={5000} />)
+  await flush()
+  expect(calls).toBe(1)
+  expect(cache.getData()).toEqual({v: 1})
+
+  // and a consumer that considers it stale does reload it
+  second.unmount()
+  render(<Comp staleMs={-1} />)
+  await flush()
+  expect(calls).toBe(2)
+})
+
+// A reload() fired because something changed must not settle to data that was
+// already on the wire before the change: joining it would serve pre-change data
+// AND stamp loadedAt on it, pinning the stale value for the whole window.
+test('a forced reload supersedes a request that predates it', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  const releases: Array<(v: Data) => void> = []
+  const load = jest.fn(async () => {
+    calls++
+    return await new Promise<Data>(resolve => {
+      releases.push(resolve)
+    })
+  })
+  let reload: (() => Promise<void>) | undefined
+  const Comp = () => {
+    'use no memo'
+    const resource = useCachedResource({cache, cacheKey: 'k', initialData: {v: 0}, load, staleMs: 5000})
+    reload = resource.reload
+    return <div>{resource.loaded ? `v${resource.data.v}` : 'pending'}</div>
+  }
+  const view = render(<Comp />)
+  await flush()
+  expect(calls).toBe(1)
+
+  // the mutation happens here, while request 1 is still outstanding
+  let forced: Promise<void> | undefined
+  act(() => {
+    forced = reload?.()
+  })
+  await flush()
+  expect(calls).toBe(2)
+
+  // request 1 lands with pre-change data and must not win
+  act(() => {
+    releases[0]?.({v: 1})
+  })
+  await flush()
+  act(() => {
+    releases[1]?.({v: 2})
+  })
+  await forced
+  await flush()
+  expect(view.getAllByText('v2')).toHaveLength(1)
+  expect(cache.getData()).toEqual({v: 2})
+})
+
+// Two consumers mounting together must share one request, not race two. This is
+// the property the module-level caches depend on: without it, sharing a cache
+// across screens still issues an RPC per screen.
+test('concurrent consumers of one cache share a single load', async () => {
+  const cache = createCachedResourceCache<Data, string>({v: 0}, 'k')
+  let calls = 0
+  let release: ((v: Data) => void) | undefined
+  const load = jest.fn(async () => {
+    calls++
+    return await new Promise<Data>(resolve => {
+      release = resolve
+    })
+  })
+  const Comp = () => {
+    const {data, loaded} = useCachedResource({cache, cacheKey: 'k', initialData: {v: 0}, load, staleMs: 5000})
+    return <div>{loaded ? `v${data.v}` : 'pending'}</div>
+  }
+  const view = render(
+    <>
+      <Comp />
+      <Comp />
+    </>
+  )
+  await flush()
+  expect(calls).toBe(1)
+
+  act(() => {
+    release?.({v: 7})
+  })
+  await flush()
+  expect(calls).toBe(1)
+  // both consumers got the single load's result
+  expect(view.getAllByText('v7')).toHaveLength(2)
+})

--- a/shared/teams/use-cached-resource.tsx
+++ b/shared/teams/use-cached-resource.tsx
@@ -5,15 +5,25 @@ import {produce} from 'immer'
 export type CachedResourceCache<T, K> = {
   clearInFlight: (request: Promise<T>) => void
   getData: () => T
+  getFailedAt: () => number
   getGeneration: () => number
   getInFlight: () => Promise<T> | undefined
+  getInFlightStartedAt: () => number
   getKey: () => K
   getLoadedAt: () => number
   invalidate: (key: K) => void
   reset: (data: T, key: K) => void
   setDataLoaded: (data: T, generation: number) => void
   setInFlight: (request: Promise<T>) => void
+  setLoadFailed: (generation: number) => void
 }
+
+// A load that never lands (it rejected, or its result was discarded because the
+// cache was invalidated mid-flight) leaves loadedAt at 0, i.e. permanently
+// stale. Without this window every re-run of the effect below would re-issue the
+// request the instant the previous one settled - an unbounded retry loop at RPC
+// speed. An explicit reload()/invalidate() still retries immediately.
+const loadFailureBackoffMs = 5_000
 
 type CachedResourceState<T> = {
   data: T
@@ -65,10 +75,28 @@ const storedState = <T, K>(
   initialData,
 })
 
+// Settling to already-current data must not produce a new state object: every
+// loadIfStale() that finds the cache fresh would otherwise force a re-render,
+// which re-runs the effect that called it, which re-renders... a loop paced only
+// by how fast React can commit.
+const settledState =
+  <T, K>(cache: CachedResourceCache<T, K>, cacheKey: K, initialData: T, data: T) =>
+  (prev: StoredCachedResourceState<T, K>): StoredCachedResourceState<T, K> =>
+    prev.cache === cache &&
+    Object.is(prev.cacheKey, cacheKey) &&
+    Object.is(prev.initialData, initialData) &&
+    Object.is(prev.data, data) &&
+    prev.loaded &&
+    !prev.loading
+      ? prev
+      : storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false})
+
 export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedResourceCache<T, K> => {
   let data = initialData
+  let failedAt = 0
   let generation = 0
   let inFlight: Promise<T> | undefined
+  let inFlightStartedAt = 0
   let loadedAt = 0
   let storedKey = key
 
@@ -79,11 +107,14 @@ export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedR
       }
     },
     getData: () => data,
+    getFailedAt: () => failedAt,
     getGeneration: () => generation,
     getInFlight: (): Promise<T> | undefined => inFlight,
+    getInFlightStartedAt: () => inFlightStartedAt,
     getKey: () => storedKey,
     getLoadedAt: () => loadedAt,
     invalidate: nextKey => {
+      failedAt = 0
       generation += 1
       inFlight = undefined
       loadedAt = 0
@@ -91,6 +122,7 @@ export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedR
     },
     reset: (nextData, nextKey) => {
       data = nextData
+      failedAt = 0
       generation += 1
       inFlight = undefined
       loadedAt = 0
@@ -99,11 +131,18 @@ export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedR
     setDataLoaded: (nextData, requestGeneration) => {
       if (generation === requestGeneration) {
         data = nextData
+        failedAt = 0
         loadedAt = Date.now()
       }
     },
     setInFlight: request => {
       inFlight = request
+      inFlightStartedAt = Date.now()
+    },
+    setLoadFailed: requestGeneration => {
+      if (generation === requestGeneration) {
+        failedAt = Date.now()
+      }
     },
   }
 }
@@ -130,19 +169,31 @@ const runLoad = async <T, K>(
   onError: ((error: unknown) => void) | undefined,
   requestVersion: number,
   requestVersionRef: React.RefObject<number>,
-  setState: React.Dispatch<React.SetStateAction<StoredCachedResourceState<T, K>>>
+  setState: React.Dispatch<React.SetStateAction<StoredCachedResourceState<T, K>>>,
+  force: boolean,
+  requestedAt: number
 ) => {
   let request: Promise<T> | undefined
+  // A forced load exists because something changed, so joining a request that
+  // was already on the wire before we asked would settle to pre-change data -
+  // and stamp loadedAt on it, holding it stale for the whole window. Only join a
+  // request that started at or after this one was asked for, which still
+  // collapses the N-mounted-consumers-reload-together case to one RPC.
+  const staleInFlight = force && cache.getInFlightStartedAt() < requestedAt
+  if (staleInFlight) {
+    cache.invalidate(cacheKey)
+  }
+  // after the invalidate above, which bumps it
+  const generation = cache.getGeneration()
   try {
-    const inFlight = cache.getInFlight()
+    const inFlight = staleInFlight ? undefined : cache.getInFlight()
     if (inFlight) {
       const data = await inFlight
       if (requestVersion === requestVersionRef.current) {
-        setState(storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false}))
+        setState(settledState(cache, cacheKey, initialData, data))
       }
       return
     }
-    const generation = cache.getGeneration()
     request = load().then(data => {
       cache.setDataLoaded(data, generation)
       return data
@@ -150,9 +201,12 @@ const runLoad = async <T, K>(
     cache.setInFlight(request)
     const data = await request
     if (requestVersion === requestVersionRef.current) {
-      setState(storedState(cache, cacheKey, initialData, {data, loaded: true, loading: false}))
+      setState(settledState(cache, cacheKey, initialData, data))
     }
   } catch (error) {
+    // record the failure even for a superseded request: the backoff belongs to
+    // the shared cache, not to whichever instance happened to own the request
+    cache.setLoadFailed(generation)
     if (requestVersion !== requestVersionRef.current) {
       return
     }
@@ -177,11 +231,35 @@ export const useCachedResource = <T, K>(props: Props<T, K>) => {
   const hasFocusedSinceMountRef = React.useRef(false)
   const requestVersionRef = React.useRef(0)
 
+  const latestRef = React.useRef({
+    cache,
+    cacheKey,
+    enabled,
+    initialData,
+    load,
+    onError,
+    staleMs,
+  })
+  React.useLayoutEffect(() => {
+    latestRef.current = {
+      cache,
+      cacheKey,
+      enabled,
+      initialData,
+      load,
+      onError,
+      staleMs,
+    }
+  }, [cache, cacheKey, enabled, initialData, load, onError, staleMs])
+
+  // deliberately does not depend on initialData: resetCache is in the main
+  // effect's dep array, and callers routinely rebuild initialData (seeding it
+  // from another store), which would re-run the effect on every such change.
   const resetCache = React.useCallback(
     (nextKey: K) => {
-      cache.reset(initialData, nextKey)
+      cache.reset(latestRef.current.initialData, nextKey)
     },
-    [cache, initialData]
+    [cache]
   )
 
   const clear = React.useCallback(
@@ -193,31 +271,14 @@ export const useCachedResource = <T, K>(props: Props<T, K>) => {
     [cache, cacheKey, initialData, resetCache]
   )
 
-  const latestRef = React.useRef({
-    cache,
-    cacheKey,
-    enabled,
-    initialData,
-    load,
-    onError,
-    resetCache,
-    staleMs,
-  })
-  React.useLayoutEffect(() => {
-    latestRef.current = {
-      cache,
-      cacheKey,
-      enabled,
-      initialData,
-      load,
-      onError,
-      resetCache,
-      staleMs,
-    }
-  }, [cache, cacheKey, enabled, initialData, load, onError, resetCache, staleMs])
-
   const loadResource = React.useCallback(async (force: boolean) => {
-    const {cache, cacheKey, enabled, initialData, load, onError, resetCache, staleMs} = latestRef.current
+    // stamped before any await so a forced load can tell an in-flight request
+    // that predates it from one issued in response to the same change
+    const requestedAt = Date.now()
+    const {cache, cacheKey, enabled, initialData, load, onError, staleMs} = latestRef.current
+    const resetCache = (nextKey: K) => {
+      cache.reset(initialData, nextKey)
+    }
     if (!Object.is(cache.getKey(), cacheKey)) {
       requestVersionRef.current += 1
       resetCache(cacheKey)
@@ -229,18 +290,33 @@ export const useCachedResource = <T, K>(props: Props<T, K>) => {
     }
     const loadedAt = cache.getLoadedAt()
     if (!force && loadedAt && Date.now() - loadedAt < staleMs) {
-      setState(
-        storedState(cache, cacheKey, initialData, {data: cache.getData(), loaded: true, loading: false})
-      )
+      setState(settledState(cache, cacheKey, initialData, cache.getData()))
+      return
+    }
+    const failedAt = cache.getFailedAt()
+    if (!force && failedAt && Date.now() - failedAt < loadFailureBackoffMs) {
       return
     }
     const requestVersion = ++requestVersionRef.current
     setState(prev =>
       prev.cache === cache && Object.is(prev.cacheKey, cacheKey) && Object.is(prev.initialData, initialData)
-        ? {...prev, loading: true}
+        ? prev.loading
+          ? prev
+          : {...prev, loading: true}
         : storedState(cache, cacheKey, initialData, {...emptyState(initialData), loading: true})
     )
-    await runLoad(cache, cacheKey, initialData, load, onError, requestVersion, requestVersionRef, setState)
+    await runLoad(
+      cache,
+      cacheKey,
+      initialData,
+      load,
+      onError,
+      requestVersion,
+      requestVersionRef,
+      setState,
+      force,
+      requestedAt
+    )
   }, [])
 
   const reload = React.useCallback(async () => {

--- a/shared/teams/use-cached-resource.tsx
+++ b/shared/teams/use-cached-resource.tsx
@@ -8,7 +8,7 @@ export type CachedResourceCache<T, K> = {
   getFailedAt: () => number
   getGeneration: () => number
   getInFlight: () => Promise<T> | undefined
-  getInFlightStartedAt: () => number
+  getInFlightSeq: () => number
   getKey: () => K
   getLoadedAt: () => number
   invalidate: (key: K) => void
@@ -24,6 +24,14 @@ export type CachedResourceCache<T, K> = {
 // request the instant the previous one settled - an unbounded retry loop at RPC
 // speed. An explicit reload()/invalidate() still retries immediately.
 const loadFailureBackoffMs = 5_000
+
+// Ordering of "was this request already on the wire when I asked?" cannot use
+// Date.now(): a mutation and the reload it triggers routinely land in the same
+// millisecond, and the two timestamps then compare equal, so the forced load
+// joins the very request it must supersede. A counter is exact.
+let inFlightSequence = 0
+const nextInFlightSeq = () => ++inFlightSequence
+const currentInFlightSeq = () => inFlightSequence
 
 type CachedResourceState<T> = {
   data: T
@@ -96,7 +104,7 @@ export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedR
   let failedAt = 0
   let generation = 0
   let inFlight: Promise<T> | undefined
-  let inFlightStartedAt = 0
+  let inFlightSeq = 0
   let loadedAt = 0
   let storedKey = key
 
@@ -110,7 +118,7 @@ export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedR
     getFailedAt: () => failedAt,
     getGeneration: () => generation,
     getInFlight: (): Promise<T> | undefined => inFlight,
-    getInFlightStartedAt: () => inFlightStartedAt,
+    getInFlightSeq: () => inFlightSeq,
     getKey: () => storedKey,
     getLoadedAt: () => loadedAt,
     invalidate: nextKey => {
@@ -137,7 +145,7 @@ export const createCachedResourceCache = <T, K>(initialData: T, key: K): CachedR
     },
     setInFlight: request => {
       inFlight = request
-      inFlightStartedAt = Date.now()
+      inFlightSeq = nextInFlightSeq()
     },
     setLoadFailed: requestGeneration => {
       if (generation === requestGeneration) {
@@ -171,15 +179,15 @@ const runLoad = async <T, K>(
   requestVersionRef: React.RefObject<number>,
   setState: React.Dispatch<React.SetStateAction<StoredCachedResourceState<T, K>>>,
   force: boolean,
-  requestedAt: number
+  requestedSeq: number
 ) => {
   let request: Promise<T> | undefined
   // A forced load exists because something changed, so joining a request that
   // was already on the wire before we asked would settle to pre-change data -
   // and stamp loadedAt on it, holding it stale for the whole window. Only join a
-  // request that started at or after this one was asked for, which still
-  // collapses the N-mounted-consumers-reload-together case to one RPC.
-  const staleInFlight = force && cache.getInFlightStartedAt() < requestedAt
+  // request that started after this one was asked for, which still collapses the
+  // N-mounted-consumers-reload-together case to one RPC.
+  const staleInFlight = force && !!cache.getInFlight() && cache.getInFlightSeq() <= requestedSeq
   if (staleInFlight) {
     cache.invalidate(cacheKey)
   }
@@ -274,7 +282,7 @@ export const useCachedResource = <T, K>(props: Props<T, K>) => {
   const loadResource = React.useCallback(async (force: boolean) => {
     // stamped before any await so a forced load can tell an in-flight request
     // that predates it from one issued in response to the same change
-    const requestedAt = Date.now()
+    const requestedSeq = currentInFlightSeq()
     const {cache, cacheKey, enabled, initialData, load, onError, staleMs} = latestRef.current
     const resetCache = (nextKey: K) => {
       cache.reset(initialData, nextKey)
@@ -315,7 +323,7 @@ export const useCachedResource = <T, K>(props: Props<T, K>) => {
       requestVersionRef,
       setState,
       force,
-      requestedAt
+      requestedSeq
     )
   }, [])
 

--- a/shared/teams/use-teams-list.tsx
+++ b/shared/teams/use-teams-list.tsx
@@ -15,6 +15,7 @@ import {
   createCachedResourceCache,
   useCachedResource,
 } from './use-cached-resource'
+import {registerExternalResetter} from '@/util/zustand'
 
 type TeamsList = {
   reload: () => void
@@ -43,6 +44,13 @@ const teamsRoleMapCache = createCachedResourceCache<T.RPCGen.TeamRoleMapAndVersi
   emptyTeamRoleMap,
   undefined
 )
+
+// module scope outlives sign-out; both are keyed by username, so the next user
+// would briefly render the previous user's team list and role map
+registerExternalResetter('teams-list-caches', () => {
+  teamsListCache.reset(emptyTeams, undefined)
+  teamsRoleMapCache.reset(emptyTeamRoleMap, undefined)
+})
 
 const teamListToArray = (list: ReadonlyArray<T.RPCGen.AnnotatedMemberInfo>) => {
   return [...Teams.teamListToMeta(list).values()]

--- a/shared/tests/e2e/electron/flows/chat-modals.test.ts
+++ b/shared/tests/e2e/electron/flows/chat-modals.test.ts
@@ -79,16 +79,16 @@ test('bot install preview opens', async ({page}, testInfo) => {
   await page.getByTestId(T.CHAT_INFO_PANEL).getByText('Bots', {exact: true}).click()
   const botRows = page.getByTestId(T.CHAT_BOT_ROW)
   await expect(botRows.first()).toBeVisible({timeout: 10_000})
-  // the row's center point lands on the "by <owner>" ConnectedUsernames link,
-  // which navigates to that profile instead of opening the bot. Click over the
-  // avatar column, which is plain ListItem body.
+  // the row center sits on the "by <owner>" username link, which navigates to
+  // that user's profile instead — click the avatar column on the left
   await botRows.first().click({position: {x: 20, y: 28}})
-  // installed bot: Edit settings; new bot: Install; restricted bot: Review
-  const installButton = page.getByText(/^(Install|Edit settings|Review)$/).first()
-  await expect(installButton).toBeVisible({timeout: 10_000})
+  // the footer button depends on the bot's state (Install / Review / Edit
+  // settings / Uninstall), so assert on the modal instead of a label
+  const installModal = page.getByTestId(T.CHAT_BOT_INSTALL).first()
+  await expect(installModal).toBeVisible({timeout: 10_000})
   await snap(page, testInfo)
   await page.locator('.icon-gen-iconfont-close:visible').first().click()
-  await expect(installButton).not.toBeVisible({timeout: 5_000})
+  await expect(installModal).not.toBeVisible({timeout: 5_000})
   // close the info panel again
   await page.locator('.icon-gen-iconfont-info:visible').first().click()
   await expect(page.getByTestId(T.CHAT_INFO_PANEL)).not.toBeVisible({timeout: 5_000})

--- a/shared/tests/e2e/electron/flows/device-wallet-modals.test.ts
+++ b/shared/tests/e2e/electron/flows/device-wallet-modals.test.ts
@@ -20,14 +20,8 @@ test('add device chooser opens', async ({page}, testInfo) => {
 test('crypto recipients team builder opens', async ({page}, testInfo) => {
   await navigateToCrypto(page)
   await page.getByTestId(T.CRYPTO_NAV_ENCRYPT).click()
-  // the recipients input sits under a pointerEvents:none wrapper (crypto/recipients.tsx)
-  // so it can't take focus — click the ClickableBox around it instead.
-  await page
-    .locator('.clickable-box2')
-    .filter({has: page.getByPlaceholder('Search people')})
-    .locator('visible=true')
-    .first()
-    .click()
+  // the "Search people" input itself is pointerEvents:none — click its wrapper
+  await page.getByTestId(T.CRYPTO_RECIPIENTS).locator('visible=true').first().click()
   const search = page.getByPlaceholder('Search Keybase').locator('visible=true')
   await expect(search.first()).toBeVisible({timeout: 5_000})
   await snap(page, testInfo)

--- a/shared/tests/e2e/electron/flows/teams-inner.test.ts
+++ b/shared/tests/e2e/electron/flows/teams-inner.test.ts
@@ -23,8 +23,9 @@ test('members tab renders', async ({page}) => {
     test.skip()
     return
   }
-  // the team view restores whichever tab was last open, so don't assume Members
-  await page.getByText('Members', {exact: true}).locator('visible=true').first().click()
+  // the team page remembers the last tab per team for the life of the app, so an
+  // earlier test can leave it on Channels/Settings — select Members explicitly
+  await page.getByTestId(T.TEAMS_TAB_MEMBERS_BUTTON).locator('visible=true').first().click()
   await expect(page.getByTestId(T.TEAMS_MEMBER_LIST).first()).toBeVisible({timeout: 5_000})
 })
 
@@ -34,10 +35,10 @@ test('settings tab renders', async ({page}) => {
     test.skip()
     return
   }
-  // 'Settings' appears in both nav sidebar and team tabs — use .nth(1) for team tab
-  await page.getByText('Settings', {exact: true}).nth(1).click()
-  // Verify we're still in the team view (Members tab still visible)
-  await expect(page.getByText('Members', {exact: true}).first()).toBeVisible({timeout: 5_000})
+  await page.getByTestId(T.TEAMS_TAB_SETTINGS_BUTTON).locator('visible=true').first().click()
+  // assert the settings BODY, not the 'Members' tab label: that label is part of
+  // the tab bar and is visible on every tab, so it passes without switching
+  await expect(page.getByTestId(T.TEAMS_SETTINGS_TAB).first()).toBeVisible({timeout: 5_000})
 })
 
 test('bots tab renders', async ({page}) => {
@@ -47,7 +48,7 @@ test('bots tab renders', async ({page}) => {
     return
   }
   await page.getByText('Bots', {exact: true}).first().click()
-  await expect(page.getByText('Members', {exact: true}).first()).toBeVisible({timeout: 5_000})
+  await expect(page.getByTestId(T.TEAMS_BOTS_TAB).first()).toBeVisible({timeout: 5_000})
 })
 
 test('channels tab renders (if big team or admin)', async ({page}) => {
@@ -62,5 +63,5 @@ test('channels tab renders (if big team or admin)', async ({page}) => {
     return
   }
   await channelsTab.click()
-  await expect(page.getByText('Members', {exact: true}).first()).toBeVisible({timeout: 5_000})
+  await expect(page.getByTestId(T.TEAMS_CHANNEL_LIST).first()).toBeVisible({timeout: 5_000})
 })

--- a/shared/tests/e2e/electron/flows/teams-modals.test.ts
+++ b/shared/tests/e2e/electron/flows/teams-modals.test.ts
@@ -145,9 +145,20 @@ test('retention warning opens', async ({page}, testInfo) => {
     test.skip()
     return
   }
-  await settles(dropdown)
-  await dropdown.click()
-  await page.getByText('7 days', {exact: true}).locator('visible=true').last().click()
+  // the settings tab re-renders as the team's retention policy lands, which can
+  // swallow the popup the first click opens — reopen until the menu sticks
+  const sevenDays = page.getByText('7 days', {exact: true}).locator('visible=true').last()
+  let menuOpen = false
+  for (let i = 0; i < 3 && !menuOpen; i++) {
+    await settles(dropdown)
+    await dropdown.click()
+    menuOpen = await becomesVisible(sevenDays, 2_000)
+  }
+  if (!menuOpen) {
+    test.skip()
+    return
+  }
+  await sevenDays.click()
   const confirm = page.getByText('Yes, set to 7 days')
   if (!(await becomesVisible(confirm, 3_000))) {
     // no warning fired (already at/below 7 days) — nothing to capture

--- a/shared/tests/e2e/electron/flows/teams-modals.test.ts
+++ b/shared/tests/e2e/electron/flows/teams-modals.test.ts
@@ -154,10 +154,10 @@ test('retention warning opens', async ({page}, testInfo) => {
     await dropdown.click()
     menuOpen = await becomesVisible(sevenDays, 2_000)
   }
-  if (!menuOpen) {
-    test.skip()
-    return
-  }
+  expect(
+    menuOpen,
+    'retention dropdown never opened its menu: no visible "7 days" option after 3 clicks on the message-deletion dropdown'
+  ).toBe(true)
   await sevenDays.click()
   const confirm = page.getByText('Yes, set to 7 days')
   if (!(await becomesVisible(confirm, 3_000))) {

--- a/shared/tests/e2e/electron/playwright.config.ts
+++ b/shared/tests/e2e/electron/playwright.config.ts
@@ -2,7 +2,9 @@ import {defineConfig} from '@playwright/test'
 
 export default defineConfig({
   testDir: './',
-  timeout: 15_000,
+  // several flows chain 3-4 five-second waits against a live service, so the
+  // per-test budget has to clear the sum of their step timeouts
+  timeout: 30_000,
   retries: 1,
   workers: 1,
   outputDir: '../../results/test-results',

--- a/shared/tests/e2e/electron/playwright.config.ts
+++ b/shared/tests/e2e/electron/playwright.config.ts
@@ -3,7 +3,10 @@ import {defineConfig} from '@playwright/test'
 export default defineConfig({
   testDir: './',
   // several flows chain 3-4 five-second waits against a live service, so the
-  // per-test budget has to clear the sum of their step timeouts
+  // per-test budget has to clear the sum of their step timeouts. Worst case is
+  // flows/teams-modals 'retention warning opens': openFirstTeam (~8s) + two 5s
+  // visibility waits + 3 reopen attempts of 5s settle + 2s menu wait each + a 3s
+  // confirm wait, which is over 30s of step budget on its own.
   timeout: 30_000,
   retries: 1,
   workers: 1,

--- a/shared/tests/e2e/shared/test-ids.ts
+++ b/shared/tests/e2e/shared/test-ids.ts
@@ -22,6 +22,9 @@ export const CHAT_EMOJI_PICKER = 'chat-emoji-picker'
 export const CHAT_ATTACHMENT_IMAGE      = 'chat-attachment-image'
 export const CHAT_ATTACHMENT_FULLSCREEN = 'chat-attachment-fullscreen'
 export const CHAT_BOT_ROW               = 'chat-bot-row'
+// the install modal's footer button varies with the bot's state (Install /
+// Review / Edit settings / Uninstall), so tests key off the modal itself
+export const CHAT_BOT_INSTALL           = 'chat-bot-install'
 export const CHAT_SUGGESTION_LIST       = 'chat-suggestion-list'
 export const CHAT_EMOJI_BUTTON          = 'chat-emoji-button'
 export const CHAT_INFO_PANEL_SETTINGS_TAB = 'chat-info-panel-settings-tab'
@@ -95,6 +98,8 @@ export const CRYPTO_DECRYPT_INPUT = 'crypto-decrypt-input'
 export const CRYPTO_SIGN_INPUT    = 'crypto-sign-input'
 export const CRYPTO_VERIFY_INPUT  = 'crypto-verify-input'
 export const CRYPTO_RUN_BUTTON    = 'crypto-run-button'
+// The recipients field is a display-only input inside a pointerEvents="none"
+// wrapper, so only this outer clickable can receive a click.
 
 // Common — keep value matching existing testID="backButton" in .maestro subflows
 export const COMMON_BACK_BUTTON = 'backButton'

--- a/shared/tests/e2e/shared/test-ids.ts
+++ b/shared/tests/e2e/shared/test-ids.ts
@@ -98,6 +98,7 @@ export const CRYPTO_DECRYPT_INPUT = 'crypto-decrypt-input'
 export const CRYPTO_SIGN_INPUT    = 'crypto-sign-input'
 export const CRYPTO_VERIFY_INPUT  = 'crypto-verify-input'
 export const CRYPTO_RUN_BUTTON    = 'crypto-run-button'
+export const CRYPTO_RECIPIENTS    = 'crypto-recipients'
 // The recipients field is a display-only input inside a pointerEvents="none"
 // wrapper, so only this outer clickable can receive a click.
 

--- a/shared/tracker/identify-session.tsx
+++ b/shared/tracker/identify-session.tsx
@@ -52,6 +52,14 @@ export type IdentifyLoadOptions = {
   maxAgeMs?: number
 }
 
+// Every map here is keyed on the username, and callers do not agree on its case:
+// a profile opens with whatever the link or the row carried, while the shared
+// mutual-teams cache next to it lowercases. Two spellings of one person would
+// otherwise mean two sessions and two identifies - exactly what this file
+// exists to prevent. Assertions are case insensitive, so the canonical form is
+// safe to send to the service as well.
+const canonicalUsername = (username: string) => username.toLowerCase()
+
 const sessions = new Map<string, Session>()
 // Survives the session being dropped when it goes idle: closing a profile and
 // reopening it should still count as "we just checked this user".
@@ -101,7 +109,10 @@ const makeSession = (username: string): Session => ({
   username,
 })
 
-const ensureSession = (username: string) => {
+// the single place a raw username becomes a key; every s.username below is
+// therefore already canonical
+const ensureSession = (rawUsername: string) => {
+  const username = canonicalUsername(rawUsername)
   const existing = sessions.get(username)
   if (existing) {
     return existing
@@ -272,10 +283,12 @@ const loadFollowing = async (s: Session, generation: number) => {
   }
 }
 
-export const loadProfileIdentify = (username: string, options: IdentifyLoadOptions) => {
-  if (!username) {
+export const loadProfileIdentify = (rawUsername: string, options: IdentifyLoadOptions) => {
+  if (!rawUsername) {
     return
   }
+  // lastCompleted below is keyed the same way the session map is
+  const username = canonicalUsername(rawUsername)
   ensureEngineSubscriptions()
   const {freshAfter, ignoreCache} = options
   const s = ensureSession(username)
@@ -375,7 +388,7 @@ const ensureEngineSubscriptions = () => {
   })
 
   subscribeToEngineAction('keybase.1.NotifyTracking.trackingChanged', action => {
-    const s = sessions.get(action.payload.params.username)
+    const s = sessions.get(canonicalUsername(action.payload.params.username))
     if (!s?.details.guiID) {
       return
     }
@@ -384,7 +397,8 @@ const ensureEngineSubscriptions = () => {
   })
 
   subscribeToEngineAction('keybase.1.NotifyUsers.userChanged', action => {
-    const {uid, username} = useCurrentUserState.getState()
+    const {uid, username: rawUsername} = useCurrentUserState.getState()
+    const username = rawUsername ? canonicalUsername(rawUsername) : ''
     if (!username || uid !== action.payload.params.uid || !sessions.has(username)) {
       return
     }
@@ -393,7 +407,8 @@ const ensureEngineSubscriptions = () => {
   })
 }
 
-export const subscribeToProfile = (username: string, cb: () => void) => {
+export const subscribeToProfile = (rawUsername: string, cb: () => void) => {
+  const username = canonicalUsername(rawUsername)
   ensureSession(username)
   let subscribers = subscribersByUsername.get(username)
   if (!subscribers) {
@@ -413,8 +428,9 @@ export const subscribeToProfile = (username: string, cb: () => void) => {
   }
 }
 
-export const getProfileDetails = (username: string) => sessions.get(username)?.details
-export const getProfileNonUserDetails = (username: string) => sessions.get(username)?.nonUserDetails
+export const getProfileDetails = (username: string) => sessions.get(canonicalUsername(username))?.details
+export const getProfileNonUserDetails = (username: string) =>
+  sessions.get(canonicalUsername(username))?.nonUserDetails
 
 registerExternalResetter('tracker-identify-sessions', () => {
   sessions.clear()

--- a/shared/tracker/identify-session.tsx
+++ b/shared/tracker/identify-session.tsx
@@ -1,0 +1,409 @@
+import * as C from '@/constants'
+import * as T from '@/constants/types'
+import logger from '@/logger'
+import {RPCError} from '@/util/errors'
+import {generateGUIID, ignorePromise} from '@/constants/utils'
+import {navigateAppend, navigateUp} from '@/constants/router'
+import {produce} from 'immer'
+import {registerExternalResetter} from '@/util/zustand'
+import {subscribeToEngineAction} from '@/engine/action-listener'
+import {useCurrentUserState} from '@/stores/current-user'
+import {useUsersState} from '@/stores/users'
+import {
+  identifyResultToDetailsState,
+  makeDetails,
+  noNonUserDetails,
+  updateTrackerDetailsBlocked,
+  updateTrackerDetailsReset,
+  updateTrackerDetailsResult,
+  updateTrackerDetailsRow,
+  updateTrackerDetailsSummary,
+  updateTrackerDetailsUserCard,
+} from './model'
+
+// One identify per user, shared by every surface showing that user. An
+// Identify3 with ignoreCache re-fetches every proof from the third party host,
+// so N surfaces each running their own identify is N times the load on those
+// hosts (and the service serializes them per uid, so they also run back to
+// back). Instead a single session per username owns the identify, accumulates
+// every identify3Ui event for it, and fans the result out to its subscribers -
+// including ones that join after the identify already started.
+type Session = {
+  details: T.Tracker.Details
+  generation: number
+  ignoreCache: boolean
+  inFlight: boolean
+  nonUserDetails: T.Tracker.NonUserDetails
+  startedAt: number
+  username: string
+}
+
+export type IdentifyLoadOptions = {
+  // Join an identify that is already running only if it started at or after
+  // this timestamp, mirroring the singleflight in go/libkb/proof_cache.go.
+  // 0: any in-flight identify is good enough (mount, focus).
+  // Date.now(): only one started in reaction to the same event (notifications).
+  // Infinity: never join, always a fresh identify (explicit user reload).
+  freshAfter: number
+  ignoreCache: boolean
+  // Skip entirely if an identify at least this strong finished less than this
+  // long ago. Only the mount path sets it: reopening a profile you just looked
+  // at should not re-run every proof check. An explicit reload leaves it unset.
+  maxAgeMs?: number
+}
+
+const sessions = new Map<string, Session>()
+// Survives the session being dropped when it goes idle: closing a profile and
+// reopening it should still count as "we just checked this user".
+const lastCompleted = new Map<string, {at: number; ignoreCache: boolean}>()
+// Kept outside of Session so a subscriber stays attached to its username even
+// if the session object behind it is replaced.
+const subscribersByUsername = new Map<string, Set<() => void>>()
+
+const notify = (username: string) => {
+  const subscribers = subscribersByUsername.get(username)
+  if (!subscribers?.size) {
+    return
+  }
+  for (const cb of [...subscribers]) {
+    cb()
+  }
+}
+
+const setDetails = (s: Session, next: T.Tracker.Details) => {
+  if (next === s.details) {
+    return
+  }
+  s.details = next
+  notify(s.username)
+}
+
+const makeSession = (username: string): Session => ({
+  details: makeDetails(username),
+  generation: 0,
+  ignoreCache: false,
+  inFlight: false,
+  nonUserDetails: noNonUserDetails,
+  startedAt: 0,
+  username,
+})
+
+const ensureSession = (username: string) => {
+  const existing = sessions.get(username)
+  if (existing) {
+    return existing
+  }
+  const created = makeSession(username)
+  sessions.set(username, created)
+  return created
+}
+
+const dropSessionIfIdle = (s: Session) => {
+  if (s.inFlight || subscribersByUsername.get(s.username)?.size) {
+    return
+  }
+  if (sessions.get(s.username) === s) {
+    sessions.delete(s.username)
+  }
+}
+
+const sessionForGuiID = (guiID: string) => {
+  for (const s of sessions.values()) {
+    if (s.details.guiID === guiID) {
+      return s
+    }
+  }
+  return undefined
+}
+
+const loadNonUserDetails = async (s: Session, generation: number) => {
+  const assertion = s.username
+  try {
+    const res = await T.RPCGen.userSearchGetNonUserDetailsRpcPromise({assertion})
+    if (s.generation !== generation || !res.isNonUser) {
+      return
+    }
+    const common = {
+      assertionKey: res.assertionKey,
+      assertionValue: res.assertionValue,
+      description: res.description,
+      siteIcon: res.siteIcon || [],
+      siteIconDarkmode: res.siteIconDarkmode || [],
+      siteIconFull: res.siteIconFull || [],
+      siteIconFullDarkmode: res.siteIconFullDarkmode || [],
+      siteURL: '',
+    }
+    if (res.service) {
+      s.nonUserDetails = {...noNonUserDetails, ...common, ...res.service}
+      notify(s.username)
+    } else {
+      const {formatPhoneNumberInternational} = await import('@/util/phone-numbers')
+      const formattedName =
+        res.assertionKey === 'phone' ? formatPhoneNumberInternational('+' + res.assertionValue) : undefined
+      const fullName = res.contact?.contactName ?? ''
+      if (s.generation !== generation) {
+        return
+      }
+      s.nonUserDetails = {...noNonUserDetails, ...common, formattedName, fullName}
+      notify(s.username)
+    }
+  } catch (error) {
+    if (error instanceof RPCError) {
+      logger.warn(`Error loading non user profile: ${error.message}`)
+    }
+  } finally {
+    dropSessionIfIdle(s)
+  }
+}
+
+export const loadNonUserProfile = (username: string) => {
+  if (!username) {
+    return
+  }
+  const s = ensureSession(username)
+  ignorePromise(loadNonUserDetails(s, s.generation))
+}
+
+const runIdentify = async (s: Session, generation: number, guiID: string, ignoreCache: boolean) => {
+  try {
+    await T.RPCGen.identify3Identify3RpcListener({
+      incomingCallMap: {},
+      params: {assertion: s.username, guiID, ignoreCache},
+      waitingKey: C.waitingKeyTrackerProfileLoad,
+    })
+  } catch (error) {
+    if (!(error instanceof RPCError) || s.generation !== generation) {
+      return
+    }
+    if (error.code === T.RPCGen.StatusCode.scresolutionfailed) {
+      setDetails(
+        s,
+        produce(s.details, draft => {
+          draft.state = 'notAUserYet'
+        })
+      )
+      loadNonUserProfile(s.username)
+    } else if (error.code === T.RPCGen.StatusCode.scnotfound) {
+      navigateUp()
+      navigateAppend({
+        name: 'keybaseLinkError',
+        params: {
+          error: `You followed a profile link for a user (${s.username}) that does not exist.`,
+        },
+      })
+    }
+    logger.error(`Error loading profile: ${error.message}`)
+  } finally {
+    if (s.generation === generation) {
+      s.inFlight = false
+      lastCompleted.set(s.username, {at: Date.now(), ignoreCache: s.ignoreCache})
+      dropSessionIfIdle(s)
+    }
+  }
+}
+
+const loadFollowers = async (s: Session, generation: number) => {
+  try {
+    const fs = await T.RPCGen.userListTrackersUnverifiedRpcPromise(
+      {assertion: s.username},
+      C.waitingKeyTrackerProfileLoad
+    )
+    if (s.generation !== generation) {
+      return
+    }
+    setDetails(
+      s,
+      produce(s.details, draft => {
+        draft.followers = new Set((fs.users ?? []).map(f => f.username))
+        draft.followersCount = fs.users?.length ?? 0
+      })
+    )
+    if (fs.users) {
+      useUsersState
+        .getState()
+        .dispatch.updates(fs.users.map(u => ({info: {fullname: u.fullName}, name: u.username})))
+    }
+  } catch (error) {
+    if (error instanceof RPCError) {
+      logger.error(`Error loading follower info: ${error.message}`)
+    }
+  }
+}
+
+const loadFollowing = async (s: Session, generation: number) => {
+  try {
+    const fs = await T.RPCGen.userListTrackingRpcPromise(
+      {assertion: s.username, filter: ''},
+      C.waitingKeyTrackerProfileLoad
+    )
+    if (s.generation !== generation) {
+      return
+    }
+    setDetails(
+      s,
+      produce(s.details, draft => {
+        draft.following = new Set((fs.users ?? []).map(f => f.username))
+        draft.followingCount = fs.users?.length ?? 0
+      })
+    )
+    if (fs.users) {
+      useUsersState
+        .getState()
+        .dispatch.updates(fs.users.map(u => ({info: {fullname: u.fullName}, name: u.username})))
+    }
+  } catch (error) {
+    if (error instanceof RPCError) {
+      logger.error(`Error loading following info: ${error.message}`)
+    }
+  }
+}
+
+export const loadProfileIdentify = (username: string, options: IdentifyLoadOptions) => {
+  if (!username) {
+    return
+  }
+  ensureEngineSubscriptions()
+  const {freshAfter, ignoreCache} = options
+  const s = ensureSession(username)
+  // A weaker in-flight identify (one that was allowed to use the proof cache)
+  // cannot stand in for a caller that asked for a forced remote check.
+  const strongEnough = s.ignoreCache || !ignoreCache
+  if (s.inFlight && strongEnough && s.startedAt >= freshAfter) {
+    return
+  }
+  // A recent finished identify counts too, so long as it was at least as strong
+  // as what is being asked for now.
+  const {maxAgeMs} = options
+  const done = lastCompleted.get(username)
+  if (maxAgeMs !== undefined && done && (done.ignoreCache || !ignoreCache) && Date.now() - done.at < maxAgeMs) {
+    return
+  }
+
+  const guiID = generateGUIID()
+  const generation = ++s.generation
+  s.ignoreCache = ignoreCache
+  s.inFlight = true
+  s.startedAt = Date.now()
+  setDetails(
+    s,
+    produce(s.details, draft => {
+      draft.guiID = guiID
+      if (!draft.resetBrokeTrack) {
+        draft.reason = ''
+      }
+      draft.state = 'checking'
+    })
+  )
+  ignorePromise(runIdentify(s, generation, guiID, ignoreCache))
+  ignorePromise(loadFollowers(s, generation))
+  ignorePromise(loadFollowing(s, generation))
+}
+
+// Registered once for the lifetime of the module. The unsubscribes are dropped
+// on purpose; sign out clears the engine listener registry wholesale and the
+// flag below lets them be re-registered on the next load.
+let engineSubscribed = false
+const ensureEngineSubscriptions = () => {
+  if (engineSubscribed) {
+    return
+  }
+  engineSubscribed = true
+
+  subscribeToEngineAction('keybase.1.identify3Ui.identify3Result', action => {
+    const {guiID, result} = action.payload.params
+    const s = sessionForGuiID(guiID)
+    if (!s) {
+      return
+    }
+    setDetails(s, updateTrackerDetailsResult(s.details, identifyResultToDetailsState(result)))
+  })
+
+  subscribeToEngineAction('keybase.1.identify3Ui.identify3UpdateRow', action => {
+    const {row} = action.payload.params
+    const s = sessionForGuiID(row.guiID)
+    if (!s) {
+      return
+    }
+    setDetails(s, updateTrackerDetailsRow(s.details, row))
+  })
+
+  subscribeToEngineAction('keybase.1.identify3Ui.identify3UserReset', action => {
+    const s = sessionForGuiID(action.payload.params.guiID)
+    if (!s) {
+      return
+    }
+    setDetails(s, updateTrackerDetailsReset(s.details))
+  })
+
+  subscribeToEngineAction('keybase.1.identify3Ui.identify3UpdateUserCard', action => {
+    const {guiID, card} = action.payload.params
+    const s = sessionForGuiID(guiID)
+    if (!s) {
+      return
+    }
+    setDetails(s, updateTrackerDetailsUserCard(s.details, card))
+    useUsersState.getState().dispatch.updates([{info: {fullname: card.fullName}, name: s.username}])
+  })
+
+  subscribeToEngineAction('keybase.1.identify3Ui.identify3Summary', action => {
+    const {summary} = action.payload.params
+    const s = sessionForGuiID(summary.guiID)
+    if (!s) {
+      return
+    }
+    setDetails(s, updateTrackerDetailsSummary(s.details, summary))
+  })
+
+  subscribeToEngineAction('keybase.1.NotifyTracking.notifyUserBlocked', action => {
+    for (const s of [...sessions.values()]) {
+      setDetails(s, updateTrackerDetailsBlocked(s.details, action.payload.params.b))
+    }
+  })
+
+  subscribeToEngineAction('keybase.1.NotifyTracking.trackingChanged', action => {
+    const s = sessions.get(action.payload.params.username)
+    if (!s?.details.guiID) {
+      return
+    }
+    lastCompleted.delete(s.username)
+    loadProfileIdentify(s.username, {freshAfter: Date.now(), ignoreCache: true})
+  })
+
+  subscribeToEngineAction('keybase.1.NotifyUsers.userChanged', action => {
+    const {uid, username} = useCurrentUserState.getState()
+    if (!username || uid !== action.payload.params.uid || !sessions.has(username)) {
+      return
+    }
+    lastCompleted.delete(username)
+    loadProfileIdentify(username, {freshAfter: Date.now(), ignoreCache: false})
+  })
+}
+
+export const subscribeToProfile = (username: string, cb: () => void) => {
+  ensureSession(username)
+  let subscribers = subscribersByUsername.get(username)
+  if (!subscribers) {
+    subscribers = new Set()
+    subscribersByUsername.set(username, subscribers)
+  }
+  subscribers.add(cb)
+  return () => {
+    subscribers.delete(cb)
+    if (!subscribers.size) {
+      subscribersByUsername.delete(username)
+    }
+    const s = sessions.get(username)
+    if (s) {
+      dropSessionIfIdle(s)
+    }
+  }
+}
+
+export const getProfileDetails = (username: string) => sessions.get(username)?.details
+export const getProfileNonUserDetails = (username: string) => sessions.get(username)?.nonUserDetails
+
+registerExternalResetter('tracker-identify-sessions', () => {
+  sessions.clear()
+  lastCompleted.clear()
+  engineSubscribed = false
+})

--- a/shared/tracker/identify-session.tsx
+++ b/shared/tracker/identify-session.tsx
@@ -56,6 +56,19 @@ const sessions = new Map<string, Session>()
 // Survives the session being dropped when it goes idle: closing a profile and
 // reopening it should still count as "we just checked this user".
 const lastCompleted = new Map<string, {at: number; ignoreCache: boolean}>()
+// An entry is only ever read against the caller's maxAgeMs, and the longest one
+// any caller passes is the profile screen's 30s recheck window, so anything this
+// old can never suppress an identify again - it is only holding a username.
+const lastCompletedTTLMs = 5 * 60_000
+
+const pruneLastCompleted = () => {
+  const now = Date.now()
+  for (const [username, done] of lastCompleted) {
+    if (now - done.at >= lastCompletedTTLMs) {
+      lastCompleted.delete(username)
+    }
+  }
+}
 // Kept outside of Session so a subscriber stays attached to its username even
 // if the session object behind it is replaced.
 const subscribersByUsername = new Map<string, Set<() => void>>()
@@ -196,6 +209,7 @@ const runIdentify = async (s: Session, generation: number, guiID: string, ignore
   } finally {
     if (s.generation === generation) {
       s.inFlight = false
+      pruneLastCompleted()
       lastCompleted.set(s.username, {at: Date.now(), ignoreCache: s.ignoreCache})
       dropSessionIfIdle(s)
     }

--- a/shared/tracker/use-profile.tsx
+++ b/shared/tracker/use-profile.tsx
@@ -13,6 +13,11 @@ import {
 // this window reuses the check that just ran; an explicit reload always forces.
 const profileRecheckMs = 30_000
 
+// There is deliberately no focus-based reload here. Only mounting, an explicit
+// reload, or a tracking / userChanged notification starts an identify: refocusing
+// a screen that stayed mounted is not a signal that the identity changed, and
+// treating it as one made every tab switch re-check every proof.
+
 type Options = {
   // surfaces that only want loadProfile() to call after an action, and never
   // read details, can skip the identify their mount would otherwise trigger

--- a/shared/tracker/use-profile.tsx
+++ b/shared/tracker/use-profile.tsx
@@ -1,304 +1,75 @@
-import * as C from '@/constants'
 import * as React from 'react'
-import * as T from '@/constants/types'
-import {generateGUIID, ignorePromise} from '@/constants/utils'
-import {useCurrentUserState} from '@/stores/current-user'
-import {useUsersState} from '@/stores/users'
-import {useEngineActionListener} from '@/engine/action-listener'
-import {produce} from 'immer'
-import logger from '@/logger'
-import {RPCError} from '@/util/errors'
-import {navigateAppend, navigateUp} from '@/constants/router'
+import {makeDetails, noNonUserDetails} from './model'
 import {
-  identifyResultToDetailsState,
-  makeDetails,
-  noNonUserDetails,
-  updateTrackerDetailsBlocked,
-  updateTrackerDetailsReset,
-  updateTrackerDetailsResult,
-  updateTrackerDetailsRow,
-  updateTrackerDetailsSummary,
-  updateTrackerDetailsUserCard,
-} from './model'
+  getProfileDetails,
+  getProfileNonUserDetails,
+  loadNonUserProfile,
+  loadProfileIdentify,
+  subscribeToProfile,
+} from './identify-session'
+
+// Reopening a profile you were just looking at re-runs every proof check, and
+// each one is an outbound request to a third-party host. Opening it again within
+// this window reuses the check that just ran; an explicit reload always forces.
+const profileRecheckMs = 30_000
 
 type Options = {
-  reloadOnFocus?: boolean
-}
-
-const loadNonUserDetails = async (
-  username: string,
-  version: number,
-  requestVersionRef: React.RefObject<number>,
-  setNonUserDetails: React.Dispatch<
-    React.SetStateAction<{details: T.Tracker.NonUserDetails; username: string}>
-  >
-) => {
-  const assertion = username
-  try {
-    const res = await T.RPCGen.userSearchGetNonUserDetailsRpcPromise({assertion})
-    if (requestVersionRef.current !== version || !res.isNonUser) {
-      return
-    }
-    const common = {
-      assertionKey: res.assertionKey,
-      assertionValue: res.assertionValue,
-      description: res.description,
-      siteIcon: res.siteIcon || [],
-      siteIconDarkmode: res.siteIconDarkmode || [],
-      siteIconFull: res.siteIconFull || [],
-      siteIconFullDarkmode: res.siteIconFullDarkmode || [],
-      siteURL: '',
-    }
-    if (res.service) {
-      setNonUserDetails({details: {...noNonUserDetails, ...common, ...res.service}, username})
-    } else {
-      const {formatPhoneNumberInternational} = await import('@/util/phone-numbers')
-      const formattedName =
-        res.assertionKey === 'phone' ? formatPhoneNumberInternational('+' + res.assertionValue) : undefined
-      const fullName = res.contact?.contactName ?? ''
-      if (requestVersionRef.current !== version) {
-        return
-      }
-      setNonUserDetails({
-        details: {...noNonUserDetails, ...common, formattedName, fullName},
-        username,
-      })
-    }
-  } catch (error) {
-    if (error instanceof RPCError) {
-      logger.warn(`Error loading non user profile: ${error.message}`)
-    }
-  }
+  // surfaces that only want loadProfile() to call after an action, and never
+  // read details, can skip the identify their mount would otherwise trigger
+  loadOnMount?: boolean
+  // Opening a profile means "check this identity now", so it forces a remote
+  // check of every proof. Incidental surfaces - a hover card, a follow button in
+  // a list - do not: they still need an identify session, but the cached proof
+  // results answer them, and forcing one re-fetches every proof from its
+  // third-party host, which those hosts rate limit.
+  cachedOnMount?: boolean
 }
 
 export const useTrackerProfile = (username: string, options?: Options) => {
-  const currentUser = useCurrentUserState(
-    C.useShallow(s => ({
-      uid: s.uid,
-      username: s.username,
-    }))
-  )
-  const [details, setDetails] = React.useState<T.Tracker.Details>(() => makeDetails(username))
-  const [nonUserDetails, setNonUserDetails] = React.useState<{
-    details: T.Tracker.NonUserDetails
-    username: string
-  }>(() => ({
-    details: {...noNonUserDetails},
+  const emptyDetails = React.useMemo(() => makeDetails(username), [username])
+
+  const subscribe = React.useCallback((cb: () => void) => subscribeToProfile(username, cb), [username])
+  const getDetails = React.useCallback(() => getProfileDetails(username) ?? emptyDetails, [
+    emptyDetails,
     username,
-  }))
-  const requestVersionRef = React.useRef(0)
-  const detailsRef = React.useRef(details)
-  const hasSeenFocusRef = React.useRef(false)
+  ])
+  const getNonUserDetails = React.useCallback(
+    () => getProfileNonUserDetails(username) ?? noNonUserDetails,
+    [username]
+  )
+  const details = React.useSyncExternalStore(subscribe, getDetails)
+  const nonUserDetails = React.useSyncExternalStore(subscribe, getNonUserDetails)
 
-  React.useEffect(() => {
-    detailsRef.current = details
-  }, [details])
-
-  const loadNonUserProfile = React.useCallback(() => {
-    if (!username) {
-      return
-    }
-    ignorePromise(
-      loadNonUserDetails(username, requestVersionRef.current, requestVersionRef, setNonUserDetails)
-    )
+  const loadNonUser = React.useCallback(() => {
+    loadNonUserProfile(username)
   }, [username])
 
+  // Every caller of this is a deliberate user action (opening reload, or a
+  // refresh after follow / profile edit), so it never joins an identify that
+  // was already running.
   const loadProfile = React.useCallback(
     (ignoreCache = true) => {
-      if (!username) {
-        return
-      }
-      const guiID = generateGUIID()
-      const version = requestVersionRef.current + 1
-      requestVersionRef.current = version
-      const preserveExistingData = detailsRef.current.username === username
-
-      setDetails(prev =>
-        produce(preserveExistingData ? prev : makeDetails(username), draft => {
-          draft.guiID = guiID
-          if (!draft.resetBrokeTrack) {
-            draft.reason = ''
-          }
-          draft.state = 'checking'
-        })
-      )
-
-      const load = async () => {
-        try {
-          await T.RPCGen.identify3Identify3RpcListener({
-            incomingCallMap: {},
-            params: {assertion: username, guiID, ignoreCache},
-            waitingKey: C.waitingKeyTrackerProfileLoad,
-          })
-        } catch (error) {
-          if (!(error instanceof RPCError) || requestVersionRef.current !== version) {
-            return
-          }
-          if (error.code === T.RPCGen.StatusCode.scresolutionfailed) {
-            setDetails(
-              produce(draft => {
-                draft.state = 'notAUserYet'
-              })
-            )
-            loadNonUserProfile()
-          } else if (error.code === T.RPCGen.StatusCode.scnotfound) {
-            navigateUp()
-            navigateAppend({
-              name: 'keybaseLinkError',
-              params: {
-                error: `You followed a profile link for a user (${username}) that does not exist.`,
-              },
-            })
-          }
-          logger.error(`Error loading profile: ${error.message}`)
-        }
-      }
-      ignorePromise(load())
-
-      const loadFollowers = async () => {
-        try {
-          const fs = await T.RPCGen.userListTrackersUnverifiedRpcPromise(
-            {assertion: username},
-            C.waitingKeyTrackerProfileLoad
-          )
-          if (requestVersionRef.current !== version) {
-            return
-          }
-          setDetails(
-            produce(draft => {
-              draft.followers = new Set((fs.users ?? []).map(f => f.username))
-              draft.followersCount = fs.users?.length ?? 0
-            })
-          )
-          if (fs.users) {
-            useUsersState
-              .getState()
-              .dispatch.updates(fs.users.map(u => ({info: {fullname: u.fullName}, name: u.username})))
-          }
-        } catch (error) {
-          if (error instanceof RPCError) {
-            logger.error(`Error loading follower info: ${error.message}`)
-          }
-        }
-      }
-      ignorePromise(loadFollowers())
-
-      const loadFollowing = async () => {
-        try {
-          const fs = await T.RPCGen.userListTrackingRpcPromise(
-            {assertion: username, filter: ''},
-            C.waitingKeyTrackerProfileLoad
-          )
-          if (requestVersionRef.current !== version) {
-            return
-          }
-          setDetails(
-            produce(draft => {
-              draft.following = new Set((fs.users ?? []).map(f => f.username))
-              draft.followingCount = fs.users?.length ?? 0
-            })
-          )
-          if (fs.users) {
-            useUsersState
-              .getState()
-              .dispatch.updates(fs.users.map(u => ({info: {fullname: u.fullName}, name: u.username})))
-          }
-        } catch (error) {
-          if (error instanceof RPCError) {
-            logger.error(`Error loading following info: ${error.message}`)
-          }
-        }
-      }
-      ignorePromise(loadFollowing())
+      loadProfileIdentify(username, {freshAfter: Infinity, ignoreCache})
     },
-    [loadNonUserProfile, username]
+    [username]
   )
 
+  const loadOnMount = options?.loadOnMount ?? true
+  const cachedOnMount = options?.cachedOnMount ?? false
   React.useEffect(() => {
-    if (username) {
-      loadProfile()
+    if (loadOnMount) {
+      loadProfileIdentify(username, {
+        freshAfter: 0,
+        ignoreCache: !cachedOnMount,
+        maxAgeMs: profileRecheckMs,
+      })
     }
-  }, [loadProfile, username])
-
-  C.Router2.useSafeFocusEffect(
-    React.useCallback(() => {
-      if (!options?.reloadOnFocus) {
-        return
-      }
-      // The initial mount path already loads once. Skip the first focus callback
-      // so entering the screen does not immediately trigger a second hard reload.
-      if (!hasSeenFocusRef.current) {
-        hasSeenFocusRef.current = true
-        return
-      }
-      loadProfile(false)
-    }, [loadProfile, options?.reloadOnFocus])
-  )
-
-  useEngineActionListener('keybase.1.NotifyTracking.trackingChanged', action => {
-    if (action.payload.params.username === username && detailsRef.current.guiID) {
-      loadProfile()
-    }
-  })
-
-  useEngineActionListener('keybase.1.identify3Ui.identify3Result', action => {
-    const {guiID, result} = action.payload.params
-    if (guiID !== detailsRef.current.guiID) {
-      return
-    }
-    setDetails(prev => updateTrackerDetailsResult(prev, identifyResultToDetailsState(result)))
-  })
-
-  useEngineActionListener('keybase.1.NotifyUsers.userChanged', action => {
-    if (currentUser.username === username && currentUser.uid === action.payload.params.uid) {
-      loadProfile(false)
-    }
-  })
-
-  useEngineActionListener('keybase.1.NotifyTracking.notifyUserBlocked', action => {
-    setDetails(prev => updateTrackerDetailsBlocked(prev, action.payload.params.b))
-  })
-
-  useEngineActionListener('keybase.1.identify3Ui.identify3UpdateRow', action => {
-    const {row} = action.payload.params
-    if (row.guiID !== detailsRef.current.guiID) {
-      return
-    }
-    setDetails(prev => updateTrackerDetailsRow(prev, row))
-  })
-
-  useEngineActionListener('keybase.1.identify3Ui.identify3UserReset', action => {
-    if (action.payload.params.guiID !== detailsRef.current.guiID) {
-      return
-    }
-    setDetails(prev => updateTrackerDetailsReset(prev))
-  })
-
-  useEngineActionListener('keybase.1.identify3Ui.identify3UpdateUserCard', action => {
-    const {guiID, card} = action.payload.params
-    if (guiID !== detailsRef.current.guiID) {
-      return
-    }
-    setDetails(prev => updateTrackerDetailsUserCard(prev, card))
-    useUsersState.getState().dispatch.updates([{info: {fullname: card.fullName}, name: username}])
-  })
-
-  useEngineActionListener('keybase.1.identify3Ui.identify3Summary', action => {
-    const {summary} = action.payload.params
-    if (summary.guiID !== detailsRef.current.guiID) {
-      return
-    }
-    setDetails(prev => updateTrackerDetailsSummary(prev, summary))
-  })
-
-  const detailsForUsername = details.username === username ? details : makeDetails(username)
-  const nonUserDetailsForUsername =
-    nonUserDetails.username === username ? nonUserDetails.details : {...noNonUserDetails}
+  }, [cachedOnMount, loadOnMount, username])
 
   return {
-    details: detailsForUsername,
-    loadNonUserProfile,
+    details,
+    loadNonUserProfile: loadNonUser,
     loadProfile,
-    nonUserDetails: nonUserDetailsForUsername,
+    nonUserDetails,
   }
 }

--- a/shared/tracker/use-profile.tsx
+++ b/shared/tracker/use-profile.tsx
@@ -71,10 +71,13 @@ export const useTrackerProfile = (username: string, options?: Options) => {
     }
   }, [cachedOnMount, loadOnMount, username])
 
-  return {
-    details,
-    loadNonUserProfile: loadNonUser,
-    loadProfile,
-    nonUserDetails,
-  }
+  return React.useMemo(
+    () => ({
+      details,
+      loadNonUserProfile: loadNonUser,
+      loadProfile,
+      nonUserDetails,
+    }),
+    [details, loadNonUser, loadProfile, nonUserDetails]
+  )
 }

--- a/shared/util/fs-platform.tsx
+++ b/shared/util/fs-platform.tsx
@@ -11,6 +11,7 @@ import {launchImageLibraryAsync} from '@/util/expo-image-picker'
 import {pickDocumentsAsync} from '@/util/expo-document-picker.native'
 import {saveAttachmentToCameraRoll, showShareActionSheet} from '@/util/platform-specific'
 import {fsCacheDir, fsDownloadDir, androidAddCompleteDownload} from 'react-native-kb'
+import {registerExternalResetter} from '@/util/zustand'
 
 // Desktop-only exports (stubs on mobile)
 export const fuseStatusToDriverStatus = (status?: T.RPCGen.FuseStatus): T.FS.DriverStatus => {
@@ -300,6 +301,11 @@ export const afterKbfsDaemonRpcStatusChangedMobile = async () => {
 }
 
 const finishedRegularDownloadIDs = new Set<string>()
+
+// module scope outlives sign-out; holds the previous user's download ids
+registerExternalResetter('fs-finished-regular-downloads', () => {
+  finishedRegularDownloadIDs.clear()
+})
 
 export const finishedRegularDownloadMobile = async (
   downloadID: string,

--- a/shared/util/use-local-badging.tsx
+++ b/shared/util/use-local-badging.tsx
@@ -26,12 +26,16 @@ export const useLocalBadging = (storeSet: ReadonlySet<string> | undefined, clear
     })
   }
 
-  C.Router2.useSafeFocusEffect(() => {
-    clearStoreBadges()
-    return () => {
-      setBadged(noBadges)
-    }
-  })
+  // clearStoreBadges must be stable in the caller: an unstable identity re-runs
+  // this focus effect every render, clearing the badges on the server repeatedly
+  C.Router2.useSafeFocusEffect(
+    React.useCallback(() => {
+      clearStoreBadges()
+      return () => {
+        setBadged(noBadges)
+      }
+    }, [clearStoreBadges])
+  )
 
   return {badged}
 }

--- a/shared/util/use-mutual-teams.tsx
+++ b/shared/util/use-mutual-teams.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import * as T from '@/constants/types'
+import logger from '@/logger'
+import {
+  type CachedResourceCache,
+  getCachedResourceCache,
+  useCachedResource,
+} from '@/teams/use-cached-resource'
+import {registerExternalResetter} from '@/util/zustand'
+
+// getMutualTeamsLocal makes the service localize every conversation the users
+// share, and each of those remotely refreshes its participant list - one call
+// was measured at ~82 outbound requests. Two consumers asking for the same
+// usernames at the same instant (the chat channel suggestor mounting twice, or
+// a profile and a suggestor for the same person) therefore has to collapse to
+// one RPC, so the cache is keyed on the usernames rather than on the screen.
+const mutualTeamsStaleMs = 60_000
+
+const emptyTeams: ReadonlyArray<T.RPCChat.SharedTeam> = []
+
+type MutualTeamsCacheMap = Map<
+  string,
+  CachedResourceCache<ReadonlyArray<T.RPCChat.SharedTeam>, string>
+>
+
+const mutualTeamsCache: MutualTeamsCacheMap = new Map()
+
+// module scope outlives sign-out and "teams you share with X" is per-user
+registerExternalResetter('mutual-teams-cache', () => {
+  mutualTeamsCache.forEach((cache, key) => cache.reset(emptyTeams, key))
+  mutualTeamsCache.clear()
+})
+
+// order-independent: two callers listing the same people must hit the same entry
+const mutualTeamsKey = (usernames: ReadonlyArray<string>) => [...usernames].sort().join(',')
+
+export const useMutualTeams = (
+  usernames: ReadonlyArray<string>,
+  waitingKey: string,
+  enabled = true,
+  // pass something that changes when the caller wants fresh data (a profile's
+  // identify guiID, say); it re-checks the stale window rather than forcing a load
+  refreshKey?: unknown
+): {loaded: boolean; loading: boolean; teams: ReadonlyArray<T.RPCChat.SharedTeam>} => {
+  const cacheKey = mutualTeamsKey(usernames)
+  // deliberately not gated on a non-empty username list: the service treats the
+  // empty case as a real query, and skipping it would change what callers get
+  const canLoad = enabled
+  // a disabled instance resets whatever cache it holds, so it must never hold
+  // the shared one
+  const [localCacheMap] = React.useState<MutualTeamsCacheMap>(() => new Map())
+  const cacheMap = canLoad ? mutualTeamsCache : localCacheMap
+  const cache = React.useMemo(
+    () => getCachedResourceCache(cacheMap, emptyTeams, cacheKey),
+    [cacheMap, cacheKey]
+  )
+  const {data, loaded, loading} = useCachedResource({
+    cache,
+    cacheKey,
+    enabled: canLoad,
+    initialData: emptyTeams,
+    load: async () => {
+      const res = await T.RPCChat.localGetMutualTeamsLocalRpcPromise(
+        {usernames: [...usernames]},
+        waitingKey
+      )
+      return res.teams ?? emptyTeams
+    },
+    onError: error => {
+      logger.warn(`Failed to load mutual teams for ${cacheKey}`, error)
+    },
+    refreshKey,
+    staleMs: mutualTeamsStaleMs,
+  })
+
+  return React.useMemo(() => ({loaded, loading, teams: data}), [loaded, loading, data])
+}

--- a/shared/wallets/index.tsx
+++ b/shared/wallets/index.tsx
@@ -118,7 +118,7 @@ const WalletsScreen = () => {
   const loadAccounts = C.useRPC(T.RPCStellar.localGetWalletAccountsLocalRpcPromise)
 
   C.Router2.useSafeFocusEffect(
-    () => {
+    React.useCallback(() => {
       loadAccounts(
         [undefined, loadAccountsWaitingKey],
         res => {
@@ -138,7 +138,7 @@ const WalletsScreen = () => {
         }
       )
       return () => {}
-    }
+    }, [loadAccounts, checkDisclaimer])
   )
 
   const loading = C.Waiting.useAnyWaiting(loadAccountsWaitingKey)

--- a/skill/keybase-rpc-log-analysis/SKILL.md
+++ b/skill/keybase-rpc-log-analysis/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: keybase-rpc-log-analysis
+description: Use when hunting redundant, duplicated or looping RPCs in the Keybase client — after a rate-limit error, a service log that rotates every few minutes, a slow or hot app, or to prove a caching fix actually reduced calls. Covers capturing a clean service log against a locally built service and reading it.
+---
+
+# Keybase RPC log analysis
+
+The Go service logs every RPC it serves and every call it makes. That log is the
+only place the client's real network behaviour is visible — the JS side shows
+intent, the log shows what actually went out. A quiet minute is ~45 lines; a
+minute with a flood is 120,000.
+
+## Capture a clean run
+
+```bash
+skill/keybase-rpc-log-analysis/scripts/clean-logs.sh --archive   # dry run without a flag
+skill/keybase-rpc-log-analysis/scripts/start-service.sh          # own terminal, foreground
+cd shared && yarn desktop:start:hot:e2e                          # another terminal
+cd shared && yarn test:e2e:desktop                               # or drive the app by hand
+```
+
+`start-service.sh` builds from this checkout, stops the running service, and logs
+with `-d --log-file` to `/tmp/kb-analysis/service.log`. Its own file matters: the
+default log is shared with everything else and a flood rotates the evidence away
+in under two minutes.
+
+`--log-file` **still rotates at 128MB** — a full e2e run produces ~220MB. Nothing
+is lost, but the analysis must include the siblings, so always pass them all:
+
+```bash
+python3 skill/keybase-rpc-log-analysis/scripts/rpc-report.py \
+  /tmp/kb-analysis/service.log-* /tmp/kb-analysis/service.log
+```
+
+The service forks kbfs from its own bin directory, and a plain `go install` of
+the service does not build it. Without kbfs the Files tab is empty and git
+fails with `KBFS client not found`, which fails every `files-*` and `git-*` e2e
+test for reasons unrelated to the change under test. `start-service.sh` warns.
+
+Ask before stopping the service or launching the app — both are the user's.
+
+## Read it
+
+| Question | Command |
+|---|---|
+| What did this run do? | `rpc-report.py <log> [--start 2026-07-24T17:23] [--end ...]` |
+| What was actually slow? | `rpc-cost.py <log> [--min-mean-ms 50]` |
+| Why is X called so much? | `rpc-why.py <log> --match 'AttachmentHTTPSrv: GetURL'` |
+| Did my fix work? | `rpc-diff.py before.log after.log` |
+
+**Run `rpc-cost.py` early.** Count and cost answer different questions, and the
+loudest line in the log is usually not the expensive one. In one capture the top
+line by count was an in-memory map lookup — 15,767 calls for 0.16s total, not
+worth touching — while the real cost was 469 team loads at 292ms each, 186
+seconds, sitting 30th by count.
+
+To *prove* a loud flood is free rather than just absent from the table, pass
+`--min-mean-ms 0 --top 400`: the default threshold hides cheap chatty ops, which
+is exactly the row you need. `AttachmentHTTPSrv: GetURL` at 4,848 calls does not
+appear at all by default, and shows as 0.04s total once it does.
+
+Analysing an already-rotated log is the same — pass
+`~/Library/Logs/keybase.service.log-<start>-<end>` directly. The filename carries
+its own window, so `--start/--end` are only for narrowing further.
+
+Read `rpc-report.py`'s sections in order:
+
+- **REMOTE** — service→server. Only these burn server rate limits. Start here.
+- **APP** — app→service. One of these usually explains a REMOTE row.
+- **BURSTS** — same call and subject, 3+ times in one second. Each row is a
+  missing cache or a remounting component.
+- **FLOODS** — most repeated lines, ids and numbers collapsed.
+
+A BURSTS row with a bare name and no `(subject)` means the subject could not be
+resolved: many RPCs log no arguments. Those rows are same-*name* only — treat
+them as a lead, not as proof the same conversation was hit twice.
+
+`rpc-why.py` answers attribution. **ROOT** (the app RPC that opened the trace) is
+usually the answer; **DRIVERS** (nearest preceding call) points at the specific
+line. **BATCHES** needs the span that logs the item count, which is normally the
+local one, not the remote it wraps — match `HybridConversationSource: GetMessages`,
+not `getMessagesRemote`. The script says so when it finds no counts.
+
+## What a bug looks like
+
+- **Same args, same second, N times** → no dedupe, or a keyed component remounting
+  as its props arrive in stages.
+- **Fires again the instant the previous lands** → a feedback loop, not user
+  action. Look for a cache that never records success, or an effect whose deps
+  change on every render.
+- **Batch sizes almost all 1** → the caller loops where it could fetch once.
+- **A per-item cost inside a loop** → e.g. a gregor state read per emoji.
+
+## Mistakes
+
+- **Guessing the trigger from neighbouring lines.** A burst surrounded by
+  startup-looking work is not necessarily startup. Correlate against something
+  independent: the mtimes of `shared/tests/results/test-results/*/test-finished-1.png`
+  give you a timestamped list of which test ran when, and `app.log` records
+  renderer reloads. One burst-per-profile-open and one burst-per-bootstrap look
+  identical in the service log until you check.
+- **Attributing to the child call.** The line directly above a flood is often
+  something the flood itself invoked. Trust ROOT over DRIVERS.
+- **Reading a fix as failed because the totals did not move.** If the app's
+  request volume changed between runs, a working cache can show flat server
+  counts. Count what the cache actually did — a hit rate, a log line — before
+  concluding anything. One cache here looked useless in one capture and turned
+  out to be a 79% reduction once the volume feeding it was fixed.
+- **Fixing what you have not measured.** Two of the loudest floods in this
+  log — 15,767 username lookups and 7,284 chain-storage misses — were worth
+  0.16s and 0.24s. Both were correctly left alone. `rpc-cost.py` first.
+- **Blaming the biggest number.** Service-side background work — the search
+  indexer especially — can dwarf the real bug. An empty ROOT means nothing asked
+  for it. Check whether it recurs on a timer before spending time on it.
+- **Reporting a burst as same-subject when it is not.** See the BURSTS caveat
+  above. If it matters, prove the subject repeats before claiming it.
+- **Using plain `grep`.** It is wrapped in this environment and truncates. Use
+  python, as the scripts do.
+- **Comparing unlike runs.** `rpc-diff.py` is only meaningful if both runs did
+  the same thing.
+
+## Shapes seen before
+
+Each of these was a real bug, and each is what its section looks like:
+
+- An app RPC in the thousands where the screen has tens of items — a per-item
+  prime re-run on every list reload.
+- A local call in the low single digits dragging thousands of lines behind it — a
+  per-item cost inside a server-side loop.
+- FLOODS dominated by one span whose BATCHES are almost all size 1.
+- An APP row whose count is a multiple of the number of times a screen was
+  opened — a component keyed on data that arrives in stages, remounting.
+- **A list row eagerly loading what only its hover popup needs.** The single
+  biggest win here was one `loadOnDemand` flag: a profile rendered a row per
+  team and each row annotated its team up front, for a popup nobody opened.
+- **A hook that subscribes to a broadcast per component instance.** One
+  notification then does N times the work, and if the work itself emits that
+  notification it compounds. Subscribe once at module scope and fan out.
+- **The same expensive load repeated because each surface holds its own copy.**
+  Two or three components asking for the same user or team at the same instant
+  is the common case, not the rare one.
+
+Where the money actually is in this client: identify/proof checks and team
+loads. Both are hundreds of milliseconds each and both fan out to several HTTP
+calls. Chat localization is cheap per call but runs over every channel.

--- a/skill/keybase-rpc-log-analysis/SKILL.md
+++ b/skill/keybase-rpc-log-analysis/SKILL.md
@@ -16,7 +16,7 @@ minute with a flood is 120,000.
 skill/keybase-rpc-log-analysis/scripts/clean-logs.sh --archive   # dry run without a flag
 skill/keybase-rpc-log-analysis/scripts/start-service.sh          # own terminal, foreground
 cd shared && yarn desktop:start:hot:e2e                          # another terminal
-cd shared && yarn test:e2e:desktop                               # or drive the app by hand
+cd shared && yarn test:e2e:desktop:rpc                           # or drive the app by hand
 ```
 
 `start-service.sh` builds from this checkout, stops the running service, and logs
@@ -24,20 +24,68 @@ with `-d --log-file` to `/tmp/kb-analysis/service.log`. Its own file matters: th
 default log is shared with everything else and a flood rotates the evidence away
 in under two minutes.
 
-`--log-file` **still rotates at 128MB** — a full e2e run produces ~220MB. Nothing
-is lost, but the analysis must include the siblings, so always pass them all:
+**Use `test:e2e:desktop:rpc`, not `test:e2e:desktop`.** The full suite is 6.6
+minutes over two projects (light and dark), which doubles every count and makes
+the log rotate. `test:e2e:desktop:rpc` is the six flows that actually drive team
+and channel loading, on one project, in 39 seconds. `test:e2e:desktop:flows`
+takes file arguments if you need a different set — always pass a single
+`--project` (it does), or light and dark each contribute a copy of every call.
+
+`--log-file` **still rotates at 128MB** — a full e2e run produces ~135MB and will
+cross it. Nothing is lost, but the analysis must then include the siblings, so
+pass them all:
 
 ```bash
 python3 skill/keybase-rpc-log-analysis/scripts/rpc-report.py \
   /tmp/kb-analysis/service.log-* /tmp/kb-analysis/service.log
 ```
 
+Rotation is easy to miss: a script that reads only `service.log` after a long run
+silently analyses the tail. Check `ls -la /tmp/kb-analysis/` before believing a
+count.
+
 The service forks kbfs from its own bin directory, and a plain `go install` of
 the service does not build it. Without kbfs the Files tab is empty and git
 fails with `KBFS client not found`, which fails every `files-*` and `git-*` e2e
 test for reasons unrelated to the change under test. `start-service.sh` warns.
+Note the installed kbfs keeps the mount when the service is swapped for a local
+build, so those tests can fail even with a `kbfs` binary in place — they are not
+in the `test:e2e:desktop:rpc` set for that reason.
 
 Ask before stopping the service or launching the app — both are the user's.
+
+## Prove a fix
+
+A before/after is only worth reporting if both runs did the same thing. What
+works:
+
+```bash
+# after: with the fix in the tree
+<reload the renderer>; : > /tmp/kb-analysis/service.log
+cd shared && yarn test:e2e:desktop:rpc
+cp /tmp/kb-analysis/service.log /tmp/kb-analysis/after.log
+
+# before: revert ONLY the source changes, keeping any new test scripts
+git stash push -- <the source files you changed>
+<reload the renderer>; : > /tmp/kb-analysis/service.log
+cd shared && yarn test:e2e:desktop:rpc
+cp /tmp/kb-analysis/service.log /tmp/kb-analysis/before.log
+git stash pop
+```
+
+- **Stash by path, not wholesale.** If the fix added the very npm script the
+  capture runs, a bare `git stash` takes it with them.
+- **Hard-reload the renderer between runs** (CDP `page.reload()` on
+  `localhost:9222`). Module-level caches — the usual subject of these fixes —
+  survive HMR, so without a reload the second run starts warm and reads better
+  than it is.
+- **The service does not need rebuilding** between runs for a JS-only fix. Leave
+  it up; only truncate its log.
+- Counting straight out of the log beats `rpc-diff.py` when you already know
+  which calls you are watching: parse `+ Server: <Name>` / `+ RemoteClient:
+  chat.1.remote.<name>`, and count how many landed within the hook's own
+  `staleMs` of the previous call for the same subject. That last number is the
+  one that says "this was a cache miss" rather than "this was work".
 
 ## Read it
 
@@ -101,6 +149,19 @@ not `getMessagesRemote`. The script says so when it finds no counts.
   identical in the service log until you check.
 - **Attributing to the child call.** The line directly above a flood is often
   something the flood itself invoked. Trust ROOT over DRIVERS.
+- **Reading a count that went to zero as a win.** A call that disappears may have
+  been *dropped*, not deduped. Before claiming it, check what the baseline calls
+  actually did: pull their `chat-trace` out of the before-log and count the work
+  hanging off it. Two `getMutualTeamsLocal` calls here went to 0 after a guard on
+  "empty argument list" — and their traces showed 82 remote refreshes and 750ms
+  each, so the service treats the empty case as a real query and the guard was
+  removing a feature, not a redundancy. A real dedupe takes N to 1, not to 0.
+- **Forgetting that one call's result is another call's input.** Suppressing a
+  call suppresses everything downstream of it, so an unrelated-looking count
+  improves for the wrong reason. `getAnnotatedTeam` read 3 in the run where
+  mutual teams was wrongly suppressed and 11 in both runs where it was not —
+  because the shared teams it returns are what then get loaded. If a metric you
+  did not touch moves, find out which call upstream stopped happening.
 - **Reading a fix as failed because the totals did not move.** If the app's
   request volume changed between runs, a working cache can show flat server
   counts. Count what the cache actually did — a hit rate, a log line — before
@@ -117,7 +178,8 @@ not `getMessagesRemote`. The script says so when it finds no counts.
 - **Using plain `grep`.** It is wrapped in this environment and truncates. Use
   python, as the scripts do.
 - **Comparing unlike runs.** `rpc-diff.py` is only meaningful if both runs did
-  the same thing.
+  the same thing — same tests, same order, same project, renderer reloaded
+  between them. See "Prove a fix".
 
 ## Shapes seen before
 
@@ -139,6 +201,19 @@ Each of these was a real bug, and each is what its section looks like:
 - **The same expensive load repeated because each surface holds its own copy.**
   Two or three components asking for the same user or team at the same instant
   is the common case, not the rare one.
+- **Two identical calls the same microsecond apart.** Not a race — two *caches*.
+  Either the hook falls back to a per-instance map (so every provider and every
+  provider-less consumer holds its own), or two different hooks issue the same
+  RPC with the same arguments from separate module caches and cannot see each
+  other's in-flight request. Both were live in this client at once. Grep the
+  codebase for the RPC name: more than one call site that is not a shared hook is
+  the tell.
+- **Calls landing inside their own stale window.** If a hook declares
+  `staleMs: 5_000` and most of its calls arrive under 5s after the previous one
+  for the same subject, the cache is not being shared — the window is doing
+  nothing because each caller has a fresh copy of it. This ratio is the single
+  most useful derived number here; 81% for `getAnnotatedTeam` is what found that
+  bug.
 
 Where the money actually is in this client: identify/proof checks and team
 loads. Both are hundreds of milliseconds each and both fan out to several HTTP

--- a/skill/keybase-rpc-log-analysis/scripts/clean-logs.sh
+++ b/skill/keybase-rpc-log-analysis/scripts/clean-logs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Clear keybase logs so the next run is the only thing in them.
+#
+#   ./clean-logs.sh            # list what would move, change nothing
+#   ./clean-logs.sh --archive  # move them to ~/Library/Logs/keybase-archive-<ts>/
+#   ./clean-logs.sh --delete   # remove them
+#
+# Default is a dry run: an unattended --delete on the wrong machine is not
+# recoverable, and the logs are often the only record of a run.
+set -euo pipefail
+
+LOGDIR="$HOME/Library/Logs"
+MODE="${1:-}"
+
+shopt -s nullglob
+FILES=("$LOGDIR"/keybase*.log "$LOGDIR"/keybase*.log-* "$LOGDIR"/Keybase.app.log)
+shopt -u nullglob
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "no keybase logs in $LOGDIR"
+  exit 0
+fi
+
+TOTAL=$(du -ch "${FILES[@]}" 2>/dev/null | tail -1 | cut -f1)
+echo "${#FILES[@]} files, $TOTAL:"
+for f in "${FILES[@]}"; do
+  printf '  %8s  %s\n' "$(du -h "$f" | cut -f1)" "$(basename "$f")"
+done
+
+case "$MODE" in
+  --archive)
+    DEST="$LOGDIR/keybase-archive-$(date +%Y%m%dT%H%M%S)"
+    mkdir -p "$DEST"
+    mv "${FILES[@]}" "$DEST/"
+    echo "moved to $DEST"
+    ;;
+  --delete)
+    rm -f "${FILES[@]}"
+    echo "deleted"
+    ;;
+  *)
+    echo
+    echo "dry run. pass --archive to move them aside, or --delete to remove them."
+    ;;
+esac

--- a/skill/keybase-rpc-log-analysis/scripts/kblog.py
+++ b/skill/keybase-rpc-log-analysis/scripts/kblog.py
@@ -1,0 +1,87 @@
+"""Shared parsing for keybase service logs.
+
+Line shape:
+  2026-07-24T17:19:03.576384-04:00 ▶ [DEBU keybase utils.go:537] 286366 ++Chat: | Body [tags:k=v,...]
+"""
+
+import re
+
+TS_LEN = 19  # 2026-07-24T17:19:03
+BODY_RE = re.compile(r"\]\s+\w+\s+(.*)")
+TAGS_RE = re.compile(r"\[tags:.*")
+TIME_RE = re.compile(r"\[time=[^\]]*\]")
+HEXID_RE = re.compile(r"[0-9a-f]{16,}")
+# an id explicitly labelled as a conversation
+CONVID_RE = re.compile(r"conv(?:ID)?[:= (]+([0-9a-f]{16,})", re.I)
+# the logged-in user's id, which appears on a great many lines. It has to be
+# excluded when guessing what a call was about, or every call looks like it
+# shares a subject.
+UID_RE = re.compile(r"uid:\s*([0-9a-f]{16,})")
+
+
+def subject_of(line, uid=None):
+    """Best guess at what a line is about: a labelled conv id, else the first id
+    that is not the logged-in user."""
+    stripped = TAGS_RE.sub("", line)
+    m = CONVID_RE.search(stripped)
+    if m:
+        return m.group(1)
+    for candidate in HEXID_RE.findall(stripped):
+        if candidate != uid:
+            return candidate
+    return None
+NUM_RE = re.compile(r"\b\d+\b")
+TRACE_RE = re.compile(r"chat-trace=(\w+)")
+
+# app -> service: a local RPC the client asked for
+SERVER_RE = re.compile(r"\+ Server: (\w+)(\([^)]*\))?")
+# service -> keybase servers: these are what burn the server-side rate limits
+REMOTE_RE = re.compile(r"\+ RemoteClient: ([\w.]+)")
+# raw HTTP to the API host
+HTTP_RE = re.compile(r"(GET|POST) (https?://[^\s?]+)")
+
+
+def body(line):
+    m = BODY_RE.search(line)
+    return (m.group(1) if m else line).rstrip()
+
+
+def normalize(line, width=95):
+    """Collapse ids, numbers and trailing metadata so repeated lines group."""
+    s = body(line)
+    s = TAGS_RE.sub("", s)
+    s = TIME_RE.sub("", s)
+    s = HEXID_RE.sub("<id>", s)
+    s = NUM_RE.sub("<n>", s)
+    return s.strip()[:width]
+
+
+def stamp(line, precision=19):
+    """precision: 19=second, 16=minute, 13=hour."""
+    return line[:precision] if len(line) >= precision else None
+
+
+def iter_lines(paths, start=None, end=None):
+    """Yield lines from each path, optionally filtered to a timestamp window.
+
+    start/end are prefixes, e.g. '2026-07-24T17:23'.
+    """
+    for path in paths:
+        with open(path, errors="ignore") as f:
+            for line in f:
+                if start or end:
+                    ts = line[:TS_LEN]
+                    if not ts.startswith("2"):
+                        continue
+                    if start and ts < start:
+                        continue
+                    # end is a prefix, so compare only that many chars: a bare
+                    # '...T19:12' must include all of 19:12, not exclude it
+                    if end and ts[: len(end)] > end:
+                        continue
+                yield line
+
+
+def trace(line):
+    m = TRACE_RE.search(line)
+    return m.group(1) if m else None

--- a/skill/keybase-rpc-log-analysis/scripts/rpc-cost.py
+++ b/skill/keybase-rpc-log-analysis/scripts/rpc-cost.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Rank operations by the time they actually took, not by how often they appear.
+
+  python3 rpc-cost.py <log>... [--top 20] [--min-mean-ms 0]
+
+Count and cost are different questions, and the loudest thing in the log is
+usually not the expensive one. In one capture the top line by count was an
+in-memory map lookup running 15,767 times for 0.16s total, while the real cost
+was 469 team loads at 292ms each - 186 seconds, and only the 30th most common
+line.
+
+Reads the [time=...] that the Go tracing helpers put on every span exit, so it
+only sees operations that are traced. Times overlap across goroutines, so the
+totals are service time, not wall clock.
+"""
+
+import argparse
+import collections
+import re
+
+import kblog
+
+# "- Namespace: Op(args) -> ok [time=1.234ms]", optionally behind a "++Chat: "
+# prefix. Keep the whole "Namespace: Op": stopping the name at the first colon
+# collapsed every "Server: X" and "RemoteClient: X" into one row, which hid the
+# per-operation breakdown this script exists to produce. A colon only ends the
+# name when it is not followed by a space.
+EXIT_RE = re.compile(
+    r"\]\s+\w+\s+(?:\+\+\w+:\s+)?-\s+((?:[^\s(:]|:(?= )|(?<=:) )+?)\s*(?:\(| ->).*\[time=([^\]]+)\]"
+)
+# Go durations are compound once they pass a minute ("1m28.867s", "1h2m3s").
+# Matching only a single number+unit silently dropped exactly the slowest spans.
+DUR_RE = re.compile(r"(?:([\d.]+)h)?(?:([\d.]+)m(?!s))?(?:([\d.]+)(ms|s|µs|ns))?$")
+UNIT_MS = {"ms": 1.0, "s": 1000.0, "µs": 0.001, "ns": 1e-6}
+
+
+def parse_duration_ms(text):
+    """Return milliseconds for a Go duration string, or None if unparseable."""
+    m = DUR_RE.match(text.strip())
+    if not m:
+        return None
+    hours, minutes, value, unit = m.groups()
+    total = 0.0
+    if hours:
+        total += float(hours) * 3_600_000
+    if minutes:
+        total += float(minutes) * 60_000
+    if value:
+        total += float(value) * UNIT_MS[unit]
+    return total if (hours or minutes or value) else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("logs", nargs="+")
+    ap.add_argument("--start")
+    ap.add_argument("--end")
+    ap.add_argument("--top", type=int, default=20)
+    ap.add_argument("--min-mean-ms", type=float, default=0.0, help="hide cheap chatty ops")
+    args = ap.parse_args()
+
+    total = collections.Counter()
+    calls = collections.Counter()
+    worst = {}
+
+    for line in kblog.iter_lines(args.logs, args.start, args.end):
+        m = EXIT_RE.search(line)
+        if not m:
+            continue
+        # "Namespace: Op" is the useful grouping; anything past that is an
+        # argument ("localizerPipeline: localizeConversation: TLF: foo") and
+        # would split one operation into a row per argument value.
+        name = ": ".join(m.group(1).strip().split(": ")[:2])[:45]
+        ms = parse_duration_ms(m.group(2))
+        if ms is None:
+            continue
+        total[name] += ms
+        calls[name] += 1
+        if ms > worst.get(name, 0):
+            worst[name] = ms
+
+    if not calls:
+        print("no traced spans with [time=] found")
+        return
+
+    print(f"{sum(calls.values())} traced spans, {sum(total.values()) / 1000:.1f}s of service time")
+    print("(times overlap across goroutines - this is service time, not wall clock)\n")
+    print(f"{'total_s':>9} {'calls':>7} {'mean_ms':>9} {'max_ms':>9}  operation")
+    shown = 0
+    for name, ms in total.most_common():
+        mean = ms / calls[name]
+        if mean < args.min_mean_ms:
+            continue
+        print(f"{ms / 1000:9.2f} {calls[name]:7d} {mean:9.2f} {worst[name]:9.1f}  {name}")
+        shown += 1
+        if shown >= args.top:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/keybase-rpc-log-analysis/scripts/rpc-diff.py
+++ b/skill/keybase-rpc-log-analysis/scripts/rpc-diff.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Compare RPC counts between two runs, to prove a fix landed.
+
+  python3 rpc-diff.py before.log after.log [--top 30]
+
+Counts app->service and service->server calls in each and prints the change.
+Only meaningful if both runs did the same thing - e.g. the same e2e suite.
+"""
+
+import argparse
+import collections
+
+import kblog
+
+
+def counts(path):
+    app, remote, http = collections.Counter(), collections.Counter(), collections.Counter()
+    for line in kblog.iter_lines([path]):
+        m = kblog.SERVER_RE.search(line)
+        if m:
+            app[m.group(1)] += 1
+        m = kblog.REMOTE_RE.search(line)
+        if m:
+            remote[m.group(1)] += 1
+        # HTTP matters as much as the RPC counts: a lot of server work - team
+        # loads, proof checks, merkle lookups - shows up only here.
+        m = kblog.HTTP_RE.search(line)
+        if m:
+            http[m.group(2)[:70]] += 1
+    return app, remote, http
+
+
+def show(title, before, after, top):
+    keys = set(before) | set(after)
+    rows = []
+    for k in keys:
+        b, a = before.get(k, 0), after.get(k, 0)
+        rows.append((a - b, b, a, k))
+    rows.sort(key=lambda r: abs(r[0]), reverse=True)
+    print(f"\n== {title}   before {sum(before.values())} -> after {sum(after.values())}")
+    print(f"{'delta':>8} {'before':>8} {'after':>8}  call")
+    for delta, b, a, k in rows[:top]:
+        if delta == 0:
+            continue
+        mark = "  <-- gone" if a == 0 and b else ("  <-- new" if b == 0 else "")
+        print(f"{delta:+8d} {b:8d} {a:8d}  {k}{mark}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("before")
+    ap.add_argument("after")
+    ap.add_argument("--top", type=int, default=30)
+    args = ap.parse_args()
+
+    ba, br, bh = counts(args.before)
+    aa, ar, ah = counts(args.after)
+    show("REMOTE  service -> keybase servers", br, ar, args.top)
+    show("APP  app -> service", ba, aa, args.top)
+    show("HTTP", bh, ah, args.top)
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/keybase-rpc-log-analysis/scripts/rpc-report.py
+++ b/skill/keybase-rpc-log-analysis/scripts/rpc-report.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Summarize RPC traffic in a keybase service log.
+
+  python3 rpc-report.py <log>... [--start 2026-07-24T17:23] [--end ...] [--top N]
+
+Sections, in the order worth reading:
+  REMOTE     service -> keybase servers. These burn the server rate limits.
+  APP        app -> service. One of these usually explains a REMOTE row.
+  HTTP       raw API calls.
+  BURSTS     same RPC, same args, >=3 times inside one second. Missing dedupe.
+  FLOODS     most repeated log lines overall, after collapsing ids/numbers.
+"""
+
+import argparse
+import collections
+import sys
+
+import kblog
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("logs", nargs="+")
+    ap.add_argument("--start", help="timestamp prefix, e.g. 2026-07-24T17:23")
+    ap.add_argument("--end")
+    ap.add_argument("--top", type=int, default=25)
+    ap.add_argument("--burst-min", type=int, default=3, help="calls in one second to flag")
+    args = ap.parse_args()
+
+    app = collections.Counter()
+    remote = collections.Counter()
+    http = collections.Counter()
+    floods = collections.Counter()
+    per_second = collections.defaultdict(collections.Counter)  # sec -> (rpc, arg) -> n
+    # Many RPCs log no arguments, so "same call twice in a second" would not prove
+    # it was the same conversation. Recover the subject by correlating on the
+    # chat-trace: the first id that shows up on the trace is what the call was for.
+    pending = {}  # trace -> (second, rpc name)
+    uid = None  # learned from the log, then excluded when guessing subjects
+    total = 0
+    first = last = None
+
+    for line in kblog.iter_lines(args.logs, args.start, args.end):
+        total += 1
+        ts = kblog.stamp(line)
+        if ts and ts.startswith("2"):
+            # min/max, not first/last seen: rotated files are often concatenated
+            # or globbed out of order, and stream order would report a range of
+            # zero width
+            first = ts if first is None or ts < first else first
+            last = ts if last is None or ts > last else last
+        floods[kblog.normalize(line)] += 1
+
+        if uid is None:
+            u = kblog.UID_RE.search(line)
+            if u:
+                uid = u.group(1)
+
+        tr = kblog.trace(line)
+        m = kblog.SERVER_RE.search(line)
+        if m:
+            name, arg = m.group(1), (m.group(2) or "")
+            app[name] += 1
+            if ts and arg:
+                per_second[ts][(name, arg[:60])] += 1
+            elif ts and tr:
+                pending[tr] = (ts, name)
+            elif ts:
+                per_second[ts][(name, "")] += 1
+        elif tr and tr in pending:
+            subject = kblog.subject_of(line, uid)
+            if subject:
+                sec, name = pending.pop(tr)
+                per_second[sec][(name, f"({subject[:16]})")] += 1
+        m = kblog.REMOTE_RE.search(line)
+        if m:
+            remote[m.group(1)] += 1
+        m = kblog.HTTP_RE.search(line)
+        if m:
+            http[m.group(2)[:80]] += 1
+
+    if not total:
+        sys.exit("no lines matched (check --start/--end)")
+
+    print(f"{total} lines  {first} .. {last}")
+
+    def section(title, counter, note=""):
+        if not counter:
+            return
+        print(f"\n== {title}  (total {sum(counter.values())}) {note}")
+        for k, v in counter.most_common(args.top):
+            print(f"{v:8d}  {k}")
+
+    section("REMOTE  service -> keybase servers", remote, "<- rate-limited")
+    section("APP  app -> service", app)
+    section("HTTP", http)
+
+    bursts = collections.Counter()
+    for sec, calls in per_second.items():
+        for (name, arg), n in calls.items():
+            if n >= args.burst_min:
+                bursts[(name, arg)] = max(bursts[(name, arg)], n)
+    if bursts:
+        print(f"\n== BURSTS  same call+subject >={args.burst_min}x in one second")
+        print("   subject in () is the call's own argument, or the first id seen on")
+        print("   its chat-trace when the call logs none. Bare name = neither.")
+        for (name, arg), n in bursts.most_common(args.top):
+            print(f"{n:8d}x  {name}{arg}")
+
+    print(f"\n== FLOODS  most repeated lines")
+    for k, v in floods.most_common(args.top):
+        print(f"{v:8d}  {k}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/keybase-rpc-log-analysis/scripts/rpc-why.py
+++ b/skill/keybase-rpc-log-analysis/scripts/rpc-why.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Explain a flood: who drives it, how it is paced, how big its batches are.
+
+  python3 rpc-why.py <log>... --match 'refreshParticipantsRemote' [--start ...] [--end ...]
+
+DRIVERS   the '+ X' logged immediately before each hit on the same chat-trace.
+          This is what turns 'GetURL is called 8000 times' into 'userEmojis calls it'.
+CADENCE   hits per second. A flat rate that never stops is a loop; spikes are mounts.
+GAPS      ms between the end of one hit and the start of the next. Consistently
+          ~0 means the caller re-fires the instant the previous lands - a feedback
+          loop, not a user action.
+BATCHES   distribution of any 'msgIDs: N' / 'convs: N' count on the line. A pile of
+          1s means the caller is not batching.
+"""
+
+import argparse
+import collections
+import re
+
+import kblog
+
+COUNT_RE = re.compile(r"(msgIDs|convs|len|msgs): (\d+)")
+# the +/-/| marker sits right after the log's sequence number, optionally behind
+# a '++Chat: ' prefix. + enters a span, - leaves it, | is a note inside one.
+MARKER_RE = re.compile(r"\]\s+\w+\s+(?:\+\+\w+:\s+)?([+\-|])\s+(.*)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("logs", nargs="+")
+    ap.add_argument("--match", required=True, help="substring to explain")
+    ap.add_argument("--start")
+    ap.add_argument("--end")
+    ap.add_argument("--top", type=int, default=10)
+    args = ap.parse_args()
+
+    drivers = collections.Counter()
+    roots = collections.Counter()
+    per_second = collections.Counter()
+    batches = collections.Counter()
+    last_enter = {}  # trace -> most recent span entered outside our match
+    root_rpc = {}  # trace -> first 'Server: X' seen, i.e. what the app asked for
+    inside = collections.Counter()  # trace -> depth inside our match
+    hits = 0
+
+    for line in kblog.iter_lines(args.logs, args.start, args.end):
+        m = MARKER_RE.search(line)
+        if not m:
+            continue
+        marker, text = m.group(1), kblog.TAGS_RE.sub("", m.group(2)).strip()
+        # Lines with no chat-trace tag are unrelated to each other. Sharing one
+        # bucket for them latched every untraced hit onto whichever "+ Server:"
+        # line happened to come first in the file and reported it as the root -
+        # a confident, wrong answer, in the section SKILL.md says to trust most.
+        tr = kblog.trace(line)
+        untraced = tr is None
+        mine = args.match in text
+
+        srv = kblog.SERVER_RE.search(line)
+        if srv and not untraced and tr not in root_rpc:
+            root_rpc[tr] = srv.group(1)
+
+        if mine and marker == "+":
+            hits += 1
+            ts = kblog.stamp(line)
+            if ts:
+                per_second[ts] += 1
+            # Every hit gets attributed to its trace's originating RPC. Do NOT gate
+            # this on nesting depth: the service fans out concurrent goroutines
+            # under a single chat-trace, so most hits are "inside" an earlier one
+            # and gating would attribute only a handful of thousands of calls.
+            if untraced:
+                roots["<untraced: no chat-trace tag>"] += 1
+            else:
+                roots[root_rpc.get(tr, "<no app RPC on this trace>")] += 1
+            # DRIVERS stays gated - the nearest preceding span is only meaningful
+            # for a hit that is not nested inside another of our own
+            if not untraced and not inside[tr]:
+                drivers[last_enter.get(tr, "<nothing preceding on this trace>")] += 1
+            c = COUNT_RE.search(text)
+            if c:
+                batches[int(c.group(2))] += 1
+            inside[tr] += 1
+        elif mine and marker == "-":
+            inside[tr] = max(0, inside[tr] - 1)
+        elif marker == "+" and not inside[tr]:
+            # a span entered outside our match is a candidate driver; spans entered
+            # while inside it are its own children
+            last_enter[tr] = text[:55]
+
+    if not hits:
+        print(f"no lines matched {args.match!r}")
+        return
+
+    print(f"{hits} hits on {args.match!r}")
+
+    print("\n== ROOT  app RPC that opened the trace this ran on")
+    for k, v in roots.most_common(args.top):
+        print(f"{v:8d}  {k}")
+    # Both buckets mean "nothing asked for this": a hit whose trace never saw a
+    # server RPC, and a hit with no trace at all. The DRIVERS placeholder is not
+    # one of them - it is only ever counted into drivers, so reading it back out
+    # of roots always added zero.
+    unrooted = roots.get("<no app RPC on this trace>", 0) + roots.get(
+        "<untraced: no chat-trace tag>", 0
+    )
+    if unrooted > hits * 0.5:
+        print("  most hits have no app RPC above them: this is service-side background")
+        print("  work, not something the client asked for. Look at DRIVERS instead, and")
+        print("  grep the trace tags for CHTBKG= to confirm.")
+
+    print("\n== DRIVERS  call logged just before, same chat-trace")
+    for k, v in drivers.most_common(args.top):
+        print(f"{v:8d}  {k}")
+
+    print("\n== CADENCE  busiest seconds")
+    for k, v in per_second.most_common(args.top):
+        print(f"{v:8d}  {k}")
+    spread = len(per_second)
+    print(f"  spread over {spread} distinct seconds, mean {hits / max(spread, 1):.1f}/s")
+
+    if batches:
+        print("\n== BATCHES  count on the line")
+        for size, n in batches.most_common(args.top):
+            print(f"{n:8d}x  size {size}")
+        ones = batches.get(1, 0)
+        if ones > sum(batches.values()) * 0.5:
+            print("  >half are size 1 - the caller is not batching")
+    else:
+        print("\n== BATCHES  none: these lines carry no item count")
+        print("  Remote calls usually do not log one. To see batch sizes, match the")
+        print("  local span that wraps this call instead - e.g. match")
+        print("  'HybridConversationSource: GetMessages' rather than 'getMessagesRemote'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/keybase-rpc-log-analysis/scripts/start-service.sh
+++ b/skill/keybase-rpc-log-analysis/scripts/start-service.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Build the service from this checkout and run it in the foreground with debug
+# logging going to its own file.
+#
+#   ./start-service.sh [logfile]      # default /tmp/kb-analysis/service.log
+#
+# Runs against the REAL home directory, so the account, teams and conversations
+# the e2e suite needs are all there. That means it replaces whatever service is
+# currently running - it stops the existing one first. It does not log you out.
+#
+# Run this in its own terminal and leave it in the foreground; ^C stops it. Then
+# start the app (yarn desktop:start:hot:e2e) so it attaches to this service
+# rather than auto-forking the installed one.
+set -euo pipefail
+
+LOGFILE="${1:-/tmp/kb-analysis/service.log}"
+mkdir -p "$(dirname "$LOGFILE")"
+
+# -P resolves symlinks before collapsing "..": this script is normally reached
+# through .claude/skills -> skill, and a logical cd would land in .claude/
+REPO="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO/go"
+
+echo "building from $REPO/go"
+go install github.com/keybase/client/go/keybase
+
+# go install honours GOBIN when it is set and only falls back to GOPATH/bin
+# otherwise, so asking for GOPATH unconditionally looks in the wrong place on
+# any setup that sets GOBIN.
+GOBIN_DIR="$(go env GOBIN)"
+BIN="${GOBIN_DIR:-$(go env GOPATH)/bin}/keybase"
+[ -x "$BIN" ] || { echo "no binary at $BIN"; exit 1; }
+echo "built $("$BIN" version -S 2>/dev/null || echo '?')"
+
+# The service does not provide the filesystem itself; it forks kbfs from the same
+# bin directory. Without it the Files tab is empty and `keybase git` fails with
+# "KBFS client not found", which fails every files-* and git-* e2e test for
+# reasons that have nothing to do with the code under test.
+#
+# The name matters: on darwin the service looks for a binary called "kbfs"
+# (install_darwin.go), but the package that builds it is kbfsfuse, so a plain
+# go install leaves you with kbfsfuse and the service still finds nothing. Hence
+# the link in the hint below.
+if [ ! -x "$(dirname "$BIN")/kbfs" ]; then
+  echo
+  echo "WARNING: no kbfs binary next to $BIN."
+  echo "  Files and git e2e tests will fail with 'KBFS client not found'."
+  echo "  To include them:"
+  echo "    go install github.com/keybase/client/go/kbfs/kbfsfuse"
+  echo "    ln -s $(dirname "$BIN")/kbfsfuse $(dirname "$BIN")/kbfs"
+  echo "  Otherwise ignore those failures - they are not regressions."
+  echo
+fi
+
+# The installed service and this one cannot share the socket. --include takes a
+# comma separated component list; an unknown flag here just prints usage and
+# leaves the old service running, which then quietly wins the socket.
+# pgrep -x matches the process NAME. Do not use pgrep -f here: the pattern would
+# also match any shell whose command line happens to contain it, including the
+# one running this check.
+if pgrep -x keybase >/dev/null 2>&1; then
+  echo "stopping the running service"
+  "$BIN" ctl stop --include service || true
+  for _ in $(seq 10); do
+    pgrep -x keybase >/dev/null 2>&1 || break
+    sleep 1
+  done
+  if pgrep -x keybase >/dev/null 2>&1; then
+    echo "service still running; kill it before rerunning"
+    exit 1
+  fi
+fi
+
+: > "$LOGFILE"
+echo "logging to $LOGFILE"
+echo
+echo "NOTE: a newly built binary has a new code signature, so macOS will prompt"
+echo "  for keychain access on first run. Until someone clicks Allow the service"
+echo "  cannot finish bootstrapping, the app sits on its splash screen, and every"
+echo "  test fails for a reason that has nothing to do with the code. Watch for the"
+echo "  prompt before walking away."
+echo
+echo "leave this running; start the app in another terminal"
+exec "$BIN" -d --log-file="$LOGFILE" service

--- a/skill/keybase-rpc-log-analysis/scripts/start-service.sh
+++ b/skill/keybase-rpc-log-analysis/scripts/start-service.sh
@@ -13,7 +13,16 @@
 # rather than auto-forking the installed one.
 set -euo pipefail
 
-LOGFILE="${1:-/tmp/kb-analysis/service.log}"
+ASSUME_YES="${KB_RPC_LOG_ASSUME_YES:-}"
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) ASSUME_YES=1 ;;
+    *) ARGS+=("$arg") ;;
+  esac
+done
+
+LOGFILE="${ARGS[0]:-/tmp/kb-analysis/service.log}"
 mkdir -p "$(dirname "$LOGFILE")"
 
 # -P resolves symlinks before collapsing "..": this script is normally reached
@@ -58,7 +67,26 @@ fi
 # pgrep -x matches the process NAME. Do not use pgrep -f here: the pattern would
 # also match any shell whose command line happens to contain it, including the
 # one running this check.
+#
+# Stopping the service is disruptive to whoever is using the app right now, so
+# it needs an explicit ok unless the caller opted out with --yes /
+# KB_RPC_LOG_ASSUME_YES=1. With no tty there is nobody to ask, so abort rather
+# than stop it behind the user's back.
 if pgrep -x keybase >/dev/null 2>&1; then
+  if [ -z "$ASSUME_YES" ]; then
+    echo "a keybase service is already running (pids: $(pgrep -x keybase | tr '\n' ' '))"
+    echo "continuing stops it with '$BIN ctl stop --include service'."
+    if [ ! -t 0 ]; then
+      echo "not interactive; refusing to stop it. rerun with --yes or KB_RPC_LOG_ASSUME_YES=1"
+      exit 1
+    fi
+    printf 'stop the running service? [y/N] '
+    read -r REPLY
+    case "$REPLY" in
+      y|Y|yes|YES) ;;
+      *) echo "aborted; the running service was left alone"; exit 1 ;;
+    esac
+  fi
   echo "stopping the running service"
   "$BIN" ctl stop --include service || true
   for _ in $(seq 10); do


### PR DESCRIPTION
Base of a two-PR stack. This one is the JS side plus tooling; the Go service changes sit on top in a follow-up PR. They are independent — nothing in `protocol/` changed, so there is no generated-type coupling, and neither side's build reads the other's tree.

Started as four failing desktop e2e tests. The rate-limit error they surfaced turned out to be real client bugs, so this grew.

## The e2e failures (4 tests)

All four were genuine test bugs, each confirmed from the Playwright trace rather than guessed:

- **crypto recipients** — the `Search people` input sits inside a `pointerEvents="none"` wrapper, so the click could never land; the trace showed `clickable-box2 ... intercepts pointer events` looping until timeout. Added a testID on the wrapping `ClickableBox`.
- **bot install preview** — two bugs. The row centre lands on the "by \<owner\>" username link, so the click opened that user's profile (it opened a *different* profile on each run, which is what gave it away). And the label regex `^(Install|Edit settings|Review)$` can never match a bot already installed unrestricted in the conversation — that footer renders only "Uninstall". Now clicks the avatar column and asserts on a modal testID.
- **teams members tab** — `lastSelectedTabs` remembers the tab per team for the app's lifetime, so an earlier test left it on Channels. Selects Members explicitly.
- **retention warning** — reopens the dropdown if the popup gets swallowed while the settings tab settles.

Per-test timeout 15s → 30s; several flows chain three 5s waits and could not fit.

## The floods

Analysis of the Go service log during a run — it rotated **128MB twice in under two minutes**. The client-side half of each is fixed here; the service-side half is in the stacked PR.

| flood | count | cause |
|---|---|---|
| `RefreshParticipants` | 1498 / 2568 per window | the team page re-primed *every* channel on every channel-list reload; ~107 remote calls a time |
| `AttachmentHTTPSrv: GetURL` | 16,512 | `userEmojis` resolves 2 attachment URLs per emoji, and the suggestor refetched the whole set on each `:` |
| `getAnnotatedTeam` | ~5/sec, self-sustaining | render loop in `useCachedResource` |
| `GetTeamRetentionLocal` | 13 in one second | settings tab keyed on server data that arrives in stages, remounting the subtree |
| `gregor.dismissCategory` | 39 per focus | inline `useSafeFocusEffect` callback re-subscribing every render |

`getAnnotatedTeam` was the subtle one, two defects composing: a fresh-cache hit built a new state object and forced a re-render that re-ran the effect that called it; and a load whose result never landed left `loadedAt` at 0, making the resource permanently stale so every effect run reissued the RPC the instant the previous settled. Both are now covered by tests that hang the pre-fix code.

Sharing one cache per team (rather than one per consumer) exposed two things the per-instance caches had hidden, both fixed here: channel create/delete fire no `teamChangedByID` and so now drop the entry explicitly, and a disabled "shadow" hook instance would reset the shared cache out from under the real loader, so shadows get a private map via `forceLocalCache`.

## Three caches that were still missing (measured, then fixed)

A full e2e run against a locally built service showed the work above had not gone far enough. **97% of all outbound server traffic in the run was a single call**, `refreshParticipantsRemote` — 2368 of 2447 remote calls, 162s of service time. Attribution put nearly all of it behind three client-side cache gaps:

1. **`getAnnotatedTeam` had no shared cache at all.** `useLoadedTeam` fell back to a per-component-instance map, and each of the three `LoadedTeamProvider` sites minted its own. **81%** of its calls landed inside their own 5s stale window, at ~200ms each. Now one module-level map, matching the channel cache.

2. **`getTLFConversationsLocal` had two caches issuing the same RPC.** `useLoadedTeamChannels` and `useAllChannelMetas` were separate module caches with identical arguments, so neither could see the other's in-flight request — visible as pairs of identical calls microseconds apart. One such call costs ~107 outbound requests. Now one loader derives channels, metas and participants from a single result.

3. **`getMutualTeamsLocal` was uncached in both callers.** The channel suggestor and the profile screen each hand-rolled their own load; the suggestor issued two in the same microsecond. One call costs ~82 outbound requests. Now one cache keyed on the sorted usernames rather than on the screen.

### Measured

Same 25 tests, same service, renderer reloaded between runs, baseline taken by reverting only the source changes:

| | before | after | |
|---|---|---|---|
| **remote calls (rate-limited)** | **1481** | **970** | **−35%** |
| `refreshParticipantsRemote` | 1450 | 939 | −35% |
| `getTLFConversationsLocal` | 11 | 7 | −36% |
| `getAnnotatedTeam` | 36 | 11 | −69% |
| ⤷ inside own 5s stale window | 31 | 3 | −90% |
| `getMutualTeamsLocal` | 2 | 1 | −50% |

One thing worth calling out, because it nearly went in as a bigger win: gating the mutual-teams load on a non-empty username list took that count to 0, but the baseline traces show those calls each did real work (82 refreshes, ~750ms). The service treats the empty list as a real query, so the guard was dropping a call rather than deduping one. It is gone, and only the duplicate collapses.

### Known remaining

- 3 `getAnnotatedTeam` and 3 `getTLFConversations` still land inside their stale window. At least one `getTLFConversations` pair is by design: after a mutation the `inFlightSeq` guard refuses to join a request that predates it. The rest is unchased.
- No e2e covers the DM cross-team `#` mention path, which is the one that actually consumes mutual teams; the tests exercise the team-conversation path.

## Sign-out

Separately, **16 module-level caches** held user data across sign-out — team member lists, the team list and role map, inbox search results, attachment handoffs, profile and tab selections, and revealed markdown spoilers, which is a privacy bug rather than a perf one. All now clear via `registerExternalResetter`. The three caches added above do the same.

## Tooling

A `keybase-rpc-log-analysis` skill: scripts to capture a clean service log against a locally built service, and to read it by volume, by cost, by attribution, and against a previous run. The write-up is mostly the mistakes — rank by cost before count (the loudest line in this log was 15,767 calls worth 0.16s, while the real expense sat 30th by count).

`yarn test:e2e:desktop:flows` takes file arguments and pins a single project so RPC counts are comparable between runs; `yarn test:e2e:desktop:rpc` is the six flows that drive team and channel loading, at 39 seconds against 6.6 minutes for the full suite.

## Verification

`yarn lint:all` (eslint + react-compiler bailouts + tsc) passes with **0 bailouts**, and the full jest suite is green (82 suites / 379 tests). The desktop e2e suite was run against a service built from this checkout: **186 passed**. The failures are the five `files-*` and two `git-*` tests, which need a kbfs mount the capture setup does not provide — the installed kbfs keeps the mount when the service is swapped for a locally built one.
