### PR TITLE
fix(kbfs): stop leaking Mobile{App,Net}State subscribe channels

### DIFF
--- a/go/kbfs/libkbfs/folder_block_manager.go
+++ b/go/kbfs/libkbfs/folder_block_manager.go
@@ -1299,6 +1299,11 @@ func (fbm *folderBlockManager) reclaimQuotaInBackground() {
 	}
 
 	timerChan := timer.C
+	// Subscribe once per state transition; NextAppStateUpdate leaks channels
+	// into MobileAppState.updateChs when called each iteration and the state
+	// never changes (e.g. on servers).
+	state := keybase1.MobileAppState_FOREGROUND
+	appStateCh := fbm.appStateUpdater.NextAppStateUpdate(&state)
 	for {
 		// Don't let the timer fire if auto-reclamation is turned off.
 		if !autoQR ||
@@ -1308,15 +1313,16 @@ func (fbm *folderBlockManager) reclaimQuotaInBackground() {
 			timerChan = make(chan time.Time)
 		}
 
-		state := keybase1.MobileAppState_FOREGROUND
 		select {
 		case <-fbm.shutdownChan:
 			return
-		case state = <-fbm.appStateUpdater.NextAppStateUpdate(&state):
+		case state = <-appStateCh:
+			appStateCh = fbm.appStateUpdater.NextAppStateUpdate(&state)
 			for state != keybase1.MobileAppState_FOREGROUND {
 				fbm.log.CDebugf(context.Background(),
 					"Pausing QR while not foregrounded: state=%s", state)
-				state = <-fbm.appStateUpdater.NextAppStateUpdate(&state)
+				state = <-appStateCh
+				appStateCh = fbm.appStateUpdater.NextAppStateUpdate(&state)
 			}
 			fbm.log.CDebugf(
 				context.Background(), "Resuming QR while foregrounded")
@@ -1577,20 +1583,26 @@ func (fbm *folderBlockManager) doCleanDiskCaches() (err error) {
 }
 
 func (fbm *folderBlockManager) cleanDiskCachesInBackground() {
+	// Subscribe once per state transition; NextAppStateUpdate leaks channels
+	// into MobileAppState.updateChs when called each iteration and the state
+	// never changes (e.g. on servers).
+	state := keybase1.MobileAppState_FOREGROUND
+	appStateCh := fbm.appStateUpdater.NextAppStateUpdate(&state)
 	// While in the foreground, clean the disk caches every time we learn about
 	// a newer latest merged revision for this TLF.
 	for {
-		state := keybase1.MobileAppState_FOREGROUND
 		select {
 		case <-fbm.latestMergedChan:
 		case <-fbm.shutdownChan:
 			return
-		case state = <-fbm.appStateUpdater.NextAppStateUpdate(&state):
+		case state = <-appStateCh:
+			appStateCh = fbm.appStateUpdater.NextAppStateUpdate(&state)
 			for state != keybase1.MobileAppState_FOREGROUND {
 				fbm.log.CDebugf(context.Background(),
 					"Pausing sync-cache cleaning while not foregrounded: "+
 						"state=%s", state)
-				state = <-fbm.appStateUpdater.NextAppStateUpdate(&state)
+				state = <-appStateCh
+				appStateCh = fbm.appStateUpdater.NextAppStateUpdate(&state)
 			}
 			fbm.log.CDebugf(context.Background(),
 				"Resuming sync-cache cleaning while foregrounded")

--- a/go/kbfs/libkbfs/prefetcher.go
+++ b/go/kbfs/libkbfs/prefetcher.go
@@ -1346,14 +1346,21 @@ func (p *blockPrefetcher) handleAppStateChange(
 		p.setPaused(false)
 	}()
 
+	// Subscribe once per state transition; NextAppStateUpdate leaks channels
+	// into MobileAppState.updateChs when called each iteration and the state
+	// never changes (e.g. on servers).
+	var appStateCh <-chan keybase1.MobileAppState
 	// Pause the prefetcher when backgrounded.
 	for *appState != keybase1.MobileAppState_FOREGROUND {
 		p.setPaused(true)
 		p.log.CDebugf(
 			context.TODO(), "Pausing prefetcher while backgrounded")
+		if appStateCh == nil {
+			appStateCh = p.appStateUpdater.NextAppStateUpdate(appState)
+		}
 		select {
-		case *appState = <-p.appStateUpdater.NextAppStateUpdate(
-			appState):
+		case *appState = <-appStateCh:
+			appStateCh = nil
 		case req := <-p.prefetchStatusCh.Out():
 			p.handleStatusRequest(req.(*prefetchStatusRequest))
 			continue
@@ -1489,6 +1496,10 @@ func (p *blockPrefetcher) run(
 	first := true
 	appState := keybase1.MobileAppState_FOREGROUND
 	netState := keybase1.MobileNetworkState_NONE
+	// Subscribe once per state transition; MobileAppState.NextUpdate leaks
+	// channels into its subscriber slice if called every loop iteration.
+	appStateCh := p.appStateUpdater.NextAppStateUpdate(&appState)
+	netStateCh := p.appStateUpdater.NextNetworkStateUpdate(&netState)
 
 	// Subscribe to settings updates while waiting for the network to
 	// change.
@@ -1545,13 +1556,16 @@ func (p *blockPrefetcher) run(
 			p.log.Debug("shutting down, clearing in flight fetches")
 			ch := chInterface.(<-chan error)
 			<-ch
-		case appState = <-p.appStateUpdater.NextAppStateUpdate(&appState):
+		case appState = <-appStateCh:
+			appStateCh = p.appStateUpdater.NextAppStateUpdate(&appState)
 			p.handleAppStateChange(&appState)
-		case netState = <-p.appStateUpdater.NextNetworkStateUpdate(&netState):
+		case netState = <-netStateCh:
+			netStateCh = p.appStateUpdater.NextNetworkStateUpdate(&netState)
 			p.handleNetStateChange(&netState, subCh)
 		case <-subCh:
 			// Settings have changed, so recheck the network state.
 			netState = keybase1.MobileNetworkState_NONE
+			netStateCh = p.appStateUpdater.NextNetworkStateUpdate(&netState)
 		case ptrInt := <-p.prefetchCancelCh.Out():
 			ptr := ptrInt.(data.BlockPointer)
 			pre, ok := p.prefetches[ptr.ID]


### PR DESCRIPTION
The prefetcher and folder block manager select loops were calling NextAppStateUpdate / NextNetworkStateUpdate on every iteration, each of which allocates a fresh channel and retains it in the corresponding subscriber slice until the state actually changes. On servers the state never changes, so the two slices grow unbounded — this accounted for ~880 MB of live heap on kbpagesd before OOM. Cache the channel across iterations and resubscribe only after it fires.

Made-with: Claude