### PR TITLE
fix(core): stop leaking MobileAppState/DesktopAppState subscribe chanels

### DIFF
--- a/go/chat/search/indexer.go
+++ b/go/chat/search/indexer.go
@@ -206,6 +206,11 @@ func (idx *Indexer) SyncLoop(stopCh chan struct{}) error {
 	after := time.After(idx.startSyncDelay)
 	appState := keybase1.MobileAppState_FOREGROUND
 	netState := keybase1.MobileNetworkState_WIFI
+	// Subscribe once per state transition; NextUpdate leaks channels into
+	// MobileAppState/MobileNetState.updateChs when called each iteration and
+	// the state never changes (e.g. on headless servers).
+	appStateCh := idx.G().MobileAppState.NextUpdate(&appState)
+	netStateCh := idx.G().MobileNetState.NextUpdate(&netState)
 	var cancelFn context.CancelFunc
 	var l sync.Mutex
 	cancelSync := func() {
@@ -262,14 +267,16 @@ func (idx *Indexer) SyncLoop(stopCh chan struct{}) error {
 			attemptSync(ctx)
 		case <-ticker.C:
 			attemptSync(ctx)
-		case appState = <-idx.G().MobileAppState.NextUpdate(&appState):
+		case appState = <-appStateCh:
+			appStateCh = idx.G().MobileAppState.NextUpdate(&appState)
 			switch appState {
 			case keybase1.MobileAppState_FOREGROUND:
 			// if we enter any state besides foreground cancel any running syncs
 			default:
 				cancelSync()
 			}
-		case netState = <-idx.G().MobileNetState.NextUpdate(&netState):
+		case netState = <-netStateCh:
+			netStateCh = idx.G().MobileNetState.NextUpdate(&netState)
 			if netState.IsLimited() {
 				// if we switch off of wifi cancel any running syncs
 				cancelSync()

--- a/go/ephemeral/lib.go
+++ b/go/ephemeral/lib.go
@@ -119,13 +119,18 @@ func (e *EKLib) backgroundKeygen(mctx libkb.MetaContext, stopCh <-chan struct{})
 
 	ticker := libkb.NewBgTicker(keygenInterval)
 	state := keybase1.MobileAppState_FOREGROUND
+	// Subscribe once per state transition; NextUpdate leaks channels into
+	// MobileAppState.updateChs when called each iteration and the state never
+	// changes (e.g. on headless servers).
+	appStateCh := mctx.G().MobileAppState.NextUpdate(&state)
 	// Run every hour but also check if enough wall clock time has elapsed when
 	// we are in a BACKGROUNDACTIVE state.
 	for {
 		select {
 		case <-ticker.C:
 			runIfNeeded(false /* force */)
-		case state = <-mctx.G().MobileAppState.NextUpdate(&state):
+		case state = <-appStateCh:
+			appStateCh = mctx.G().MobileAppState.NextUpdate(&state)
 			if state == keybase1.MobileAppState_BACKGROUNDACTIVE {
 				// Before running we pause briefly so we don't stampede for
 				// resources with other background tasks. libkb.BgTicker

--- a/go/service/gregor.go
+++ b/go/service/gregor.go
@@ -274,10 +274,16 @@ func (g *gregorHandler) monitorAppState() {
 	// Wait for state updates and react accordingly
 	state := keybase1.MobileAppState_FOREGROUND
 	suspended := false
+	// Subscribe once per state transition; NextUpdate/NextSuspendUpdate leak
+	// channels into their subscriber slices when called each iteration and the
+	// state never changes (e.g. on headless servers).
+	appStateCh := g.G().MobileAppState.NextUpdate(&state)
+	suspendCh := g.G().DesktopAppState.NextSuspendUpdate(&suspended)
 	for {
 		monitorAction := monitorNoop
 		select {
-		case state = <-g.G().MobileAppState.NextUpdate(&state):
+		case state = <-appStateCh:
+			appStateCh = g.G().MobileAppState.NextUpdate(&state)
 			switch state {
 			case keybase1.MobileAppState_FOREGROUND:
 				g.forcePing(ctx)
@@ -287,7 +293,8 @@ func (g *gregorHandler) monitorAppState() {
 			case keybase1.MobileAppState_BACKGROUND, keybase1.MobileAppState_INACTIVE:
 				monitorAction = monitorDisconnect
 			}
-		case suspended = <-g.G().DesktopAppState.NextSuspendUpdate(&suspended):
+		case suspended = <-suspendCh:
+			suspendCh = g.G().DesktopAppState.NextSuspendUpdate(&suspended)
 			if !suspended {
 				monitorAction = monitorConnect
 				g.chatLog.Debug(ctx, "resumed, connecting")


### PR DESCRIPTION
Three hot-loop callers of MobileAppState.NextUpdate / MobileNetState.NextUpdate / DesktopAppState.NextSuspendUpdate were re-subscribing every iteration of a multi-case select. Each call allocates a fresh channel and retains it in the corresponding subscriber slice until the state actually changes — which on headless service deployments is effectively never. Cache the channel across iterations and resubscribe only after it fires.

Sites fixed: chat/search/indexer.go (app+net), service/gregor.go (app+suspend), ephemeral/lib.go (app).

Made-with: Claude