### PR TITLE
perf(identify): singleflight concurrent remote proof checks

### DIFF
--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1093,6 +1094,101 @@ func TestNoSelfHostedIdentifyInPassiveMode(t *testing.T) {
 	// Alice ID's Eve, in chat mode, with a track. Assert that we get an
 	// Active proof checker mode for rooter.
 	runTest(keybase1.TLFIdentifyBehavior_CHAT_GUI, true, true, libkb.ProofCheckerModeActive)
+}
+
+func testForcedIdentifyReusesProofCheckedAfterRequest(t *testing.T, checkErr libkb.ProofError) {
+	tc := SetupEngineTest(t, "id")
+	defer tc.Cleanup()
+
+	eve := CreateAndSignupFakeUser(tc, "e")
+	_, _, err := proveRooter(tc.G, eve, libkb.GetDefaultSigVersion(tc.G))
+	require.NoError(t, err)
+	Logout(tc)
+	_ = CreateAndSignupFakeUser(tc, "a")
+
+	tc.G.ProofCache.DisableDisk()
+	require.NoError(t, tc.G.ProofCache.Reset())
+
+	tester := newIdentify2WithUIDTester(tc.G)
+	tc.G.SetProofServices(tester)
+
+	var checks int64
+	firstCheckStarted := make(chan struct{})
+	releaseFirstCheck := make(chan struct{})
+	tester.checkStatusHook = func(libkb.SigHint, libkb.ProofCheckerMode) libkb.ProofError {
+		if atomic.AddInt64(&checks, 1) == 1 {
+			close(firstCheckStarted)
+			<-releaseFirstCheck
+		}
+		return checkErr
+	}
+
+	newEngine := func() *Identify2WithUID {
+		return NewIdentify2WithUID(tc.G, &keybase1.Identify2Arg{
+			Uid:              eve.UID(),
+			ForceRemoteCheck: true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
+			NeedProofSet:     true,
+		})
+	}
+	run := func(eng *Identify2WithUID) <-chan error {
+		resultCh := make(chan error, 1)
+		go func() {
+			resultCh <- eng.runReturnError(identify2MetaContext(tc, &FakeIdentifyUI{}))
+		}()
+		return resultCh
+	}
+
+	first := newEngine()
+	first.requestedAt = tc.G.Clock().Now()
+	firstResult := run(first)
+	select {
+	case <-firstCheckStarted:
+	case <-time.After(10 * time.Second):
+		close(releaseFirstCheck)
+		t.Fatal("first proof check did not start")
+	}
+
+	// The second request arrives while the first owns the per-UID identify lock.
+	// Its proof check will run only after the first identify completes.
+	second := newEngine()
+	second.requestedAt = tc.G.Clock().Now()
+	secondResult := run(second)
+	close(releaseFirstCheck)
+
+	require.NoError(t, <-firstResult)
+	require.NoError(t, <-secondResult)
+	require.Equal(t, int64(1), atomic.LoadInt64(&checks))
+
+	// A request made after the shared result was produced still forces a new
+	// remote check.
+	third := newEngine()
+	third.requestedAt = tc.G.Clock().Now()
+	require.NoError(t, <-run(third))
+	require.Equal(t, int64(2), atomic.LoadInt64(&checks))
+}
+
+func TestForcedIdentifyReusesProofCheckedAfterRequest(t *testing.T) {
+	testForcedIdentifyReusesProofCheckedAfterRequest(t, nil)
+}
+
+func TestForcedIdentifyReusesSoftFailureCheckedAfterRequest(t *testing.T) {
+	testForcedIdentifyReusesProofCheckedAfterRequest(
+		t, libkb.NewProofError(keybase1.ProofStatus_HTTP_500, "temporary failure"))
+}
+
+func TestResolveThenIdentify2RecordsRequestBeforeResolution(t *testing.T) {
+	tc := SetupEngineTest(t, "id")
+	defer tc.Cleanup()
+
+	requestedAt := time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+	tc.G.SetClock(clockwork.NewFakeClockAt(requestedAt))
+	arg := keybase1.Identify2Arg{UserAssertion: "("}
+	eng := NewResolveThenIdentify2(tc.G, &arg)
+
+	require.Error(t, eng.Run(NewMetaContextForTest(tc)))
+	require.NotNil(t, eng.i2eng)
+	require.Equal(t, requestedAt, eng.i2eng.requestedAt)
 }
 
 func TestSkipExternalChecks(t *testing.T) {

--- a/go/engine/identify2_test.go
+++ b/go/engine/identify2_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1093,6 +1094,110 @@ func TestNoSelfHostedIdentifyInPassiveMode(t *testing.T) {
 	// Alice ID's Eve, in chat mode, with a track. Assert that we get an
 	// Active proof checker mode for rooter.
 	runTest(keybase1.TLFIdentifyBehavior_CHAT_GUI, true, true, libkb.ProofCheckerModeActive)
+}
+
+func testForcedIdentifyReusesProofCheckedAfterRequest(t *testing.T, checkErr libkb.ProofError) {
+	tc := SetupEngineTest(t, "id")
+	defer tc.Cleanup()
+
+	eve := CreateAndSignupFakeUser(tc, "e")
+	_, _, err := proveRooter(tc.G, eve, libkb.GetDefaultSigVersion(tc.G))
+	require.NoError(t, err)
+	Logout(tc)
+	_ = CreateAndSignupFakeUser(tc, "a")
+
+	tc.G.ProofCache.DisableDisk()
+	require.NoError(t, tc.G.ProofCache.Reset())
+
+	// Use a fake clock to avoid system clock granularity issues on Windows
+	// where time.Now() can have ~15ms resolution, causing T1 == T2.
+	fakeClock := clockwork.NewFakeClock()
+	tc.G.SetClock(fakeClock)
+
+	tester := newIdentify2WithUIDTester(tc.G)
+	tc.G.SetProofServices(tester)
+
+	var checks int64
+	firstCheckStarted := make(chan struct{})
+	releaseFirstCheck := make(chan struct{})
+	tester.checkStatusHook = func(libkb.SigHint, libkb.ProofCheckerMode) libkb.ProofError {
+		if atomic.AddInt64(&checks, 1) == 1 {
+			close(firstCheckStarted)
+			<-releaseFirstCheck
+		}
+		// Advance clock when check completes to ensure cache timestamp > requestedAt
+		fakeClock.Advance(time.Millisecond)
+		return checkErr
+	}
+
+	newEngine := func() *Identify2WithUID {
+		return NewIdentify2WithUID(tc.G, &keybase1.Identify2Arg{
+			Uid:              eve.UID(),
+			ForceRemoteCheck: true,
+			IdentifyBehavior: keybase1.TLFIdentifyBehavior_CLI,
+			NeedProofSet:     true,
+		})
+	}
+	run := func(eng *Identify2WithUID) <-chan error {
+		resultCh := make(chan error, 1)
+		go func() {
+			resultCh <- eng.runReturnError(identify2MetaContext(tc, &FakeIdentifyUI{}))
+		}()
+		return resultCh
+	}
+
+	first := newEngine()
+	first.requestedAt = tc.G.Clock().Now()
+	firstResult := run(first)
+	select {
+	case <-firstCheckStarted:
+	case <-time.After(10 * time.Second):
+		close(releaseFirstCheck)
+		t.Fatal("first proof check did not start")
+	}
+
+	// The second request arrives while the first owns the per-UID identify lock.
+	// Its proof check will run only after the first identify completes.
+	fakeClock.Advance(time.Millisecond)
+	second := newEngine()
+	second.requestedAt = tc.G.Clock().Now()
+	secondResult := run(second)
+	close(releaseFirstCheck)
+
+	require.NoError(t, <-firstResult)
+	require.NoError(t, <-secondResult)
+	require.Equal(t, int64(1), atomic.LoadInt64(&checks))
+
+	// A request made after the shared result was produced still forces a new
+	// remote check.
+	fakeClock.Advance(time.Millisecond)
+	third := newEngine()
+	third.requestedAt = tc.G.Clock().Now()
+	require.NoError(t, <-run(third))
+	require.Equal(t, int64(2), atomic.LoadInt64(&checks))
+}
+
+func TestForcedIdentifyReusesProofCheckedAfterRequest(t *testing.T) {
+	testForcedIdentifyReusesProofCheckedAfterRequest(t, nil)
+}
+
+func TestForcedIdentifyReusesSoftFailureCheckedAfterRequest(t *testing.T) {
+	testForcedIdentifyReusesProofCheckedAfterRequest(
+		t, libkb.NewProofError(keybase1.ProofStatus_HTTP_500, "temporary failure"))
+}
+
+func TestResolveThenIdentify2RecordsRequestBeforeResolution(t *testing.T) {
+	tc := SetupEngineTest(t, "id")
+	defer tc.Cleanup()
+
+	requestedAt := time.Date(2026, time.July, 28, 12, 0, 0, 0, time.UTC)
+	tc.G.SetClock(clockwork.NewFakeClockAt(requestedAt))
+	arg := keybase1.Identify2Arg{UserAssertion: "("}
+	eng := NewResolveThenIdentify2(tc.G, &arg)
+
+	require.Error(t, eng.Run(NewMetaContextForTest(tc)))
+	require.NotNil(t, eng.i2eng)
+	require.Equal(t, requestedAt, eng.i2eng.requestedAt)
 }
 
 func TestSkipExternalChecks(t *testing.T) {

--- a/go/engine/identify2_with_uid.go
+++ b/go/engine/identify2_with_uid.go
@@ -252,6 +252,10 @@ type Identify2WithUID struct {
 
 	resultCh chan<- error
 
+	// When this identify was asked for. If it waits behind another identify of
+	// the same user, it may reuse proof results produced after this point.
+	requestedAt time.Time
+
 	// For eagerly checking remote Assertions as they come in, these
 	// member variables maintain state, protected by the remotesMutex.
 	remotesMutex     sync.Mutex
@@ -328,6 +332,13 @@ func (e *Identify2WithUID) Run(m libkb.MetaContext) (err error) {
 
 	if e.arg.Uid.IsNil() {
 		return libkb.NoUIDError{}
+	}
+
+	// This identify may reuse proof results produced by an identify already
+	// running for the same user, but only results completed after it was
+	// requested. ResolveThenIdentify2 records this before assertion resolution.
+	if e.requestedAt.IsZero() {
+		e.requestedAt = m.G().Clock().Now()
 	}
 
 	// Only the first send matters, but we don't want to block the subsequent no-op
@@ -884,7 +895,7 @@ func (e *Identify2WithUID) runIdentifyUI(m libkb.MetaContext) (err error) {
 	e.metaContext = m
 	if them.IDTable() == nil {
 		m.Debug("| No IDTable for user")
-	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), iui, e, identifyTableMode); err != nil {
+	} else if err = them.IDTable().Identify(m, e.state, e.forceRemoteCheck(), e.requestedAt, iui, e, identifyTableMode); err != nil {
 		m.Debug("| Failure in running IDTable")
 		return err
 	}

--- a/go/engine/resolve_identify2.go
+++ b/go/engine/resolve_identify2.go
@@ -127,6 +127,9 @@ func (e *ResolveThenIdentify2) Run(m libkb.MetaContext) (err error) {
 	defer m.Trace("ResolveThenIdentify2#Run", &err)()
 
 	e.i2eng = NewIdentify2WithUID(m.G(), e.arg)
+	// Record the request before resolving its assertion. Another identify can
+	// finish a proof check while this request is still resolving.
+	e.i2eng.requestedAt = m.G().Clock().Now()
 	if e.responsibleGregorItem != nil {
 		e.i2eng.SetResponsibleGregorItem(e.responsibleGregorItem)
 	}

--- a/go/libkb/id_table.go
+++ b/go/libkb/id_table.go
@@ -1668,11 +1668,13 @@ const (
 	IdentifyTableModeActive  IdentifyTableMode = iota
 )
 
-func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
+// requestedAt is when the identify this table walk belongs to was asked for. It
+// bounds which newly cached remote proof results a forced check may reuse.
+func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteCheck bool, requestedAt time.Time, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
 	errs := make(chan error, len(is.res.ProofChecks))
 	for _, lcr := range is.res.ProofChecks {
 		go func(l *LinkCheckResult) {
-			errs <- idt.identifyActiveProof(m, l, is, forceRemoteCheck, ui, ccl, itm)
+			errs <- idt.identifyActiveProof(m, l, is, forceRemoteCheck, requestedAt, ui, ccl, itm)
 		}(lcr)
 	}
 
@@ -1701,8 +1703,8 @@ func (idt *IdentityTable) Identify(m MetaContext, is IdentifyState, forceRemoteC
 
 // =========================================================================
 
-func (idt *IdentityTable) identifyActiveProof(m MetaContext, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
-	idt.proofRemoteCheck(m, is.HasPreviousTrack(), forceRemoteCheck, lcr, itm)
+func (idt *IdentityTable) identifyActiveProof(m MetaContext, lcr *LinkCheckResult, is IdentifyState, forceRemoteCheck bool, requestedAt time.Time, ui IdentifyUI, ccl CheckCompletedListener, itm IdentifyTableMode) error {
+	idt.proofRemoteCheck(m, is.HasPreviousTrack(), forceRemoteCheck, requestedAt, lcr, itm)
 	if ccl != nil {
 		ccl.CCLCheckCompleted(lcr)
 	}
@@ -1726,6 +1728,7 @@ type LinkCheckResult struct {
 	tmpTrackExpireTime   time.Time
 	position             int
 	torWarning           bool
+	proofCacheRequestKey *proofCacheRequestKey
 }
 
 func (l LinkCheckResult) GetDiff() TrackDiff        { return l.diff }
@@ -1763,11 +1766,12 @@ func (idt *IdentityTable) ComputeRemoteDiff(tracked, trackedTmp, observed keybas
 	return ret
 }
 
-func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forceRemoteCheck bool, res *LinkCheckResult, itm IdentifyTableMode) {
+func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forceRemoteCheck bool, requestedAt time.Time, res *LinkCheckResult, itm IdentifyTableMode) {
 	p := res.link
 
 	m.Debug("+ RemoteCheckProof %s", p.ToDebugString())
 	doCache := false
+	checkCompleted := false
 	pvlHashUsed := keybase1.MerkleStoreKitHash("")
 	sid := p.GetSigID()
 
@@ -1785,6 +1789,11 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 		}
 
 		if doCache {
+			// Only make a result eligible for request coalescing when the check
+			// returned normally and its caller's context is still live.
+			if !checkCompleted || m.Ctx().Err() != nil {
+				res.proofCacheRequestKey = nil
+			}
 			m.Debug("| Caching results under key=%s pvlHash=%s", sid, pvlHashUsed)
 			if cacheErr := idt.G().ProofCache.Put(sid, res, pvlHashUsed); cacheErr != nil {
 				m.Warning("proof cache put error: %s", cacheErr)
@@ -1828,21 +1837,6 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 		}
 	}
 
-	if !forceRemoteCheck {
-		res.cached = m.G().ProofCache.Get(sid, pvlU.Hash)
-		m.Debug("| Proof cache lookup for %s: %+v", sid, res.cached)
-		if res.cached != nil && res.cached.Freshness() == keybase1.CheckResultFreshness_FRESH {
-			res.err = res.cached.Status
-			res.verifiedHint = res.cached.VerifiedHint
-			m.Debug("| Early exit after proofCache hit for %s", sid)
-			return
-		}
-	}
-
-	// From this point on in the function, we'll be putting our results into
-	// cache (in the defer above).
-	doCache = true
-
 	// ProofCheckerModeActive or Passive mainly decides whether we need to reach out to
 	// self-hosted services. We want to avoid so doing when the user is acting passively
 	// (such as when receiving a message).
@@ -1854,7 +1848,40 @@ func (idt *IdentityTable) proofRemoteCheck(m MetaContext, hasPreviousTrack, forc
 	if res.hint != nil {
 		hint = *res.hint
 	}
+	requestKey := proofCacheRequestKey{
+		mode:      pcm,
+		apiURL:    hint.GetAPIURL(),
+		checkText: hint.GetCheckText(),
+	}
+
+	var cached *CheckResult
+	if forceRemoteCheck {
+		cached = m.G().ProofCache.getForRequest(sid, pvlU.Hash, requestedAt, requestKey)
+		m.Debug("| Proof request cache lookup for %s: %+v", sid, cached)
+	} else {
+		cached = m.G().ProofCache.Get(sid, pvlU.Hash)
+		m.Debug("| Proof cache lookup for %s: %+v", sid, cached)
+		// Preserve the cached result for the soft-error fallback below even when
+		// it is too old for the normal early return.
+		res.cached = cached
+	}
+	if cached != nil && (forceRemoteCheck || cached.Freshness() == keybase1.CheckResultFreshness_FRESH) {
+		res.err = cached.Status
+		res.verifiedHint = cached.VerifiedHint
+		if forceRemoteCheck {
+			m.Debug("| Early exit after proofCache hit produced during this request for %s", sid)
+		} else {
+			m.Debug("| Early exit after proofCache hit for %s", sid)
+		}
+		return
+	}
+
+	// From this point on in the function, we'll be putting our results into
+	// cache (in the defer above).
+	doCache = true
+	res.proofCacheRequestKey = &requestKey
 	res.verifiedHint, res.err = pc.CheckStatus(m, hint, pcm, pvlU)
+	checkCompleted = true
 
 	// If no error than all good
 	if res.err == nil {

--- a/go/libkb/proof_cache.go
+++ b/go/libkb/proof_cache.go
@@ -19,6 +19,16 @@ type CheckResult struct {
 	VerifiedHint *SigHint   // client provided verified hint if any
 	Time         time.Time  // When the last check was
 	PvlHash      string     // Added after other fields. Some entries may not have this packed.
+	// requestKey is memory-only metadata. It lets a forced identify reuse a
+	// matching check that completed after the identify was requested, including
+	// soft failures that the normal proof-cache policy intentionally rejects.
+	requestKey *proofCacheRequestKey
+}
+
+type proofCacheRequestKey struct {
+	mode      ProofCheckerMode
+	apiURL    string
+	checkText string
 }
 
 func (cr CheckResult) Pack() *jsonw.Wrapper {
@@ -216,6 +226,38 @@ func (pc *ProofCache) Get(sid keybase1.SigID, pvlHash keybase1.MerkleStoreKitHas
 	return cr
 }
 
+// getForRequest returns only a matching in-memory result produced strictly
+// after requestedAt. Unlike Get, it may return a soft failure: this is
+// short-lived request coalescing, not a change to normal cache freshness.
+func (pc *ProofCache) getForRequest(sid keybase1.SigID, pvlHash keybase1.MerkleStoreKitHash, requestedAt time.Time, key proofCacheRequestKey) *CheckResult {
+	if pc == nil || requestedAt.IsZero() {
+		return nil
+	}
+	if err := pc.setup(); err != nil {
+		return nil
+	}
+
+	pc.RLock()
+	defer pc.RUnlock()
+
+	tmp, found := pc.lru.Peek(sid)
+	if !found {
+		return nil
+	}
+	cr, ok := tmp.(CheckResult)
+	if !ok {
+		pc.G().Log.Errorf("Bad type assertion in ProofCache.getForRequest")
+		return nil
+	}
+	if cr.PvlHash != string(pvlHash) || cr.requestKey == nil || *cr.requestKey != key {
+		return nil
+	}
+	if !cr.Time.After(requestedAt) {
+		return nil
+	}
+	return &cr
+}
+
 func (pc *ProofCache) dbKey(sid keybase1.SigID) (DbKey, string) {
 	sidstr := sid.String()
 	key := DbKey{Typ: DBProofCheck, Key: sidstr}
@@ -290,6 +332,7 @@ func (pc *ProofCache) Put(sid keybase1.SigID, lcr *LinkCheckResult, pvlHash keyb
 		VerifiedHint: lcr.verifiedHint,
 		Time:         pc.G().Clock().Now(),
 		PvlHash:      string(pvlHash),
+		requestKey:   lcr.proofCacheRequestKey,
 	}
 	pc.memPut(sid, cr)
 	return pc.dbPut(sid, cr)

--- a/go/libkb/proof_cache_test.go
+++ b/go/libkb/proof_cache_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package libkb
+
+import (
+	"testing"
+	"time"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProofCacheGetForRequest(t *testing.T) {
+	tc := SetupTest(t, "proof_cache_request", 0)
+	defer tc.Cleanup()
+
+	cache := NewProofCache(tc.G, 10)
+	sid := keybase1.SigID("proof")
+	pvlHash := keybase1.MerkleStoreKitHash("pvl")
+	storedAt := time.Now()
+	key := proofCacheRequestKey{
+		mode:      ProofCheckerModeActive,
+		apiURL:    "https://example.test/proof",
+		checkText: "proof text",
+	}
+	cache.memPut(sid, CheckResult{
+		Contextified: NewContextified(tc.G),
+		Status:       NewProofError(keybase1.ProofStatus_HTTP_500, "temporary failure"),
+		Time:         storedAt,
+		PvlHash:      string(pvlHash),
+		requestKey:   &key,
+	})
+
+	// A cache result must be strictly newer than the request. Equal timestamps
+	// can occur with coarse clocks and do not prove that the check followed it.
+	require.Nil(t, cache.getForRequest(sid, pvlHash, storedAt, key))
+
+	got := cache.getForRequest(sid, pvlHash, storedAt.Add(-time.Nanosecond), key)
+	require.NotNil(t, got)
+	require.Equal(t, keybase1.ProofStatus_HTTP_500, got.Status.GetProofStatus())
+
+	wrongMode := key
+	wrongMode.mode = ProofCheckerModePassive
+	require.Nil(t, cache.getForRequest(sid, pvlHash, storedAt.Add(-time.Nanosecond), wrongMode))
+
+	wrongHint := key
+	wrongHint.checkText = "different proof text"
+	require.Nil(t, cache.getForRequest(sid, pvlHash, storedAt.Add(-time.Nanosecond), wrongHint))
+	require.Nil(t, cache.getForRequest(sid, keybase1.MerkleStoreKitHash("other"), storedAt.Add(-time.Nanosecond), key))
+
+	// The normal proof cache policy still rejects soft failures.
+	require.Nil(t, cache.Get(sid, pvlHash))
+}


### PR DESCRIPTION
adapted from https://github.com/keybase/client/pull/29467

@mmaxim 