### PR TITLE
fix(avatar): restore nameless team placeholder, align team border radius

### DIFF
--- a/shared/common-adapters/avatar/avatar.css
+++ b/shared/common-adapters/avatar/avatar.css
@@ -15,76 +15,85 @@
   contain: layout style paint;
 }
 
-/* Outer container sizes - no border-radius so follow icons aren't clipped */
+/* Outer container sizes - no border-radius so follow icons aren't clipped.
+   --team-radius is inherited by the inner clip and the team border overlay so they
+   always round identically. */
 .avatar.avatar-team-size-128,
 .avatar.avatar-user-size-128 {
   width: 128px;
   height: 128px;
+  --team-radius: 16px;
 }
 .avatar.avatar-team-size-16,
 .avatar.avatar-user-size-16 {
   width: 16px;
   height: 16px;
+  --team-radius: 4px;
 }
 .avatar.avatar-team-size-24,
 .avatar.avatar-user-size-24 {
   width: 24px;
   height: 24px;
+  --team-radius: 6px;
 }
 .avatar.avatar-team-size-32,
 .avatar.avatar-user-size-32 {
   width: 32px;
   height: 32px;
+  --team-radius: 6px;
 }
 .avatar.avatar-team-size-48,
 .avatar.avatar-user-size-48 {
   width: 48px;
   height: 48px;
+  --team-radius: 8px;
 }
 .avatar.avatar-team-size-64,
 .avatar.avatar-user-size-64 {
   width: 64px;
   height: 64px;
+  --team-radius: 10px;
 }
 .avatar.avatar-team-size-96,
 .avatar.avatar-user-size-96 {
   width: 96px;
   height: 96px;
+  --team-radius: 12px;
 }
 
 /* Inner wrapper sizes with border-radius for clipping */
 .avatar-inner.avatar-team-size-128 {
-  border-radius: 16px;
+  border-radius: var(--team-radius);
   width: 128px;
   height: 128px;
 }
 .avatar-inner.avatar-team-size-16 {
-  border-radius: 4px;
+  border-radius: var(--team-radius);
   width: 16px;
   height: 16px;
 }
 .avatar-inner.avatar-team-size-24 {
-  border-radius: 6px;
+  border-radius: var(--team-radius);
   width: 24px;
   height: 24px;
 }
 .avatar-inner.avatar-team-size-32 {
-  border-radius: 6px;
+  border-radius: var(--team-radius);
   width: 32px;
   height: 32px;
 }
 .avatar-inner.avatar-team-size-48 {
-  border-radius: 8px;
+  border-radius: var(--team-radius);
   width: 48px;
   height: 48px;
 }
 .avatar-inner.avatar-team-size-64 {
-  border-radius: 10px;
+  border-radius: var(--team-radius);
   width: 64px;
   height: 64px;
 }
 .avatar-inner.avatar-team-size-96 {
-  border-radius: 12px;
+  border-radius: var(--team-radius);
   width: 96px;
   height: 96px;
 }
@@ -142,7 +151,7 @@
 
 
 .avatar-border-team {
-  border-radius: 8px;
+  border-radius: var(--team-radius, 8px);
   background: rgba(0, 0, 0, 0);
   flex-shrink: 0;
   position: absolute;

--- a/shared/common-adapters/avatar/index.tsx
+++ b/shared/common-adapters/avatar/index.tsx
@@ -22,6 +22,9 @@ type Props = {
   onLoad?: () => void
   testID?: string
   size: 128 | 96 | 64 | 48 | 32 | 24 | 16
+  // for callsites that will never have a name (e.g. the 'create a team' button); without it
+  // a nameless team avatar holds a blank box forever waiting for a teamname that never comes
+  showPlaceholder?: boolean
   style?: Styles.CustomStyles<'borderStyle'>
   teamname?: string
   username?: string
@@ -160,6 +163,7 @@ const borderTeamStyle = {
 
 function Avatar(p: Props) {
   const {size, teamname, username, isTeam: _isTeam, onClick: _onClick, style, children, testID} = p
+  const {showPlaceholder} = p
   const {imageOverrideUrl, crop} = p
   const isTeam = _isTeam || !!teamname
   const name = isTeam ? teamname : username
@@ -271,7 +275,7 @@ function Avatar(p: Props) {
             }}
           />
         </>
-      ) : name || !isTeam ? (
+      ) : name || !isTeam || showPlaceholder ? (
         // with a name the placeholder type is known correct; with no name at all, team
         // callsites pass isTeam so anything else is a user (e.g. signup's empty avatar)
         <Image source={placeholderSource} style={cached.image} />

--- a/shared/teams/main/index.tsx
+++ b/shared/teams/main/index.tsx
@@ -31,7 +31,7 @@ const TeamBigButtons = (props: {onCreateTeam: () => void; onJoinTeam: () => void
     >
       <Kb.Text type="BodyBig">Create a team</Kb.Text>
       <Kb.Box2 direction="vertical" relative={true}>
-        <Kb.Avatar isTeam={true} size={96} />
+        <Kb.Avatar isTeam={true} size={96} showPlaceholder={true} />
         <Kb.Icon type="iconfont-add-solid" sizeType="Default" style={styles.teamPlus} />
       </Kb.Box2>
     </Kb.ClickableBox>


### PR DESCRIPTION
Follow-up to #29440.

**Nameless team avatars went blank on mobile.** That PR made mobile `Avatar` hold a blank sized box when there is no source yet, so the placeholder only shows on a real load failure. That's right for the team page (teamname arrives a beat later), but the teams list "Create a team" button renders `<Kb.Avatar isTeam={true} size={96} />` with no name at all — it waited forever and showed an empty grey square.

Added an explicit `showPlaceholder` prop for callsites that will never have a name, and set it on that button. Every other `isTeam` callsite in the app passes a `teamname`, so the loading-hold behavior is unchanged.

**Desktop team border radius.** `.avatar-border-team` hardcoded `border-radius: 8px` while the inner clip varies 4–16px by size, so at 96 the outline corners didn't match the fill corners. Both now read a `--team-radius` custom property set on the size class.

Known and deliberately left alone: native `sizeToTeamBorderRadius` is ~2px squarer than the CSS values at most sizes, and the team placeholder PNGs are circle rings inside a rounded-square frame.

`yarn lint` and `yarn tsc` clean.