### PR TITLE
fix(chat): stop giphy popup from flashing narrow before it fills

### DIFF
--- a/shared/chat/conversation/giphy/index.tsx
+++ b/shared/chat/conversation/giphy/index.tsx
@@ -39,7 +39,7 @@ const DesktopGiphySearch = () => {
     )
   }
   return (
-    <Kb.Box2 direction="vertical" relative={true} style={styles.outerContainer}>
+    <Kb.Box2 direction="vertical" alignSelf="stretch" relative={true} style={styles.outerContainer}>
       <Kb.Box2
         direction="vertical"
         ref={divRef as React.RefObject<DivRef>}


### PR DESCRIPTION
## Problem

On Electron, the giphy popup briefly rendered as a small centered box, then expanded to full width once the GIF results loaded.

## Cause

`Box2` applies `align-self: center` when neither `fullWidth` nor `fullHeight` is set (`common-adapters/box.tsx:204` → `.box2_centered`). The giphy outer container set neither, so it shrink-wrapped its content — the loading/empty state was narrow, and it only widened as previews arrived.

## Fix

Stretch the outer container. `alignSelf="stretch"` rather than `fullWidth` because the container carries `marginH: small`, and `width: 100%` on top of those margins would overflow.