### PR TITLE
fix(search): stop the chat index corrupting itself, and cut the service-side floods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,4 +23,6 @@ Repo root is `client/`. TS source lives in `shared/`. Always use absolute paths 
 - Plans created by superpowers skills go into `plans/` at the repo root.
 
 ## Validation
+After Go changes (from `go/`): always run both the tests for every package you touched (`go test ./chat/... ./libkb/...` etc.) and the linter (`golangci-lint run --timeout 30m ./...`, same as `make golangci-lint`). CI runs golangci-lint with `--new-from-rev <base>` and gosec/govet/revive/staticcheck are enabled — nothing else in the repo (no pre-commit hook, not `yarn lint:all`) runs it for you, so a skipped lint pass = red CI.
+
 After TS changes (from `shared/`): `yarn lint:all` (= `yarn lint` && `yarn lint:bailouts` && `yarn tsc`). Plain `yarn lint` is eslint only and does NOT catch react-compiler bailouts — no compiler rule is wired into `eslint.config.mjs`, so bailouts only surface via `lint:bailouts`. Repo baseline is 0 bailouts; keep it there. When debugging visually, skip until fix is confirmed. Never delete the ESLint cache.

--- a/go/chat/emojisource.go
+++ b/go/chat/emojisource.go
@@ -495,15 +495,27 @@ func (s *DevConvEmojiSource) ToggleAnimations(ctx context.Context, uid gregor1.U
 func (s *DevConvEmojiSource) RemoteToLocalSource(ctx context.Context, uid gregor1.UID,
 	remote chat1.EmojiRemoteSource,
 ) (source chat1.EmojiLoadSource, noAnimSource chat1.EmojiLoadSource, err error) {
+	return s.remoteToLocalSource(ctx, remote, s.animationsDisabled(ctx, uid))
+}
+
+// callers converting a whole set of emojis pass noAnim in so the gregor state is
+// read once for the set instead of once per emoji
+func (s *DevConvEmojiSource) remoteToLocalSource(ctx context.Context, remote chat1.EmojiRemoteSource,
+	noAnim bool,
+) (source chat1.EmojiLoadSource, noAnimSource chat1.EmojiLoadSource, err error) {
 	typ, err := remote.Typ()
 	if err != nil {
 		return source, noAnimSource, err
 	}
-	noAnim := s.animationsDisabled(ctx, uid)
 	switch typ {
 	case chat1.EmojiRemoteSourceTyp_MESSAGE:
 		msg := remote.Message()
 		sourceURL := s.G().AttachmentURLSrv.GetURL(ctx, msg.ConvID, msg.MsgID, false, noAnim, true)
+		if noAnim {
+			// same arguments, so the second lookup would return the same URL
+			ret := chat1.NewEmojiLoadSourceWithHttpsrv(sourceURL)
+			return ret, ret, nil
+		}
 		noAnimSourceURL := s.G().AttachmentURLSrv.GetURL(ctx, msg.ConvID, msg.MsgID, false, true, true)
 		return chat1.NewEmojiLoadSourceWithHttpsrv(sourceURL),
 			chat1.NewEmojiLoadSourceWithHttpsrv(noAnimSourceURL), nil
@@ -573,6 +585,9 @@ func (s *DevConvEmojiSource) getNoSet(ctx context.Context, uid gregor1.UID, conv
 	}
 	convs := ibox.Convs
 	seenAliases := make(map[string]int)
+	// read once for the whole set: this runs for every emoji the user has, and each
+	// read is a full gregor state fetch
+	noAnim := s.animationsDisabled(ctx, uid)
 	addEmojis := func(convs []chat1.ConversationLocal, isCrossTeam bool) {
 		if opts.OnlyInTeam && isCrossTeam {
 			return
@@ -596,7 +611,7 @@ func (s *DevConvEmojiSource) getNoSet(ctx context.Context, uid gregor1.UID, conv
 					continue
 				}
 				var creationInfo *chat1.EmojiCreationInfo
-				source, noAnimSource, err := s.RemoteToLocalSource(ctx, uid, storedEmoji)
+				source, noAnimSource, err := s.remoteToLocalSource(ctx, storedEmoji, noAnim)
 				if err != nil {
 					s.Debug(ctx, "Get: skipping emoji on remote-to-local error: %s", err)
 					continue
@@ -954,9 +969,11 @@ func (s *DevConvEmojiSource) Decorate(ctx context.Context, body string, uid greg
 	offset := 0
 	added := 0
 	isReacji := messageType == chat1.MessageType_REACTION
+	// read once for the whole message rather than once per matched emoji
+	noAnim := s.animationsDisabled(ctx, uid)
 	for _, match := range matches {
 		if remoteSource, ok := emojiMap[match.name]; ok {
-			source, noAnimSource, err := s.RemoteToLocalSource(ctx, uid, remoteSource)
+			source, noAnimSource, err := s.remoteToLocalSource(ctx, remoteSource, noAnim)
 			if err != nil {
 				s.Debug(ctx, "Decorate: failed to get local source: %s", err)
 				continue

--- a/go/chat/participantsource.go
+++ b/go/chat/participantsource.go
@@ -18,9 +18,23 @@ import (
 )
 
 type partDiskStorage struct {
-	Uids []gregor1.UID
-	Hash string
+	Uids     []gregor1.UID
+	Hash     string
+	CachedAt time.Time
 }
+
+// How long a cached participant list is served without asking the server. Every
+// localization of a team conversation asks for participants, so a team screen
+// with N channels used to mean N remote round trips every time it loaded, even
+// when nothing had changed and the server only answered HashMatch. Membership
+// changes arrive by server push for anything that re-localizes the conversation.
+//
+// Known gap: nothing deletes the cached entry, and every production caller
+// passes DataSourceAll (the RemoteOnly path exists but is unused), so a
+// membership change that does not re-localize can take up to this long to show
+// up in a participant list or @-mention completion. Before the cache that was
+// one cheap HashMatch round trip per localization instead.
+const participantsCacheFreshness = 5 * time.Minute
 
 type CachingParticipantSource struct {
 	globals.Contextified
@@ -130,6 +144,10 @@ func (s *CachingParticipantSource) GetNonblock(ctx context.Context, uid gregor1.
 			if found {
 				resCh <- types.ParticipantResult{Uids: local.Uids}
 				localHash = local.Hash
+				if !local.CachedAt.IsZero() &&
+					s.G().GetClock().Since(local.CachedAt) < participantsCacheFreshness {
+					return
+				}
 			}
 		default:
 		}
@@ -147,12 +165,23 @@ func (s *CachingParticipantSource) GetNonblock(ctx context.Context, uid gregor1.
 			}
 			if partRes.HashMatch {
 				s.Debug(ctx, "GetNonblock: hash match on remote, all done")
+				// nothing changed, but record that we just checked so the next
+				// localization of this conv can be served from disk
+				var local partDiskStorage
+				found, err := s.encryptedDB.Get(ctx, s.dbKey(uid, conv.GetConvID()), &local)
+				if err == nil && found {
+					local.CachedAt = s.G().GetClock().Now()
+					if err := s.encryptedDB.Put(ctx, s.dbKey(uid, conv.GetConvID()), local); err != nil {
+						s.Debug(ctx, "GetNonblock: failed to record refresh time: %s", err)
+					}
+				}
 				return
 			}
 
 			if err := s.encryptedDB.Put(ctx, s.dbKey(uid, conv.GetConvID()), partDiskStorage{
-				Uids: partRes.Uids,
-				Hash: partRes.Hash,
+				Uids:     partRes.Uids,
+				Hash:     partRes.Hash,
+				CachedAt: s.G().GetClock().Now(),
 			}); err != nil {
 				s.Debug(ctx, "GetNonblock: failed to store participants: %s", err)
 			}

--- a/go/chat/participantsource.go
+++ b/go/chat/participantsource.go
@@ -24,13 +24,14 @@ type partDiskStorage struct {
 }
 
 // How long a cached participant list is served without asking the server. Every
-// localization of a team conversation asks for participants, so a team screen
-// with N channels used to mean N remote round trips every time it loaded, even
-// when nothing had changed and the server only answered HashMatch. Membership
-// changes arrive by server push for anything that re-localizes the conversation.
+// localization of a team conversation asks for participants, so without this a
+// team screen with N channels costs N remote round trips every time it loads,
+// even when nothing has changed and the server only answers HashMatch.
 //
-// A membership push drops the entry for the convs it touches (see Invalidate),
-// so this bounds only changes that arrive by neither push nor re-localization.
+// A membership push expires the entry for the convs it touches (see Invalidate),
+// so this bounds only changes that arrive by neither a push nor a cache miss.
+// Re-localizing a conversation is served from this cache like any other read, so
+// it is not itself a refresh path.
 const participantsCacheFreshness = 5 * time.Minute
 
 type CachingParticipantSource struct {
@@ -101,16 +102,35 @@ func (s *CachingParticipantSource) dbKey(uid gregor1.UID, convID chat1.Conversat
 	}
 }
 
-// Invalidate drops the cached list for these convs. Membership pushes call it,
+// Invalidate expires the cached list for these convs. Membership pushes call it,
 // so a join or leave shows up in participant lists and @-mention completion at
 // the next read instead of waiting out participantsCacheFreshness.
+//
+// It expires rather than deletes: the stale list is still the best answer
+// available until the server replies, and callers depend on getting it. A
+// local-only read has nowhere else to go, and a local-and-remote read emits the
+// cached list first so the UI has something to draw while the refresh is in
+// flight. The stored hash is kept for the same reason it is normally kept -- the
+// server derives it from the membership, so if it still matches, the push
+// changed something that does not affect this list and the refetch is free.
 func (s *CachingParticipantSource) Invalidate(ctx context.Context, uid gregor1.UID,
 	convIDs []chat1.ConversationID,
 ) {
 	for _, convID := range convIDs {
 		lock := s.locktab.AcquireOnName(ctx, s.G(), convID.String())
-		if err := s.encryptedDB.Delete(ctx, s.dbKey(uid, convID)); err != nil {
-			s.Debug(ctx, "Invalidate: failed to delete participants for %s: %s", convID, err)
+		var local partDiskStorage
+		found, err := s.encryptedDB.Get(ctx, s.dbKey(uid, convID), &local)
+		switch {
+		case err != nil:
+			s.Debug(ctx, "Invalidate: failed to read participants for %s: %s", convID, err)
+			if err := s.encryptedDB.Delete(ctx, s.dbKey(uid, convID)); err != nil {
+				s.Debug(ctx, "Invalidate: failed to delete participants for %s: %s", convID, err)
+			}
+		case found:
+			local.CachedAt = time.Time{}
+			if err := s.encryptedDB.Put(ctx, s.dbKey(uid, convID), local); err != nil {
+				s.Debug(ctx, "Invalidate: failed to expire participants for %s: %s", convID, err)
+			}
 		}
 		lock.Release(ctx)
 	}
@@ -142,9 +162,10 @@ func (s *CachingParticipantSource) GetNonblock(ctx context.Context, uid gregor1.
 
 		// load local first and send to channel
 		localHash := ""
+		var local partDiskStorage
+		var foundLocal bool
 		switch dataSource {
 		case types.InboxSourceDataSourceAll, types.InboxSourceDataSourceLocalOnly:
-			var local partDiskStorage
 			found, err := s.encryptedDB.Get(ctx, s.dbKey(uid, conv.GetConvID()), &local)
 			if err != nil {
 				resCh <- types.ParticipantResult{Err: err}
@@ -154,6 +175,7 @@ func (s *CachingParticipantSource) GetNonblock(ctx context.Context, uid gregor1.
 				return
 			}
 			if found {
+				foundLocal = true
 				resCh <- types.ParticipantResult{Uids: local.Uids}
 				localHash = local.Hash
 				if !local.CachedAt.IsZero() &&
@@ -178,10 +200,18 @@ func (s *CachingParticipantSource) GetNonblock(ctx context.Context, uid gregor1.
 			if partRes.HashMatch {
 				s.Debug(ctx, "GetNonblock: hash match on remote, all done")
 				// nothing changed, but record that we just checked so the next
-				// localization of this conv can be served from disk
-				var local partDiskStorage
-				found, err := s.encryptedDB.Get(ctx, s.dbKey(uid, conv.GetConvID()), &local)
-				if err == nil && found {
+				// localization of this conv can be served from disk. Only the
+				// remote-only path has to read here: every other path already
+				// has the entry in hand from the local read above.
+				if !foundLocal {
+					found, err := s.encryptedDB.Get(ctx, s.dbKey(uid, conv.GetConvID()), &local)
+					if err != nil {
+						s.Debug(ctx, "GetNonblock: failed to read back after hash match: %s", err)
+						return
+					}
+					foundLocal = found
+				}
+				if foundLocal {
 					local.CachedAt = s.G().GetClock().Now()
 					if err := s.encryptedDB.Put(ctx, s.dbKey(uid, conv.GetConvID()), local); err != nil {
 						s.Debug(ctx, "GetNonblock: failed to record refresh time: %s", err)

--- a/go/chat/participantsource.go
+++ b/go/chat/participantsource.go
@@ -29,11 +29,8 @@ type partDiskStorage struct {
 // when nothing had changed and the server only answered HashMatch. Membership
 // changes arrive by server push for anything that re-localizes the conversation.
 //
-// Known gap: nothing deletes the cached entry, and every production caller
-// passes DataSourceAll (the RemoteOnly path exists but is unused), so a
-// membership change that does not re-localize can take up to this long to show
-// up in a participant list or @-mention completion. Before the cache that was
-// one cheap HashMatch round trip per localization instead.
+// A membership push drops the entry for the convs it touches (see Invalidate),
+// so this bounds only changes that arrive by neither push nor re-localization.
 const participantsCacheFreshness = 5 * time.Minute
 
 type CachingParticipantSource struct {
@@ -101,6 +98,21 @@ func (s *CachingParticipantSource) dbKey(uid gregor1.UID, convID chat1.Conversat
 	return libkb.DbKey{
 		Typ: libkb.DBChatParticipants,
 		Key: uid.String() + convID.String(),
+	}
+}
+
+// Invalidate drops the cached list for these convs. Membership pushes call it,
+// so a join or leave shows up in participant lists and @-mention completion at
+// the next read instead of waiting out participantsCacheFreshness.
+func (s *CachingParticipantSource) Invalidate(ctx context.Context, uid gregor1.UID,
+	convIDs []chat1.ConversationID,
+) {
+	for _, convID := range convIDs {
+		lock := s.locktab.AcquireOnName(ctx, s.G(), convID.String())
+		if err := s.encryptedDB.Delete(ctx, s.dbKey(uid, convID)); err != nil {
+			s.Debug(ctx, "Invalidate: failed to delete participants for %s: %s", convID, err)
+		}
+		lock.Release(ctx)
 	}
 }
 

--- a/go/chat/participantsource_invalidate_test.go
+++ b/go/chat/participantsource_invalidate_test.go
@@ -1,0 +1,227 @@
+package chat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/chat/utils"
+	"github.com/keybase/client/go/externalstest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingParticipantSource records what Invalidate was asked to drop. Only that
+// method is exercised here, so the rest comes from the dummy.
+type recordingParticipantSource struct {
+	types.DummyParticipantSource
+	calls [][]chat1.ConversationID
+}
+
+func (r *recordingParticipantSource) Invalidate(ctx context.Context, uid gregor1.UID,
+	convIDs []chat1.ConversationID,
+) {
+	ids := make([]chat1.ConversationID, len(convIDs))
+	copy(ids, convIDs)
+	r.calls = append(r.calls, ids)
+}
+
+func convIDForTest(b byte) chat1.ConversationID {
+	return chat1.ConversationID([]byte{b, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+}
+
+// invalidateParticipants only reaches ParticipantsSource, so these two run
+// without a chat harness or a signed-in user.
+func setupInvalidateTest(t *testing.T, label string) (*PushHandler, *recordingParticipantSource, gregor1.UID) {
+	tc := externalstest.SetupTest(t, label, 2)
+	t.Cleanup(tc.Cleanup)
+	rec := &recordingParticipantSource{}
+	g := globals.NewContext(tc.G, &globals.ChatContext{ParticipantsSource: rec})
+	// Built directly rather than through NewPushHandler: that wires an identify
+	// notifier onto the ConnectionManager, which a bare test context has no need
+	// for and does not have. invalidateParticipants reaches neither.
+	handler := &PushHandler{
+		Contextified: globals.NewContextified(g),
+		DebugLabeler: utils.NewDebugLabeler(g.ExternalG(), "PushHandler", false),
+	}
+	return handler, rec, gregor1.UID([]byte{1, 2, 3, 4})
+}
+
+// A membership update names the same conv in more than one bucket, and every
+// bucket has to be covered, so the conv list is deduped and every field read.
+func TestInvalidateParticipantsCoversAndDedupes(t *testing.T) {
+	handler, rec, uid := setupInvalidateTest(t, "invalidate-dedupe")
+
+	dup := convIDForTest(1)
+	res := types.MembershipUpdateRes{
+		RoleUpdates: []chat1.ConversationLocal{{
+			Info: chat1.ConversationInfoLocal{Id: dup},
+		}},
+		UserJoinedConvs: []chat1.ConversationLocal{{
+			Info: chat1.ConversationInfoLocal{Id: convIDForTest(2)},
+		}},
+		UserRemovedConvs:   []chat1.ConversationMember{{ConvID: convIDForTest(3)}},
+		UserResetConvs:     []chat1.ConversationMember{{ConvID: convIDForTest(4)}},
+		OthersJoinedConvs:  []chat1.ConversationMember{{ConvID: dup}},
+		OthersRemovedConvs: []chat1.ConversationMember{{ConvID: convIDForTest(5)}},
+		OthersResetConvs:   []chat1.ConversationMember{{ConvID: convIDForTest(6)}},
+	}
+
+	handler.invalidateParticipants(context.TODO(), uid, res)
+
+	require.Len(t, rec.calls, 1)
+	got := rec.calls[0]
+	require.Len(t, got, 6, "the conv named in two buckets must be invalidated once")
+	want := []chat1.ConversationID{
+		dup, convIDForTest(2), convIDForTest(3),
+		convIDForTest(4), convIDForTest(5), convIDForTest(6),
+	}
+	require.Equal(t, want, got, "every membership bucket must be covered, in first-seen order")
+}
+
+// Nothing changed means nothing to invalidate, and the source must not be woken
+// for an empty list.
+func TestInvalidateParticipantsSkipsEmptyUpdate(t *testing.T) {
+	handler, rec, uid := setupInvalidateTest(t, "invalidate-empty")
+	handler.invalidateParticipants(context.TODO(), uid, types.MembershipUpdateRes{})
+	require.Empty(t, rec.calls)
+}
+
+// Invalidate expires the entry rather than dropping it, so the stale list is
+// still there to answer with while the refresh is in flight. A local-and-remote
+// read must therefore emit twice: the cached list, then the fresh one.
+func TestParticipantsSourceInvalidateKeepsLocalAnswer(t *testing.T) {
+	useRemoteMock = false
+	defer func() { useRemoteMock = true }()
+	ctc := makeChatTestContext(t, "TestParticipantsSourceInvalidateKeepsLocalAnswer", 2)
+	defer ctc.cleanup()
+
+	timeout := 20 * time.Second
+	users := ctc.users()
+	tc := ctc.world.Tcs[users[0].Username]
+	ctx := ctc.as(t, users[0]).startCtx
+	uid := gregor1.UID(users[0].GetUID().ToBytes())
+
+	info := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_TEAM, users[1])
+	conv, err := utils.GetUnverifiedConv(ctx, tc.Context(), uid, info.Id,
+		types.InboxSourceDataSourceAll)
+	require.NoError(t, err)
+	convID := conv.GetConvID()
+
+	// prime the cache
+	uids, err := tc.Context().ParticipantsSource.Get(ctx, uid, convID,
+		types.InboxSourceDataSourceAll)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(uids))
+
+	tc.Context().ParticipantsSource.Invalidate(ctx, uid, []chat1.ConversationID{convID})
+
+	// local first, then remote - two results, not one
+	ch := tc.Context().ParticipantsSource.GetNonblock(ctx, uid, convID,
+		types.InboxSourceDataSourceAll)
+	var got [][]gregor1.UID
+	for i := 0; i < 2; i++ {
+		select {
+		case pres := <-ch:
+			require.NoError(t, pres.Err)
+			got = append(got, pres.Uids)
+		case <-time.After(timeout):
+			require.Fail(t, "expected a local result then a remote one after Invalidate")
+		}
+	}
+	require.Len(t, got, 2)
+	require.Equal(t, 2, len(got[0]), "the expired list must still be served locally")
+	require.Equal(t, 2, len(got[1]))
+}
+
+// A local-only read has nowhere else to go, so an expired entry must still
+// answer it rather than coming back empty.
+func TestParticipantsSourceLocalOnlyAfterInvalidate(t *testing.T) {
+	useRemoteMock = false
+	defer func() { useRemoteMock = true }()
+	ctc := makeChatTestContext(t, "TestParticipantsSourceLocalOnlyAfterInvalidate", 2)
+	defer ctc.cleanup()
+
+	users := ctc.users()
+	tc := ctc.world.Tcs[users[0].Username]
+	ctx := ctc.as(t, users[0]).startCtx
+	uid := gregor1.UID(users[0].GetUID().ToBytes())
+
+	info := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_TEAM, users[1])
+	conv, err := utils.GetUnverifiedConv(ctx, tc.Context(), uid, info.Id,
+		types.InboxSourceDataSourceAll)
+	require.NoError(t, err)
+	convID := conv.GetConvID()
+
+	_, err = tc.Context().ParticipantsSource.Get(ctx, uid, convID,
+		types.InboxSourceDataSourceAll)
+	require.NoError(t, err)
+
+	tc.Context().ParticipantsSource.Invalidate(ctx, uid, []chat1.ConversationID{convID})
+
+	uids, err := tc.Context().ParticipantsSource.Get(ctx, uid, convID,
+		types.InboxSourceDataSourceLocalOnly)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(uids),
+		"an expired entry must still answer a local-only read")
+}
+
+// Within the freshness window a repeat read is served from disk; past it the
+// server is consulted again. The clock is faked in these tests, so the window
+// only elapses when the test says so.
+func TestParticipantsSourceCacheFreshness(t *testing.T) {
+	useRemoteMock = false
+	defer func() { useRemoteMock = true }()
+	ctc := makeChatTestContext(t, "TestParticipantsSourceCacheFreshness", 2)
+	defer ctc.cleanup()
+
+	timeout := 20 * time.Second
+	users := ctc.users()
+	tc := ctc.world.Tcs[users[0].Username]
+	ctx := ctc.as(t, users[0]).startCtx
+	uid := gregor1.UID(users[0].GetUID().ToBytes())
+
+	info := mustCreateConversationForTest(t, ctc, users[0], chat1.TopicType_CHAT,
+		chat1.ConversationMembersType_TEAM, users[1])
+	conv, err := utils.GetUnverifiedConv(ctx, tc.Context(), uid, info.Id,
+		types.InboxSourceDataSourceAll)
+	require.NoError(t, err)
+	convID := conv.GetConvID()
+
+	_, err = tc.Context().ParticipantsSource.Get(ctx, uid, convID,
+		types.InboxSourceDataSourceAll)
+	require.NoError(t, err)
+
+	// inside the window: one result, straight from disk, no remote leg
+	ch := tc.Context().ParticipantsSource.GetNonblock(ctx, uid, convID,
+		types.InboxSourceDataSourceAll)
+	select {
+	case pres := <-ch:
+		require.NoError(t, pres.Err)
+		require.Equal(t, 2, len(pres.Uids))
+	case <-time.After(timeout):
+		require.Fail(t, "no uids")
+	}
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "a fresh entry must not produce a second, remote result")
+	case <-time.After(timeout):
+		require.Fail(t, "channel was never closed")
+	}
+
+	// past the window: local first, then the refreshed remote answer
+	ctc.advanceFakeClock(participantsCacheFreshness + time.Minute)
+	ch = tc.Context().ParticipantsSource.GetNonblock(ctx, uid, convID,
+		types.InboxSourceDataSourceAll)
+	count := 0
+	for pres := range ch {
+		require.NoError(t, pres.Err)
+		count++
+	}
+	require.Equal(t, 2, count, "an expired entry must go back to the server")
+}

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -1093,7 +1093,18 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 		for _, c := range updateRes.UserResetConvs {
 			g.notifyReset(ctx, uid, c.ConvID, c.TopicType)
 		}
-		g.invalidateParticipants(ctx, uid, updateRes)
+		// Off the push path: Invalidate takes the same per-conv lock GetNonblock
+		// holds across its remote refresh, so a conv being refreshed right now
+		// would stall this handler - and every later out-of-band message with it -
+		// for an RPC apiece, in series.
+		//
+		// Started before the notifications so it is normally ahead of the reads
+		// they provoke. Losing that race costs one stale participant list, which
+		// the read after it corrects; blocking here costs every notification
+		// behind us.
+		go func(ctx context.Context) {
+			g.invalidateParticipants(ctx, uid, updateRes)
+		}(globals.BackgroundChatCtx(ctx, g.G()))
 		g.notifyMembersUpdate(ctx, uid, updateRes)
 		g.notifyConvUpdates(ctx, uid, updateRes.RoleUpdates)
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -864,6 +864,43 @@ func (g *PushHandler) notifyReset(ctx context.Context, uid gregor1.UID,
 	g.G().ActivityNotifier.ResetConversation(ctx, uid, convID, topicType)
 }
 
+// invalidateParticipants drops the cached participant list for every conv whose
+// membership just changed. Without this the cache serves the pre-change list
+// until it expires, which for a conv that never re-localizes is the whole
+// freshness window.
+func (g *PushHandler) invalidateParticipants(ctx context.Context, uid gregor1.UID,
+	membersRes types.MembershipUpdateRes,
+) {
+	seen := make(map[chat1.ConvIDStr]struct{})
+	var convIDs []chat1.ConversationID
+	add := func(convID chat1.ConversationID) {
+		convIDStr := convID.ConvIDStr()
+		if _, ok := seen[convIDStr]; ok {
+			return
+		}
+		seen[convIDStr] = struct{}{}
+		convIDs = append(convIDs, convID)
+	}
+	for _, conv := range membersRes.RoleUpdates {
+		add(conv.GetConvID())
+	}
+	for _, conv := range membersRes.UserJoinedConvs {
+		add(conv.GetConvID())
+	}
+	for _, cms := range [][]chat1.ConversationMember{
+		membersRes.UserRemovedConvs, membersRes.UserResetConvs,
+		membersRes.OthersJoinedConvs, membersRes.OthersRemovedConvs, membersRes.OthersResetConvs,
+	} {
+		for _, cm := range cms {
+			add(cm.ConvID)
+		}
+	}
+	if len(convIDs) == 0 {
+		return
+	}
+	g.G().ParticipantsSource.Invalidate(ctx, uid, convIDs)
+}
+
 func (g *PushHandler) notifyMembersUpdate(ctx context.Context, uid gregor1.UID,
 	membersRes types.MembershipUpdateRes,
 ) {
@@ -1053,6 +1090,7 @@ func (g *PushHandler) MembershipUpdate(ctx context.Context, m gregor.OutOfBandMe
 		for _, c := range updateRes.UserResetConvs {
 			g.notifyReset(ctx, uid, c.ConvID, c.TopicType)
 		}
+		g.invalidateParticipants(ctx, uid, updateRes)
 		g.notifyMembersUpdate(ctx, uid, updateRes)
 		g.notifyConvUpdates(ctx, uid, updateRes.RoleUpdates)
 

--- a/go/chat/push.go
+++ b/go/chat/push.go
@@ -864,10 +864,13 @@ func (g *PushHandler) notifyReset(ctx context.Context, uid gregor1.UID,
 	g.G().ActivityNotifier.ResetConversation(ctx, uid, convID, topicType)
 }
 
-// invalidateParticipants drops the cached participant list for every conv whose
-// membership just changed. Without this the cache serves the pre-change list
-// until it expires, which for a conv that never re-localizes is the whole
-// freshness window.
+// invalidateParticipants expires the cached participant list for every conv
+// whose membership just changed. It is the only thing that shortens the wait:
+// re-localizing the conv reads through the same cache, so nothing else goes back
+// to the server before the freshness window is up.
+//
+// Unlike notifyMembersUpdate this does not filter on topic type -- the
+// participant cache is keyed by conv regardless of what the conv is for.
 func (g *PushHandler) invalidateParticipants(ctx context.Context, uid gregor1.UID,
 	membersRes types.MembershipUpdateRes,
 ) {

--- a/go/chat/search/flush_test.go
+++ b/go/chat/search/flush_test.go
@@ -458,6 +458,58 @@ func TestAddDoesNotMarkSeenWhenIndexingFails(t *testing.T) {
 		"message was marked indexed even though indexing it failed")
 }
 
+// IDs the server will never return - deleted messages, gaps that never existed -
+// cannot be closed by indexing them, so before MarkSeen they held numMissing
+// above zero forever and SelectiveSync re-fetched the same conv every interval.
+func TestMarkSeenClosesUnfetchableIDs(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "mark-seen-converges")
+
+	conv := chat1.Conversation{
+		Metadata: chat1.ConversationMetadata{ConversationID: convID},
+		MaxMsgSummaries: []chat1.MessageSummary{
+			{MsgID: 3, MessageType: chat1.MessageType_TEXT},
+		},
+	}
+
+	require.NoError(t, s.Add(ctx, convID, []chat1.MessageUnboxed{
+		textMsgForTest(1, "hello world"),
+		textMsgForTest(3, "hello world"),
+	}))
+
+	missing, err := s.MissingIDForConv(ctx, conv)
+	require.NoError(t, err)
+	require.Equal(t, []chat1.MessageID{2}, missing,
+		"the ID the fetch could not produce must read as missing until marked")
+
+	// The fetch that asked for 2 succeeded and did not return it, so nothing
+	// else is coming for that ID.
+	require.NoError(t, s.MarkSeen(ctx, convID, []chat1.MessageID{2}))
+
+	missing, err = s.MissingIDForConv(ctx, conv)
+	require.NoError(t, err)
+	require.Empty(t, missing, "a marked ID must not keep the conv incomplete")
+
+	fullyIndexed, err := s.FullyIndexed(ctx, conv)
+	require.NoError(t, err)
+	require.True(t, fullyIndexed, "conv must converge once every ID is accounted for")
+}
+
+// MarkSeen goes through the pending set like every other metadata mutation; a
+// write-through would be undone by a concurrent flush's snapshot.
+func TestMarkSeenSurvivesEviction(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "mark-seen-eviction")
+
+	require.NoError(t, s.MarkSeen(ctx, convID, []chat1.MessageID{9}))
+	s.mdCache.Purge()
+
+	s.RLock()
+	md, err := s.getMetadataLocked(ctx, convID)
+	s.RUnlock()
+	require.NoError(t, err)
+	require.Contains(t, md.SeenIDs, chat1.MessageID(9),
+		"the mark was lost once the metadata left the cache")
+}
+
 func textMsgForTest(id chat1.MessageID, body string) chat1.MessageUnboxed {
 	return chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
 		ClientHeader: chat1.MessageClientHeaderVerified{

--- a/go/chat/search/flush_test.go
+++ b/go/chat/search/flush_test.go
@@ -246,9 +246,9 @@ func TestFlushSignalledWhenPendingSetIsFull(t *testing.T) {
 	ctx, s, _, convID := setupFlushTestStore(t, "flush-size-bound")
 
 	s.Lock()
-	for i := 0; i < maxDirtyEntries-1; i++ {
+	for i := chat1.MessageID(0); i < maxDirtyEntries-1; i++ {
 		te := newTokenEntry()
-		te.MsgIDs[chat1.MessageID(i)] = chat1.EmptyStruct{}
+		te.MsgIDs[i] = chat1.EmptyStruct{}
 		require.NoError(t, s.putTokenEntry(ctx, convID, fmt.Sprintf("tok%d", i), te))
 	}
 	s.Unlock()
@@ -276,9 +276,9 @@ func TestPendingCountTracksDistinctEntries(t *testing.T) {
 	ctx, s, _, convID := setupFlushTestStore(t, "flush-size-distinct")
 
 	s.Lock()
-	for i := 0; i < maxDirtyEntries*2; i++ {
+	for i := chat1.MessageID(0); i < maxDirtyEntries*2; i++ {
 		te := newTokenEntry()
-		te.MsgIDs[chat1.MessageID(i)] = chat1.EmptyStruct{}
+		te.MsgIDs[i] = chat1.EmptyStruct{}
 		require.NoError(t, s.putTokenEntry(ctx, convID, "same", te))
 	}
 	count := s.dirtyCount

--- a/go/chat/search/flush_test.go
+++ b/go/chat/search/flush_test.go
@@ -1,0 +1,596 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/externalstest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+// The caches are bounded LRUs (3000 tokens, 10000 aliases, 500 metadata) and a
+// heavy index pass writes far more than that between flushes, so a dirty entry
+// being evicted before it reaches disk is the normal case, not a corner one.
+// Purging in these tests stands in for that eviction: it leaves the entry dirty
+// but no longer resident, which is the state eviction produces.
+//
+// The real disk store encrypts with the device key and so needs a logged-in
+// user; this fake keeps the tests to the contract that matters, which is what
+// Flush wrote and what a read returns after an eviction.
+type memDiskStorage struct {
+	sync.Mutex
+	tokens  map[string]*tokenEntry
+	aliases map[string]*aliasEntry
+	md      map[chat1.ConvIDStr]*indexMetadata
+
+	// set to make the corresponding call fail, so the error paths - which are
+	// where entries get lost - are reachable from a test
+	failTokenPut error
+	failAliasPut error
+	failMdPut    error
+	failTokenGet error
+
+	// runs once, during a PutTokenEntry, to interleave an operation with a
+	// flush's disk writes - which happen outside the store lock
+	onPutToken func()
+}
+
+func newMemDiskStorage() *memDiskStorage {
+	return &memDiskStorage{
+		tokens:  make(map[string]*tokenEntry),
+		aliases: make(map[string]*aliasEntry),
+		md:      make(map[chat1.ConvIDStr]*indexMetadata),
+	}
+}
+
+func (m *memDiskStorage) key(convID chat1.ConversationID, token string) string {
+	return convID.ConvIDStr().String() + ":" + token
+}
+
+func (m *memDiskStorage) GetTokenEntry(ctx context.Context, convID chat1.ConversationID,
+	token string,
+) (*tokenEntry, error) {
+	m.Lock()
+	defer m.Unlock()
+	if m.failTokenGet != nil {
+		return nil, m.failTokenGet
+	}
+	return m.tokens[m.key(convID, token)], nil
+}
+
+func (m *memDiskStorage) PutTokenEntry(ctx context.Context, convID chat1.ConversationID,
+	token string, te *tokenEntry,
+) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.failTokenPut != nil {
+		return m.failTokenPut
+	}
+	if te == nil {
+		return fmt.Errorf("PutTokenEntry called with a nil entry: a delete must not be written as a value")
+	}
+	if m.onPutToken != nil {
+		hook := m.onPutToken
+		m.onPutToken = nil
+		m.Unlock()
+		hook()
+		m.Lock()
+	}
+	m.tokens[m.key(convID, token)] = te
+	return nil
+}
+
+func (m *memDiskStorage) RemoveTokenEntry(ctx context.Context, convID chat1.ConversationID, token string) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.tokens, m.key(convID, token))
+}
+
+func (m *memDiskStorage) GetAliasEntry(ctx context.Context, alias string) (*aliasEntry, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.aliases[alias], nil
+}
+
+func (m *memDiskStorage) PutAliasEntry(ctx context.Context, alias string, ae *aliasEntry) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.failAliasPut != nil {
+		return m.failAliasPut
+	}
+	if ae == nil {
+		return fmt.Errorf("PutAliasEntry called with a nil entry: a delete must not be written as a value")
+	}
+	m.aliases[alias] = ae
+	return nil
+}
+
+func (m *memDiskStorage) RemoveAliasEntry(ctx context.Context, alias string) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.aliases, alias)
+}
+
+func (m *memDiskStorage) GetMetadata(ctx context.Context, convID chat1.ConversationID) (*indexMetadata, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.md[convID.ConvIDStr()], nil
+}
+
+func (m *memDiskStorage) PutMetadata(ctx context.Context, convID chat1.ConversationID, md *indexMetadata) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.failMdPut != nil {
+		return m.failMdPut
+	}
+	m.md[convID.ConvIDStr()] = md
+	return nil
+}
+
+func (m *memDiskStorage) Clear(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) error {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.md, convID.ConvIDStr())
+	return nil
+}
+
+func setupFlushTestStore(t *testing.T, label string) (context.Context, *store, *memDiskStorage, chat1.ConversationID) {
+	tc := externalstest.SetupTest(t, label, 2)
+	t.Cleanup(tc.Cleanup)
+	g := globals.NewContext(tc.G, &globals.ChatContext{})
+	s := newStore(g, gregor1.UID([]byte{1, 2, 3, 4}))
+	disk := newMemDiskStorage()
+	s.diskStorage = disk
+	convID := chat1.ConversationID([]byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	})
+	return context.TODO(), s, disk, convID
+}
+
+func TestFlushWritesEvictedTokens(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "flush-evicted-token")
+
+	te := newTokenEntry()
+	te.MsgIDs[7] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", te))
+	s.Unlock()
+
+	// evicted before the flush loop got to it
+	s.tokenCache.Purge()
+
+	require.NoError(t, s.Flush())
+
+	onDisk, err := disk.GetTokenEntry(ctx, convID, "alpha")
+	require.NoError(t, err)
+	require.NotNil(t, onDisk, "an evicted dirty token must still be written to disk")
+	require.Contains(t, onDisk.MsgIDs, chat1.MessageID(7))
+}
+
+func TestFlushWritesEvictedAliases(t *testing.T) {
+	ctx, s, disk, _ := setupFlushTestStore(t, "flush-evicted-alias")
+
+	ae := newAliasEntry()
+	ae.Aliases["alpha"] = 1
+	s.Lock()
+	require.NoError(t, s.putAliasEntry(ctx, "alp", ae))
+	s.Unlock()
+
+	s.aliasCache.Purge()
+
+	require.NoError(t, s.Flush())
+
+	onDisk, err := disk.GetAliasEntry(ctx, "alp")
+	require.NoError(t, err)
+	require.NotNil(t, onDisk, "an evicted dirty alias must still be written to disk")
+	require.Contains(t, onDisk.Aliases, "alpha")
+}
+
+// Losing metadata is the one that costs search history: SeenIDs is what records
+// a message as indexed, so dropping it silently un-indexes messages whose tokens
+// were already written.
+func TestFlushWritesEvictedMetadata(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "flush-evicted-md")
+
+	require.NoError(t, s.MarkSeen(ctx, convID, []chat1.MessageID{1, 2, 3}))
+
+	s.mdCache.Purge()
+
+	require.NoError(t, s.Flush())
+
+	onDisk, err := disk.GetMetadata(ctx, convID)
+	require.NoError(t, err)
+	require.NotNil(t, onDisk, "evicted dirty metadata must still be written to disk")
+	require.Contains(t, onDisk.SeenIDs, chat1.MessageID(2))
+}
+
+// An evicted dirty entry used to fall through to the copy on disk, which is by
+// definition stale - it is missing precisely the writes that are still dirty.
+// Further updates were then built on top of that stale copy.
+func TestReadAfterEvictionDoesNotSeeStaleDisk(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "flush-stale-read")
+
+	first := newTokenEntry()
+	first.MsgIDs[1] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", first))
+	s.Unlock()
+	require.NoError(t, s.Flush())
+
+	// a second write that is still dirty when the entry is evicted
+	second := newTokenEntry()
+	second.MsgIDs[1] = chat1.EmptyStruct{}
+	second.MsgIDs[2] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", second))
+	s.Unlock()
+
+	s.tokenCache.Purge()
+
+	s.Lock()
+	got, err := s.getTokenEntry(ctx, convID, "alpha")
+	s.Unlock()
+	require.NoError(t, err)
+	require.Contains(t, got.MsgIDs, chat1.MessageID(2),
+		"read fell through to the stale copy on disk instead of the pending write")
+}
+
+// Pending entries are pinned in memory until flushed, so without a size bound a
+// fast writer decides how much accumulates between the 15s ticks.
+func TestFlushSignalledWhenPendingSetIsFull(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "flush-size-bound")
+
+	s.Lock()
+	for i := 0; i < maxDirtyEntries-1; i++ {
+		te := newTokenEntry()
+		te.MsgIDs[chat1.MessageID(i)] = chat1.EmptyStruct{}
+		require.NoError(t, s.putTokenEntry(ctx, convID, fmt.Sprintf("tok%d", i), te))
+	}
+	s.Unlock()
+
+	select {
+	case <-s.flushNeeded():
+		require.Fail(t, "asked for a flush below the bound")
+	default:
+	}
+
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "last", newTokenEntry()))
+	s.Unlock()
+
+	select {
+	case <-s.flushNeeded():
+	default:
+		require.Fail(t, "crossing the bound must ask for a flush")
+	}
+}
+
+// Rewriting the same key does not grow the pending set, so it must not count
+// toward the bound - otherwise a hot token flushes constantly for no reason.
+func TestPendingCountTracksDistinctEntries(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "flush-size-distinct")
+
+	s.Lock()
+	for i := 0; i < maxDirtyEntries*2; i++ {
+		te := newTokenEntry()
+		te.MsgIDs[chat1.MessageID(i)] = chat1.EmptyStruct{}
+		require.NoError(t, s.putTokenEntry(ctx, convID, "same", te))
+	}
+	count := s.dirtyCount
+	s.Unlock()
+
+	require.Equal(t, 1, count, "rewrites of one key must count once")
+
+	select {
+	case <-s.flushNeeded():
+		require.Fail(t, "rewriting one key must not trip the bound")
+	default:
+	}
+}
+
+func TestFlushResetsPendingCount(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "flush-size-reset")
+
+	s.Lock()
+	for i := 0; i < maxDirtyEntries; i++ {
+		require.NoError(t, s.putTokenEntry(ctx, convID, fmt.Sprintf("tok%d", i), newTokenEntry()))
+	}
+	s.Unlock()
+
+	require.NoError(t, s.Flush())
+
+	s.Lock()
+	count := s.dirtyCount
+	s.Unlock()
+	require.Equal(t, 0, count, "flush must clear the pending count with the maps")
+
+	// and the signal it answered must not still be queued, or the loop spins
+	select {
+	case <-s.flushNeeded():
+		require.Fail(t, "a flush left its own signal pending")
+	default:
+	}
+}
+
+func TestMetadataReadAfterEvictionKeepsSeenIDs(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "flush-stale-md-read")
+
+	require.NoError(t, s.MarkSeen(ctx, convID, []chat1.MessageID{1}))
+	require.NoError(t, s.Flush())
+	require.NoError(t, s.MarkSeen(ctx, convID, []chat1.MessageID{2}))
+
+	s.mdCache.Purge()
+
+	s.RLock()
+	md, err := s.getMetadataLocked(ctx, convID)
+	s.RUnlock()
+	require.NoError(t, err)
+	require.Contains(t, md.SeenIDs, chat1.MessageID(2),
+		"an unflushed SeenID was lost to a cache eviction")
+
+	// and the id must survive the round trip rather than only living in memory
+	require.NoError(t, s.Flush())
+	onDisk, err := disk.GetMetadata(ctx, convID)
+	require.NoError(t, err)
+	require.Contains(t, onDisk.SeenIDs, chat1.MessageID(2))
+}
+
+// A write that never reached disk must go back into the pending set. Before
+// this, Flush cleared dirty tracking before writing, so a failed write was
+// dropped: nothing marks a token entry dirty again once its message is indexed,
+// while the live metadata keeps its SeenIDs. The next successful flush then
+// recorded those messages as indexed with no tokens behind them.
+func TestFlushRequeuesUnwrittenEntriesOnFailure(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "flush-requeue")
+
+	te := newTokenEntry()
+	te.MsgIDs[7] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", te))
+	s.Unlock()
+	require.NoError(t, s.MarkSeen(ctx, convID, []chat1.MessageID{7}))
+
+	disk.Lock()
+	disk.failTokenPut = fmt.Errorf("disk is full")
+	disk.Unlock()
+
+	require.Error(t, s.Flush(), "a failed write must surface")
+
+	// metadata must not have landed while its token did not
+	onDisk, err := disk.GetMetadata(ctx, convID)
+	require.NoError(t, err)
+	require.Nil(t, onDisk, "metadata was published without the tokens behind it")
+
+	s.Lock()
+	pending := s.dirtyCount
+	_, tokenPending := s.dirtyTokens[convID.ConvIDStr()]["alpha"]
+	_, mdPending := s.dirtyMetadata[convID.ConvIDStr()]
+	s.Unlock()
+	require.True(t, tokenPending, "the token that failed to write was dropped")
+	require.True(t, mdPending, "the metadata that was never attempted was dropped")
+	require.Equal(t, 2, pending, "dirtyCount must match what was put back")
+
+	// once the disk recovers, the retry writes everything
+	disk.Lock()
+	disk.failTokenPut = nil
+	disk.Unlock()
+	require.NoError(t, s.Flush())
+
+	gotToken, err := disk.GetTokenEntry(ctx, convID, "alpha")
+	require.NoError(t, err)
+	require.NotNil(t, gotToken, "the retry did not write the token")
+	require.Contains(t, gotToken.MsgIDs, chat1.MessageID(7))
+	gotMd, err := disk.GetMetadata(ctx, convID)
+	require.NoError(t, err)
+	require.NotNil(t, gotMd)
+	require.Contains(t, gotMd.SeenIDs, chat1.MessageID(7))
+}
+
+// Requeueing must not clobber a write that happened after the snapshot was
+// taken - that value is newer than the one that failed.
+func TestRequeueKeepsNewerPendingWrite(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "flush-requeue-newer")
+
+	stale := newTokenEntry()
+	stale.MsgIDs[1] = chat1.EmptyStruct{}
+	newer := newTokenEntry()
+	newer.MsgIDs[2] = chat1.EmptyStruct{}
+
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", newer))
+	s.Unlock()
+
+	s.requeue([]tokenSnapshot{{convID: convID, token: "alpha", entry: stale}}, nil, nil)
+
+	s.Lock()
+	got := s.dirtyTokens[convID.ConvIDStr()]["alpha"]
+	count := s.dirtyCount
+	s.Unlock()
+	require.Contains(t, got.MsgIDs, chat1.MessageID(2), "requeue overwrote a newer pending write")
+	require.Equal(t, 1, count, "requeue double-counted an entry that was already pending")
+}
+
+// Remove used to write metadata straight to disk, ahead of the tokens for any
+// SeenIDs an in-flight Add had put on the same live object.
+func TestRemoveRoutesMetadataThroughOverlay(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "remove-ordering")
+
+	msg := textMsgForTest(3, "hello world")
+	require.NoError(t, s.Add(ctx, convID, []chat1.MessageUnboxed{msg}))
+
+	require.NoError(t, s.Remove(ctx, convID, []chat1.MessageUnboxed{msg}))
+
+	onDisk, err := disk.GetMetadata(ctx, convID)
+	require.NoError(t, err)
+	require.Nil(t, onDisk,
+		"Remove published metadata to disk directly, ahead of the pending tokens")
+
+	s.Lock()
+	_, mdPending := s.dirtyMetadata[convID.ConvIDStr()]
+	s.Unlock()
+	require.True(t, mdPending, "Remove must leave metadata pending like every other writer")
+}
+
+// Add marked a message seen before indexing it, so an indexing failure left the
+// message recorded as indexed with no tokens - and nothing re-indexes a message
+// the metadata already accounts for.
+func TestAddDoesNotMarkSeenWhenIndexingFails(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "add-mark-after-work")
+
+	disk.Lock()
+	disk.failTokenGet = fmt.Errorf("cannot read token entry")
+	disk.Unlock()
+
+	msg := textMsgForTest(5, "hello world")
+	require.Error(t, s.Add(ctx, convID, []chat1.MessageUnboxed{msg}),
+		"the indexing failure must surface")
+
+	s.RLock()
+	md, err := s.getMetadataLocked(ctx, convID)
+	s.RUnlock()
+	require.NoError(t, err)
+	require.NotContains(t, md.SeenIDs, chat1.MessageID(5),
+		"message was marked indexed even though indexing it failed")
+}
+
+func textMsgForTest(id chat1.MessageID, body string) chat1.MessageUnboxed {
+	return chat1.NewMessageUnboxedWithValid(chat1.MessageUnboxedValid{
+		ClientHeader: chat1.MessageClientHeaderVerified{
+			MessageType: chat1.MessageType_TEXT,
+			Conv:        chat1.ConversationIDTriple{TopicType: chat1.TopicType_CHAT},
+		},
+		MessageBody:  chat1.NewMessageBodyWithText(chat1.MessageText{Body: body}),
+		ServerHeader: chat1.MessageServerHeader{MessageID: id},
+	})
+}
+
+// Bumping indexMetadataVersion is how a damaged index gets rebuilt: a conv whose
+// metadata claims messages are indexed reads as complete, so nothing revisits
+// it and only a version change discards it. That makes the mismatch check
+// load-bearing rather than incidental.
+func TestStaleVersionEntriesAreDiscarded(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "stale-version")
+
+	staleToken := newTokenEntry()
+	staleToken.Version = "1:1"
+	staleToken.MsgIDs[7] = chat1.EmptyStruct{}
+	require.NoError(t, disk.PutTokenEntry(ctx, convID, "alpha", staleToken))
+
+	staleMd := newIndexMetadata()
+	staleMd.Version = "1:1"
+	staleMd.SeenIDs[7] = chat1.EmptyStruct{}
+	require.NoError(t, disk.PutMetadata(ctx, convID, staleMd))
+
+	s.Lock()
+	gotToken, err := s.getTokenEntry(ctx, convID, "alpha")
+	s.Unlock()
+	require.NoError(t, err)
+	require.NotContains(t, gotToken.MsgIDs, chat1.MessageID(7),
+		"an entry written by an older index version was served instead of discarded")
+
+	s.RLock()
+	gotMd, err := s.getMetadataLocked(ctx, convID)
+	s.RUnlock()
+	require.NoError(t, err)
+	require.NotContains(t, gotMd.SeenIDs, chat1.MessageID(7),
+		"stale metadata was kept, so the conv would still read as indexed")
+}
+
+// A delete that lands while a flush is writing must survive that flush. Flush
+// snapshots under the lock but writes outside it, so a delete applied straight
+// to disk in that window was immediately undone by the write that followed and
+// the entry stayed searchable forever. Queuing the delete instead orders it
+// after the write.
+func TestDeleteDuringFlushIsNotResurrected(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "delete-during-flush")
+
+	te := newTokenEntry()
+	te.MsgIDs[7] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", te))
+	s.Unlock()
+
+	// delete the entry midway through the flush that is writing it
+	disk.Lock()
+	disk.onPutToken = func() {
+		s.Lock()
+		s.deleteTokenEntry(ctx, convID, "alpha")
+		s.Unlock()
+	}
+	disk.Unlock()
+
+	require.NoError(t, s.Flush())
+	// that flush wrote the value it had already snapshotted; the delete is
+	// pending behind it and must be applied by the next one
+	require.NoError(t, s.Flush())
+
+	onDisk, err := disk.GetTokenEntry(ctx, convID, "alpha")
+	require.NoError(t, err)
+	require.Nil(t, onDisk,
+		"a delete issued during a flush was undone by that flush's write")
+
+	s.Lock()
+	got, err := s.getTokenEntry(ctx, convID, "alpha")
+	s.Unlock()
+	require.NoError(t, err)
+	require.NotContains(t, got.MsgIDs, chat1.MessageID(7),
+		"the resurrected entry is still readable")
+}
+
+// A queued delete must be visible to readers immediately, rather than reading
+// back the copy that is still on disk until the next flush.
+func TestPendingDeleteIsNotReadFromDisk(t *testing.T) {
+	ctx, s, disk, convID := setupFlushTestStore(t, "pending-delete-read")
+
+	te := newTokenEntry()
+	te.MsgIDs[7] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convID, "alpha", te))
+	s.Unlock()
+	require.NoError(t, s.Flush())
+
+	onDisk, err := disk.GetTokenEntry(ctx, convID, "alpha")
+	require.NoError(t, err)
+	require.NotNil(t, onDisk, "precondition: the entry is on disk")
+
+	s.Lock()
+	s.deleteTokenEntry(ctx, convID, "alpha")
+	got, err := s.getTokenEntry(ctx, convID, "alpha")
+	s.Unlock()
+	require.NoError(t, err)
+	require.NotContains(t, got.MsgIDs, chat1.MessageID(7),
+		"a pending delete must not read back the copy still on disk")
+
+	require.NoError(t, s.Flush())
+	onDisk, err = disk.GetTokenEntry(ctx, convID, "alpha")
+	require.NoError(t, err)
+	require.Nil(t, onDisk, "the queued delete never reached disk")
+}
+
+// The failure path must not undo a delete: requeue puts unwritten snapshots
+// back, and a delete that happened since the snapshot has to win.
+func TestRequeueDoesNotResurrectDeletedEntry(t *testing.T) {
+	ctx, s, _, convID := setupFlushTestStore(t, "requeue-delete")
+
+	stale := newTokenEntry()
+	stale.MsgIDs[7] = chat1.EmptyStruct{}
+
+	// the delete lands after the snapshot was taken
+	s.Lock()
+	s.deleteTokenEntry(ctx, convID, "alpha")
+	s.Unlock()
+
+	s.requeue([]tokenSnapshot{{convID: convID, token: "alpha", entry: stale}}, nil, nil)
+
+	s.Lock()
+	entry, ok := s.dirtyTokens[convID.ConvIDStr()]["alpha"]
+	s.Unlock()
+	require.True(t, ok, "the delete should still be pending")
+	require.Nil(t, entry,
+		"requeue resurrected an entry that was deleted after the snapshot")
+}

--- a/go/chat/search/flush_test.go
+++ b/go/chat/search/flush_test.go
@@ -209,9 +209,9 @@ func TestFlushWritesEvictedMetadata(t *testing.T) {
 	require.Contains(t, onDisk.SeenIDs, chat1.MessageID(2))
 }
 
-// An evicted dirty entry used to fall through to the copy on disk, which is by
-// definition stale - it is missing precisely the writes that are still dirty.
-// Further updates were then built on top of that stale copy.
+// A read of an evicted dirty entry must come from the pending set, not disk. The
+// copy on disk is by definition stale - it is missing precisely the writes that
+// are still dirty - and further updates would be built on top of it.
 func TestReadAfterEvictionDoesNotSeeStaleDisk(t *testing.T) {
 	ctx, s, _, convID := setupFlushTestStore(t, "flush-stale-read")
 
@@ -415,8 +415,9 @@ func TestRequeueKeepsNewerPendingWrite(t *testing.T) {
 	require.Equal(t, 1, count, "requeue double-counted an entry that was already pending")
 }
 
-// Remove used to write metadata straight to disk, ahead of the tokens for any
-// SeenIDs an in-flight Add had put on the same live object.
+// Remove must route metadata through the overlay, not straight to disk: writing
+// it directly publishes it ahead of the tokens for any SeenIDs an in-flight Add
+// has put on the same live object.
 func TestRemoveRoutesMetadataThroughOverlay(t *testing.T) {
 	ctx, s, disk, convID := setupFlushTestStore(t, "remove-ordering")
 
@@ -554,10 +555,9 @@ func TestStaleVersionEntriesAreDiscarded(t *testing.T) {
 }
 
 // A delete that lands while a flush is writing must survive that flush. Flush
-// snapshots under the lock but writes outside it, so a delete applied straight
-// to disk in that window was immediately undone by the write that followed and
-// the entry stayed searchable forever. Queuing the delete instead orders it
-// after the write.
+// snapshots under the lock but writes outside it, so a delete applied straight to
+// disk in that window is undone by the write that follows and the entry stays
+// searchable forever. Queuing the delete instead orders it after the write.
 func TestDeleteDuringFlushIsNotResurrected(t *testing.T) {
 	ctx, s, disk, convID := setupFlushTestStore(t, "delete-during-flush")
 
@@ -577,8 +577,8 @@ func TestDeleteDuringFlushIsNotResurrected(t *testing.T) {
 	disk.Unlock()
 
 	require.NoError(t, s.Flush())
-	// that flush wrote the value it had already snapshotted; the delete is
-	// pending behind it and must be applied by the next one
+	// that flush writes the value it snapshotted; the delete is pending behind it
+	// and must be applied by the next one
 	require.NoError(t, s.Flush())
 
 	onDisk, err := disk.GetTokenEntry(ctx, convID, "alpha")

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -26,14 +27,14 @@ type storageAdd struct {
 	ctx    context.Context
 	convID chat1.ConversationID
 	msgs   []chat1.MessageUnboxed
-	cb     chan struct{}
+	cb     chan error
 }
 
 type storageRemove struct {
 	ctx    context.Context
 	convID chat1.ConversationID
 	msgs   []chat1.MessageUnboxed
-	cb     chan struct{}
+	cb     chan error
 }
 
 type Indexer struct {
@@ -62,6 +63,12 @@ type Indexer struct {
 	selectiveSyncActive   bool
 	flushDelay            time.Duration
 
+	// convID -> how a conv's last reindex attempt went. A conv whose missing
+	// count did not move is backed off rather than retried every interval.
+	// See stalledConvs in SelectiveSync.
+	stalledMu    sync.Mutex
+	stalledConvs map[chat1.ConvIDStr]stalledConv
+
 	// for testing
 	consumeCh                            chan chat1.ConversationID
 	reindexCh                            chan chat1.ConversationID
@@ -82,6 +89,7 @@ func NewIndexer(g *globals.Context) *Indexer {
 		clock:        clockwork.NewRealClock(),
 		flushDelay:   15 * time.Second,
 		storageCh:    make(chan any, 100),
+		stalledConvs: make(map[chat1.ConvIDStr]stalledConv),
 	}
 	switch idx.G().GetAppType() {
 	case libkb.MobileAppType:
@@ -297,7 +305,20 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 	defer idx.Unlock()
 	ch := make(chan struct{})
 	if idx.started {
+		// Write out what is pending before dropping it. ClearMemory discards the
+		// overlay, and the flush loop is about to stop, so anything not written
+		// here is simply lost - work that has to be done again at best, and at
+		// worst tokens whose metadata already reached disk.
+		if err := idx.store.Flush(); err != nil {
+			idx.Debug(ctx, "Stop: final flush failed: %s", err)
+		}
 		idx.store.ClearMemory()
+		// entries are keyed by convID only, and team convs are shared between
+		// users on this device: a count left by the previous user must not
+		// decide anything for the next one
+		idx.stalledMu.Lock()
+		idx.stalledConvs = make(map[chat1.ConvIDStr]stalledConv)
+		idx.stalledMu.Unlock()
 		idx.started = false
 		close(idx.stopCh)
 		go func() {
@@ -373,12 +394,33 @@ func (idx *Indexer) consumeResultsForTest(convID chat1.ConversationID, err error
 	}
 }
 
-func (idx *Indexer) storageDispatch(op any) {
+// storageDispatch queues op, reporting whether it was accepted. A caller that
+// waits on the op's callback must close it itself when this returns false:
+// dropping the op silently left that callback with nobody to close it, and the
+// waiter - reindexConv does an unconditional receive - parked forever. In
+// SelectiveSync that leaks the sync's cancel func, so every later attempt sees
+// "already running" and background indexing is done until the process restarts.
+func (idx *Indexer) storageDispatch(op any) bool {
 	select {
 	case idx.storageCh <- op:
+		return true
 	default:
 		idx.Debug(context.Background(), "storageDispatch: failed to dispatch storage operation")
+		return false
 	}
+}
+
+// releaseStorageCB wakes an op's waiter, reporting whether the op actually ran.
+// The channel is buffered, so the send never blocks even with nobody waiting,
+// and a waiter that receives from a closed channel reads nil - success.
+func releaseStorageCB(cb chan error, err error) {
+	if cb == nil {
+		return
+	}
+	if err != nil {
+		cb <- err
+	}
+	close(cb)
 }
 
 func (idx *Indexer) storageLoop(stopCh chan struct{}) error {
@@ -388,7 +430,21 @@ func (idx *Indexer) storageLoop(stopCh chan struct{}) error {
 		select {
 		case <-stopCh:
 			idx.Debug(ctx, "storageLoop: shutting down")
-			return nil
+			// Release anything still queued. These ops will not run, but a
+			// caller blocked on one's callback would never wake up otherwise.
+			for {
+				select {
+				case iop := <-idx.storageCh:
+					switch op := iop.(type) {
+					case storageAdd:
+						releaseStorageCB(op.cb, errStorageStopped)
+					case storageRemove:
+						releaseStorageCB(op.cb, errStorageStopped)
+					}
+				default:
+					return nil
+				}
+			}
 		case iop := <-idx.storageCh:
 			switch op := iop.(type) {
 			case storageAdd:
@@ -397,14 +453,14 @@ func (idx *Indexer) storageLoop(stopCh chan struct{}) error {
 					idx.Debug(op.ctx, "storageLoop: add failed: %s", err)
 				}
 				idx.consumeResultsForTest(op.convID, err)
-				close(op.cb)
+				releaseStorageCB(op.cb, err)
 			case storageRemove:
 				err := idx.store.Remove(op.ctx, op.convID, op.msgs)
 				if err != nil {
 					idx.Debug(op.ctx, "storageLoop: remove failed: %s", err)
 				}
 				idx.consumeResultsForTest(op.convID, err)
-				close(op.cb)
+				releaseStorageCB(op.cb, err)
 			}
 		}
 	}
@@ -418,6 +474,11 @@ func (idx *Indexer) flushLoop(stopCh chan struct{}) error {
 		case <-stopCh:
 			idx.Debug(ctx, "flushLoop: shutting down")
 			return nil
+		case <-idx.store.flushNeeded():
+			// too much pending to wait out the interval
+			if err := idx.store.Flush(); err != nil {
+				idx.Debug(ctx, "flushLoop: failed to flush: %s", err)
+			}
 		case <-idx.clock.After(idx.flushDelay):
 			if err := idx.store.Flush(); err != nil {
 				idx.Debug(ctx, "flushLoop: failed to flush: %s", err)
@@ -454,8 +515,8 @@ func (idx *Indexer) Add(ctx context.Context, convID chat1.ConversationID,
 
 func (idx *Indexer) add(ctx context.Context, convID chat1.ConversationID,
 	msgs []chat1.MessageUnboxed, force bool,
-) (cb chan struct{}, err error) {
-	cb = make(chan struct{})
+) (cb chan error, err error) {
+	cb = make(chan error, 1)
 	if idx.G().GetEnv().GetDisableSearchIndexer() {
 		close(cb)
 		return cb, nil
@@ -472,12 +533,16 @@ func (idx *Indexer) add(ctx context.Context, convID chat1.ConversationID,
 	defer idx.Trace(ctx, &err,
 		"Indexer.Add conv: %v, msgs: %d, force: %v",
 		convID, len(msgs), force)()
-	idx.storageDispatch(storageAdd{
+	if !idx.storageDispatch(storageAdd{
 		ctx:    globals.BackgroundChatCtx(ctx, idx.G()),
 		convID: convID,
 		msgs:   msgs,
 		cb:     cb,
-	})
+	}) {
+		// nothing will run this op, so nothing will close cb
+		close(cb)
+		return cb, errStorageQueueFull
+	}
 	return cb, nil
 }
 
@@ -496,8 +561,8 @@ func (idx *Indexer) Remove(ctx context.Context, convID chat1.ConversationID,
 
 func (idx *Indexer) remove(ctx context.Context, convID chat1.ConversationID,
 	msgs []chat1.MessageUnboxed, force bool,
-) (cb chan struct{}, err error) {
-	cb = make(chan struct{})
+) (cb chan error, err error) {
+	cb = make(chan error, 1)
 	if idx.G().GetEnv().GetDisableSearchIndexer() {
 		close(cb)
 		return cb, nil
@@ -514,12 +579,16 @@ func (idx *Indexer) remove(ctx context.Context, convID chat1.ConversationID,
 	defer idx.Trace(ctx, &err,
 		"Indexer.Remove conv: %v, msgs: %d, force: %v",
 		convID, len(msgs), force)()
-	idx.storageDispatch(storageRemove{
+	if !idx.storageDispatch(storageRemove{
 		ctx:    globals.BackgroundChatCtx(ctx, idx.G()),
 		convID: convID,
 		msgs:   msgs,
 		cb:     cb,
-	})
+	}) {
+		// nothing will run this op, so nothing will close cb
+		close(cb)
+		return cb, errStorageQueueFull
+	}
 	return cb, nil
 }
 
@@ -547,67 +616,74 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 		utils.GetRemoteConvDisplayName(rconv), minIdxID, maxIdxID, len(missingIDs))()
 
 	reason := chat1.GetThreadReason_INDEXED_SEARCH
-	if len(missingIDs) < idx.pageSize {
-		msgs, err := idx.G().ConvSource.GetMessages(ctx, rconv.GetConvID(), idx.uid, missingIDs, &reason,
-			nil, false)
+	// Page over the MISSING ids, not over the raw min..max range. Paging the
+	// range re-fetched everything already indexed (measured: 57,648 already-seen
+	// messages re-added in a single pass) and, because each pass restarts at the
+	// lowest missing id and stops once the inbox-wide budget is spent, the top of
+	// a large conv was never reachable at all.
+	for start := 0; start < len(missingIDs); start += idx.pageSize {
+		select {
+		case <-ctx.Done():
+			return completedJobs, ctx.Err()
+		default:
+		}
+		end := start + idx.pageSize
+		if end > len(missingIDs) {
+			end = len(missingIDs)
+		}
+		chunk := missingIDs[start:end]
+		msgs, err := idx.G().ConvSource.GetMessages(ctx, convID, idx.uid, chunk, &reason, nil, false)
 		if err != nil {
 			if utils.IsPermanentErr(err) {
-				return 0, err
+				return completedJobs, err
 			}
-			return 0, nil
+			// transient: leave these ids missing so a later pass retries them
+			continue
 		}
 		cb, err := idx.add(ctx, convID, msgs, true)
 		if err != nil {
-			return 0, err
+			return completedJobs, err
 		}
-		<-cb
-		completedJobs++
-	} else {
-		query := &chat1.GetThreadQuery{
-			DisablePostProcessThread: true,
-			MarkAsRead:               false,
-		}
-		for i := minIdxID; i < maxIdxID; i += chat1.MessageID(idx.pageSize) { //nolint:gosec // G115: pageSize is a small positive config value, safe to convert
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			default:
+		select {
+		case addErr := <-cb:
+			if addErr != nil {
+				// The op failed or never ran, so nothing in this chunk was
+				// indexed. Marking it seen here would record those messages as
+				// indexed with no tokens behind them, and the conv would never
+				// be revisited to fix it.
+				return completedJobs, addErr
 			}
-			pagination := utils.MessageIDControlToPagination(ctx, idx.DebugLabeler, &chat1.MessageIDControl{
-				Num:   idx.pageSize,
-				Pivot: &i,
-				Mode:  chat1.MessageIDControlMode_NEWERMESSAGES,
-			}, nil)
-			tv, err := idx.G().ConvSource.Pull(ctx, convID, idx.uid, reason, nil, query, pagination)
+		case <-ctx.Done():
+			return completedJobs, ctx.Err()
+		}
+		// The fetch succeeded, so every id we asked for is now accounted for:
+		// the ones that came back were indexed by add(), and the ones that did
+		// not are ids the source will never produce. Without this the latter
+		// keep the conv permanently "not fully indexed".
+		if err := idx.store.MarkSeen(ctx, convID, chunk); err != nil {
+			// The store is failing, not the conv. Give up on this conv rather
+			// than paging on: without the mark these ids stay missing, so
+			// counting the job would make a storage failure look like a stalled
+			// conv and back it off for a reason that has nothing to do with it.
+			return completedJobs, err
+		}
+		completedJobs++
+		if numJobs > 0 && completedJobs >= numJobs {
+			break
+		}
+		if inboxIndexStatus != nil {
+			status, err := idx.store.IndexStatus(ctx, conv)
 			if err != nil {
-				if utils.IsPermanentErr(err) {
-					return 0, err
-				}
+				idx.Debug(ctx, "updateInboxIndex: unable to get index status %v", err)
 				continue
 			}
-			cb, err := idx.add(ctx, convID, tv.Messages, true)
+			inboxIndexStatus.addConv(status, conv)
+			percentIndexed, err := inboxIndexStatus.updateUI(ctx)
 			if err != nil {
-				return 0, err
-			}
-			<-cb
-			completedJobs++
-			if numJobs > 0 && completedJobs >= numJobs {
-				break
-			}
-			if inboxIndexStatus != nil {
-				status, err := idx.store.IndexStatus(ctx, conv)
-				if err != nil {
-					idx.Debug(ctx, "updateInboxIndex: unable to get index status %v", err)
-					continue
-				}
-				inboxIndexStatus.addConv(status, conv)
-				percentIndexed, err := inboxIndexStatus.updateUI(ctx)
-				if err != nil {
-					idx.Debug(ctx, "unable to update ui %v", err)
-				} else {
-					idx.Debug(ctx, "%v is %d%% indexed, inbox is %d%% indexed",
-						utils.GetRemoteConvDisplayName(rconv), status.percentIndexed(), percentIndexed)
-				}
+				idx.Debug(ctx, "unable to update ui %v", err)
+			} else {
+				idx.Debug(ctx, "%v is %d%% indexed, inbox is %d%% indexed",
+					utils.GetRemoteConvDisplayName(rconv), status.percentIndexed(), percentIndexed)
 			}
 		}
 	}
@@ -728,6 +804,99 @@ func (idx *Indexer) setSelectiveSyncActive(val bool) {
 // SelectiveSync queues up a small number of jobs on the background loader
 // periodically so our index can cover all conversations. The number of jobs
 // varies between desktop and mobile so mobile can be more conservative.
+// A stalled conv is retried after 2, then 4, then 8, then every 12 skipped
+// intervals - so on desktop it settles to one attempt per 13 passes, a bit over
+// an hour, reached after ~90 minutes. Even a permanently stuck conv is retried
+// occasionally: nothing is suppressed forever on the strength of an inference.
+//
+// With reindexConv now marking fetched-but-unreturned ids as seen, a conv should
+// converge on its own and never reach here. This is the backstop for whatever
+// still cannot converge, not the mechanism.
+// errStorageQueueFull reports that a storage op was never queued. Callers that
+// mark work as done once the op completes must not do so on this error: the op
+// did not run, so nothing was indexed.
+var errStorageQueueFull = errors.New("search storage queue full, operation dropped")
+
+// errStorageStopped reports that a queued op was released by shutdown rather
+// than run. Same contract as errStorageQueueFull: the op did not run.
+var errStorageStopped = errors.New("search storage loop stopped, operation dropped")
+
+const maxStallSkips = 12
+
+// the largest exponent used for the backoff; see recordIndexProgress
+const maxStallStreak = 4
+
+type stalledConv struct {
+	numMissing uint
+	// intervals still to skip before the next attempt
+	skips int
+	// consecutive no-progress attempts, doubling the backoff each time
+	streak uint
+}
+
+// convStalled reports whether to skip this conv on this pass, and consumes one
+// of its backoff intervals if so.
+//
+// The backoff is deliberately bounded rather than permanent. "numMissing did not
+// move" is strong evidence that the missing IDs cannot be fetched, but it is not
+// proof: reindexConv restarts at the lowest missing ID and stops once it has
+// spent the pass budget, so a conv whose budgeted pages happened to cover only
+// unfetchable IDs looks identical to a stuck one while still having real work
+// further up its range. Backing off instead of suppressing means that conv
+// resumes on its own, and a genuinely stuck one still costs ~1/12th of what it
+// did.
+func (idx *Indexer) convStalled(convID chat1.ConversationID, numMissing uint) bool {
+	idx.stalledMu.Lock()
+	defer idx.stalledMu.Unlock()
+	convIDStr := convID.ConvIDStr()
+	prev, ok := idx.stalledConvs[convIDStr]
+	if !ok || prev.numMissing != numMissing {
+		// never seen, or something changed the conv since: give it an attempt
+		return false
+	}
+	if prev.skips <= 0 {
+		return false
+	}
+	prev.skips--
+	idx.stalledConvs[convIDStr] = prev
+	return true
+}
+
+// recordIndexProgress stores the missing count after an attempt, so the next
+// pass can tell whether that attempt accomplished anything. A conv that has
+// reached 0 needs no entry: FullyIndexed already skips it.
+func (idx *Indexer) recordIndexProgress(ctx context.Context, conv chat1.Conversation, before uint) {
+	status, err := idx.store.IndexStatus(ctx, conv)
+	if err != nil {
+		idx.Debug(ctx, "recordIndexProgress: unable to get index status: %v", err)
+		return
+	}
+	convIDStr := conv.GetConvID().ConvIDStr()
+	idx.stalledMu.Lock()
+	defer idx.stalledMu.Unlock()
+	if status.fullyIndexed() || status.numMissing != before {
+		// done, or made progress: clear any marker so it keeps getting attempts
+		delete(idx.stalledConvs, convIDStr)
+		return
+	}
+	// Clamp the EXPONENT, not the result: streak is unbounded, and a large
+	// enough shift overflows int negative (then to 0), which reads as "no skips"
+	// and silently turns the backoff off for good.
+	streak := idx.stalledConvs[convIDStr].streak + 1
+	if streak > maxStallStreak {
+		streak = maxStallStreak
+	}
+	skips := 1 << streak
+	if skips > maxStallSkips {
+		skips = maxStallSkips
+	}
+	idx.stalledConvs[convIDStr] = stalledConv{
+		numMissing: status.numMissing,
+		skips:      skips,
+		streak:     streak,
+	}
+}
+
 func (idx *Indexer) SelectiveSync(ctx context.Context) (err error) {
 	defer idx.Trace(ctx, &err, "SelectiveSync")()
 	defer idx.PerfTrace(ctx, &err, "SelectiveSync")()
@@ -750,22 +919,52 @@ func (idx *Indexer) SelectiveSync(ctx context.Context) (err error) {
 		default:
 		}
 		convID := conv.GetConvID()
-		fullyIndexed, err := idx.store.FullyIndexed(ctx, conv.Conv)
+		// one status read, not one per question: each is an O(maxID-minID) scan
+		// of SeenIDs under the store lock
+		status, err := idx.store.IndexStatus(ctx, conv.Conv)
 		if err != nil {
 			idx.Debug(ctx, "SelectiveSync: Unable to get md for conv: %v, %v", convID, err)
 			continue
 		}
-		if fullyIndexed {
+		if status.fullyIndexed() {
+			continue
+		}
+
+		// A conv is "fully indexed" only when numMissing hits 0, and numMissing
+		// counts every ID in the min..max range. IDs the server will never
+		// return - deleted, or never delivered to us - therefore stay missing
+		// forever, so such a conv is never fully indexed and SelectiveSync
+		// re-queues it every syncInterval. Each pass re-fetches thousands of
+		// messages that are already indexed, marks nothing new, and burns the
+		// whole maxSyncConvs budget: measured at ~1800 remote getMessages every
+		// 5 minutes, indefinitely, on an idle desktop client, with numMissing
+		// byte-identical across 7 consecutive cycles.
+		//
+		// So skip a conv whose missing count did not move on its last attempt.
+		// Anything that actually changes the conv - a new message, a delete,
+		// clearing the index - changes the count and lets it back in, so this
+		// only suppresses the provably unproductive case.
+		if idx.convStalled(convID, status.numMissing) {
 			continue
 		}
 
 		completedJobs, err := idx.reindexConv(ctx, conv, numJobs, nil)
 		if err != nil {
 			idx.Debug(ctx, "Unable to reindex conv: %v, %v", convID, err)
-			continue
-		} else if completedJobs == 0 {
+			// the pages it did finish still spent budget
+			numJobs -= completedJobs
+			if numJobs <= 0 {
+				break
+			}
 			continue
 		}
+		if completedJobs == 0 {
+			// also the transient-fetch-failure path in reindexConv, which is
+			// indistinguishable from no progress here. Don't record a stall for
+			// it: a network blip would suppress the conv until it next changes.
+			continue
+		}
+		idx.recordIndexProgress(ctx, conv.Conv, status.numMissing)
 		idx.Debug(ctx, "SelectiveSync: Indexed completed jobs %d", completedJobs)
 		numJobs -= completedJobs
 		if numJobs <= 0 {
@@ -861,6 +1060,11 @@ func (idx *Indexer) Clear(ctx context.Context, uid gregor1.UID, convID chat1.Con
 	if store == nil {
 		return nil
 	}
+	// clearing the index resets what is missing, so this conv gets fresh
+	// attempts rather than staying suppressed at its old count
+	idx.stalledMu.Lock()
+	delete(idx.stalledConvs, convID.ConvIDStr())
+	idx.stalledMu.Unlock()
 	return store.Clear(ctx, uid, convID)
 }
 
@@ -871,6 +1075,9 @@ func (idx *Indexer) OnDbNuke(mctx libkb.MetaContext) (err error) {
 	if !idx.started {
 		return nil
 	}
+	idx.stalledMu.Lock()
+	idx.stalledConvs = make(map[chat1.ConvIDStr]stalledConv)
+	idx.stalledMu.Unlock()
 	idx.store.ClearMemory()
 	return nil
 }

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -75,7 +75,7 @@ type Indexer struct {
 
 	// convID -> how a conv's last reindex attempt went. A conv whose missing
 	// count did not move is backed off rather than retried every interval.
-	// See stalledConvs in SelectiveSync.
+	// See convStalled and recordIndexProgress for the backoff schedule.
 	stalledMu    sync.Mutex
 	stalledConvs map[chat1.ConvIDStr]stalledConv
 
@@ -315,14 +315,6 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 	defer idx.Unlock()
 	ch := make(chan struct{})
 	if idx.started {
-		// Write out what is pending before dropping it. ClearMemory discards the
-		// overlay, and the flush loop is about to stop, so anything not written
-		// here is simply lost - work that has to be done again at best, and at
-		// worst tokens whose metadata already reached disk.
-		if err := idx.store.Flush(); err != nil {
-			idx.Debug(ctx, "Stop: final flush failed: %s", err)
-		}
-		idx.store.ClearMemory()
 		// stall counts describe one indexer run, so drop them with it: a count
 		// carried into the next Start would clamp a conv on evidence gathered
 		// before the restart
@@ -334,7 +326,30 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 		go func() {
 			idx.Debug(context.Background(), "Stop: waiting for shutdown")
 			_ = idx.eg.Wait()
-			idx.Debug(context.Background(), "Stop: shutdown complete")
+			// Write out what is pending before dropping it. ClearMemory discards
+			// the overlay and the flush loop has stopped, so anything not written
+			// here is simply lost - work that has to be done again at best, and
+			// at worst tokens whose metadata already reached disk.
+			//
+			// This waits for the loops rather than running inline in Stop:
+			// storageLoop keeps writing into the overlay until stopCh closes, so
+			// a flush taken before that misses whatever lands in between and
+			// ClearMemory then drops it. It also keeps a flush of up to
+			// maxDirtyEntries individually-encrypted writes off idx.Lock, which
+			// every Add, Remove, Suspend and Clear has to take.
+			//
+			// On the logout path this flush fails: logout clears the device
+			// encryption key before it runs the logout hooks that reach us, and
+			// the store encrypts per write. Tokens and metadata share the
+			// overlay and are dropped together, so disk stays consistent and the
+			// work is redone after the next login -- but the write-out only
+			// really happens at process shutdown.
+			ctx := context.Background()
+			if err := idx.store.Flush(); err != nil {
+				idx.Debug(ctx, "Stop: final flush failed: %s", err)
+			}
+			idx.store.ClearMemory()
+			idx.Debug(ctx, "Stop: shutdown complete")
 			close(ch)
 		}()
 	} else {
@@ -406,24 +421,29 @@ func (idx *Indexer) consumeResultsForTest(convID chat1.ConversationID, err error
 
 // storageDispatch queues op, reporting whether it was accepted. A caller that
 // waits on the op's callback must close it itself when this returns false:
-// dropping the op silently left that callback with nobody to close it, and the
-// waiter - reindexConv does an unconditional receive - parked forever. In
-// SelectiveSync that leaks the sync's cancel func, so every later attempt sees
-// "already running" and background indexing is done until the process restarts.
+// nothing else will, and the waiter - reindexConv does an unconditional receive
+// - would park forever. In SelectiveSync that parks the sync holding its cancel
+// func, so every later attempt sees "already running" and background indexing is
+// finished for the life of the process.
 // It also refuses to queue once the indexer is stopping. Nothing is left to run
-// the op then, and the drain that would have released its callback has already
-// walked the queue.
+// the op then, and the drain that would have released its callback may already
+// have walked the queue.
 func (idx *Indexer) storageDispatch(op storageOp) bool {
+	// The queue check has to happen under the same lock hold as the started
+	// check, and Stop clears started and closes stopCh under that lock. Testing
+	// started, releasing, then sending leaves a window where Stop runs in
+	// between and the drain has already walked the queue, so the op is enqueued
+	// with nobody left to release its callback. Selecting on stopCh instead of
+	// holding the lock does not close it either: once stopCh is closed both
+	// cases are ready and Go picks between them at random. The send is
+	// non-blocking and storageLoop never takes idx.Lock, so holding it here
+	// cannot deadlock.
 	idx.Lock()
-	stopCh := idx.stopCh
-	started := idx.started
-	idx.Unlock()
-	if !started {
+	defer idx.Unlock()
+	if !idx.started {
 		return false
 	}
 	select {
-	case <-stopCh:
-		return false
 	case idx.storageCh <- op:
 		return true
 	default:
@@ -618,13 +638,20 @@ func (idx *Indexer) remove(ctx context.Context, convID chat1.ConversationID,
 	return cb, nil
 }
 
-// reindexConv attempts to fill in any missing messages from the index.  For a
-// small number of messages we use the GetMessages api to fill in the holes. If
-// our index is missing many messages, we page through and add batches of
-// missing messages.
+// reindexConv fills in the messages this conv is missing from the index. It
+// chunks the missing ids pageSize at a time, fetches each chunk with GetMessages
+// and indexes it, then marks the whole chunk seen so ids the source will never
+// produce stop counting as missing. It stops early once numJobs chunks are done,
+// so a large conv is filled in across several passes.
 func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversation,
 	numJobs int, inboxIndexStatus *inboxIndexStatus,
 ) (completedJobs int, err error) {
+	if idx.G().GetEnv().GetDisableSearchIndexer() {
+		// add() drops everything in this case, so paging on would MarkSeen ids
+		// that were never indexed and leave them permanently unsearchable if the
+		// indexer is turned back on.
+		return 0, nil
+	}
 	conv := rconv.Conv
 	convID := conv.GetConvID()
 	missingIDs, err := idx.store.MissingIDForConv(ctx, conv)
@@ -642,11 +669,11 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 		utils.GetRemoteConvDisplayName(rconv), minIdxID, maxIdxID, len(missingIDs))()
 
 	reason := chat1.GetThreadReason_INDEXED_SEARCH
-	// Page over the MISSING ids, not over the raw min..max range. Paging the
-	// range re-fetched everything already indexed (measured: 57,648 already-seen
-	// messages re-added in a single pass) and, because each pass restarts at the
-	// lowest missing id and stops once the inbox-wide budget is spent, the top of
-	// a large conv was never reachable at all.
+	// Page over the MISSING ids, not over the raw min..max range. The range
+	// includes everything already indexed - tens of thousands of messages in a
+	// large conv - and re-fetching those spends the inbox-wide budget before
+	// reaching the missing ones. Each pass restarts at the lowest missing id, so
+	// the top of a large conv is otherwise never reachable.
 	for start := 0; start < len(missingIDs); start += idx.pageSize {
 		select {
 		case <-ctx.Done():
@@ -683,9 +710,10 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 			return completedJobs, ctx.Err()
 		}
 		// The fetch succeeded, so every id we asked for is now accounted for:
-		// the ones that came back were indexed by add(), and the ones that did
-		// not are ids the source will never produce. Without this the latter
-		// keep the conv permanently "not fully indexed".
+		// the ones that came back were indexed by add() -- or skipped by it as
+		// unindexable, which is equally final -- and the ones that did not are
+		// ids the source will never produce. Unmarked, the latter hold the conv
+		// at "not fully indexed" permanently.
 		if err := idx.store.MarkSeen(ctx, convID, chunk); err != nil {
 			// The store is failing, not the conv. Give up on this conv rather
 			// than paging on: without the mark these ids stay missing, so
@@ -827,17 +855,6 @@ func (idx *Indexer) setSelectiveSyncActive(val bool) {
 	idx.selectiveSyncActive = val
 }
 
-// SelectiveSync queues up a small number of jobs on the background loader
-// periodically so our index can cover all conversations. The number of jobs
-// varies between desktop and mobile so mobile can be more conservative.
-// A stalled conv is retried after 2, then 4, then 8, then every 12 skipped
-// intervals - so on desktop it settles to one attempt per 13 passes, a bit over
-// an hour, reached after ~90 minutes. Even a permanently stuck conv is retried
-// occasionally: nothing is suppressed forever on the strength of an inference.
-//
-// With reindexConv now marking fetched-but-unreturned ids as seen, a conv should
-// converge on its own and never reach here. This is the backstop for whatever
-// still cannot converge, not the mechanism.
 // errStorageQueueFull reports that a storage op was never queued. Callers that
 // mark work as done once the op completes must not do so on this error: the op
 // did not run, so nothing was indexed.
@@ -890,7 +907,7 @@ func (idx *Indexer) convStalled(convID chat1.ConversationID, numMissing uint) bo
 
 // recordIndexProgress stores the missing count after an attempt, so the next
 // pass can tell whether that attempt accomplished anything. A conv that has
-// reached 0 needs no entry: FullyIndexed already skips it.
+// reached 0 needs no entry: its caller skips a fully indexed conv anyway.
 func (idx *Indexer) recordIndexProgress(ctx context.Context, conv chat1.Conversation, before uint) {
 	status, err := idx.store.IndexStatus(ctx, conv)
 	if err != nil {
@@ -905,9 +922,10 @@ func (idx *Indexer) recordIndexProgress(ctx context.Context, conv chat1.Conversa
 		delete(idx.stalledConvs, convIDStr)
 		return
 	}
-	// Clamp the EXPONENT, not the result: streak is unbounded, and a large
-	// enough shift overflows int negative (then to 0), which reads as "no skips"
-	// and silently turns the backoff off for good.
+	// Clamp the EXPONENT, not the result. Nothing else bounds how many times a
+	// conv fails to converge, and a large enough shift overflows int negative
+	// (then to 0), which reads as "no skips" and silently turns the backoff off
+	// for good.
 	streak := idx.stalledConvs[convIDStr].streak + 1
 	if streak > maxStallStreak {
 		streak = maxStallStreak
@@ -923,6 +941,17 @@ func (idx *Indexer) recordIndexProgress(ctx context.Context, conv chat1.Conversa
 	}
 }
 
+// SelectiveSync queues up a small number of jobs on the background loader
+// periodically so our index can cover all conversations. The number of jobs
+// varies between desktop and mobile so mobile can be more conservative.
+// A stalled conv is retried after 2, then 4, then 8, then every 12 skipped
+// intervals - so on desktop it settles to one attempt per 13 passes, a bit over
+// an hour, reached after ~90 minutes. Even a permanently stuck conv is retried
+// occasionally: nothing is suppressed forever on the strength of an inference.
+//
+// reindexConv marks fetched-but-unreturned ids as seen, so a conv converges on
+// its own and should never reach the backoff at all. It is the backstop for
+// whatever still cannot converge, not the mechanism.
 func (idx *Indexer) SelectiveSync(ctx context.Context) (err error) {
 	defer idx.Trace(ctx, &err, "SelectiveSync")()
 	defer idx.PerfTrace(ctx, &err, "SelectiveSync")()
@@ -961,10 +990,9 @@ func (idx *Indexer) SelectiveSync(ctx context.Context) (err error) {
 		// return - deleted, or never delivered to us - therefore stay missing
 		// forever, so such a conv is never fully indexed and SelectiveSync
 		// re-queues it every syncInterval. Each pass re-fetches thousands of
-		// messages that are already indexed, marks nothing new, and burns the
-		// whole maxSyncConvs budget: measured at ~1800 remote getMessages every
-		// 5 minutes, indefinitely, on an idle desktop client, with numMissing
-		// byte-identical across 7 consecutive cycles.
+		// already-indexed messages, marks nothing new, and burns the whole
+		// maxSyncConvs budget - on the order of a thousand remote getMessages
+		// every syncInterval, indefinitely, on an idle client.
 		//
 		// So skip a conv whose missing count did not move on its last attempt.
 		// Anything that actually changes the conv - a new message, a delete,

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -423,6 +423,28 @@ func releaseStorageCB(cb chan error, err error) {
 	close(cb)
 }
 
+// drainStorageQueue releases every op still queued at shutdown. They will not
+// run, so each callback reports errStorageStopped: a caller told an op finished
+// marks its messages as indexed, and nothing put them there.
+//
+// Split out of storageLoop because that select has both cases ready once stopCh
+// closes and Go picks between them at random, which is untestable from outside.
+func (idx *Indexer) drainStorageQueue() {
+	for {
+		select {
+		case iop := <-idx.storageCh:
+			switch op := iop.(type) {
+			case storageAdd:
+				releaseStorageCB(op.cb, errStorageStopped)
+			case storageRemove:
+				releaseStorageCB(op.cb, errStorageStopped)
+			}
+		default:
+			return
+		}
+	}
+}
+
 func (idx *Indexer) storageLoop(stopCh chan struct{}) error {
 	ctx := context.Background()
 	idx.Debug(ctx, "storageLoop: starting")
@@ -430,21 +452,8 @@ func (idx *Indexer) storageLoop(stopCh chan struct{}) error {
 		select {
 		case <-stopCh:
 			idx.Debug(ctx, "storageLoop: shutting down")
-			// Release anything still queued. These ops will not run, but a
-			// caller blocked on one's callback would never wake up otherwise.
-			for {
-				select {
-				case iop := <-idx.storageCh:
-					switch op := iop.(type) {
-					case storageAdd:
-						releaseStorageCB(op.cb, errStorageStopped)
-					case storageRemove:
-						releaseStorageCB(op.cb, errStorageStopped)
-					}
-				default:
-					return nil
-				}
-			}
+			idx.drainStorageQueue()
+			return nil
 		case iop := <-idx.storageCh:
 			switch op := iop.(type) {
 			case storageAdd:

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -23,6 +23,12 @@ import (
 // is read, a prerequisite for searching.
 const minPriorityScore = 10
 
+// storageOp is what every queued storage operation has in common: a waiter that
+// must be released whether or not the op ever runs.
+type storageOp interface {
+	callback() chan error
+}
+
 type storageAdd struct {
 	ctx    context.Context
 	convID chat1.ConversationID
@@ -30,12 +36,16 @@ type storageAdd struct {
 	cb     chan error
 }
 
+func (o storageAdd) callback() chan error { return o.cb }
+
 type storageRemove struct {
 	ctx    context.Context
 	convID chat1.ConversationID
 	msgs   []chat1.MessageUnboxed
 	cb     chan error
 }
+
+func (o storageRemove) callback() chan error { return o.cb }
 
 type Indexer struct {
 	globals.Contextified
@@ -54,7 +64,7 @@ type Indexer struct {
 	clock        clockwork.Clock
 	eg           errgroup.Group
 	uid          gregor1.UID
-	storageCh    chan any
+	storageCh    chan storageOp
 
 	maxSyncConvs          int
 	startSyncDelay        time.Duration
@@ -88,7 +98,7 @@ func NewIndexer(g *globals.Context) *Indexer {
 		pokeSyncCh:   make(chan struct{}, 100),
 		clock:        clockwork.NewRealClock(),
 		flushDelay:   15 * time.Second,
-		storageCh:    make(chan any, 100),
+		storageCh:    make(chan storageOp, 100),
 		stalledConvs: make(map[chat1.ConvIDStr]stalledConv),
 	}
 	switch idx.G().GetAppType() {
@@ -313,9 +323,9 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 			idx.Debug(ctx, "Stop: final flush failed: %s", err)
 		}
 		idx.store.ClearMemory()
-		// entries are keyed by convID only, and team convs are shared between
-		// users on this device: a count left by the previous user must not
-		// decide anything for the next one
+		// stall counts describe one indexer run, so drop them with it: a count
+		// carried into the next Start would clamp a conv on evidence gathered
+		// before the restart
 		idx.stalledMu.Lock()
 		idx.stalledConvs = make(map[chat1.ConvIDStr]stalledConv)
 		idx.stalledMu.Unlock()
@@ -400,8 +410,20 @@ func (idx *Indexer) consumeResultsForTest(convID chat1.ConversationID, err error
 // waiter - reindexConv does an unconditional receive - parked forever. In
 // SelectiveSync that leaks the sync's cancel func, so every later attempt sees
 // "already running" and background indexing is done until the process restarts.
-func (idx *Indexer) storageDispatch(op any) bool {
+// It also refuses to queue once the indexer is stopping. Nothing is left to run
+// the op then, and the drain that would have released its callback has already
+// walked the queue.
+func (idx *Indexer) storageDispatch(op storageOp) bool {
+	idx.Lock()
+	stopCh := idx.stopCh
+	started := idx.started
+	idx.Unlock()
+	if !started {
+		return false
+	}
 	select {
+	case <-stopCh:
+		return false
 	case idx.storageCh <- op:
 		return true
 	default:
@@ -432,13 +454,8 @@ func releaseStorageCB(cb chan error, err error) {
 func (idx *Indexer) drainStorageQueue() {
 	for {
 		select {
-		case iop := <-idx.storageCh:
-			switch op := iop.(type) {
-			case storageAdd:
-				releaseStorageCB(op.cb, errStorageStopped)
-			case storageRemove:
-				releaseStorageCB(op.cb, errStorageStopped)
-			}
+		case op := <-idx.storageCh:
+			releaseStorageCB(op.callback(), errStorageStopped)
 		default:
 			return
 		}

--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -62,9 +62,12 @@ type Indexer struct {
 	resumeWait   time.Duration
 	started      bool
 	clock        clockwork.Clock
-	eg           errgroup.Group
-	uid          gregor1.UID
-	storageCh    chan storageOp
+	// the loops of the current run. Replaced by each Start rather than reused:
+	// Stop waits on it from a goroutine, and a Group cannot be added to while
+	// somebody is waiting on it.
+	eg        *errgroup.Group
+	uid       gregor1.UID
+	storageCh chan storageOp
 
 	maxSyncConvs          int
 	startSyncDelay        time.Duration
@@ -143,34 +146,41 @@ func (idx *Indexer) SetUID(uid gregor1.UID) {
 	idx.store = newStore(idx.G(), uid)
 }
 
+// startLoopLocked runs f as part of the current run, opening one if there isn't
+// one yet. Callers hold idx.Lock.
+func (idx *Indexer) startLoopLocked(f func(stopCh chan struct{}) error) {
+	if !idx.started {
+		idx.started = true
+		idx.newRunLocked()
+	}
+	stopCh, eg := idx.stopCh, idx.eg
+	eg.Go(func() error { return f(stopCh) })
+}
+
+// newRunLocked gives this run its own stop channel and errgroup, so nothing a
+// previous run is still shutting down can be confused for part of this one.
+// Callers hold idx.Lock.
+func (idx *Indexer) newRunLocked() {
+	idx.stopCh = make(chan struct{})
+	idx.eg = new(errgroup.Group)
+}
+
 func (idx *Indexer) StartFlushLoop() {
 	idx.Lock()
 	defer idx.Unlock()
-	if !idx.started {
-		idx.started = true
-		idx.stopCh = make(chan struct{})
-	}
-	idx.eg.Go(func() error { return idx.flushLoop(idx.stopCh) })
+	idx.startLoopLocked(idx.flushLoop)
 }
 
 func (idx *Indexer) StartStorageLoop() {
 	idx.Lock()
 	defer idx.Unlock()
-	if !idx.started {
-		idx.started = true
-		idx.stopCh = make(chan struct{})
-	}
-	idx.eg.Go(func() error { return idx.storageLoop(idx.stopCh) })
+	idx.startLoopLocked(idx.storageLoop)
 }
 
 func (idx *Indexer) StartSyncLoop() {
 	idx.Lock()
 	defer idx.Unlock()
-	if !idx.started {
-		idx.started = true
-		idx.stopCh = make(chan struct{})
-	}
-	idx.eg.Go(func() error { return idx.SyncLoop(idx.stopCh) })
+	idx.startLoopLocked(idx.SyncLoop)
 }
 
 func (idx *Indexer) SetFlushDelay(dur time.Duration) {
@@ -187,12 +197,12 @@ func (idx *Indexer) Start(ctx context.Context, uid gregor1.UID) {
 	idx.uid = uid
 	idx.store = newStore(idx.G(), uid)
 	idx.started = true
-	idx.stopCh = make(chan struct{})
+	idx.newRunLocked()
 	if !idx.G().IsMobileAppType() && !idx.G().GetEnv().GetDisableSearchIndexer() {
-		idx.eg.Go(func() error { return idx.SyncLoop(idx.stopCh) })
+		idx.startLoopLocked(idx.SyncLoop)
 	}
-	idx.eg.Go(func() error { return idx.flushLoop(idx.stopCh) })
-	idx.eg.Go(func() error { return idx.storageLoop(idx.stopCh) })
+	idx.startLoopLocked(idx.flushLoop)
+	idx.startLoopLocked(idx.storageLoop)
 }
 
 func (idx *Indexer) CancelSync(ctx context.Context) {
@@ -323,9 +333,18 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 		idx.stalledMu.Unlock()
 		idx.started = false
 		close(idx.stopCh)
+		// Read this run's store and errgroup under the lock. Stop clears started
+		// immediately, so a Start can run before the goroutine below does, and it
+		// replaces both -- reading the fields out there would wait on the new
+		// run's loops and then flush and ClearMemory the new run's store, dropping
+		// its pending writes and never writing out this run's.
+		store, eg := idx.store, idx.eg
 		go func() {
 			idx.Debug(context.Background(), "Stop: waiting for shutdown")
-			_ = idx.eg.Wait()
+			if eg != nil {
+				// nil when nothing ever started a loop, which only a test does
+				_ = eg.Wait()
+			}
 			// Write out what is pending before dropping it. ClearMemory discards
 			// the overlay and the flush loop has stopped, so anything not written
 			// here is simply lost - work that has to be done again at best, and
@@ -345,10 +364,10 @@ func (idx *Indexer) Stop(ctx context.Context) chan struct{} {
 			// work is redone after the next login -- but the write-out only
 			// really happens at process shutdown.
 			ctx := context.Background()
-			if err := idx.store.Flush(); err != nil {
+			if err := store.Flush(); err != nil {
 				idx.Debug(ctx, "Stop: final flush failed: %s", err)
 			}
-			idx.store.ClearMemory()
+			store.ClearMemory()
 			idx.Debug(ctx, "Stop: shutdown complete")
 			close(ch)
 		}()
@@ -638,11 +657,16 @@ func (idx *Indexer) remove(ctx context.Context, convID chat1.ConversationID,
 	return cb, nil
 }
 
+// maxConsecutiveFetchFailures is how many transient fetch failures in a row
+// reindexConv tolerates before it abandons the conv for this pass. Two rather
+// than one so a single bad chunk does not stop a conv that is otherwise fine.
+const maxConsecutiveFetchFailures = 2
+
 // reindexConv fills in the messages this conv is missing from the index. It
 // chunks the missing ids pageSize at a time, fetches each chunk with GetMessages
 // and indexes it, then marks the whole chunk seen so ids the source will never
-// produce stop counting as missing. It stops early once numJobs chunks are done,
-// so a large conv is filled in across several passes.
+// produce stop counting as missing. It stops early once numJobs chunks have been
+// attempted, so a large conv is filled in across several passes.
 func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversation,
 	numJobs int, inboxIndexStatus *inboxIndexStatus,
 ) (completedJobs int, err error) {
@@ -674,6 +698,12 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 	// large conv - and re-fetching those spends the inbox-wide budget before
 	// reaching the missing ones. Each pass restarts at the lowest missing id, so
 	// the top of a large conv is otherwise never reachable.
+	// A failed fetch spends the same remote round trip a completed page does, so
+	// both count against the pass budget. Counting only completed pages lets a
+	// conv whose fetches keep failing page over its whole missing range in one
+	// pass -- hundreds of round trips for one conv, with numJobs bounding nothing.
+	budgetSpent := 0
+	consecutiveFetchFailures := 0
 	for start := 0; start < len(missingIDs); start += idx.pageSize {
 		select {
 		case <-ctx.Done():
@@ -691,8 +721,21 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 				return completedJobs, err
 			}
 			// transient: leave these ids missing so a later pass retries them
+			budgetSpent++
+			consecutiveFetchFailures++
+			if consecutiveFetchFailures >= maxConsecutiveFetchFailures {
+				// it is the network failing rather than these particular ids, so
+				// paging on just spends the budget on the same failure
+				idx.Debug(ctx, "reindexConv: giving up on conv after %d consecutive fetch failures: %s",
+					consecutiveFetchFailures, err)
+				return completedJobs, nil
+			}
+			if numJobs > 0 && budgetSpent >= numJobs {
+				return completedJobs, nil
+			}
 			continue
 		}
+		consecutiveFetchFailures = 0
 		cb, err := idx.add(ctx, convID, msgs, true)
 		if err != nil {
 			return completedJobs, err
@@ -722,7 +765,8 @@ func (idx *Indexer) reindexConv(ctx context.Context, rconv types.RemoteConversat
 			return completedJobs, err
 		}
 		completedJobs++
-		if numJobs > 0 && completedJobs >= numJobs {
+		budgetSpent++
+		if numJobs > 0 && budgetSpent >= numJobs {
 			break
 		}
 		if inboxIndexStatus != nil {

--- a/go/chat/search/md.go
+++ b/go/chat/search/md.go
@@ -9,7 +9,22 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 )
 
-const indexMetadataVersion = 3
+// 3 -> 4 discards every conversation's index metadata, which is what makes a
+// damaged index repair itself. Several bugs could leave the metadata recording
+// messages as indexed while the tokens making them findable never reached disk:
+// writes evicted from the cache before a flush, a flush that failed partway,
+// Remove publishing metadata ahead of its tokens, and Add marking a message
+// before indexing it. Such a conversation reads as fully indexed, so nothing
+// revisits it and the messages stay unsearchable.
+//
+// Dropping the metadata alone - rather than bumping indexVersion, which would
+// discard the token and alias entries too - means every message is re-indexed
+// onto the entries already on disk, so search keeps working throughout the
+// repair instead of going dark until the rebuild catches up. The cost is that
+// surviving alias refcounts are inflated further by the re-add, and that token
+// entries naming since-deleted messages survive; those are filtered at search
+// time by the message lookup, so they cost a lookup, not a wrong result.
+const indexMetadataVersion = 4
 
 type indexMetadata struct {
 	SeenIDs map[chat1.MessageID]chat1.EmptyStruct `codec:"s"`

--- a/go/chat/search/md.go
+++ b/go/chat/search/md.go
@@ -9,21 +9,19 @@ import (
 	"github.com/keybase/client/go/protocol/chat1"
 )
 
-// 3 -> 4 discards every conversation's index metadata, which is what makes a
-// damaged index repair itself. Several bugs could leave the metadata recording
-// messages as indexed while the tokens making them findable never reached disk:
-// writes evicted from the cache before a flush, a flush that failed partway,
-// Remove publishing metadata ahead of its tokens, and Add marking a message
-// before indexing it. Such a conversation reads as fully indexed, so nothing
-// revisits it and the messages stay unsearchable.
+// Bumping this discards every conversation's index metadata, which is how a
+// damaged index repairs itself: a conversation whose metadata records messages
+// as indexed while the tokens making them findable never reached disk reads as
+// fully indexed, so nothing revisits it and those messages stay unsearchable.
+// Dropping the metadata makes every message missing again and forces a reindex.
 //
-// Dropping the metadata alone - rather than bumping indexVersion, which would
-// discard the token and alias entries too - means every message is re-indexed
-// onto the entries already on disk, so search keeps working throughout the
-// repair instead of going dark until the rebuild catches up. The cost is that
-// surviving alias refcounts are inflated further by the re-add, and that token
-// entries naming since-deleted messages survive; those are filtered at search
-// time by the message lookup, so they cost a lookup, not a wrong result.
+// Metadata only, rather than bumping indexVersion, which would discard the token
+// and alias entries too: re-indexing onto the entries already on disk keeps
+// search working throughout the repair instead of going dark until the rebuild
+// catches up. The cost is that surviving alias refcounts are inflated further by
+// the re-add, and that token entries naming since-deleted messages survive.
+// Those are filtered at search time by the message lookup, so they cost a
+// lookup, not a wrong result.
 const indexMetadataVersion = 4
 
 type indexMetadata struct {

--- a/go/chat/search/reindex_test.go
+++ b/go/chat/search/reindex_test.go
@@ -341,3 +341,44 @@ func TestPendingAliasDeleteIsNotReadFromDisk(t *testing.T) {
 	require.Empty(t, got.Aliases,
 		"a pending alias delete must read as empty, not fall through to the copy on disk")
 }
+
+// A fetch that fails spends the same remote round trip a completed page does. If
+// only completed pages count, a conv whose fetches keep failing pages over its
+// entire missing range in one pass and numJobs bounds nothing.
+func TestReindexConvStopsAfterRepeatedFetchFailures(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, _, rconv := setupReindexTest(t, "reindex-repeated-failures", 50)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	cs.mu.Lock()
+	for _, first := range []chat1.MessageID{1, 11, 21, 31, 41} {
+		cs.errs[first] = transientErr{fmt.Errorf("network blip")}
+	}
+	cs.mu.Unlock()
+
+	completed, err := idx.reindexConv(ctx, rconv, 0, nil)
+	require.NoError(t, err, "a transient failure must not fail the whole conv")
+	require.Equal(t, 0, completed)
+	require.Len(t, cs.calls(), maxConsecutiveFetchFailures,
+		"a conv whose fetches keep failing must be abandoned, not paged to the end")
+}
+
+// The budget counts round trips, so a failed one leaves less of it for the rest
+// of the pass.
+func TestReindexConvChargesFailedFetchesToBudget(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, _, rconv := setupReindexTest(t, "reindex-failure-budget", 50)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	// second chunk only, so the failures never run consecutively
+	cs.mu.Lock()
+	cs.errs[11] = transientErr{fmt.Errorf("network blip")}
+	cs.mu.Unlock()
+
+	completed, err := idx.reindexConv(ctx, rconv, 2, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, completed, "only the chunk that succeeded counts as a job")
+	require.Len(t, cs.calls(), 2, "the failed fetch must spend budget like a completed one")
+}

--- a/go/chat/search/reindex_test.go
+++ b/go/chat/search/reindex_test.go
@@ -1,0 +1,343 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/externalstest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+// reindexConv reaches ConversationSource.GetMessages and nothing else on the paths under
+// test, so the interface is embedded and left nil: any other method called here
+// panics rather than silently returning a zero value.
+type stubConvSource struct {
+	types.ConversationSource
+
+	mu       sync.Mutex
+	requests [][]chat1.MessageID
+	// keyed by the first id of the chunk, so a test can fail one chunk only
+	errs map[chat1.MessageID]error
+	// ids to withhold from the reply even though they were asked for
+	withhold map[chat1.MessageID]bool
+}
+
+// IsPermanentErr treats any plain error as permanent, so exercising the
+// retry-later branch needs an error that reports itself transient. The real one
+// lives in package chat, which this package cannot import.
+type transientErr struct{ inner error }
+
+var _ types.UnboxingError = transientErr{}
+
+func (e transientErr) Error() string                  { return e.inner.Error() }
+func (e transientErr) InternalError() string          { return e.inner.Error() }
+func (e transientErr) Inner() error                   { return e.inner }
+func (e transientErr) IsPermanent() bool              { return false }
+func (e transientErr) IsCritical() bool               { return false }
+func (e transientErr) VersionKind() chat1.VersionKind { return "" }
+func (e transientErr) VersionNumber() int             { return 0 }
+func (e transientErr) ExportType() chat1.MessageUnboxedErrorType {
+	return chat1.MessageUnboxedErrorType_MISC
+}
+func (e transientErr) ToStatus() keybase1.Status { return keybase1.Status{} }
+
+func newStubConvSource() *stubConvSource {
+	return &stubConvSource{
+		errs:     make(map[chat1.MessageID]error),
+		withhold: make(map[chat1.MessageID]bool),
+	}
+}
+
+func (s *stubConvSource) GetMessages(ctx context.Context, convID chat1.ConversationID,
+	uid gregor1.UID, msgIDs []chat1.MessageID, reason *chat1.GetThreadReason,
+	ri func() chat1.RemoteInterface, resolveSupersedes bool,
+) ([]chat1.MessageUnboxed, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	chunk := make([]chat1.MessageID, len(msgIDs))
+	copy(chunk, msgIDs)
+	s.requests = append(s.requests, chunk)
+	if len(msgIDs) > 0 {
+		if err, ok := s.errs[msgIDs[0]]; ok {
+			return nil, err
+		}
+	}
+	var res []chat1.MessageUnboxed
+	for _, id := range msgIDs {
+		if s.withhold[id] {
+			continue
+		}
+		res = append(res, textMsgForTest(id, fmt.Sprintf("message %d", id)))
+	}
+	return res, nil
+}
+
+func (s *stubConvSource) calls() [][]chat1.MessageID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res := make([][]chat1.MessageID, len(s.requests))
+	copy(res, s.requests)
+	return res
+}
+
+// maxID is the conv's newest message id; nothing is indexed, so every id from 1
+// to maxID reads as missing.
+func setupReindexTest(t *testing.T, label string, maxID chat1.MessageID) (
+	*Indexer, *stubConvSource, chat1.Conversation, types.RemoteConversation,
+) {
+	tc := externalstest.SetupTest(t, label, 2)
+	t.Cleanup(tc.Cleanup)
+	cs := newStubConvSource()
+	g := globals.NewContext(tc.G, &globals.ChatContext{
+		CtxFactory: stubCtxFactory{},
+		ConvSource: cs,
+	})
+	idx := NewIndexer(g)
+	idx.SetUID(gregor1.UID([]byte{1, 2, 3, 4}))
+	idx.store.diskStorage = newMemDiskStorage()
+
+	convID := chat1.ConversationID([]byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	})
+	conv := chat1.Conversation{
+		Metadata:        chat1.ConversationMetadata{ConversationID: convID},
+		MaxMsgSummaries: []chat1.MessageSummary{{MsgID: maxID}},
+	}
+	return idx, cs, conv, types.RemoteConversation{Conv: conv}
+}
+
+// startStorage runs the storage loop, which is what actually applies the ops
+// reindexConv dispatches and releases the callbacks it waits on.
+func startStorage(t *testing.T, idx *Indexer) {
+	idx.Lock()
+	idx.started = true
+	idx.stopCh = make(chan struct{})
+	stopCh := idx.stopCh
+	idx.Unlock()
+	go func() { _ = idx.storageLoop(stopCh) }()
+	t.Cleanup(func() { close(stopCh) })
+}
+
+func seenIDs(t *testing.T, idx *Indexer, conv chat1.Conversation) map[chat1.MessageID]chat1.EmptyStruct {
+	idx.store.Lock()
+	defer idx.store.Unlock()
+	md, err := idx.store.getMetadataLocked(context.TODO(), conv.GetConvID())
+	require.NoError(t, err)
+	return md.SeenIDs
+}
+
+// The headline of the paging rewrite: only ids that are actually missing are
+// fetched. Paging the raw min..max range re-fetches everything already indexed,
+// which spends the budget before reaching the ids that need it.
+func TestReindexConvPagesOverMissingIDsOnly(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, conv, rconv := setupReindexTest(t, "reindex-missing-only", 30)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	// mark the first 20 ids as already accounted for
+	var alreadySeen []chat1.MessageID
+	for id := chat1.MessageID(1); id <= 20; id++ {
+		alreadySeen = append(alreadySeen, id)
+	}
+	require.NoError(t, idx.store.MarkSeen(ctx, conv.GetConvID(), alreadySeen))
+
+	completed, err := idx.reindexConv(ctx, rconv, 0, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, completed)
+
+	calls := cs.calls()
+	require.Len(t, calls, 1, "only the 10 missing ids should have been fetched")
+	require.Equal(t, []chat1.MessageID{21, 22, 23, 24, 25, 26, 27, 28, 29, 30}, calls[0])
+	for _, chunk := range calls {
+		for _, id := range chunk {
+			require.Greater(t, id, chat1.MessageID(20), "an already-seen id was refetched")
+		}
+	}
+}
+
+// An id the source will not return can never be indexed, so a successful fetch
+// has to close it out. Otherwise it holds numMissing above zero forever and the
+// conv is re-queued every sync interval for work that cannot accomplish anything.
+func TestReindexConvMarksUnreturnedIDsSeen(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, conv, rconv := setupReindexTest(t, "reindex-mark-seen", 5)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	// the server has no message 3 for us - deleted, or never delivered
+	cs.mu.Lock()
+	cs.withhold[3] = true
+	cs.mu.Unlock()
+
+	_, err := idx.reindexConv(ctx, rconv, 0, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, seenIDs(t, idx, conv), chat1.MessageID(3),
+		"an id the source will never return must still be marked seen")
+
+	missing, err := idx.store.MissingIDForConv(ctx, conv)
+	require.NoError(t, err)
+	require.Empty(t, missing, "the conv must converge rather than stay permanently incomplete")
+}
+
+// A transient fetch failure says nothing about the ids, so they stay missing and
+// a later pass retries them while the rest of the conv still makes progress.
+func TestReindexConvDoesNotMarkSeenOnFetchError(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, conv, rconv := setupReindexTest(t, "reindex-fetch-error", 20)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	cs.mu.Lock()
+	cs.errs[1] = transientErr{fmt.Errorf("network blip")}
+	cs.mu.Unlock()
+
+	completed, err := idx.reindexConv(ctx, rconv, 0, nil)
+	require.NoError(t, err, "a transient failure must not fail the whole conv")
+	require.Equal(t, 1, completed, "only the chunk that succeeded counts as a job")
+
+	seen := seenIDs(t, idx, conv)
+	require.NotContains(t, seen, chat1.MessageID(1), "a failed chunk must stay missing")
+	require.Contains(t, seen, chat1.MessageID(11), "the chunk that succeeded must be marked")
+}
+
+// A store failure is about the store, not the conv: nothing was indexed, so
+// nothing may be marked seen, or the messages are recorded as indexed with no
+// tokens behind them and nothing ever revisits them.
+func TestReindexConvStopsOnAddFailure(t *testing.T) {
+	ctx := context.TODO()
+	idx, _, conv, rconv := setupReindexTest(t, "reindex-add-failure", 10)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	disk := newMemDiskStorage()
+	idx.store.diskStorage = disk
+	disk.Lock()
+	disk.failTokenGet = fmt.Errorf("cannot read token entry")
+	disk.Unlock()
+
+	_, err := idx.reindexConv(ctx, rconv, 0, nil)
+	require.Error(t, err, "a failed add must fail the conv")
+
+	disk.Lock()
+	disk.failTokenGet = nil
+	disk.Unlock()
+	require.Empty(t, seenIDs(t, idx, conv), "nothing may be marked seen when indexing failed")
+}
+
+func TestReindexConvRespectsJobBudget(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, _, rconv := setupReindexTest(t, "reindex-budget", 50)
+	startStorage(t, idx)
+	idx.SetPageSize(10)
+
+	completed, err := idx.reindexConv(ctx, rconv, 2, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, completed)
+	require.Len(t, cs.calls(), 2, "the budget must stop the paging, not just the count")
+}
+
+// A disabled indexer drops everything add() is given, so paging on would mark
+// ids seen with nothing indexed behind them - and they would stay that way if
+// indexing were turned back on.
+func TestReindexConvSkipsWhenIndexerDisabled(t *testing.T) {
+	ctx := context.TODO()
+	idx, cs, conv, rconv := setupReindexTest(t, "reindex-disabled", 10)
+	startStorage(t, idx)
+	t.Setenv("KEYBASE_DISABLE_SEARCH_INDEXER", "1")
+	require.True(t, idx.G().GetEnv().GetDisableSearchIndexer())
+
+	completed, err := idx.reindexConv(ctx, rconv, 0, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, completed)
+	require.Empty(t, cs.calls(), "a disabled indexer must not fetch anything")
+	require.Empty(t, seenIDs(t, idx, conv), "a disabled indexer must not mark anything seen")
+}
+
+// The flush loop wakes on a full pending set as well as on its timer, so a burst
+// of indexing does not sit in memory for a whole flush interval.
+func TestFlushLoopFlushesOnPendingSignal(t *testing.T) {
+	ctx := context.TODO()
+	idx, _, _, _ := setupReindexTest(t, "flush-signal", 10)
+	disk := newMemDiskStorage()
+	idx.store.diskStorage = disk
+
+	// long enough that only the pending signal can be what fires
+	idx.SetFlushDelay(time.Hour)
+	idx.Lock()
+	idx.started = true
+	idx.stopCh = make(chan struct{})
+	stopCh := idx.stopCh
+	idx.Unlock()
+	go func() { _ = idx.flushLoop(stopCh) }()
+	t.Cleanup(func() { close(stopCh) })
+
+	convID := chat1.ConversationID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	idx.store.Lock()
+	for i := 0; i < maxDirtyEntries; i++ {
+		te := newTokenEntry()
+		te.MsgIDs[chat1.MessageID(i)] = chat1.EmptyStruct{}
+		require.NoError(t, idx.store.putTokenEntry(ctx, convID, fmt.Sprintf("token%d", i), te))
+	}
+	idx.store.Unlock()
+
+	require.Eventually(t, func() bool {
+		onDisk, err := disk.GetTokenEntry(ctx, convID, "token0")
+		return err == nil && onDisk != nil
+	}, 10*time.Second, 10*time.Millisecond,
+		"a full pending set must trigger a flush without waiting for the timer")
+}
+
+// Clearing one conversation must not take every other conversation's pending
+// writes with it: the disk clear is per-conv but ClearMemory is global.
+func TestClearPreservesOtherConvsPendingWrites(t *testing.T) {
+	ctx, s, disk, convA := setupFlushTestStore(t, "clear-other-convs")
+	convB := chat1.ConversationID([]byte{
+		9, 9, 9, 9, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	})
+
+	teA := newTokenEntry()
+	teA.MsgIDs[1] = chat1.EmptyStruct{}
+	teB := newTokenEntry()
+	teB.MsgIDs[2] = chat1.EmptyStruct{}
+	s.Lock()
+	require.NoError(t, s.putTokenEntry(ctx, convA, "alpha", teA))
+	require.NoError(t, s.putTokenEntry(ctx, convB, "beta", teB))
+	s.Unlock()
+
+	require.NoError(t, s.Clear(ctx, s.uid, convA))
+
+	onDisk, err := disk.GetTokenEntry(ctx, convB, "beta")
+	require.NoError(t, err)
+	require.NotNil(t, onDisk, "another conv's pending write must survive a single-conv clear")
+	require.Contains(t, onDisk.MsgIDs, chat1.MessageID(2))
+}
+
+// The alias read path has the same pending-delete hazard as the token one: a
+// queued delete must hide the copy still on disk.
+func TestPendingAliasDeleteIsNotReadFromDisk(t *testing.T) {
+	ctx, s, disk, _ := setupFlushTestStore(t, "alias-tombstone")
+
+	ae := newAliasEntry()
+	ae.add("alpha")
+	require.NoError(t, disk.PutAliasEntry(ctx, "al", ae))
+
+	s.Lock()
+	defer s.Unlock()
+	s.deleteAliasEntry(ctx, "al")
+
+	got, err := s.getAliasEntry(ctx, "al")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Empty(t, got.Aliases,
+		"a pending alias delete must read as empty, not fall through to the copy on disk")
+}

--- a/go/chat/search/reindex_test.go
+++ b/go/chat/search/reindex_test.go
@@ -283,9 +283,9 @@ func TestFlushLoopFlushesOnPendingSignal(t *testing.T) {
 
 	convID := chat1.ConversationID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	idx.store.Lock()
-	for i := 0; i < maxDirtyEntries; i++ {
+	for i := chat1.MessageID(0); i < maxDirtyEntries; i++ {
 		te := newTokenEntry()
-		te.MsgIDs[chat1.MessageID(i)] = chat1.EmptyStruct{}
+		te.MsgIDs[i] = chat1.EmptyStruct{}
 		require.NoError(t, idx.store.putTokenEntry(ctx, convID, fmt.Sprintf("token%d", i), te))
 	}
 	idx.store.Unlock()

--- a/go/chat/search/stall_test.go
+++ b/go/chat/search/stall_test.go
@@ -224,12 +224,13 @@ func TestDroppedStorageOpDoesNotStrandCaller(t *testing.T) {
 // and a conv that reaches numMissing 0 that way is never revisited.
 func TestStorageLoopReleasesQueuedCallbacksOnShutdown(t *testing.T) {
 	idx, _ := setupStallTestIndexer(t, "dispatch-shutdown")
-	stopCh := make(chan struct{})
 	cb := make(chan error, 1)
 	idx.storageCh <- storageAdd{cb: cb}
 
-	close(stopCh)
-	require.NoError(t, idx.storageLoop(stopCh))
+	// the drain directly, not storageLoop: with stopCh closed both of its select
+	// cases are ready and Go picks at random, so going through the loop would
+	// run the op half the time and test nothing the other half
+	idx.drainStorageQueue()
 
 	select {
 	case err := <-cb:

--- a/go/chat/search/stall_test.go
+++ b/go/chat/search/stall_test.go
@@ -265,3 +265,25 @@ func TestStorageLoopReleasesQueuedCallbacksOnShutdown(t *testing.T) {
 		require.Fail(t, "a queued op's callback was abandoned at shutdown")
 	}
 }
+
+// Stop finishes its work in a goroutine, and Stop clears started before that
+// goroutine runs, so a Start can install a new store in between. Reading
+// idx.store from out there would flush and -- worse -- ClearMemory the wrong
+// store: the new run's pending writes dropped, this run's never written.
+//
+// The failure is a data race rather than a wrong value, so this is a -race test:
+// it passes trivially without the detector.
+func TestStopDoesNotReachForANewerStore(t *testing.T) {
+	idx, _ := setupStallTestIndexer(t, "stop-start-store")
+	uid := gregor1.UID([]byte{1, 2, 3, 4})
+	ctx := context.TODO()
+	for range 20 {
+		idx.Start(ctx, uid)
+		stopped := idx.Stop(ctx)
+		// deliberately not waiting on stopped before restarting: that gap is
+		// exactly what this covers
+		idx.Start(ctx, uid)
+		<-stopped
+		<-idx.Stop(ctx)
+	}
+}

--- a/go/chat/search/stall_test.go
+++ b/go/chat/search/stall_test.go
@@ -1,0 +1,241 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/chat/globals"
+	"github.com/keybase/client/go/chat/types"
+	"github.com/keybase/client/go/externalstest"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/gregor1"
+	"github.com/stretchr/testify/require"
+)
+
+// The stall backoff only fires for a conv that cannot converge, which a healthy
+// client never produces: SelectiveSync drains every conv to numMissing 0 and
+// skips it thereafter. These paths are therefore unreachable from an end-to-end
+// run and can only be covered here.
+
+// add() converts its context with globals.BackgroundChatCtx, which reaches for
+// the context factory. Nothing on the paths under test uses what it returns, so
+// a stub keeps these tests from needing the whole chat harness.
+type stubCtxFactory struct{}
+
+func (stubCtxFactory) NewKeyFinder() types.KeyFinder   { return nil }
+func (stubCtxFactory) NewUPAKFinder() types.UPAKFinder { return nil }
+
+func setupStallTestIndexer(t *testing.T, label string) (*Indexer, chat1.Conversation) {
+	tc := externalstest.SetupTest(t, label, 2)
+	t.Cleanup(tc.Cleanup)
+	g := globals.NewContext(tc.G, &globals.ChatContext{CtxFactory: stubCtxFactory{}})
+	idx := NewIndexer(g)
+	idx.SetUID(gregor1.UID([]byte{1, 2, 3, 4}))
+
+	convID := chat1.ConversationID([]byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+	})
+	conv := chat1.Conversation{
+		Metadata: chat1.ConversationMetadata{ConversationID: convID},
+		// nothing is indexed, so this conv reads as 100 missing ids
+		MaxMsgSummaries: []chat1.MessageSummary{{MsgID: 100}},
+	}
+	return idx, conv
+}
+
+// A failed store.Add was logged and then reported to the caller as a completed
+// op, so reindexConv marked the whole chunk seen against messages that never
+// made it into the index.
+func TestStorageLoopReportsAddFailure(t *testing.T) {
+	idx, _ := setupStallTestIndexer(t, "storage-add-failure")
+	disk := newMemDiskStorage()
+	idx.store.diskStorage = disk
+	disk.Lock()
+	disk.failTokenGet = fmt.Errorf("cannot read token entry")
+	disk.Unlock()
+
+	stopCh := make(chan struct{})
+	go func() { _ = idx.storageLoop(stopCh) }()
+	t.Cleanup(func() { close(stopCh) })
+
+	convID := chat1.ConversationID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	cb := make(chan error, 1)
+	idx.storageCh <- storageAdd{
+		ctx:    context.TODO(),
+		convID: convID,
+		msgs:   []chat1.MessageUnboxed{textMsgForTest(1, "hello world")},
+		cb:     cb,
+	}
+
+	select {
+	case err := <-cb:
+		require.Error(t, err,
+			"a failed add reported success, so its messages get marked indexed")
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "the caller was never woken")
+	}
+}
+
+func TestConvStalledBackoff(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "stall-backoff")
+	convID := conv.GetConvID()
+
+	// a conv never seen before is always given an attempt
+	require.False(t, idx.convStalled(convID, 100),
+		"a conv with no recorded history must not be skipped")
+
+	// an attempt that moved nothing earns a backoff
+	idx.recordIndexProgress(ctx, conv, 100)
+	require.True(t, idx.convStalled(convID, 100), "first skip")
+	require.True(t, idx.convStalled(convID, 100), "second skip")
+	require.False(t, idx.convStalled(convID, 100),
+		"backoff must expire rather than suppress the conv permanently")
+
+	// a different missing count means something changed the conv, so it gets an
+	// attempt immediately whatever the backoff said
+	idx.recordIndexProgress(ctx, conv, 100)
+	require.False(t, idx.convStalled(convID, 99),
+		"a changed missing count must clear the backoff")
+}
+
+func TestConvStalledClearedByProgress(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "stall-progress")
+	convID := conv.GetConvID()
+
+	idx.recordIndexProgress(ctx, conv, 100)
+	require.True(t, idx.convStalled(convID, 100))
+
+	// "before" higher than the current count is an attempt that made progress:
+	// the marker must be dropped so the conv keeps getting full attempts
+	idx.recordIndexProgress(ctx, conv, 500)
+	require.False(t, idx.convStalled(convID, 100),
+		"a conv that made progress must not stay backed off")
+
+	idx.stalledMu.Lock()
+	_, ok := idx.stalledConvs[convID.ConvIDStr()]
+	idx.stalledMu.Unlock()
+	require.False(t, ok, "progress must delete the entry, not just zero it")
+}
+
+// TestStallStreakDoesNotOverflow pins the clamp on the shift exponent. streak is
+// unbounded, so `1 << streak` on a conv that never converges eventually shifts
+// past the width of an int: the result goes negative and then to 0, which reads
+// as "no skips left" and silently disables the backoff for good. Clamping the
+// result instead of the exponent does not help - the shift has already
+// overflowed by then.
+func TestStallStreakDoesNotOverflow(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "stall-overflow")
+	convID := conv.GetConvID()
+
+	// well past the 64 rounds it takes to shift an int to zero
+	for i := 0; i < 200; i++ {
+		idx.recordIndexProgress(ctx, conv, 100)
+
+		idx.stalledMu.Lock()
+		entry := idx.stalledConvs[convID.ConvIDStr()]
+		idx.stalledMu.Unlock()
+
+		require.Greater(t, entry.skips, 0,
+			"round %d: skips fell to %d, so the backoff is off", i, entry.skips)
+		require.LessOrEqual(t, entry.skips, maxStallSkips,
+			"round %d: skips %d exceeds the cap", i, entry.skips)
+		require.LessOrEqual(t, entry.streak, uint(maxStallStreak),
+			"round %d: streak %d was not clamped", i, entry.streak)
+
+		// consume the backoff so the next round records another no-progress
+		// attempt rather than sitting on this one
+		for idx.convStalled(convID, 100) {
+		}
+	}
+}
+
+func TestStopResetsStalledConvs(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "stall-stop")
+	convID := conv.GetConvID()
+
+	idx.recordIndexProgress(ctx, conv, 100)
+	require.True(t, idx.convStalled(convID, 100), "conv is backed off before Stop")
+
+	idx.Lock()
+	idx.started = true
+	idx.stopCh = make(chan struct{})
+	idx.Unlock()
+	<-idx.Stop(ctx)
+
+	// entries are keyed by convID alone and team convs are shared between users
+	// on one device, so a count left by the previous user must not decide
+	// anything for the next one
+	require.False(t, idx.convStalled(convID, 100),
+		"Stop must clear the backoff so the next user starts clean")
+}
+
+func TestClearResetsStalledConv(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "stall-clear")
+	convID := conv.GetConvID()
+
+	idx.recordIndexProgress(ctx, conv, 100)
+	require.True(t, idx.convStalled(convID, 100), "conv is backed off before Clear")
+
+	require.NoError(t, idx.Clear(ctx, idx.uid, convID))
+
+	// clearing the index resets what is missing, so the old count must not keep
+	// the conv suppressed
+	require.False(t, idx.convStalled(convID, 100),
+		"Clear must drop the backoff for that conv")
+}
+
+// A dropped storage op used to leave its callback unclosed, and reindexConv
+// waits on that callback. The waiter parked forever, which leaked SelectiveSync's
+// cancel func and left every later pass reporting "already running" - background
+// indexing dead until the process restarted.
+func TestDroppedStorageOpDoesNotStrandCaller(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "dispatch-full")
+	convID := conv.GetConvID()
+
+	// fill the dispatch queue so the next op cannot be accepted
+	for len(idx.storageCh) < cap(idx.storageCh) {
+		idx.storageCh <- storageAdd{}
+	}
+
+	msgs := []chat1.MessageUnboxed{textMsgForTest(1, "hello world")}
+	cb, err := idx.add(ctx, convID, msgs, true)
+	require.ErrorIs(t, err, errStorageQueueFull,
+		"a dropped op must be reported, or the caller marks unindexed messages as seen")
+
+	select {
+	case <-cb:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "callback of a dropped op was never closed; caller would hang forever")
+	}
+}
+
+// Ops still queued when the loop shuts down have nobody left to run them, so
+// their callbacks have to be released - and released with an error. Waking the
+// caller with a bare "done" is worse than hanging it: reindexConv then marks the
+// chunk seen, recording messages as indexed that were never handed to the store,
+// and a conv that reaches numMissing 0 that way is never revisited.
+func TestStorageLoopReleasesQueuedCallbacksOnShutdown(t *testing.T) {
+	idx, _ := setupStallTestIndexer(t, "dispatch-shutdown")
+	stopCh := make(chan struct{})
+	cb := make(chan error, 1)
+	idx.storageCh <- storageAdd{cb: cb}
+
+	close(stopCh)
+	require.NoError(t, idx.storageLoop(stopCh))
+
+	select {
+	case err := <-cb:
+		require.ErrorIs(t, err, errStorageStopped,
+			"an op that never ran reported success, so its messages get marked indexed")
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "a queued op's callback was abandoned at shutdown")
+	}
+}

--- a/go/chat/search/stall_test.go
+++ b/go/chat/search/stall_test.go
@@ -45,8 +45,8 @@ func setupStallTestIndexer(t *testing.T, label string) (*Indexer, chat1.Conversa
 	return idx, conv
 }
 
-// A failed store.Add was logged and then reported to the caller as a completed
-// op, so reindexConv marked the whole chunk seen against messages that never
+// A failed store.Add must reach the caller as an error, not as a completed op:
+// reindexConv marks the whole chunk seen on success, against messages that never
 // made it into the index.
 func TestStorageLoopReportsAddFailure(t *testing.T) {
 	idx, _ := setupStallTestIndexer(t, "storage-add-failure")
@@ -121,12 +121,12 @@ func TestConvStalledClearedByProgress(t *testing.T) {
 	require.False(t, ok, "progress must delete the entry, not just zero it")
 }
 
-// TestStallStreakDoesNotOverflow pins the clamp on the shift exponent. streak is
-// unbounded, so `1 << streak` on a conv that never converges eventually shifts
-// past the width of an int: the result goes negative and then to 0, which reads
-// as "no skips left" and silently disables the backoff for good. Clamping the
-// result instead of the exponent does not help - the shift has already
-// overflowed by then.
+// TestStallStreakDoesNotOverflow pins the clamp on the shift exponent. Nothing
+// else bounds streak, so `1 << streak` on a conv that never converges shifts past
+// the width of an int: the result goes negative and then to 0, which reads as "no
+// skips left" and silently disables the backoff for good. Clamping the result
+// instead of the exponent does not help - the shift has already overflowed by
+// then.
 func TestStallStreakDoesNotOverflow(t *testing.T) {
 	ctx := context.TODO()
 	idx, conv := setupStallTestIndexer(t, "stall-overflow")
@@ -191,14 +191,21 @@ func TestClearResetsStalledConv(t *testing.T) {
 		"Clear must drop the backoff for that conv")
 }
 
-// A dropped storage op used to leave its callback unclosed, and reindexConv
-// waits on that callback. The waiter parked forever, which leaked SelectiveSync's
-// cancel func and left every later pass reporting "already running" - background
-// indexing dead until the process restarted.
+// reindexConv waits on a storage op's callback, so a dropped op must still close
+// it. An unclosed callback parks the waiter forever, holding SelectiveSync's
+// cancel func and leaving every later pass reporting "already running" -
+// background indexing dead until the process restarts.
 func TestDroppedStorageOpDoesNotStrandCaller(t *testing.T) {
 	ctx := context.TODO()
 	idx, conv := setupStallTestIndexer(t, "dispatch-full")
 	convID := conv.GetConvID()
+
+	// storageDispatch returns at its !started check otherwise, so the queue never
+	// comes into it and the branch under test is never reached.
+	idx.Lock()
+	idx.started = true
+	idx.stopCh = make(chan struct{})
+	idx.Unlock()
 
 	// fill the dispatch queue so the next op cannot be accepted
 	for len(idx.storageCh) < cap(idx.storageCh) {
@@ -214,6 +221,24 @@ func TestDroppedStorageOpDoesNotStrandCaller(t *testing.T) {
 	case <-cb:
 	case <-time.After(5 * time.Second):
 		require.Fail(t, "callback of a dropped op was never closed; caller would hang forever")
+	}
+}
+
+// A stopped indexer refuses the op for a different reason than a full queue, and
+// must release the caller just the same.
+func TestDispatchOnStoppedIndexerDoesNotStrandCaller(t *testing.T) {
+	ctx := context.TODO()
+	idx, conv := setupStallTestIndexer(t, "dispatch-stopped")
+
+	msgs := []chat1.MessageUnboxed{textMsgForTest(1, "hello world")}
+	cb, err := idx.add(ctx, conv.GetConvID(), msgs, true)
+	require.ErrorIs(t, err, errStorageQueueFull,
+		"a op refused by a stopped indexer must be reported like any other drop")
+
+	select {
+	case <-cb:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "callback of a refused op was never closed; caller would hang forever")
 	}
 }
 

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -29,6 +29,31 @@ const (
 	aliasDiskVersion = 1
 )
 
+// Pending entries are held until the next flush, so a long flush interval and a
+// fast writer together decide how much lives in memory. An index pass writes
+// thousands of tokens a second, which would otherwise sit there for the whole
+// flushDelay. This bounds the pending set instead of the clock: cross it and a
+// flush is asked for immediately.
+//
+// It is a trigger, not a ceiling. The flush cannot run until the writer releases
+// s.Lock, and one Add writes a whole batch of tokens and aliases under a single
+// hold, so the set peaks at roughly this plus one batch.
+//
+// It therefore has to sit well above one batch. A page of 300 messages produces
+// ~2600 entries, so a 1000 bound was crossed by every single batch and turned
+// into "flush after every batch": measured at 65 flushes in 2.9s, a 0.04s median
+// gap, rewriting hot tokens to disk - each one re-encrypted whole, not as a
+// delta - on every pass instead of once an interval. Raising it to 20000 cut
+// that to 7 flushes over a comparable window.
+//
+// Note this counts entries, not bytes, and the two differ by a lot: an entry
+// holding one message id and one holding ten thousand both count as 1. A fresh
+// index is a few MB at this bound, but a mature conversation's entries are much
+// larger - the pending set is biased towards hot tokens, whose posting lists are
+// the longest - so 35-40MB is the realistic ceiling there. A byte-based bound
+// would measure the thing that actually matters.
+const maxDirtyEntries = 20000
+
 type tokenEntry struct {
 	Version string                                `codec:"v"`
 	MsgIDs  map[chat1.MessageID]chat1.EmptyStruct `codec:"m"`
@@ -256,10 +281,21 @@ type store struct {
 	mdCache     *lru.Cache
 	diskStorage diskStorage
 
-	// Track dirty entries that need to be flushed to disk
-	dirtyTokens   map[chat1.ConvIDStr]map[string]struct{} // map[convIDStr][token]
-	dirtyAliases  map[string]struct{}                     // map[alias]
-	dirtyMetadata map[chat1.ConvIDStr]struct{}            // map[convIDStr]
+	// Entries written but not yet on disk. These hold the entry itself, not just
+	// its key: the caches above are bounded LRUs, so a dirty entry can be evicted
+	// before the next flush. Keying alone meant such an entry was skipped by
+	// Flush and lost, while a subsequent read fell through to the stale copy on
+	// disk and built further updates on top of it. Reads therefore consult these
+	// before disk, and Flush writes from these rather than from the caches.
+	dirtyTokens   map[chat1.ConvIDStr]map[string]*tokenEntry // map[convIDStr][token]
+	dirtyAliases  map[string]*aliasEntry                     // map[alias]
+	dirtyMetadata map[chat1.ConvIDStr]*indexMetadata         // map[convIDStr]
+
+	// how many entries are pending across all three maps above, and a one-slot
+	// nudge to the flush loop for when that gets big. Buffered and sent to
+	// without blocking: a signal already waiting is the same request.
+	dirtyCount    int
+	flushNeededCh chan struct{}
 
 	flushMtx sync.Mutex // Synchronizes flush operations to disk
 }
@@ -283,9 +319,10 @@ func newStore(g *globals.Context, uid gregor1.UID) *store {
 		tokenCache:    tc,
 		mdCache:       mc,
 		diskStorage:   newDiskStore(g, uid, keyFn, encrypteddb.New(g.ExternalG(), dbFn, keyFn), g.LocalChatDb),
-		dirtyTokens:   make(map[chat1.ConvIDStr]map[string]struct{}),
-		dirtyAliases:  make(map[string]struct{}),
-		dirtyMetadata: make(map[chat1.ConvIDStr]struct{}),
+		dirtyTokens:   make(map[chat1.ConvIDStr]map[string]*tokenEntry),
+		dirtyAliases:  make(map[string]*aliasEntry),
+		dirtyMetadata: make(map[chat1.ConvIDStr]*indexMetadata),
+		flushNeededCh: make(chan struct{}, 1),
 	}
 }
 
@@ -471,6 +508,15 @@ func (s *store) getTokenEntry(ctx context.Context, convID chat1.ConversationID, 
 	if te, ok := s.tokenCache.Get(cacheKey); ok {
 		return te.(*tokenEntry), nil
 	}
+	// evicted from the cache but not yet flushed: the copy on disk is stale
+	if te, ok := s.dirtyTokens[convID.ConvIDStr()][token]; ok {
+		if te == nil {
+			// pending delete: the copy still on disk is about to go
+			return newTokenEntry(), nil
+		}
+		s.tokenCache.Add(cacheKey, te)
+		return te, nil
+	}
 	if res, err = s.diskStorage.GetTokenEntry(ctx, convID, token); err != nil {
 		return nil, err
 	}
@@ -488,6 +534,15 @@ func (s *store) getTokenEntry(ctx context.Context, convID chat1.ConversationID, 
 func (s *store) getAliasEntry(ctx context.Context, alias string) (res *aliasEntry, err error) {
 	if dat, ok := s.aliasCache.Get(alias); ok {
 		return dat.(*aliasEntry), nil
+	}
+	// evicted from the cache but not yet flushed: the copy on disk is stale
+	if ae, ok := s.dirtyAliases[alias]; ok {
+		if ae == nil {
+			// pending delete: the copy still on disk is about to go
+			return newAliasEntry(), nil
+		}
+		s.aliasCache.Add(alias, ae)
+		return ae, nil
 	}
 	if res, err = s.diskStorage.GetAliasEntry(ctx, alias); err != nil {
 		return nil, err
@@ -511,16 +566,42 @@ func (s *store) putTokenEntry(ctx context.Context, convID chat1.ConversationID,
 
 	convIDStr := convID.ConvIDStr()
 	if s.dirtyTokens[convIDStr] == nil {
-		s.dirtyTokens[convIDStr] = make(map[string]struct{})
+		s.dirtyTokens[convIDStr] = make(map[string]*tokenEntry)
 	}
-	s.dirtyTokens[convIDStr][token] = struct{}{}
+	if _, ok := s.dirtyTokens[convIDStr][token]; !ok {
+		s.dirtyCount++
+	}
+	s.dirtyTokens[convIDStr][token] = te
+	s.signalFlushIfFullLocked()
 
 	return nil
 }
 
+// signalFlushIfFullLocked asks the flush loop to run early once enough entries
+// are pending. Callers hold s.Lock; the send never blocks, so it cannot deadlock
+// against the flush it is asking for.
+func (s *store) signalFlushIfFullLocked() {
+	if s.dirtyCount < maxDirtyEntries {
+		return
+	}
+	select {
+	case s.flushNeededCh <- struct{}{}:
+	default:
+	}
+}
+
+// flushNeeded fires when the pending set has grown past maxDirtyEntries.
+func (s *store) flushNeeded() <-chan struct{} {
+	return s.flushNeededCh
+}
+
 func (s *store) putAliasEntry(ctx context.Context, alias string, ae *aliasEntry) (err error) {
 	s.aliasCache.Add(alias, ae)
-	s.dirtyAliases[alias] = struct{}{}
+	if _, ok := s.dirtyAliases[alias]; !ok {
+		s.dirtyCount++
+	}
+	s.dirtyAliases[alias] = ae
+	s.signalFlushIfFullLocked()
 
 	return nil
 }
@@ -528,7 +609,11 @@ func (s *store) putAliasEntry(ctx context.Context, alias string, ae *aliasEntry)
 func (s *store) putMetadata(ctx context.Context, convID chat1.ConversationID, md *indexMetadata) (err error) {
 	convIDStr := convID.ConvIDStr()
 	s.mdCache.Add(convIDStr, md)
-	s.dirtyMetadata[convIDStr] = struct{}{}
+	if _, ok := s.dirtyMetadata[convIDStr]; !ok {
+		s.dirtyCount++
+	}
+	s.dirtyMetadata[convIDStr] = md
+	s.signalFlushIfFullLocked()
 
 	return nil
 }
@@ -540,24 +625,30 @@ func (s *store) deleteTokenEntry(ctx context.Context, convID chat1.ConversationI
 
 	s.tokenCache.Remove(cacheKey)
 
+	// Queue the delete rather than writing it through. Flush snapshots under the
+	// lock but writes outside it, so a delete applied straight to disk in that
+	// window was undone by the write that followed, and requeueing a failed
+	// write could put a deleted entry back. Ordering both through the pending
+	// set keeps the last operation the one that lands.
 	convIDStr := convID.ConvIDStr()
-	if tokens, ok := s.dirtyTokens[convIDStr]; ok {
-		delete(tokens, token)
-		// Clean up empty map
-		if len(tokens) == 0 {
-			delete(s.dirtyTokens, convIDStr)
-		}
+	if s.dirtyTokens[convIDStr] == nil {
+		s.dirtyTokens[convIDStr] = make(map[string]*tokenEntry)
 	}
-
-	// Delete from disk immediately
-	s.diskStorage.RemoveTokenEntry(ctx, convID, token)
+	if _, pending := s.dirtyTokens[convIDStr][token]; !pending {
+		s.dirtyCount++
+	}
+	s.dirtyTokens[convIDStr][token] = nil
+	s.signalFlushIfFullLocked()
 }
 
 func (s *store) deleteAliasEntry(ctx context.Context, alias string) {
 	s.aliasCache.Remove(alias)
-	delete(s.dirtyAliases, alias)
-	// Delete from disk immediately
-	s.diskStorage.RemoveAliasEntry(ctx, alias)
+	// queued, not written through - see deleteTokenEntry
+	if _, pending := s.dirtyAliases[alias]; !pending {
+		s.dirtyCount++
+	}
+	s.dirtyAliases[alias] = nil
+	s.signalFlushIfFullLocked()
 }
 
 // addTokens add the given tokens to the index under the given message
@@ -716,6 +807,39 @@ func (s *store) ConvIndexStats(ctx context.Context, conv chat1.Conversation) (re
 	}, nil
 }
 
+// MarkSeen records IDs as accounted for without indexing anything for them.
+//
+// A conv is "fully indexed" only when every ID between its min and max is in
+// SeenIDs, but an ID the server will not return for us can never get there by
+// being indexed: deleted messages, and gaps that never existed. Before this,
+// those IDs kept numMissing above zero forever, so the conv was never fully
+// indexed and SelectiveSync re-fetched the same already-indexed messages every
+// interval, permanently. Callers mark the IDs they asked for after a fetch that
+// succeeded - the source affirmatively answered for that range, so anything
+// absent from the reply is not coming.
+func (s *store) MarkSeen(ctx context.Context, convID chat1.ConversationID, ids []chat1.MessageID) (err error) {
+	if len(ids) == 0 {
+		return nil
+	}
+	s.Lock()
+	defer s.Unlock()
+	md, err := s.getMetadataLocked(ctx, convID)
+	if err != nil {
+		return err
+	}
+	modified := false
+	for _, id := range ids {
+		if _, ok := md.SeenIDs[id]; !ok {
+			md.SeenIDs[id] = chat1.EmptyStruct{}
+			modified = true
+		}
+	}
+	if !modified {
+		return nil
+	}
+	return s.putMetadata(ctx, convID, md)
+}
+
 // getMetadataLocked returns the live cached metadata for convID, populating the
 // cache from disk on a miss. The returned *indexMetadata is shared and its
 // SeenIDs map may be mutated, so callers must hold s.RLock for read-only access
@@ -724,6 +848,12 @@ func (s *store) getMetadataLocked(ctx context.Context, convID chat1.Conversation
 	convIDStr := convID.ConvIDStr()
 	if cached, ok := s.mdCache.Get(convIDStr); ok {
 		return cached.(*indexMetadata), nil
+	}
+	// evicted from the cache but not yet flushed: the copy on disk is stale, and
+	// for metadata that means losing SeenIDs and re-indexing what it recorded
+	if md, ok := s.dirtyMetadata[convIDStr]; ok {
+		s.mdCache.Add(convIDStr, md)
+		return md, nil
 	}
 
 	if res, err = s.diskStorage.GetMetadata(ctx, convID); err != nil {
@@ -758,6 +888,14 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 	}
 	reason := chat1.GetThreadReason_INDEXED_SEARCH
 	superseded := make(map[chat1.MessageID]supersededFetch, len(msgs))
+
+	// Collect what every message in this batch supersedes, then fetch the whole
+	// set in one call. Asking per message meant one GetMessages round trip per
+	// edit or attachment upload: a backfill of a large conversation issued tens
+	// of thousands of single-message fetches.
+	superIDsByMsg := make(map[chat1.MessageID][]chat1.MessageID, len(msgs))
+	var allSuperIDs []chat1.MessageID
+	seenSuperID := make(map[chat1.MessageID]bool)
 	for _, msg := range msgs {
 		switch msg.GetMessageType() {
 		case chat1.MessageType_ATTACHMENTUPLOADED, chat1.MessageType_EDIT:
@@ -766,18 +904,60 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 				s.Debug(ctx, "Add: unable to get supersedes: %v", err)
 				continue
 			}
-			supersededMsgs, err := s.G().ChatHelper.GetMessages(ctx, s.uid, convID, superIDs,
-				false /* resolveSupersedes */, &reason)
-			if err != nil {
-				s.Debug(ctx, "Add: unable to fetch superseded messages: %v", err)
-				continue
+			superIDsByMsg[msg.GetMessageID()] = superIDs
+			for _, superID := range superIDs {
+				if !seenSuperID[superID] {
+					seenSuperID[superID] = true
+					allSuperIDs = append(allSuperIDs, superID)
+				}
 			}
-			fetch := supersededFetch{msgs: supersededMsgs}
-			if msg.GetMessageType() == chat1.MessageType_EDIT {
-				fetch.tokens = tokensFromMsg(msg)
-			}
-			superseded[msg.GetMessageID()] = fetch
 		}
+	}
+
+	supersededByID := make(map[chat1.MessageID]chat1.MessageUnboxed, len(allSuperIDs))
+	if len(allSuperIDs) > 0 {
+		supersededMsgs, err := s.G().ChatHelper.GetMessages(ctx, s.uid, convID, allSuperIDs,
+			false /* resolveSupersedes */, &reason)
+		if err != nil {
+			// the batch tells us nothing about which ID was at fault, so fall back
+			// to the per-message fetches and let each one fail on its own
+			s.Debug(ctx, "Add: unable to fetch superseded messages in bulk: %v", err)
+			for _, superIDs := range superIDsByMsg {
+				single, err := s.G().ChatHelper.GetMessages(ctx, s.uid, convID, superIDs,
+					false /* resolveSupersedes */, &reason)
+				if err != nil {
+					s.Debug(ctx, "Add: unable to fetch superseded messages: %v", err)
+					continue
+				}
+				for _, sm := range single {
+					supersededByID[sm.GetMessageID()] = sm
+				}
+			}
+		} else {
+			for _, sm := range supersededMsgs {
+				supersededByID[sm.GetMessageID()] = sm
+			}
+		}
+	}
+
+	for _, msg := range msgs {
+		superIDs, ok := superIDsByMsg[msg.GetMessageID()]
+		if !ok {
+			continue
+		}
+		fetch := supersededFetch{}
+		for _, superID := range superIDs {
+			if sm, ok := supersededByID[superID]; ok {
+				fetch.msgs = append(fetch.msgs, sm)
+			}
+		}
+		if len(fetch.msgs) == 0 {
+			continue
+		}
+		if msg.GetMessageType() == chat1.MessageType_EDIT {
+			fetch.tokens = tokensFromMsg(msg)
+		}
+		superseded[msg.GetMessageID()] = fetch
 	}
 
 	s.Lock()
@@ -800,26 +980,29 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 		if _, ok := seenIDs[msg.GetMessageID()]; ok {
 			continue
 		}
-		modified = true
-		seenIDs[msg.GetMessageID()] = chat1.EmptyStruct{}
+		// Mark seen only once the indexing behind the mark has succeeded. md is
+		// the live shared object and is usually already pending, so marking up
+		// front committed the mark whatever happened next: an error here left
+		// the message recorded as indexed with no tokens for it, and nothing
+		// re-indexes a message the metadata already accounts for.
 		// NOTE DELETE and DELETEHISTORY are handled through calls to `remove`,
 		// other messages will be added if there is any content that can be
 		// indexed.
 		switch msg.GetMessageType() {
 		case chat1.MessageType_ATTACHMENTUPLOADED:
 			for _, sm := range superseded[msg.GetMessageID()].msgs {
-				seenIDs[sm.GetMessageID()] = chat1.EmptyStruct{}
 				err := s.addMsg(ctx, convID, sm)
 				if err != nil {
 					return err
 				}
+				seenIDs[sm.GetMessageID()] = chat1.EmptyStruct{}
+				modified = true
 			}
 		case chat1.MessageType_EDIT:
 			fetch := superseded[msg.GetMessageID()]
 			// remove the original message text and replace it with the edited
 			// contents (using the original id in the index)
 			for _, sm := range fetch.msgs {
-				seenIDs[sm.GetMessageID()] = chat1.EmptyStruct{}
 				err := s.removeMsg(ctx, convID, sm)
 				if err != nil {
 					return err
@@ -828,6 +1011,8 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 				if err != nil {
 					return err
 				}
+				seenIDs[sm.GetMessageID()] = chat1.EmptyStruct{}
+				modified = true
 			}
 		default:
 			err := s.addMsg(ctx, convID, msg)
@@ -835,6 +1020,8 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 				return err
 			}
 		}
+		seenIDs[msg.GetMessageID()] = chat1.EmptyStruct{}
+		modified = true
 	}
 	return nil
 }
@@ -860,14 +1047,18 @@ func (s *store) Remove(ctx context.Context, convID chat1.ConversationID,
 			continue
 		}
 		modified = true
-		seenIDs[msg.GetMessageID()] = chat1.EmptyStruct{}
 		err := s.removeMsg(ctx, convID, msg)
 		if err != nil {
 			return err
 		}
 	}
 	if modified {
-		return s.diskStorage.PutMetadata(ctx, convID, md)
+		// Through the overlay, never straight to disk. md is the live shared
+		// object, so it carries SeenIDs from an Add whose token entries are
+		// still only pending; writing it here published "these messages are
+		// indexed" ahead of the tokens backing them, and a conv that reaches
+		// numMissing 0 that way is never looked at again.
+		return s.putMetadata(ctx, convID, md)
 	}
 	return nil
 }
@@ -881,14 +1072,31 @@ func (s *store) ClearMemory() {
 	s.tokenCache.Purge()
 	s.mdCache.Purge()
 
-	s.dirtyTokens = make(map[chat1.ConvIDStr]map[string]struct{})
-	s.dirtyAliases = make(map[string]struct{})
-	s.dirtyMetadata = make(map[chat1.ConvIDStr]struct{})
+	s.dirtyTokens = make(map[chat1.ConvIDStr]map[string]*tokenEntry)
+	s.dirtyAliases = make(map[string]*aliasEntry)
+	s.dirtyMetadata = make(map[chat1.ConvIDStr]*indexMetadata)
+	s.dirtyCount = 0
+	select {
+	case <-s.flushNeededCh:
+	default:
+	}
 }
 
 func (s *store) Clear(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) error {
+	// ClearMemory is global while the disk clear is for one conv, so clearing a
+	// single conversation used to throw away every other conversation's pending
+	// writes. Flush first so only this conv's index is actually lost.
+	if err := s.Flush(); err != nil {
+		s.Debug(ctx, "Clear: flush before clear failed: %s", err)
+	}
 	s.ClearMemory()
 	return s.diskStorage.Clear(ctx, uid, convID)
+}
+
+type tokenSnapshot struct {
+	convID chat1.ConversationID
+	token  string
+	entry  *tokenEntry
 }
 
 func (s *store) Flush() error {
@@ -898,12 +1106,7 @@ func (s *store) Flush() error {
 	s.flushMtx.Lock()
 	defer s.flushMtx.Unlock()
 
-	// Snapshot the cache entries that need to be flushed to disk.
-	type tokenSnapshot struct {
-		convID chat1.ConversationID
-		token  string
-		entry  *tokenEntry
-	}
+	// Snapshot the entries that need to be flushed to disk.
 	var tokenSnapshots []tokenSnapshot
 	aliasSnapshots := make(map[string]*aliasEntry)
 	mdSnapshots := make(map[chat1.ConvIDStr]*indexMetadata)
@@ -922,37 +1125,33 @@ func (s *store) Flush() error {
 				s.Debug(ctx, "Flush: invalid convID %s: %s", convIDStr, err)
 				continue
 			}
-			for token := range tokens {
-				cacheKey := s.tokenCacheKey(convID, token)
-				if cachedVal, ok := s.tokenCache.Get(cacheKey); ok {
-					te := cachedVal.(*tokenEntry)
-					tokenSnapshots = append(tokenSnapshots, tokenSnapshot{
-						convID: convID,
-						token:  token,
-						entry:  te.dup(),
-					})
-				}
+			for token, te := range tokens {
+				tokenSnapshots = append(tokenSnapshots, tokenSnapshot{
+					convID: convID,
+					token:  token,
+					entry:  te.dup(),
+				})
 			}
 		}
 
-		for alias := range s.dirtyAliases {
-			if cachedVal, ok := s.aliasCache.Get(alias); ok {
-				ae := cachedVal.(*aliasEntry)
-				aliasSnapshots[alias] = ae.dup()
-			}
+		for alias, ae := range s.dirtyAliases {
+			aliasSnapshots[alias] = ae.dup()
 		}
 
-		for convIDStr := range s.dirtyMetadata {
-			if cachedVal, ok := s.mdCache.Get(convIDStr); ok {
-				md := cachedVal.(*indexMetadata)
-				mdSnapshots[convIDStr] = md.dup()
-			}
+		for convIDStr, md := range s.dirtyMetadata {
+			mdSnapshots[convIDStr] = md.dup()
 		}
 
 		// Clear dirty tracking
-		s.dirtyTokens = make(map[chat1.ConvIDStr]map[string]struct{})
-		s.dirtyAliases = make(map[string]struct{})
-		s.dirtyMetadata = make(map[chat1.ConvIDStr]struct{})
+		s.dirtyTokens = make(map[chat1.ConvIDStr]map[string]*tokenEntry)
+		s.dirtyAliases = make(map[string]*aliasEntry)
+		s.dirtyMetadata = make(map[chat1.ConvIDStr]*indexMetadata)
+		s.dirtyCount = 0
+		// drop a signal raised before this flush: it has just been answered
+		select {
+		case <-s.flushNeededCh:
+		default:
+		}
 
 		s.Unlock()
 	}
@@ -960,31 +1159,92 @@ func (s *store) Flush() error {
 	s.Debug(ctx, "Flush: writing %d tokens, %d aliases, %d metadata to disk",
 		len(tokenSnapshots), len(aliasSnapshots), len(mdSnapshots))
 
-	for _, snapshot := range tokenSnapshots {
+	for i, snapshot := range tokenSnapshots {
+		// a nil entry is a queued delete, not a value to write
+		if snapshot.entry == nil {
+			s.diskStorage.RemoveTokenEntry(ctx, snapshot.convID, snapshot.token)
+			continue
+		}
 		if err := s.diskStorage.PutTokenEntry(ctx, snapshot.convID, snapshot.token, snapshot.entry); err != nil {
 			s.Debug(ctx, "Flush: failed to write token: %s", err)
+			s.requeue(tokenSnapshots[i:], aliasSnapshots, mdSnapshots)
 			return err
 		}
 	}
+	tokenSnapshots = nil
 
 	for alias, ae := range aliasSnapshots {
+		if ae == nil {
+			s.diskStorage.RemoveAliasEntry(ctx, alias)
+			delete(aliasSnapshots, alias)
+			continue
+		}
 		if err := s.diskStorage.PutAliasEntry(ctx, alias, ae); err != nil {
 			s.Debug(ctx, "Flush: failed to write alias: %s", err)
+			s.requeue(nil, aliasSnapshots, mdSnapshots)
 			return err
 		}
+		delete(aliasSnapshots, alias)
 	}
 
 	for convIDStr, md := range mdSnapshots {
 		convID, err := chat1.MakeConvID(string(convIDStr))
 		if err != nil {
 			s.Debug(ctx, "Flush: invalid convID %s: %s", convIDStr, err)
+			delete(mdSnapshots, convIDStr)
 			continue
 		}
 		if err := s.diskStorage.PutMetadata(ctx, convID, md); err != nil {
 			s.Debug(ctx, "Flush: failed to write metadata: %s", err)
+			s.requeue(nil, nil, mdSnapshots)
 			return err
 		}
+		delete(mdSnapshots, convIDStr)
 	}
 
 	return nil
+}
+
+// requeue puts snapshots that never reached disk back into the pending set so a
+// later flush retries them.
+//
+// Without this a failed write was simply dropped: the entry had already been
+// removed from dirty tracking before the write was attempted, and nothing marks
+// it dirty again, since nobody mutates a token entry for a message that is
+// already indexed. The live metadata meanwhile keeps its SeenIDs, so the next
+// successful flush would record those messages as indexed with no tokens on
+// disk - unsearchable, and never re-indexed because the conv reads as complete.
+//
+// A key written again since the snapshot was taken is left alone: that pending
+// value is newer than what failed to write.
+func (s *store) requeue(tokens []tokenSnapshot, aliases map[string]*aliasEntry,
+	mds map[chat1.ConvIDStr]*indexMetadata,
+) {
+	s.Lock()
+	defer s.Unlock()
+	for _, snapshot := range tokens {
+		convIDStr := snapshot.convID.ConvIDStr()
+		if s.dirtyTokens[convIDStr] == nil {
+			s.dirtyTokens[convIDStr] = make(map[string]*tokenEntry)
+		}
+		if _, ok := s.dirtyTokens[convIDStr][snapshot.token]; ok {
+			continue
+		}
+		s.dirtyTokens[convIDStr][snapshot.token] = snapshot.entry
+		s.dirtyCount++
+	}
+	for alias, ae := range aliases {
+		if _, ok := s.dirtyAliases[alias]; ok {
+			continue
+		}
+		s.dirtyAliases[alias] = ae
+		s.dirtyCount++
+	}
+	for convIDStr, md := range mds {
+		if _, ok := s.dirtyMetadata[convIDStr]; ok {
+			continue
+		}
+		s.dirtyMetadata[convIDStr] = md
+		s.dirtyCount++
+	}
 }

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -40,11 +40,9 @@ const (
 // hold, so the set peaks at roughly this plus one batch.
 //
 // It therefore has to sit well above one batch. A page of 300 messages produces
-// ~2600 entries, so a 1000 bound was crossed by every single batch and turned
-// into "flush after every batch": measured at 65 flushes in 2.9s, a 0.04s median
-// gap, rewriting hot tokens to disk - each one re-encrypted whole, not as a
-// delta - on every pass instead of once an interval. Raising it to 20000 cut
-// that to 7 flushes over a comparable window.
+// ~2600 entries, so a bound near that degenerates into "flush after every
+// batch", rewriting hot tokens to disk - each one re-encrypted whole, not as a
+// delta - on every pass instead of once an interval.
 //
 // Note this counts entries, not bytes, and the two differ by a lot: an entry
 // holding one message id and one holding ten thousand both count as 1. A fresh
@@ -283,10 +281,9 @@ type store struct {
 
 	// Entries written but not yet on disk. These hold the entry itself, not just
 	// its key: the caches above are bounded LRUs, so a dirty entry can be evicted
-	// before the next flush. Keying alone meant such an entry was skipped by
-	// Flush and lost, while a subsequent read fell through to the stale copy on
-	// disk and built further updates on top of it. Reads therefore consult these
-	// before disk, and Flush writes from these rather than from the caches.
+	// before the next flush, and a key-only record of it would name an entry that
+	// is no longer anywhere in memory. Reads consult these before disk, and Flush
+	// writes from these rather than from the caches.
 	dirtyTokens   map[chat1.ConvIDStr]map[string]*tokenEntry // map[convIDStr][token]
 	dirtyAliases  map[string]*aliasEntry                     // map[alias]
 	dirtyMetadata map[chat1.ConvIDStr]*indexMetadata         // map[convIDStr]
@@ -590,7 +587,7 @@ func (s *store) signalFlushIfFullLocked() {
 	}
 }
 
-// flushNeeded fires when the pending set has grown past maxDirtyEntries.
+// flushNeeded fires once the pending set reaches maxDirtyEntries.
 func (s *store) flushNeeded() <-chan struct{} {
 	return s.flushNeededCh
 }
@@ -814,12 +811,12 @@ func (s *store) ConvIndexStats(ctx context.Context, conv chat1.Conversation) (re
 //
 // A conv is "fully indexed" only when every ID between its min and max is in
 // SeenIDs, but an ID the server will not return for us can never get there by
-// being indexed: deleted messages, and gaps that never existed. Before this,
-// those IDs kept numMissing above zero forever, so the conv was never fully
-// indexed and SelectiveSync re-fetched the same already-indexed messages every
-// interval, permanently. Callers mark the IDs they asked for after a fetch that
-// succeeded - the source affirmatively answered for that range, so anything
-// absent from the reply is not coming.
+// being indexed: deleted messages, and gaps that never existed. Left unmarked
+// they hold numMissing above zero forever, so the conv is never fully indexed
+// and SelectiveSync re-fetches the same already-indexed messages every interval.
+// Callers mark the IDs they asked for after a fetch that succeeded - the source
+// affirmatively answered for that range, so anything absent from the reply is
+// not coming.
 func (s *store) MarkSeen(ctx context.Context, convID chat1.ConversationID, ids []chat1.MessageID) (err error) {
 	if len(ids) == 0 {
 		return nil
@@ -893,9 +890,9 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 	superseded := make(map[chat1.MessageID]supersededFetch, len(msgs))
 
 	// Collect what every message in this batch supersedes, then fetch the whole
-	// set in one call. Asking per message meant one GetMessages round trip per
-	// edit or attachment upload: a backfill of a large conversation issued tens
-	// of thousands of single-message fetches.
+	// set in one call. Asking per message costs one GetMessages round trip per
+	// edit or attachment upload, which over a backfill of a large conversation
+	// is tens of thousands of single-message fetches.
 	superIDsByMsg := make(map[chat1.MessageID][]chat1.MessageID, len(msgs))
 	var allSuperIDs []chat1.MessageID
 	seenSuperID := make(map[chat1.MessageID]bool)
@@ -943,6 +940,7 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 		}
 	}
 
+	unresolved := make(map[chat1.MessageID]bool)
 	for _, msg := range msgs {
 		superIDs, ok := superIDsByMsg[msg.GetMessageID()]
 		if !ok {
@@ -955,6 +953,13 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 			}
 		}
 		if len(fetch.msgs) == 0 {
+			// We know what this message supersedes but could not fetch it, so
+			// its content has nowhere to go. Record that rather than falling
+			// through as a no-op, or the message would be marked seen with the
+			// edit never applied and nothing would revisit it.
+			if len(superIDs) > 0 {
+				unresolved[msg.GetMessageID()] = true
+			}
 			continue
 		}
 		if msg.GetMessageType() == chat1.MessageType_EDIT {
@@ -984,13 +989,18 @@ func (s *store) Add(ctx context.Context, convID chat1.ConversationID,
 			continue
 		}
 		// Mark seen only once the indexing behind the mark has succeeded. md is
-		// the live shared object and is usually already pending, so marking up
-		// front committed the mark whatever happened next: an error here left
-		// the message recorded as indexed with no tokens for it, and nothing
-		// re-indexes a message the metadata already accounts for.
+		// the live shared object and is usually already pending, so a mark made
+		// up front stands whatever happens next: the message ends up recorded as
+		// indexed with no tokens for it, and nothing re-indexes a message the
+		// metadata already accounts for. The same reasoning covers a message
+		// whose superseded target could not be fetched -- leave it unseen so a
+		// later pass can try again.
 		// NOTE DELETE and DELETEHISTORY are handled through calls to `remove`,
 		// other messages will be added if there is any content that can be
 		// indexed.
+		if unresolved[msg.GetMessageID()] {
+			continue
+		}
 		switch msg.GetMessageType() {
 		case chat1.MessageType_ATTACHMENTUPLOADED:
 			for _, sm := range superseded[msg.GetMessageID()].msgs {
@@ -1086,9 +1096,11 @@ func (s *store) ClearMemory() {
 }
 
 func (s *store) Clear(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID) error {
-	// ClearMemory is global while the disk clear is for one conv, so clearing a
-	// single conversation used to throw away every other conversation's pending
-	// writes. Flush first so only this conv's index is actually lost.
+	// ClearMemory is global while the disk clear is for one conv, so flush first:
+	// otherwise clearing one conversation discards every other conversation's
+	// pending writes along with it. If the flush fails those writes are still
+	// lost - the clear proceeds regardless, since leaving this conv's index half
+	// dropped is worse.
 	if err := s.Flush(); err != nil {
 		s.Debug(ctx, "Clear: flush before clear failed: %s", err)
 	}
@@ -1211,12 +1223,12 @@ func (s *store) Flush() error {
 // requeue puts snapshots that never reached disk back into the pending set so a
 // later flush retries them.
 //
-// Without this a failed write was simply dropped: the entry had already been
-// removed from dirty tracking before the write was attempted, and nothing marks
-// it dirty again, since nobody mutates a token entry for a message that is
-// already indexed. The live metadata meanwhile keeps its SeenIDs, so the next
-// successful flush would record those messages as indexed with no tokens on
-// disk - unsearchable, and never re-indexed because the conv reads as complete.
+// A dropped failure is unrecoverable: the entry leaves dirty tracking before the
+// write is attempted, and nothing marks it dirty again, since nobody mutates a
+// token entry for a message that is already indexed. The live metadata meanwhile
+// keeps its SeenIDs, so the next successful flush records those messages as
+// indexed with no tokens on disk - unsearchable, and never re-indexed because the
+// conv reads as complete.
 //
 // A key written again since the snapshot was taken is left alone: that pending
 // value is newer than what failed to write.

--- a/go/chat/search/storage.go
+++ b/go/chat/search/storage.go
@@ -625,11 +625,14 @@ func (s *store) deleteTokenEntry(ctx context.Context, convID chat1.ConversationI
 
 	s.tokenCache.Remove(cacheKey)
 
-	// Queue the delete rather than writing it through. Flush snapshots under the
-	// lock but writes outside it, so a delete applied straight to disk in that
-	// window was undone by the write that followed, and requeueing a failed
-	// write could put a deleted entry back. Ordering both through the pending
-	// set keeps the last operation the one that lands.
+	// Flush snapshots pending mutations under s.Lock, then applies them to disk
+	// after releasing the lock. A write-through delete could therefore race:
+	//
+	//   flush snapshots old value -> delete removes disk key -> flush writes old value
+	//
+	// Queue a nil tombstone instead. A later flush applies it after any older
+	// snapshot, and requeue() will not replace the tombstone with a failed older
+	// write. This preserves the ordering of in-memory mutations.
 	convIDStr := convID.ConvIDStr()
 	if s.dirtyTokens[convIDStr] == nil {
 		s.dirtyTokens[convIDStr] = make(map[string]*tokenEntry)
@@ -1227,6 +1230,10 @@ func (s *store) requeue(tokens []tokenSnapshot, aliases map[string]*aliasEntry,
 		if s.dirtyTokens[convIDStr] == nil {
 			s.dirtyTokens[convIDStr] = make(map[string]*tokenEntry)
 		}
+		// A value queued since the snapshot was taken - including a nil
+		// tombstone from a delete - describes a later state of the entry than
+		// the one whose write failed, so restoring the snapshot over it would
+		// roll that mutation back.
 		if _, ok := s.dirtyTokens[convIDStr][snapshot.token]; ok {
 			continue
 		}

--- a/go/chat/types/interfaces.go
+++ b/go/chat/types/interfaces.go
@@ -642,6 +642,9 @@ type ParticipantSource interface {
 	GetWithNotifyNonblock(ctx context.Context, uid gregor1.UID, convID chat1.ConversationID,
 		dataSource InboxSourceDataSourceTyp)
 	GetParticipantsFromUids(ctx context.Context, uids []gregor1.UID) ([]chat1.ConversationLocalParticipant, error)
+	// Invalidate drops any cached participant list for these convs, so the next
+	// read goes to the server rather than waiting out the cache freshness.
+	Invalidate(ctx context.Context, uid gregor1.UID, convIDs []chat1.ConversationID)
 }
 
 type EmojiSource interface {

--- a/go/chat/types/types.go
+++ b/go/chat/types/types.go
@@ -874,6 +874,10 @@ func (d DummyParticipantSource) GetParticipantsFromUids(
 	return nil, nil
 }
 
+func (d DummyParticipantSource) Invalidate(ctx context.Context, uid gregor1.UID,
+	convIDs []chat1.ConversationID) {
+}
+
 type DummyEmojiSource struct{}
 
 var _ EmojiSource = (*DummyEmojiSource)(nil)

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -252,6 +252,10 @@ type Identify2WithUID struct {
 
 	resultCh chan<- error
 
+	// When this identify was asked for; bounds which in-flight remote proof
+	// checks it may share with concurrent identifies of the same user.
+	requestedAt time.Time
+
 	// For eagerly checking remote Assertions as they come in, these
 	// member variables maintain state, protected by the remotesMutex.
 	remotesMutex     sync.Mutex
@@ -329,6 +333,10 @@ func (e *Identify2WithUID) Run(m libkb.MetaContext) (err error) {
 	if e.arg.Uid.IsNil() {
 		return libkb.NoUIDError{}
 	}
+
+	// Remote proof checks started from here on may be shared with other identify
+	// sessions, but only if they started after this point.
+	e.requestedAt = m.G().Clock().Now()
 
 	// Only the first send matters, but we don't want to block the subsequent no-op
 	// sends. This code will break when we have more than 100 unblocking opportunities.
@@ -884,7 +892,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	e.metaContext = m
 	if them.IDTable() == nil {
 		m.Debug("| No IDTable for user")
-	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), iui, e, identifyTableMode); err != nil {
+	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), e.requestedAt, iui, e, identifyTableMode); err != nil {
 		m.Debug("| Failure in running IDTable")
 		return err
 	}

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -252,7 +252,7 @@ type Identify2WithUID struct {
 
 	resultCh chan<- error
 
-	// When this identify was asked for; bounds which in-flight remote proof
+	// When this identify was asked for; bounds which still-running remote proof
 	// checks it may share with concurrent identifies of the same user.
 	requestedAt time.Time
 
@@ -334,8 +334,8 @@ func (e *Identify2WithUID) Run(m libkb.MetaContext) (err error) {
 		return libkb.NoUIDError{}
 	}
 
-	// Remote proof checks started from here on may be shared with other identify
-	// sessions, but only if they started after this point.
+	// This identify may share another session's remote proof check, but only one
+	// that started at or after this point and is still running when we ask.
 	e.requestedAt = m.G().Clock().Now()
 
 	// Only the first send matters, but we don't want to block the subsequent no-op

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -754,8 +754,8 @@ func (g *GlobalContext) GetImplicitTeamConflictInfoCacher() LRUer {
 }
 
 func (g *GlobalContext) SetImplicitTeamConflictInfoCacher(l LRUer) {
-	g.cacheMu.RLock()
-	defer g.cacheMu.RUnlock()
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
 	g.itciCacher = l
 }
 
@@ -766,8 +766,8 @@ func (g *GlobalContext) GetImplicitTeamCacher() MemLRUer {
 }
 
 func (g *GlobalContext) SetImplicitTeamCacher(l MemLRUer) {
-	g.cacheMu.RLock()
-	defer g.cacheMu.RUnlock()
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
 	g.iteamCacher = l
 }
 
@@ -778,9 +778,6 @@ func (g *GlobalContext) GetAnnotatedTeamCacher() AnnotatedTeamCacher {
 }
 
 func (g *GlobalContext) SetAnnotatedTeamCacher(c AnnotatedTeamCacher) {
-	// a write needs the write lock: GetAnnotatedTeamCacher runs from
-	// NotifyRouter.HandleTeamChangedByID on every team notification. The
-	// neighbouring setters take RLock here too, and are equally wrong.
 	g.cacheMu.Lock()
 	defer g.cacheMu.Unlock()
 	g.annotatedTeamCacher = c
@@ -793,8 +790,8 @@ func (g *GlobalContext) GetKVRevisionCache() KVRevisionCacher {
 }
 
 func (g *GlobalContext) SetKVRevisionCache(kvr KVRevisionCacher) {
-	g.cacheMu.RLock()
-	defer g.cacheMu.RUnlock()
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
 	g.kvRevisionCache = kvr
 }
 

--- a/go/libkb/globals.go
+++ b/go/libkb/globals.go
@@ -91,23 +91,24 @@ type GlobalContext struct {
 	loadUserLockTab        *LockTable
 	teamAuditor            TeamAuditor
 	teamBoxAuditor         TeamBoxAuditor
-	stellar                Stellar            // Stellar related ops
-	deviceEKStorage        DeviceEKStorage    // Store device ephemeral keys
-	userEKBoxStorage       UserEKBoxStorage   // Store user ephemeral key boxes
-	teamEKBoxStorage       TeamEKBoxStorage   // Store team ephemeral key boxes
-	teambotEKBoxStorage    TeamEKBoxStorage   // Store team bot ephemeral key boxes
-	ekLib                  EKLib              // Wrapper to call ephemeral key methods
-	teambotBotKeyer        TeambotBotKeyer    // TeambotKeyer for bot members
-	teambotMemberKeyer     TeambotMemberKeyer // TeambotKeyer for non-bot members
-	itciCacher             LRUer              // Cacher for implicit team conflict info
-	iteamCacher            MemLRUer           // In memory cacher for implicit teams
-	cardCache              *UserCardCache     // cache of keybase1.UserCard objects
-	fullSelfer             FullSelfer         // a loader that gets the full self object
-	pvlSource              MerkleStore        // a cache and fetcher for pvl
-	paramProofStore        MerkleStore        // a cache and fetcher for param proofs
-	externalURLStore       MerkleStore        // a cache and fetcher for external urls
-	PayloadCache           *PayloadCache      // cache of ChainLink payload json wrappers
-	kvRevisionCache        KVRevisionCacher   // cache of revisions for verifying key-value store results
+	stellar                Stellar             // Stellar related ops
+	deviceEKStorage        DeviceEKStorage     // Store device ephemeral keys
+	userEKBoxStorage       UserEKBoxStorage    // Store user ephemeral key boxes
+	teamEKBoxStorage       TeamEKBoxStorage    // Store team ephemeral key boxes
+	teambotEKBoxStorage    TeamEKBoxStorage    // Store team bot ephemeral key boxes
+	ekLib                  EKLib               // Wrapper to call ephemeral key methods
+	teambotBotKeyer        TeambotBotKeyer     // TeambotKeyer for bot members
+	teambotMemberKeyer     TeambotMemberKeyer  // TeambotKeyer for non-bot members
+	itciCacher             LRUer               // Cacher for implicit team conflict info
+	iteamCacher            MemLRUer            // In memory cacher for implicit teams
+	annotatedTeamCacher    AnnotatedTeamCacher // In memory cacher for keybase1.AnnotatedTeam
+	cardCache              *UserCardCache      // cache of keybase1.UserCard objects
+	fullSelfer             FullSelfer          // a loader that gets the full self object
+	pvlSource              MerkleStore         // a cache and fetcher for pvl
+	paramProofStore        MerkleStore         // a cache and fetcher for param proofs
+	externalURLStore       MerkleStore         // a cache and fetcher for external urls
+	PayloadCache           *PayloadCache       // cache of ChainLink payload json wrappers
+	kvRevisionCache        KVRevisionCacher    // cache of revisions for verifying key-value store results
 	Pegboard               *Pegboard
 
 	GpgClient        *GpgCLI        // A standard GPG-client (optional)
@@ -768,6 +769,21 @@ func (g *GlobalContext) SetImplicitTeamCacher(l MemLRUer) {
 	g.cacheMu.RLock()
 	defer g.cacheMu.RUnlock()
 	g.iteamCacher = l
+}
+
+func (g *GlobalContext) GetAnnotatedTeamCacher() AnnotatedTeamCacher {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	return g.annotatedTeamCacher
+}
+
+func (g *GlobalContext) SetAnnotatedTeamCacher(c AnnotatedTeamCacher) {
+	// a write needs the write lock: GetAnnotatedTeamCacher runs from
+	// NotifyRouter.HandleTeamChangedByID on every team notification. The
+	// neighbouring setters take RLock here too, and are equally wrong.
+	g.cacheMu.Lock()
+	defer g.cacheMu.Unlock()
+	g.annotatedTeamCacher = c
 }
 
 func (g *GlobalContext) GetKVRevisionCache() KVRevisionCacher {

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1856,7 +1856,7 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 	if res.hint != nil {
 		hint = *res.hint
 	}
-	res.verifiedHint, res.err = idt.checkStatusShared(m, pc, hint, pcm, pvlU, sid, requestedAt)
+	res.verifiedHint, res.err = idt.checkStatusShared(m, pc, hint, pcm, pvlU, sid, requestedAt, forceRemoteCheck)
 
 	// If no error than all good
 	if res.err == nil {
@@ -1882,23 +1882,34 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 // checkStatusShared performs the outbound check of a remote proof, collapsing it
 // with an identical check that another identify session already started after
 // this one was requested. Several UI surfaces routinely identify the same user at
-// the same moment (profile screen, tracker popup, profile card), and each one
-// used to send its own request to the third-party service; those services rate
-// limit, and a throttled fetch shows up to the user as a broken proof.
+// the same moment (profile screen, tracker popup, profile card), and one request
+// per surface to the third-party service risks being rate limited; a throttled
+// fetch shows up to the user as a broken proof.
 //
-// This only shares work, never results: a check is eligible only if it began at
-// or after requestedAt, so what the caller gets back is a live check that ran
-// during its own request. Nothing is remembered past the check, so this neither
-// lengthens any cache lifetime nor lets a stale answer stand in for a new one.
+// This only shares work, never results: a check is eligible only while it is
+// still running and only if it began at or after requestedAt, so what the caller
+// gets back is a check that was live during its own request. Nothing is
+// remembered past the check, so this neither lengthens any cache lifetime nor
+// lets a stale answer stand in for a new one.
+//
+// forceRemoteCheck callers never share. They are asking to bypass the caches, so
+// answering them from work someone else started -- however recent -- is not what
+// they asked for.
 func (idt *IdentityTable) checkStatusShared(m MetaContext, pc ProofChecker, hint SigHint,
 	pcm ProofCheckerMode, pvlU keybase1.MerkleStoreEntry, sid keybase1.SigID,
-	requestedAt time.Time,
+	requestedAt time.Time, forceRemoteCheck bool,
 ) (*SigHint, ProofError) {
 	// Everything that can change the outcome of the check has to be in the key:
 	// which proof, which pvl script, which checker mode (passive checks skip
-	// self-hosted services), and which hint we're checking against.
-	key := fmt.Sprintf("%s|%s|%d|%s|%s", sid, pvlU.Hash, pcm, hint.GetAPIURL(), hint.GetCheckText())
+	// self-hosted services), and which hint we're checking against. %q so a
+	// separator inside a server-supplied hint can't make two different checks
+	// collide on one key.
+	key := fmt.Sprintf("%s|%s|%d|%q|%q", sid, pvlU.Hash, pcm, hint.GetAPIURL(), hint.GetCheckText())
 
+	// A zero requestedAt is CheckFlightBegin's "never share" signal.
+	if forceRemoteCheck {
+		requestedAt = time.Time{}
+	}
 	mine, theirs := m.G().ProofCache.CheckFlightBegin(key, requestedAt, m.G().Clock().Now())
 
 	if theirs != nil {
@@ -1906,6 +1917,9 @@ func (idt *IdentityTable) checkStatusShared(m MetaContext, pc ProofChecker, hint
 			m.Debug("| Shared an in-flight remote proof check for %s (started %s)", sid, theirs.startedAt)
 			return verifiedHint, perr
 		}
+		// Falls through to our own check. wait also reports unusable when it was
+		// our own context that died, in which case this check fails immediately
+		// on that same dead context rather than reaching the network.
 		return pc.CheckStatus(m, hint, pcm, pvlU)
 	}
 
@@ -1914,8 +1928,14 @@ func (idt *IdentityTable) checkStatusShared(m MetaContext, pc ProofChecker, hint
 	if mine != nil {
 		// Deferred so a panic in the checker still closes the flight. Otherwise
 		// the entry sits in the LRU with an open channel and every session that
-		// shares it blocks until its own context is canceled.
-		defer func() { mine.finish(verifiedHint, perr, m.Ctx().Err() == nil) }()
+		// shares it blocks until its own context is canceled. `completed` keeps
+		// the panic path from publishing (nil, nil) -- which reads downstream as
+		// a passing proof -- to everyone waiting on us.
+		completed := false
+		defer func() { mine.finish(verifiedHint, perr, completed && m.Ctx().Err() == nil) }()
+		verifiedHint, perr = pc.CheckStatus(m, hint, pcm, pvlU)
+		completed = true
+		return verifiedHint, perr
 	}
 	verifiedHint, perr = pc.CheckStatus(m, hint, pcm, pvlU)
 	return verifiedHint, perr

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1668,11 +1668,13 @@ const (
 	IdentifyTableModeActive  IdentifyTableMode = iota
 )
 
-func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
+// requestedAt is when the identify this table walk belongs to was asked for. It
+// bounds which in-flight remote proof checks this walk is allowed to share.
+func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteCheck bool, requestedAt time.Time, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
 	errs := make(chan error, len(is.res.ProofChecks))
 	for _, lcr := range is.res.ProofChecks {
 		go func(l *LinkCheckResult) {
-			errs <- idt.identifyActiveProof(m, l, is, forceRemoteCheck, ui, ccl, itm)
+			errs <- idt.identifyActiveProof(m, l, is, forceRemoteCheck, requestedAt, ui, ccl, itm)
 		}(lcr)
 	}
 
@@ -1701,8 +1703,8 @@ func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteC
 
 // =========================================================================
 
-func (idt *IdentityTable) identifyActiveProof(m MetaContext, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
-	idt.proofRemoteCheck(m, is.HasPreviousTrack(), forceRemoteCheck, lcr, itm)
+func (idt *IdentityTable) identifyActiveProof(m MetaContext, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, requestedAt time.Time, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
+	idt.proofRemoteCheck(m, is.HasPreviousTrack(), forceRemoteCheck, requestedAt, lcr, itm)
 	if ccl != nil {
 		ccl.CCLCheckCompleted(lcr)
 	}
@@ -1763,7 +1765,7 @@ func (idt *IdentityTable) ComputeRemoteDiff(tracked, trackedTmp, observed keybas
 	return ret
 }
 
-func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forceRemoteCheck bool, res *LinkCheckResult, itm IdentifyTableMode) {
+func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forceRemoteCheck bool, requestedAt time.Time, res *LinkCheckResult, itm IdentifyTableMode) {
 	p := res.link
 
 	m.Debug("+ RemoteCheckProof %s", p.ToDebugString())
@@ -1854,7 +1856,7 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 	if res.hint != nil {
 		hint = *res.hint
 	}
-	res.verifiedHint, res.err = pc.CheckStatus(m, hint, pcm, pvlU)
+	res.verifiedHint, res.err = idt.checkStatusShared(m, pc, hint, pcm, pvlU, sid, requestedAt)
 
 	// If no error than all good
 	if res.err == nil {
@@ -1875,6 +1877,48 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 	}
 
 	m.Debug("| Check status (%s) failed with error: %s", p.ToDebugString(), res.err.Error())
+}
+
+// checkStatusShared performs the outbound check of a remote proof, collapsing it
+// with an identical check that another identify session already started after
+// this one was requested. Several UI surfaces routinely identify the same user at
+// the same moment (profile screen, tracker popup, profile card), and each one
+// used to send its own request to the third-party service; those services rate
+// limit, and a throttled fetch shows up to the user as a broken proof.
+//
+// This only shares work, never results: a check is eligible only if it began at
+// or after requestedAt, so what the caller gets back is a live check that ran
+// during its own request. Nothing is remembered past the check, so this neither
+// lengthens any cache lifetime nor lets a stale answer stand in for a new one.
+func (idt *IdentityTable) checkStatusShared(m MetaContext, pc ProofChecker, hint SigHint,
+	pcm ProofCheckerMode, pvlU keybase1.MerkleStoreEntry, sid keybase1.SigID,
+	requestedAt time.Time,
+) (*SigHint, ProofError) {
+	// Everything that can change the outcome of the check has to be in the key:
+	// which proof, which pvl script, which checker mode (passive checks skip
+	// self-hosted services), and which hint we're checking against.
+	key := fmt.Sprintf("%s|%s|%d|%s|%s", sid, pvlU.Hash, pcm, hint.GetAPIURL(), hint.GetCheckText())
+
+	mine, theirs := m.G().ProofCache.CheckFlightBegin(key, requestedAt, m.G().Clock().Now())
+
+	if theirs != nil {
+		if verifiedHint, perr, usable := theirs.wait(m.Ctx()); usable {
+			m.Debug("| Shared an in-flight remote proof check for %s (started %s)", sid, theirs.startedAt)
+			return verifiedHint, perr
+		}
+		return pc.CheckStatus(m, hint, pcm, pvlU)
+	}
+
+	var verifiedHint *SigHint
+	var perr ProofError
+	if mine != nil {
+		// Deferred so a panic in the checker still closes the flight. Otherwise
+		// the entry sits in the LRU with an open channel and every session that
+		// shares it blocks until its own context is canceled.
+		defer func() { mine.finish(verifiedHint, perr, m.Ctx().Err() == nil) }()
+	}
+	verifiedHint, perr = pc.CheckStatus(m, hint, pcm, pvlU)
+	return verifiedHint, perr
 }
 
 // VerifyReverseSig checks reverse signature using the key provided.

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -965,6 +965,16 @@ type MemLRUer interface {
 	OnDbNuke(mctx MetaContext) error
 }
 
+// AnnotatedTeamCacher memoizes the expensive, mostly off-chain bundle of data that
+// backs the team page in the UI. Implemented in the teams package; the interface lives
+// here so NotifyRouter can invalidate entries when a team changes.
+type AnnotatedTeamCacher interface {
+	Get(mctx MetaContext, teamID keybase1.TeamID) (keybase1.AnnotatedTeam, bool)
+	Put(mctx MetaContext, teamID keybase1.TeamID, team keybase1.AnnotatedTeam)
+	Remove(teamID keybase1.TeamID)
+	Clear()
+}
+
 type ClockContext interface {
 	GetClock() clockwork.Clock
 }

--- a/go/libkb/interfaces.go
+++ b/go/libkb/interfaces.go
@@ -969,8 +969,6 @@ type MemLRUer interface {
 // backs the team page in the UI. Implemented in the teams package; the interface lives
 // here so NotifyRouter can invalidate entries when a team changes.
 type AnnotatedTeamCacher interface {
-	Get(mctx MetaContext, teamID keybase1.TeamID) (keybase1.AnnotatedTeam, bool)
-	Put(mctx MetaContext, teamID keybase1.TeamID, team keybase1.AnnotatedTeam)
 	Remove(teamID keybase1.TeamID)
 	Clear()
 }

--- a/go/libkb/notify_router.go
+++ b/go/libkb/notify_router.go
@@ -2193,6 +2193,12 @@ func (n *NotifyRouter) HandleTeamChangedByID(ctx context.Context,
 		return
 	}
 
+	// Any change to the team, local or server-pushed, drops the memoized
+	// AnnotatedTeam so the next UI read rebuilds it from the server.
+	if c := n.G().GetAnnotatedTeamCacher(); c != nil {
+		c.Remove(teamID)
+	}
+
 	arg := keybase1.TeamChangedByIDArg{
 		TeamID:              teamID,
 		LatestSeqno:         latestSeqno,

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -4,6 +4,7 @@
 package libkb
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -111,6 +112,85 @@ type ProofCache struct {
 	lru   *lru.Cache
 	sync.RWMutex
 	noDisk bool
+
+	flightMu sync.Mutex
+	flights  *lru.Cache
+}
+
+// proofCheckFlightCapacity bounds the singleflight table. It is a memory bound
+// only: sharing is gated on when a check started, never on how long an entry has
+// been kept around, so retention can't make a shared answer any staler.
+const proofCheckFlightCapacity = 500
+
+// proofCheckFlight is one outbound remote proof check that other identify
+// sessions may share instead of issuing a duplicate request of their own.
+type proofCheckFlight struct {
+	startedAt time.Time
+	doneCh    chan struct{}
+
+	// Only valid once doneCh is closed.
+	hint   *SigHint
+	err    ProofError
+	usable bool
+}
+
+func (f *proofCheckFlight) finish(hint *SigHint, err ProofError, usable bool) {
+	f.hint = hint
+	f.err = err
+	f.usable = usable
+	close(f.doneCh)
+}
+
+// wait blocks until the shared check finishes. usable is false when the result
+// can't stand in for the caller's own check (the owning goroutine was canceled),
+// in which case the caller must do its own check.
+func (f *proofCheckFlight) wait(ctx context.Context) (hint *SigHint, err ProofError, usable bool) {
+	select {
+	case <-f.doneCh:
+		return f.hint, f.err, f.usable
+	case <-ctx.Done():
+		return nil, nil, false
+	}
+}
+
+// CheckFlightBegin either registers the caller as the one that will perform the
+// outbound proof check for key (returning mine), or hands back a check another
+// session already has going that can answer for the caller (returning theirs).
+//
+// requestedAt is when the caller asked for this check. A check may only be
+// shared if it *started* at or after that moment, so the shared answer is never
+// older than one the caller would have produced by doing the work itself. That
+// makes this a pure singleflight: it collapses duplicate concurrent work without
+// letting any result outlive the freshness its requester asked for.
+func (pc *ProofCache) CheckFlightBegin(key string, requestedAt, now time.Time) (mine, theirs *proofCheckFlight) {
+	if pc == nil {
+		return nil, nil
+	}
+
+	pc.flightMu.Lock()
+	defer pc.flightMu.Unlock()
+
+	if pc.flights == nil {
+		l, err := lru.New(proofCheckFlightCapacity)
+		if err != nil {
+			return nil, nil
+		}
+		pc.flights = l
+	}
+
+	// A zero requestedAt would make every entry look eligible, so callers that
+	// can't say when they asked never share.
+	if !requestedAt.IsZero() {
+		if tmp, found := pc.flights.Get(key); found {
+			if f, ok := tmp.(*proofCheckFlight); ok && !f.startedAt.Before(requestedAt) {
+				return nil, f
+			}
+		}
+	}
+
+	f := &proofCheckFlight{startedAt: now, doneCh: make(chan struct{})}
+	pc.flights.Add(key, f)
+	return f, nil
 }
 
 func NewProofCache(g *GlobalContext, capac int) *ProofCache {
@@ -124,6 +204,12 @@ func (pc *ProofCache) DisableDisk() {
 }
 
 func (pc *ProofCache) Reset() error {
+	pc.flightMu.Lock()
+	if pc.flights != nil {
+		pc.flights.Purge()
+	}
+	pc.flightMu.Unlock()
+
 	pc.Lock()
 	defer pc.Unlock()
 	return pc.initCache()

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -118,8 +118,9 @@ type ProofCache struct {
 }
 
 // proofCheckFlightCapacity bounds the singleflight table. It is a memory bound
-// only: sharing is gated on when a check started, never on how long an entry has
-// been kept around, so retention can't make a shared answer any staler.
+// only: an entry is shareable exactly while its check is still running, so how
+// long a finished entry lingers before eviction can't affect what any caller
+// gets back.
 const proofCheckFlightCapacity = 500
 
 // ProofCheckFlight is one outbound remote proof check that other identify
@@ -152,9 +153,11 @@ func (f *ProofCheckFlight) finished() bool {
 	}
 }
 
-// wait blocks until the shared check finishes. usable is false when the result
-// can't stand in for the caller's own check (the owning goroutine was canceled),
-// in which case the caller must do its own check.
+// wait blocks until the shared check finishes. usable is false either because
+// the result can't stand in for the caller's own check (the owning goroutine was
+// canceled, or it panicked before producing one) or because the caller's own ctx
+// died first. Callers must fall back to their own check, which the second case
+// makes pointless -- hence the separate ctx error check at the call site.
 func (f *ProofCheckFlight) wait(ctx context.Context) (hint *SigHint, err ProofError, usable bool) {
 	select {
 	case <-f.doneCh:
@@ -168,11 +171,14 @@ func (f *ProofCheckFlight) wait(ctx context.Context) (hint *SigHint, err ProofEr
 // outbound proof check for key (returning mine), or hands back a check another
 // session already has going that can answer for the caller (returning theirs).
 //
-// requestedAt is when the caller asked for this check. A check may only be
-// shared if it *started* at or after that moment, so the shared answer is never
-// older than one the caller would have produced by doing the work itself. That
-// makes this a pure singleflight: it collapses duplicate concurrent work without
-// letting any result outlive the freshness its requester asked for.
+// A check is shareable only while it is still running, and only if it started at
+// or after requestedAt (when the caller asked for it). Both halves are needed to
+// keep this a pure singleflight rather than a second result cache: requestedAt
+// is stamped when the identify begins but the check runs much later, after the
+// user load and the identify UI round trip, so an already-finished flight can
+// easily satisfy the start-time test while its answer is seconds old. Requiring
+// the check to still be in flight means every caller either does the work or
+// waits on work that is genuinely happening during its own request.
 func (pc *ProofCache) CheckFlightBegin(key string, requestedAt, now time.Time) (mine, theirs *ProofCheckFlight) {
 	if pc == nil {
 		return nil, nil
@@ -194,15 +200,14 @@ func (pc *ProofCache) CheckFlightBegin(key string, requestedAt, now time.Time) (
 	if !requestedAt.IsZero() {
 		if tmp, found := pc.flights.Get(key); found {
 			if f, ok := tmp.(*ProofCheckFlight); ok && !f.startedAt.Before(requestedAt) {
-				// A finished flight whose owner was canceled can't answer for
-				// anyone, so keeping it would make every later caller fall back
-				// to its own check without ever forming a new flight. Drop it
-				// and let this caller lead one that others can share.
-				if f.finished() && !f.usable {
-					pc.flights.Remove(key)
-				} else {
+				// A finished flight is a result, not work in progress, and this
+				// table is not a result cache -- keeping it would let one check
+				// answer callers arbitrarily long after it completed. Drop it so
+				// this caller leads a fresh one that others can share.
+				if !f.finished() {
 					return nil, f
 				}
+				pc.flights.Remove(key)
 			}
 		}
 	}

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -122,9 +122,9 @@ type ProofCache struct {
 // been kept around, so retention can't make a shared answer any staler.
 const proofCheckFlightCapacity = 500
 
-// proofCheckFlight is one outbound remote proof check that other identify
+// ProofCheckFlight is one outbound remote proof check that other identify
 // sessions may share instead of issuing a duplicate request of their own.
-type proofCheckFlight struct {
+type ProofCheckFlight struct {
 	startedAt time.Time
 	doneCh    chan struct{}
 
@@ -134,17 +134,28 @@ type proofCheckFlight struct {
 	usable bool
 }
 
-func (f *proofCheckFlight) finish(hint *SigHint, err ProofError, usable bool) {
+func (f *ProofCheckFlight) finish(hint *SigHint, err ProofError, usable bool) {
 	f.hint = hint
 	f.err = err
 	f.usable = usable
 	close(f.doneCh)
 }
 
+// finished reports whether the check is done. Only meaningful under flightMu,
+// where it gates reuse of the flight's result fields.
+func (f *ProofCheckFlight) finished() bool {
+	select {
+	case <-f.doneCh:
+		return true
+	default:
+		return false
+	}
+}
+
 // wait blocks until the shared check finishes. usable is false when the result
 // can't stand in for the caller's own check (the owning goroutine was canceled),
 // in which case the caller must do its own check.
-func (f *proofCheckFlight) wait(ctx context.Context) (hint *SigHint, err ProofError, usable bool) {
+func (f *ProofCheckFlight) wait(ctx context.Context) (hint *SigHint, err ProofError, usable bool) {
 	select {
 	case <-f.doneCh:
 		return f.hint, f.err, f.usable
@@ -162,7 +173,7 @@ func (f *proofCheckFlight) wait(ctx context.Context) (hint *SigHint, err ProofEr
 // older than one the caller would have produced by doing the work itself. That
 // makes this a pure singleflight: it collapses duplicate concurrent work without
 // letting any result outlive the freshness its requester asked for.
-func (pc *ProofCache) CheckFlightBegin(key string, requestedAt, now time.Time) (mine, theirs *proofCheckFlight) {
+func (pc *ProofCache) CheckFlightBegin(key string, requestedAt, now time.Time) (mine, theirs *ProofCheckFlight) {
 	if pc == nil {
 		return nil, nil
 	}
@@ -182,13 +193,21 @@ func (pc *ProofCache) CheckFlightBegin(key string, requestedAt, now time.Time) (
 	// can't say when they asked never share.
 	if !requestedAt.IsZero() {
 		if tmp, found := pc.flights.Get(key); found {
-			if f, ok := tmp.(*proofCheckFlight); ok && !f.startedAt.Before(requestedAt) {
-				return nil, f
+			if f, ok := tmp.(*ProofCheckFlight); ok && !f.startedAt.Before(requestedAt) {
+				// A finished flight whose owner was canceled can't answer for
+				// anyone, so keeping it would make every later caller fall back
+				// to its own check without ever forming a new flight. Drop it
+				// and let this caller lead one that others can share.
+				if f.finished() && !f.usable {
+					pc.flights.Remove(key)
+				} else {
+					return nil, f
+				}
 			}
 		}
 	}
 
-	f := &proofCheckFlight{startedAt: now, doneCh: make(chan struct{})}
+	f := &ProofCheckFlight{startedAt: now, doneCh: make(chan struct{})}
 	pc.flights.Add(key, f)
 	return f, nil
 }

--- a/go/libkb/proof_cache_flight_test.go
+++ b/go/libkb/proof_cache_flight_test.go
@@ -1,0 +1,75 @@
+package libkb
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestProofCheckFlightSharesConcurrentCheck(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	// Two sessions ask at the same moment; the first one starts the check.
+	mine, theirs := pc.CheckFlightBegin("k", t0, t0.Add(time.Millisecond))
+	if mine == nil || theirs != nil {
+		t.Fatalf("first caller should own the flight, got mine=%v theirs=%v", mine, theirs)
+	}
+
+	mine2, theirs2 := pc.CheckFlightBegin("k", t0, t0.Add(2*time.Millisecond))
+	if mine2 != nil || theirs2 != mine {
+		t.Fatalf("second caller should share the first flight")
+	}
+
+	hint := NewVerifiedSigHint("", "remote", "api", "human", "text")
+	go mine.finish(hint, nil, true)
+
+	gotHint, gotErr, usable := theirs2.wait(context.Background())
+	if !usable || gotErr != nil || gotHint != hint {
+		t.Fatalf("shared result mismatch: %v %v %v", gotHint, gotErr, usable)
+	}
+}
+
+func TestProofCheckFlightNotSharedWithLaterRequest(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0)
+	mine.finish(nil, nil, true)
+
+	// A request made after that check started must not be answered by it.
+	mine2, theirs2 := pc.CheckFlightBegin("k", t0.Add(time.Nanosecond), t0.Add(time.Second))
+	if theirs2 != nil || mine2 == nil {
+		t.Fatalf("a later request must run its own check")
+	}
+}
+
+func TestProofCheckFlightZeroRequestedAtNeverShares(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0)
+	mine.finish(nil, nil, true)
+
+	mine2, theirs2 := pc.CheckFlightBegin("k", time.Time{}, t0)
+	if theirs2 != nil || mine2 == nil {
+		t.Fatalf("a caller with no request time must run its own check")
+	}
+}
+
+func TestProofCheckFlightUnusableResultFallsThrough(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0)
+	// Owner was canceled, so its result can't stand in for anyone else.
+	mine.finish(nil, nil, false)
+
+	_, theirs := pc.CheckFlightBegin("k", t0, t0)
+	if theirs == nil {
+		t.Fatal("expected to find the flight")
+	}
+	if _, _, usable := theirs.wait(context.Background()); usable {
+		t.Fatal("canceled result must not be usable")
+	}
+}

--- a/go/libkb/proof_cache_flight_test.go
+++ b/go/libkb/proof_cache_flight_test.go
@@ -2,8 +2,12 @@ package libkb
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
 func TestProofCheckFlightSharesConcurrentCheck(t *testing.T) {
@@ -28,6 +32,155 @@ func TestProofCheckFlightSharesConcurrentCheck(t *testing.T) {
 	if !usable || gotErr != nil || gotHint != hint {
 		t.Fatalf("shared result mismatch: %v %v %v", gotHint, gotErr, usable)
 	}
+}
+
+// requestedAt is stamped when the identify starts, but the proof check runs much
+// later -- after the user load and the identify UI round trip. A flight that
+// started inside that gap satisfies the start-time test even though it finished
+// long ago, so completion, not start time, is what has to end sharing.
+func TestProofCheckFlightNotSharedOnceFinished(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0.Add(time.Millisecond))
+	mine.finish(NewVerifiedSigHint("", "remote", "api", "human", "text"), nil, true)
+
+	// Same request time, but the check it would share completed a minute ago.
+	mine2, theirs2 := pc.CheckFlightBegin("k", t0, t0.Add(time.Minute))
+	if theirs2 != nil {
+		t.Fatal("a finished check must not answer a later caller")
+	}
+	if mine2 == nil {
+		t.Fatal("expected to own a new flight")
+	}
+	if mine2 == mine {
+		t.Fatal("expected a distinct flight, not the finished one")
+	}
+}
+
+func TestProofCheckFlightPropagatesResultToWaiter(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0)
+	_, theirs := pc.CheckFlightBegin("k", t0, t0)
+	if theirs != mine {
+		t.Fatal("expected to share the running flight")
+	}
+
+	perr := NewProofError(keybase1.ProofStatus_NOT_FOUND, "nope")
+	go mine.finish(nil, perr, true)
+
+	gotHint, gotErr, usable := theirs.wait(context.Background())
+	if !usable {
+		t.Fatal("expected a usable result")
+	}
+	if gotHint != nil {
+		t.Fatalf("expected no hint, got %v", gotHint)
+	}
+	if gotErr != perr {
+		t.Fatalf("expected the leader's ProofError, got %v", gotErr)
+	}
+}
+
+func TestProofCheckFlightWaiterCtxCancel(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0)
+	_, theirs := pc.CheckFlightBegin("k", t0, t0)
+	if theirs != mine {
+		t.Fatal("expected to share the running flight")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	hint, err, usable := theirs.wait(ctx)
+	if usable {
+		t.Fatal("a caller whose own ctx died must not use the result")
+	}
+	if hint != nil || err != nil {
+		t.Fatalf("expected no result on cancel, got %v %v", hint, err)
+	}
+
+	// The leader is untouched: it finishes and its answer is still shareable
+	// by anyone still waiting.
+	mine.finish(nil, nil, true)
+}
+
+func TestProofCheckFlightConcurrentSingleLeader(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	const n = 50
+	var wg sync.WaitGroup
+	var leaders int64
+	hint := NewVerifiedSigHint("", "remote", "api", "human", "text")
+	start := make(chan struct{})
+	results := make(chan *SigHint, n)
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			mine, theirs := pc.CheckFlightBegin("k", t0, t0)
+			switch {
+			case mine != nil:
+				atomic.AddInt64(&leaders, 1)
+				mine.finish(hint, nil, true)
+				results <- hint
+			case theirs != nil:
+				got, _, usable := theirs.wait(context.Background())
+				if usable {
+					results <- got
+				} else {
+					results <- hint
+				}
+			default:
+				results <- hint
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	// Callers that lose the race to a *finished* flight legitimately lead their
+	// own, so the leader count is not pinned to 1 -- but every caller must come
+	// away with the same answer and none may be stranded.
+	if atomic.LoadInt64(&leaders) < 1 {
+		t.Fatal("expected at least one leader")
+	}
+	count := 0
+	for got := range results {
+		count++
+		if got != hint {
+			t.Fatalf("caller got an unexpected result: %v", got)
+		}
+	}
+	if count != n {
+		t.Fatalf("expected %d results, got %d", n, count)
+	}
+}
+
+func TestProofCheckFlightResetPurges(t *testing.T) {
+	pc := NewProofCache(nil, 10)
+	t0 := time.Now()
+
+	mine, _ := pc.CheckFlightBegin("k", t0, t0)
+	if err := pc.Reset(); err != nil {
+		t.Fatalf("Reset: %s", err)
+	}
+
+	mine2, theirs2 := pc.CheckFlightBegin("k", t0, t0)
+	if theirs2 != nil {
+		t.Fatal("Reset must drop in-flight entries")
+	}
+	if mine2 == nil || mine2 == mine {
+		t.Fatal("expected a fresh flight after Reset")
+	}
+	mine.finish(nil, nil, true)
 }
 
 func TestProofCheckFlightNotSharedWithLaterRequest(t *testing.T) {

--- a/go/libkb/proof_cache_flight_test.go
+++ b/go/libkb/proof_cache_flight_test.go
@@ -57,7 +57,7 @@ func TestProofCheckFlightZeroRequestedAtNeverShares(t *testing.T) {
 	}
 }
 
-func TestProofCheckFlightUnusableResultFallsThrough(t *testing.T) {
+func TestProofCheckFlightUnusableResultDropped(t *testing.T) {
 	pc := NewProofCache(nil, 10)
 	t0 := time.Now()
 
@@ -65,11 +65,25 @@ func TestProofCheckFlightUnusableResultFallsThrough(t *testing.T) {
 	// Owner was canceled, so its result can't stand in for anyone else.
 	mine.finish(nil, nil, false)
 
-	_, theirs := pc.CheckFlightBegin("k", t0, t0)
-	if theirs == nil {
-		t.Fatal("expected to find the flight")
+	// The dead flight is dropped so the next caller leads a fresh one...
+	mine2, theirs2 := pc.CheckFlightBegin("k", t0, t0)
+	if theirs2 != nil {
+		t.Fatal("must not share a finished unusable flight")
 	}
-	if _, _, usable := theirs.wait(context.Background()); usable {
-		t.Fatal("canceled result must not be usable")
+	if mine2 == nil {
+		t.Fatal("expected to own a new flight")
+	}
+
+	// ...which concurrent callers can then share.
+	_, theirs3 := pc.CheckFlightBegin("k", t0, t0)
+	if theirs3 != mine2 {
+		t.Fatal("expected to share the new flight")
+	}
+
+	hint := &SigHint{apiURL: "https://example.com/proof"}
+	go mine2.finish(hint, nil, true)
+	got, _, usable := theirs3.wait(context.Background())
+	if !usable || got != hint {
+		t.Fatalf("expected shared usable result, got usable=%v hint=%v", usable, got)
 	}
 }

--- a/go/teams/annotated_cache.go
+++ b/go/teams/annotated_cache.go
@@ -151,6 +151,9 @@ func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID
 			}()
 		}
 
+		// Age the entry from when the load started, not when it finished: the
+		// data describes the server state as of the request, so a slow loader
+		// must not buy the result extra TTL it has already spent being stale.
 		startedAt := mctx.G().Clock().Now()
 		res, err = loader(mctx.Ctx(), mctx.G(), teamID)
 

--- a/go/teams/annotated_cache.go
+++ b/go/teams/annotated_cache.go
@@ -1,0 +1,179 @@
+package teams
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// annotatedTeamCacheTTL bounds how stale a memoized AnnotatedTeam can be when no
+// invalidating event arrives. Every local mutation and every server-pushed team
+// change purges the entry (see NotifyRouter.HandleTeamChangedByID and
+// invalidateCaches), so this window only covers off-chain changes made elsewhere
+// that we were not notified about.
+const annotatedTeamCacheTTL = 10 * time.Second
+
+// maxAnnotatedTeamCacheWaits caps how many times a caller will wait on somebody
+// else's in-flight load before doing the load itself, so a pathological stream of
+// invalidations cannot livelock a request.
+const maxAnnotatedTeamCacheWaits = 3
+
+type annotatedTeamCacheEntry struct {
+	team     keybase1.AnnotatedTeam
+	cachedAt time.Time
+}
+
+// annotatedTeamCache memoizes GetAnnotatedTeam. GetAnnotatedTeam is expensive: a
+// force-repolled team load plus four separate server round trips (team/for_user,
+// team/get?showcase_only, team/access_requests, team/disable_tars), and the UI asks
+// for the same team many times while a team page is open. This cache both collapses
+// concurrent identical loads into one (single-flight) and serves a short-lived
+// memoized copy to sequential callers.
+type annotatedTeamCache struct {
+	sync.Mutex
+	entries map[keybase1.TeamID]annotatedTeamCacheEntry
+	// inflight[teamID] is closed when the current load for teamID finishes.
+	inflight map[keybase1.TeamID]chan struct{}
+	// gen[teamID] is bumped by Remove/Clear. A load that started before a bump does
+	// not get cached, since it may have read pre-change data.
+	gen map[keybase1.TeamID]uint64
+}
+
+var _ libkb.AnnotatedTeamCacher = (*annotatedTeamCache)(nil)
+
+func newAnnotatedTeamCache() *annotatedTeamCache {
+	return &annotatedTeamCache{
+		entries:  make(map[keybase1.TeamID]annotatedTeamCacheEntry),
+		inflight: make(map[keybase1.TeamID]chan struct{}),
+		gen:      make(map[keybase1.TeamID]uint64),
+	}
+}
+
+func (c *annotatedTeamCache) Get(mctx libkb.MetaContext, teamID keybase1.TeamID) (res keybase1.AnnotatedTeam, ok bool) {
+	c.Lock()
+	defer c.Unlock()
+	return c.getLocked(mctx, teamID)
+}
+
+func (c *annotatedTeamCache) getLocked(mctx libkb.MetaContext, teamID keybase1.TeamID) (res keybase1.AnnotatedTeam, ok bool) {
+	e, ok := c.entries[teamID]
+	if !ok {
+		return res, false
+	}
+	if mctx.G().Clock().Now().Sub(e.cachedAt) >= annotatedTeamCacheTTL {
+		delete(c.entries, teamID)
+		return res, false
+	}
+	return e.team, true
+}
+
+func (c *annotatedTeamCache) Put(mctx libkb.MetaContext, teamID keybase1.TeamID, team keybase1.AnnotatedTeam) {
+	c.Lock()
+	defer c.Unlock()
+	c.entries[teamID] = annotatedTeamCacheEntry{team: team, cachedAt: mctx.G().Clock().Now()}
+}
+
+func (c *annotatedTeamCache) Remove(teamID keybase1.TeamID) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.entries, teamID)
+	c.gen[teamID]++
+}
+
+func (c *annotatedTeamCache) Clear() {
+	c.Lock()
+	defer c.Unlock()
+	for teamID := range c.entries {
+		c.gen[teamID]++
+	}
+	for teamID := range c.inflight {
+		c.gen[teamID]++
+	}
+	c.entries = make(map[keybase1.TeamID]annotatedTeamCacheEntry)
+}
+
+func (c *annotatedTeamCache) OnLogout(mctx libkb.MetaContext) error {
+	c.Clear()
+	return nil
+}
+
+func (c *annotatedTeamCache) OnDbNuke(mctx libkb.MetaContext) error {
+	c.Clear()
+	return nil
+}
+
+type annotatedTeamLoader func(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (keybase1.AnnotatedTeam, error)
+
+// load returns a memoized AnnotatedTeam if we have a fresh one, waits for an
+// already-running load of the same team if there is one, and otherwise runs loader.
+func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID, loader annotatedTeamLoader) (res keybase1.AnnotatedTeam, err error) {
+	for waits := 0; ; waits++ {
+		c.Lock()
+		if cached, ok := c.getLocked(mctx, teamID); ok {
+			c.Unlock()
+			mctx.Debug("annotatedTeamCache: hit for %v", teamID)
+			return cached, nil
+		}
+		if ch, ok := c.inflight[teamID]; ok && waits < maxAnnotatedTeamCacheWaits {
+			c.Unlock()
+			mctx.Debug("annotatedTeamCache: waiting on in-flight load for %v", teamID)
+			select {
+			case <-ch:
+				continue
+			case <-mctx.Ctx().Done():
+				return res, mctx.Ctx().Err()
+			}
+		}
+		startedGen := c.gen[teamID]
+		ch := make(chan struct{})
+		hasLead := false
+		if _, ok := c.inflight[teamID]; !ok {
+			c.inflight[teamID] = ch
+			hasLead = true
+		}
+		c.Unlock()
+
+		// The leader must release its slot even if loader panics: the RPC
+		// handler recovers, but a populated inflight entry whose channel is
+		// never closed would make every later load of this team block until its
+		// ctx dies, for the life of the process. Deferred rather than inline for
+		// that reason; this path always returns below, so despite the enclosing
+		// loop it is registered at most once.
+		if hasLead {
+			defer func() {
+				c.Lock()
+				delete(c.inflight, teamID)
+				c.Unlock()
+				close(ch)
+			}()
+		}
+
+		startedAt := mctx.G().Clock().Now()
+		res, err = loader(mctx.Ctx(), mctx.G(), teamID)
+
+		c.Lock()
+		if err == nil && c.gen[teamID] == startedGen {
+			c.entries[teamID] = annotatedTeamCacheEntry{team: res, cachedAt: startedAt}
+		}
+		c.Unlock()
+		return res, err
+	}
+}
+
+func NewAnnotatedTeamCacheAndInstall(g *libkb.GlobalContext) {
+	cache := newAnnotatedTeamCache()
+	g.SetAnnotatedTeamCacher(cache)
+	g.AddLogoutHook(cache, "annotatedTeamCache")
+	g.AddDbNukeHook(cache, "annotatedTeamCache")
+}
+
+// ClearAnnotatedTeamCache drops the memoized AnnotatedTeam for a team, forcing the
+// next read to go to the server.
+func ClearAnnotatedTeamCache(g *libkb.GlobalContext, teamID keybase1.TeamID) {
+	if c := g.GetAnnotatedTeamCacher(); c != nil {
+		c.Remove(teamID)
+	}
+}

--- a/go/teams/annotated_cache.go
+++ b/go/teams/annotated_cache.go
@@ -111,30 +111,20 @@ type annotatedTeamLoader func(ctx context.Context, g *libkb.GlobalContext, teamI
 // already-running load of the same team if there is one, and otherwise runs loader.
 func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID, loader annotatedTeamLoader) (res keybase1.AnnotatedTeam, err error) {
 	for waits := 0; ; waits++ {
-		c.Lock()
-		if cached, ok := c.getLocked(mctx, teamID); ok {
-			c.Unlock()
+		cached, hit, wait, lead, startedGen := c.beginLoad(mctx, teamID, waits < maxAnnotatedTeamCacheWaits)
+		switch {
+		case hit:
 			mctx.Debug("annotatedTeamCache: hit for %v", teamID)
 			return cached, nil
-		}
-		if ch, ok := c.inflight[teamID]; ok && waits < maxAnnotatedTeamCacheWaits {
-			c.Unlock()
+		case wait != nil:
 			mctx.Debug("annotatedTeamCache: waiting on in-flight load for %v", teamID)
 			select {
-			case <-ch:
+			case <-wait:
 				continue
 			case <-mctx.Ctx().Done():
 				return res, mctx.Ctx().Err()
 			}
 		}
-		startedGen := c.gen[teamID]
-		ch := make(chan struct{})
-		hasLead := false
-		if _, ok := c.inflight[teamID]; !ok {
-			c.inflight[teamID] = ch
-			hasLead = true
-		}
-		c.Unlock()
 
 		// The leader must release its slot even if loader panics: the RPC
 		// handler recovers, but a populated inflight entry whose channel is
@@ -142,13 +132,8 @@ func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID
 		// ctx dies, for the life of the process. Deferred rather than inline for
 		// that reason; this path always returns below, so despite the enclosing
 		// loop it is registered at most once.
-		if hasLead {
-			defer func() {
-				c.Lock()
-				delete(c.inflight, teamID)
-				c.Unlock()
-				close(ch)
-			}()
+		if lead != nil {
+			defer c.endLoad(teamID, lead)
 		}
 
 		// Age the entry from when the load started, not when it finished: the
@@ -156,14 +141,57 @@ func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID
 		// must not buy the result extra TTL it has already spent being stale.
 		startedAt := mctx.G().Clock().Now()
 		res, err = loader(mctx.Ctx(), mctx.G(), teamID)
-
-		c.Lock()
-		if err == nil && c.gen[teamID] == startedGen {
-			c.entries[teamID] = annotatedTeamCacheEntry{team: res, cachedAt: startedAt}
+		if err == nil {
+			c.storeLoad(teamID, res, startedAt, startedGen)
 		}
-		c.Unlock()
 		return res, err
 	}
+}
+
+// beginLoad decides in one locked step what this caller does next: take a fresh
+// cached team (hit), block on somebody else's load (wait), or run the load - as
+// its leader if the slot was free (lead non-nil), otherwise alongside it.
+// startedGen pins the invalidation generation the load reads at.
+func (c *annotatedTeamCache) beginLoad(mctx libkb.MetaContext, teamID keybase1.TeamID, canWait bool) (
+	cached keybase1.AnnotatedTeam, hit bool, wait, lead chan struct{}, startedGen uint64,
+) {
+	c.Lock()
+	defer c.Unlock()
+	if cached, ok := c.getLocked(mctx, teamID); ok {
+		return cached, true, nil, nil, 0
+	}
+	if ch, ok := c.inflight[teamID]; ok {
+		if canWait {
+			return cached, false, ch, nil, 0
+		}
+		// Somebody is loading, but this caller has waited its share, so it goes
+		// ahead without claiming the slot.
+		return cached, false, nil, nil, c.gen[teamID]
+	}
+	ch := make(chan struct{})
+	c.inflight[teamID] = ch
+	return cached, false, nil, ch, c.gen[teamID]
+}
+
+// endLoad releases the leader's slot and wakes everyone waiting on it.
+func (c *annotatedTeamCache) endLoad(teamID keybase1.TeamID, lead chan struct{}) {
+	c.Lock()
+	delete(c.inflight, teamID)
+	c.Unlock()
+	close(lead)
+}
+
+// storeLoad memoizes a finished load, unless the team was invalidated while it
+// ran - that result may have read pre-change data.
+func (c *annotatedTeamCache) storeLoad(teamID keybase1.TeamID, team keybase1.AnnotatedTeam,
+	startedAt time.Time, startedGen uint64,
+) {
+	c.Lock()
+	defer c.Unlock()
+	if c.gen[teamID] != startedGen {
+		return
+	}
+	c.entries[teamID] = annotatedTeamCacheEntry{team: team, cachedAt: startedAt}
 }
 
 func NewAnnotatedTeamCacheAndInstall(g *libkb.GlobalContext) {

--- a/go/teams/annotated_cache.go
+++ b/go/teams/annotated_cache.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -12,14 +13,31 @@ import (
 // annotatedTeamCacheTTL bounds how stale a memoized AnnotatedTeam can be when no
 // invalidating event arrives. Every local mutation and every server-pushed team
 // change purges the entry (see NotifyRouter.HandleTeamChangedByID and
-// invalidateCaches), so this window only covers off-chain changes made elsewhere
-// that we were not notified about.
+// invalidateCaches), so this window covers what those do not tell us about:
+// member resets and deletions, username and full-name changes, and off-chain
+// changes made elsewhere. Those come from the UIDMapper and produce no team
+// sigchain change, so nothing invalidates on them.
 const annotatedTeamCacheTTL = 10 * time.Second
+
+// minAnnotatedTeamCacheLifetime is how long an entry is guaranteed to be usable
+// no matter how slow the load that produced it was. Entries age from when their
+// load started, and a load can take longer than the whole TTL -- GetAnnotatedTeam
+// fans out to several round trips, one of which budgets 10s by itself. Without a
+// floor those loads are cached already expired, so every waiter wakes to a miss
+// and reloads: the teams that most need memoizing would get none, and the cache
+// would amplify their cost instead.
+const minAnnotatedTeamCacheLifetime = annotatedTeamCacheTTL / 2
 
 // maxAnnotatedTeamCacheWaits caps how many times a caller will wait on somebody
 // else's in-flight load before doing the load itself, so a pathological stream of
 // invalidations cannot livelock a request.
 const maxAnnotatedTeamCacheWaits = 3
+
+// annotatedTeamCacheSize bounds resident entries. An AnnotatedTeam carries the
+// full member, invite and join-request lists, and entries are only dropped when
+// that same team is read again, so an unbounded map retains one per team ever
+// visited for the whole session.
+const annotatedTeamCacheSize = 50
 
 type annotatedTeamCacheEntry struct {
 	team     keybase1.AnnotatedTeam
@@ -34,19 +52,30 @@ type annotatedTeamCacheEntry struct {
 // memoized copy to sequential callers.
 type annotatedTeamCache struct {
 	sync.Mutex
-	entries map[keybase1.TeamID]annotatedTeamCacheEntry
+	entries *lru.Cache
 	// inflight[teamID] is closed when the current load for teamID finishes.
 	inflight map[keybase1.TeamID]chan struct{}
-	// gen[teamID] is bumped by Remove/Clear. A load that started before a bump does
-	// not get cached, since it may have read pre-change data.
+	// gen[teamID] is bumped by Remove. A load that started before a bump does not
+	// get cached, since it may have read pre-change data.
 	gen map[keybase1.TeamID]uint64
+	// epoch is bumped by Clear, which has no team to key on. Per-team gens cannot
+	// carry it: Clear can only walk the teams it can see, and a load whose team is
+	// in neither entries nor inflight -- one running alongside a leader that has
+	// already finished and errored -- would be missed and cache the old account's
+	// data. AnnotatedTeam is viewer-specific, so that matters.
+	epoch uint64
 }
 
 var _ libkb.AnnotatedTeamCacher = (*annotatedTeamCache)(nil)
 
 func newAnnotatedTeamCache() *annotatedTeamCache {
+	entries, err := lru.New(annotatedTeamCacheSize)
+	if err != nil {
+		// only returned for a non-positive size, which is a constant here
+		panic(err)
+	}
 	return &annotatedTeamCache{
-		entries:  make(map[keybase1.TeamID]annotatedTeamCacheEntry),
+		entries:  entries,
 		inflight: make(map[keybase1.TeamID]chan struct{}),
 		gen:      make(map[keybase1.TeamID]uint64),
 	}
@@ -59,40 +88,38 @@ func (c *annotatedTeamCache) Get(mctx libkb.MetaContext, teamID keybase1.TeamID)
 }
 
 func (c *annotatedTeamCache) getLocked(mctx libkb.MetaContext, teamID keybase1.TeamID) (res keybase1.AnnotatedTeam, ok bool) {
-	e, ok := c.entries[teamID]
+	tmp, ok := c.entries.Get(teamID)
 	if !ok {
 		return res, false
 	}
+	e, ok := tmp.(annotatedTeamCacheEntry)
+	if !ok {
+		c.entries.Remove(teamID)
+		return res, false
+	}
 	if mctx.G().Clock().Now().Sub(e.cachedAt) >= annotatedTeamCacheTTL {
-		delete(c.entries, teamID)
+		c.entries.Remove(teamID)
 		return res, false
 	}
 	return e.team, true
 }
 
-func (c *annotatedTeamCache) Put(mctx libkb.MetaContext, teamID keybase1.TeamID, team keybase1.AnnotatedTeam) {
-	c.Lock()
-	defer c.Unlock()
-	c.entries[teamID] = annotatedTeamCacheEntry{team: team, cachedAt: mctx.G().Clock().Now()}
-}
-
 func (c *annotatedTeamCache) Remove(teamID keybase1.TeamID) {
 	c.Lock()
 	defer c.Unlock()
-	delete(c.entries, teamID)
+	c.entries.Remove(teamID)
 	c.gen[teamID]++
 }
 
 func (c *annotatedTeamCache) Clear() {
 	c.Lock()
 	defer c.Unlock()
-	for teamID := range c.entries {
-		c.gen[teamID]++
-	}
-	for teamID := range c.inflight {
-		c.gen[teamID]++
-	}
-	c.entries = make(map[keybase1.TeamID]annotatedTeamCacheEntry)
+	c.epoch++
+	c.entries.Purge()
+	// gen only matters for loads that are still running, and the epoch bump above
+	// already invalidates every one of those. Dropping it here keeps the map from
+	// growing by one entry per team ever invalidated, for the life of the process.
+	c.gen = make(map[keybase1.TeamID]uint64)
 }
 
 func (c *annotatedTeamCache) OnLogout(mctx libkb.MetaContext) error {
@@ -111,7 +138,7 @@ type annotatedTeamLoader func(ctx context.Context, g *libkb.GlobalContext, teamI
 // already-running load of the same team if there is one, and otherwise runs loader.
 func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID, loader annotatedTeamLoader) (res keybase1.AnnotatedTeam, err error) {
 	for waits := 0; ; waits++ {
-		cached, hit, wait, lead, startedGen := c.beginLoad(mctx, teamID, waits < maxAnnotatedTeamCacheWaits)
+		cached, hit, wait, lead, startedGen, startedEpoch := c.beginLoad(mctx, teamID, waits < maxAnnotatedTeamCacheWaits)
 		switch {
 		case hit:
 			mctx.Debug("annotatedTeamCache: hit for %v", teamID)
@@ -139,10 +166,12 @@ func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID
 		// Age the entry from when the load started, not when it finished: the
 		// data describes the server state as of the request, so a slow loader
 		// must not buy the result extra TTL it has already spent being stale.
+		// storeLoad applies the floor that keeps a very slow load from being
+		// cached already expired.
 		startedAt := mctx.G().Clock().Now()
 		res, err = loader(mctx.Ctx(), mctx.G(), teamID)
 		if err == nil {
-			c.storeLoad(teamID, res, startedAt, startedGen)
+			c.storeLoad(mctx, teamID, res, startedAt, startedGen, startedEpoch)
 		}
 		return res, err
 	}
@@ -151,26 +180,26 @@ func (c *annotatedTeamCache) load(mctx libkb.MetaContext, teamID keybase1.TeamID
 // beginLoad decides in one locked step what this caller does next: take a fresh
 // cached team (hit), block on somebody else's load (wait), or run the load - as
 // its leader if the slot was free (lead non-nil), otherwise alongside it.
-// startedGen pins the invalidation generation the load reads at.
+// startedGen and startedEpoch pin the invalidation state the load reads at.
 func (c *annotatedTeamCache) beginLoad(mctx libkb.MetaContext, teamID keybase1.TeamID, canWait bool) (
-	cached keybase1.AnnotatedTeam, hit bool, wait, lead chan struct{}, startedGen uint64,
+	cached keybase1.AnnotatedTeam, hit bool, wait, lead chan struct{}, startedGen, startedEpoch uint64,
 ) {
 	c.Lock()
 	defer c.Unlock()
 	if cached, ok := c.getLocked(mctx, teamID); ok {
-		return cached, true, nil, nil, 0
+		return cached, true, nil, nil, 0, 0
 	}
 	if ch, ok := c.inflight[teamID]; ok {
 		if canWait {
-			return cached, false, ch, nil, 0
+			return cached, false, ch, nil, 0, 0
 		}
 		// Somebody is loading, but this caller has waited its share, so it goes
 		// ahead without claiming the slot.
-		return cached, false, nil, nil, c.gen[teamID]
+		return cached, false, nil, nil, c.gen[teamID], c.epoch
 	}
 	ch := make(chan struct{})
 	c.inflight[teamID] = ch
-	return cached, false, nil, ch, c.gen[teamID]
+	return cached, false, nil, ch, c.gen[teamID], c.epoch
 }
 
 // endLoad releases the leader's slot and wakes everyone waiting on it.
@@ -183,15 +212,28 @@ func (c *annotatedTeamCache) endLoad(teamID keybase1.TeamID, lead chan struct{})
 
 // storeLoad memoizes a finished load, unless the team was invalidated while it
 // ran - that result may have read pre-change data.
-func (c *annotatedTeamCache) storeLoad(teamID keybase1.TeamID, team keybase1.AnnotatedTeam,
-	startedAt time.Time, startedGen uint64,
+func (c *annotatedTeamCache) storeLoad(mctx libkb.MetaContext, teamID keybase1.TeamID,
+	team keybase1.AnnotatedTeam, startedAt time.Time, startedGen, startedEpoch uint64,
 ) {
 	c.Lock()
 	defer c.Unlock()
-	if c.gen[teamID] != startedGen {
+	if c.gen[teamID] != startedGen || c.epoch != startedEpoch {
 		return
 	}
-	c.entries[teamID] = annotatedTeamCacheEntry{team: team, cachedAt: startedAt}
+	// Two loads for the same team can run at once, because a caller that has used
+	// up its waits proceeds alongside the leader. They can finish in either order,
+	// so refuse to replace a newer result with an older one.
+	if tmp, ok := c.entries.Get(teamID); ok {
+		if e, ok := tmp.(annotatedTeamCacheEntry); ok && !startedAt.After(e.cachedAt) {
+			return
+		}
+	}
+	// A load slower than the TTL would otherwise be stored already expired, so
+	// give every entry a minimum usable lifetime.
+	if floor := mctx.G().Clock().Now().Add(-annotatedTeamCacheTTL + minAnnotatedTeamCacheLifetime); startedAt.Before(floor) {
+		startedAt = floor
+	}
+	c.entries.Add(teamID, annotatedTeamCacheEntry{team: team, cachedAt: startedAt})
 }
 
 func NewAnnotatedTeamCacheAndInstall(g *libkb.GlobalContext) {

--- a/go/teams/annotated_cache_test.go
+++ b/go/teams/annotated_cache_test.go
@@ -1,0 +1,147 @@
+package teams
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func annotatedCacheTestSetup(t *testing.T) (libkb.TestContext, libkb.MetaContext, *annotatedTeamCache, clockwork.FakeClock) {
+	tc := SetupTest(t, "annotated_cache", 1)
+	clock := clockwork.NewFakeClock()
+	tc.G.SetClock(clock)
+	cache, ok := tc.G.GetAnnotatedTeamCacher().(*annotatedTeamCache)
+	require.True(t, ok, "ServiceInit should install an annotatedTeamCache")
+	return tc, libkb.NewMetaContextForTest(tc), cache, clock
+}
+
+func TestAnnotatedTeamCacheReusesWithinTTL(t *testing.T) {
+	tc, mctx, cache, clock := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("aaa")
+	var calls int32
+	loader := func(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.AnnotatedTeam, error) {
+		atomic.AddInt32(&calls, 1)
+		return keybase1.AnnotatedTeam{TeamID: id, Name: "team.one"}, nil
+	}
+
+	for i := 0; i < 5; i++ {
+		res, err := cache.load(mctx, teamID, loader)
+		require.NoError(t, err)
+		require.Equal(t, "team.one", res.Name)
+	}
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls))
+
+	clock.Advance(annotatedTeamCacheTTL + 1)
+	_, err := cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}
+
+func TestAnnotatedTeamCacheInvalidation(t *testing.T) {
+	tc, mctx, cache, _ := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("bbb")
+	var calls int32
+	loader := func(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.AnnotatedTeam, error) {
+		atomic.AddInt32(&calls, 1)
+		return keybase1.AnnotatedTeam{TeamID: id}, nil
+	}
+
+	_, err := cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	cache.Remove(teamID)
+	_, err = cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, atomic.LoadInt32(&calls))
+
+	cache.Clear()
+	_, err = cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, atomic.LoadInt32(&calls))
+}
+
+// A load that was in flight when the team changed must not be cached, or we would
+// serve pre-change data for the whole TTL.
+func TestAnnotatedTeamCacheDropsRacedLoad(t *testing.T) {
+	tc, mctx, cache, _ := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("ccc")
+	var calls int32
+	loader := func(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.AnnotatedTeam, error) {
+		atomic.AddInt32(&calls, 1)
+		cache.Remove(teamID)
+		return keybase1.AnnotatedTeam{TeamID: id}, nil
+	}
+
+	_, err := cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	_, ok := cache.Get(mctx, teamID)
+	require.False(t, ok, "a load raced by an invalidation should not be cached")
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls))
+}
+
+func TestAnnotatedTeamCacheSingleFlight(t *testing.T) {
+	tc, mctx, cache, _ := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("ddd")
+	var calls int32
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	loader := func(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.AnnotatedTeam, error) {
+		atomic.AddInt32(&calls, 1)
+		entered <- struct{}{}
+		<-release
+		return keybase1.AnnotatedTeam{TeamID: id, Name: "team.four"}, nil
+	}
+
+	var wg sync.WaitGroup
+	results := make([]keybase1.AnnotatedTeam, 8)
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			res, err := cache.load(mctx, teamID, loader)
+			require.NoError(t, err)
+			results[i] = res
+		}(i)
+	}
+	<-entered
+	close(release)
+	wg.Wait()
+
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls))
+	for _, res := range results {
+		require.Equal(t, "team.four", res.Name)
+	}
+}
+
+func TestAnnotatedTeamCacheDoesNotCacheErrors(t *testing.T) {
+	tc, mctx, cache, _ := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("eee")
+	var calls int32
+	loadErr := errors.New("nope")
+	loader := func(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.AnnotatedTeam, error) {
+		atomic.AddInt32(&calls, 1)
+		return keybase1.AnnotatedTeam{}, loadErr
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err := cache.load(mctx, teamID, loader)
+		require.ErrorIs(t, err, loadErr)
+	}
+	require.EqualValues(t, 3, atomic.LoadInt32(&calls))
+}

--- a/go/teams/annotated_cache_test.go
+++ b/go/teams/annotated_cache_test.go
@@ -3,9 +3,11 @@ package teams
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -108,23 +110,146 @@ func TestAnnotatedTeamCacheSingleFlight(t *testing.T) {
 
 	var wg sync.WaitGroup
 	results := make([]keybase1.AnnotatedTeam, 8)
+	errs := make(chan error, len(results))
+	// Hold every caller until the leader is inside the loader, so they cannot
+	// serialize and take plain TTL hits instead - that would let this pass with
+	// in-flight coalescing deleted entirely. require/assert are not used off the
+	// test goroutine: testify's FailNow calls runtime.Goexit there, which skips
+	// wg.Done and hangs the test instead of reporting it.
+	start := make(chan struct{})
 	for i := range results {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
+			<-start
 			res, err := cache.load(mctx, teamID, loader)
-			require.NoError(t, err)
+			if err != nil {
+				errs <- err
+				return
+			}
 			results[i] = res
 		}(i)
 	}
+	// The leader has to be in the loader before the rest are let go, so run it
+	// first and only then release them onto the in-flight slot.
+	go func() { close(start) }()
 	<-entered
+	// Everyone still to arrive now finds a populated inflight entry and waits.
+	require.Eventually(t, func() bool {
+		cache.Lock()
+		defer cache.Unlock()
+		_, ok := cache.inflight[teamID]
+		return ok
+	}, time.Second, time.Millisecond, "expected an in-flight slot for the leader")
 	close(release)
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 
 	require.EqualValues(t, 1, atomic.LoadInt32(&calls))
 	for _, res := range results {
 		require.Equal(t, "team.four", res.Name)
 	}
+}
+
+// A load slower than the TTL is stored already expired unless storeLoad floors
+// its age, which turns the cache into pure overhead for exactly the teams whose
+// loads are slow enough to be worth memoizing.
+func TestAnnotatedTeamCacheSlowLoadIsStillUsable(t *testing.T) {
+	tc, mctx, cache, clock := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("slow")
+	var calls int32
+	loader := func(ctx context.Context, g *libkb.GlobalContext, id keybase1.TeamID) (keybase1.AnnotatedTeam, error) {
+		atomic.AddInt32(&calls, 1)
+		// the load itself takes longer than the whole TTL
+		clock.Advance(annotatedTeamCacheTTL * 2)
+		return keybase1.AnnotatedTeam{TeamID: id, Name: "team.slow"}, nil
+	}
+
+	res, err := cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	require.Equal(t, "team.slow", res.Name)
+
+	res, err = cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	require.Equal(t, "team.slow", res.Name)
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls), "a slow load must still be cached")
+
+	// It gets the floor, not a full fresh TTL.
+	clock.Advance(minAnnotatedTeamCacheLifetime + 1)
+	_, err = cache.load(mctx, teamID, loader)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}
+
+// Clear has no team to key on, so a load whose team is in neither entries nor
+// inflight - one running alongside a leader that already finished - is invisible
+// to a per-team generation bump.
+func TestAnnotatedTeamCacheClearDropsUntrackedLoad(t *testing.T) {
+	tc, mctx, cache, clock := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("untracked")
+
+	// A leader claims the slot.
+	_, _, _, lead, _, _ := cache.beginLoad(mctx, teamID, true)
+	require.NotNil(t, lead)
+
+	// A caller out of waits proceeds alongside it.
+	_, _, wait, alsoLead, gen, epoch := cache.beginLoad(mctx, teamID, false)
+	require.Nil(t, wait)
+	require.Nil(t, alsoLead)
+
+	// The leader errors, so it releases the slot and caches nothing. The team is
+	// now in neither entries nor inflight.
+	cache.endLoad(teamID, lead)
+
+	cache.Clear()
+
+	// The straggler finishes with data read before the Clear.
+	cache.storeLoad(mctx, teamID, keybase1.AnnotatedTeam{TeamID: teamID, Name: "stale.team"},
+		clock.Now(), gen, epoch)
+
+	_, ok := cache.Get(mctx, teamID)
+	require.False(t, ok, "a load that started before Clear must not be cached after it")
+}
+
+func TestAnnotatedTeamCacheDoesNotRegressToOlderResult(t *testing.T) {
+	tc, mctx, cache, clock := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	teamID := keybase1.TeamID("ordering")
+	older := clock.Now()
+	newer := older.Add(time.Second)
+
+	cache.storeLoad(mctx, teamID, keybase1.AnnotatedTeam{TeamID: teamID, Name: "newer"}, newer, 0, 0)
+	// An older load that started first but finished last must not win.
+	cache.storeLoad(mctx, teamID, keybase1.AnnotatedTeam{TeamID: teamID, Name: "older"}, older, 0, 0)
+
+	res, ok := cache.Get(mctx, teamID)
+	require.True(t, ok)
+	require.Equal(t, "newer", res.Name)
+}
+
+func TestAnnotatedTeamCacheBoundsResidentEntries(t *testing.T) {
+	tc, mctx, cache, clock := annotatedCacheTestSetup(t)
+	defer tc.Cleanup()
+
+	for i := 0; i < annotatedTeamCacheSize*2; i++ {
+		teamID := keybase1.TeamID(fmt.Sprintf("team%d", i))
+		cache.storeLoad(mctx, teamID, keybase1.AnnotatedTeam{TeamID: teamID}, clock.Now(), 0, 0)
+	}
+	require.Equal(t, annotatedTeamCacheSize, cache.entries.Len())
+
+	// The oldest are the ones dropped.
+	_, ok := cache.Get(mctx, keybase1.TeamID("team0"))
+	require.False(t, ok)
+	_, ok = cache.Get(mctx, keybase1.TeamID(fmt.Sprintf("team%d", annotatedTeamCacheSize*2-1)))
+	require.True(t, ok)
 }
 
 func TestAnnotatedTeamCacheDoesNotCacheErrors(t *testing.T) {

--- a/go/teams/handler.go
+++ b/go/teams/handler.go
@@ -241,6 +241,7 @@ func invalidateCaches(mctx libkb.MetaContext, teamID keybase1.TeamID) {
 	// refresh the KBFS Favorites cache since it no longer should contain
 	// this team.
 	mctx.G().NotifyRouter.HandleFavoritesChanged(mctx.G().GetMyUID())
+	ClearAnnotatedTeamCache(mctx.G(), teamID)
 	if ekLib := mctx.G().GetEKLib(); ekLib != nil {
 		ekLib.PurgeTeamEKCachesForTeamID(mctx, teamID)
 		ekLib.PurgeTeambotEKCachesForTeamID(mctx, teamID)
@@ -308,6 +309,10 @@ func HandleChangeNotification(ctx context.Context, g *libkb.GlobalContext, rows 
 
 func HandleTeamMemberShowcaseChange(ctx context.Context, g *libkb.GlobalContext) (err error) {
 	defer g.CTrace(ctx, "HandleTeamMemberShowcaseChange", &err)()
+	// The notification does not say which team changed, so drop everything.
+	if c := g.GetAnnotatedTeamCacher(); c != nil {
+		c.Clear()
+	}
 	g.NotifyRouter.HandleTeamMetadataUpdate(ctx)
 	return nil
 }
@@ -518,6 +523,10 @@ func assertCanAcceptKeybaseInvite(ctx context.Context, g *libkb.GlobalContext, u
 func HandleOpenTeamAccessRequest(ctx context.Context, g *libkb.GlobalContext, msg keybase1.TeamOpenReqMsg) (err error) {
 	ctx = libkb.WithLogTag(ctx, "CLKR")
 	defer g.CTrace(ctx, "HandleOpenTeamAccessRequest", &err)()
+
+	// Access requests are off-chain, so a membership change is not guaranteed to
+	// follow; drop the memoized team so the UI picks up the new request list.
+	ClearAnnotatedTeamCache(g, msg.TeamID)
 
 	return RetryIfPossible(ctx, g, func(ctx context.Context, _ int) error {
 		team, err := Load(ctx, g, keybase1.LoadTeamArg{

--- a/go/teams/init.go
+++ b/go/teams/init.go
@@ -12,6 +12,7 @@ func ServiceInit(g *libkb.GlobalContext) {
 	NewBoxAuditorAndInstall(g)
 	NewImplicitTeamConflictInfoCacheAndInstall(g)
 	NewImplicitTeamCacheAndInstall(g)
+	NewAnnotatedTeamCacheAndInstall(g)
 	hidden.NewChainManagerAndInstall(g)
 	NewTeamRoleMapManagerAndInstall(g)
 }

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -34,9 +34,21 @@ func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id
 // GetAnnotatedTeam bundles up various data, both on and off chain, about a specific team for
 // consumption by the UI. In particular, it supplies almost all of the information on a team's
 // subpage in the Teams tab.
-// It always repolls to ensure latest version of a team, but member infos (username, full name, if
-// they reset or not) are subject to UIDMapper caching.
+//
+// The result is memoized (see annotated_cache.go): concurrent requests for the same team share
+// one load, and repeat requests inside a short window reuse the previous result. Any team change
+// we hear about, local or server-pushed, invalidates the entry.
 func GetAnnotatedTeam(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (res keybase1.AnnotatedTeam, err error) {
+	cache, _ := g.GetAnnotatedTeamCacher().(*annotatedTeamCache)
+	if cache == nil {
+		return loadAnnotatedTeam(ctx, g, teamID)
+	}
+	return cache.load(libkb.NewMetaContext(ctx, g), teamID, loadAnnotatedTeam)
+}
+
+// loadAnnotatedTeam always repolls to ensure latest version of a team, but member infos
+// (username, full name, if they reset or not) are subject to UIDMapper caching.
+func loadAnnotatedTeam(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (res keybase1.AnnotatedTeam, err error) {
 	tracer := g.CTimeTracer(ctx, "GetAnnotatedTeam", true)
 	defer tracer.Finish()
 

--- a/go/teams/service_helper.go
+++ b/go/teams/service_helper.go
@@ -37,10 +37,16 @@ func LoadTeamPlusApplicationKeys(ctx context.Context, g *libkb.GlobalContext, id
 //
 // The result is memoized (see annotated_cache.go): concurrent requests for the same team share
 // one load, and repeat requests inside a short window reuse the previous result. Any team change
-// we hear about, local or server-pushed, invalidates the entry.
+// we hear about, local or server-pushed, invalidates the entry. A caller that has already waited
+// on several loads of the same team stops waiting and loads alongside them, so "share one load"
+// holds for the common case rather than universally.
 func GetAnnotatedTeam(ctx context.Context, g *libkb.GlobalContext, teamID keybase1.TeamID) (res keybase1.AnnotatedTeam, err error) {
+	// Reaches past the interface for the unexported load. Anything else installed
+	// as the cacher would silently stop memoizing while NotifyRouter kept calling
+	// Remove on it, so say so rather than quietly halving the feature.
 	cache, _ := g.GetAnnotatedTeamCacher().(*annotatedTeamCache)
 	if cache == nil {
+		g.Log.CDebugf(ctx, "GetAnnotatedTeam: no annotatedTeamCache installed, loading uncached")
 		return loadAnnotatedTeam(ctx, g, teamID)
 	}
 	return cache.load(libkb.NewMetaContext(ctx, g), teamID, loadAnnotatedTeam)

--- a/go/uidmap/uidmap.go
+++ b/go/uidmap/uidmap.go
@@ -139,6 +139,7 @@ func (u *UIDMap) findFullNameLocally(ctx context.Context, g libkb.UIDMapperConte
 	}
 
 	u.fullNameCache.Add(uid, tmp)
+	ret = &tmp
 	return ret, foundOnDisk
 }
 


### PR DESCRIPTION
**Stacked on #29466** — review that one first; this diff is `go/` only and is empty of JS. The two are independent (no `protocol/` change, so no generated-type coupling), but the base carries a defensive UI fix that the index rebuild here is what actually triggers, so it should land first.

Service-side half of the RPC-flood work. Most of it is the chat search index, which turned out to be corrupting itself rather than merely being noisy.

## The search index

Chasing a `GetMessages` flood — 14,621 single-message calls in one run — led into the indexer, and the flood was a symptom.

`reindexConv` paged over a conv's raw min..max message range rather than over the ids actually missing, so every pass re-fetched everything already indexed (measured at 57,648 already-seen messages re-added in a single pass) while never reaching the top of a large conv, because each pass restarts at the lowest missing id and stops once the inbox-wide budget is spent. And a conv can never reach `numMissing` 0 while ids the server will never return (deleted, or never delivered) keep counting as missing, so `SelectiveSync` re-queued it every interval forever: **~1800 remote `getMessages` every 5 minutes on an idle desktop client**, with `numMissing` byte-identical across 7 consecutive cycles.

Fixing that exposed a worse class of bug underneath. Several paths could publish "these messages are indexed" without the tokens that make them findable ever reaching disk — writes evicted from the cache before a flush, a flush that failed partway, `Remove` writing metadata ahead of its pending tokens, `Add` marking a message before indexing it, deletes racing the flush's write-outside-the-lock window, and a storage op whose callback reported success when the op had failed or never run at all. Each leaves a conv reading as fully indexed with messages no search will ever return, and **nothing revisits a conv that reads as complete**. Every one is covered by a test that fails against the pre-fix code.

Because such a conv cannot repair itself, the index has to be dropped once on upgrade. `indexMetadataVersion` goes 3 → 4 to do that. Bumping `indexVersion` instead — the obvious move — would have taken the token and alias entries with it and left inbox search returning nothing until the rebuild finished, which on a large inbox is hours of a working feature simply being gone. The damage is confined to the metadata, so only the metadata is dropped: every conv re-indexes onto the token entries already on disk and search keeps working throughout.

Two things survive that a full rebuild would have cleared: alias refcounts, already inflated by the old re-indexing loop and inflated further by the re-add, and token entries naming since-deleted messages, which are filtered when a search resolves them and so cost a lookup rather than a wrong result.

Also here: a bounded backoff for convs that genuinely cannot converge (rather than suppressing them outright, since "numMissing did not move" is strong evidence but not proof), and `maxDirtyEntries` raised 1000 → 20000 after it turned out to sit below the ~2600 entries one 300-message page produces and had become "flush after every batch".

## Everything else

- **`getAnnotatedTeam` memoized** — the mostly off-chain bundle behind the team page was rebuilt on every read: 469 team loads at 292ms each, 186 seconds in one run. Invalidation hangs off the `teamChangedByID` notification that already exists.
- **Concurrent proof checks shared** — several surfaces identify the same user at once and each sent its own request to the third-party service, which rate limits; a throttled fetch shows up to the user as a broken proof. Shares work, never results: a check is eligible only if it began at or after the caller's `requestedAt`.
- **Per-item cost hoisted out of three loops** — a gregor state read per emoji, the indexer's superseded fetches batched, conversation participants served from a five-minute cache.

## Verification

`go build ./...`, `go vet`, and `chat/search` under `-race` (8 consecutive runs clean). The `teams` `TestAudit*` / `TestBoxAudit*` failures reproduce identically on `master` — they need a live server.

Validated live against a service built from this checkout, driven by the desktop e2e suite (324k log lines):

- **Index converges** — `mkbot#` went 56,661 → 29,961 missing in one pass, ~26.7k messages indexed. Zero `store.Add` failures, zero dropped ops, zero stall backoffs.
- **Search survives the rebuild** — real message hits returned while the index reported `Indexing: 10%`. Under an `indexVersion` bump that would have been nothing but conversation-name matches.
- **Flush cadence** — 10 flushes at a 30.0s median gap, against 65 flushes in 2.9s (0.04s median) before.
- **`refreshParticipantsRemote`** — 190 in a window whose baseline was 1498–2568.

Five warnings in 324k lines, all benign (one startup firehose, four app-disconnect EOFs). No errors, no panics.
