### PR TITLE
fix(kbfs): back off in waitForCompleteFlush instead of spinning

### DIFF
--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -2690,10 +2690,22 @@ func (j *tlfJournal) wait(ctx context.Context) error {
 	return nil
 }
 
+func (j *tlfJournal) getLastFlushErr() error {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	return j.lastFlushErr
+}
+
 func (j *tlfJournal) waitForCompleteFlush(ctx context.Context) error {
 	// Now we wait for the journal to completely empty.  Waiting on
 	// the wg isn't enough, because conflicts/squashes can cause the
 	// journal to pause and we'll be called too early.
+	//
+	// A failing flush returns as fast as it can fail, so this loop needs its
+	// own backoff.  Signaling work here cancels the background flusher's retry
+	// timer, so its backoff cannot throttle us.
+	retry := backoff.NewExponentialBackOff()
+	retry.MaxElapsedTime = 0
 	for {
 		blockEntryCount, mdEntryCount, err := j.getJournalEntryCounts()
 		if err != nil {
@@ -2712,9 +2724,31 @@ func (j *tlfJournal) waitForCompleteFlush(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		_, noLock := j.lastFlushErr.(kbfsmd.ServerErrorLockConflict)
+
+		flushErr := j.getLastFlushErr()
+		_, noLock := flushErr.(kbfsmd.ServerErrorLockConflict)
 		if noLock {
-			return j.lastFlushErr
+			return flushErr
+		}
+		if flushErr == nil {
+			// A conflict or squash pauses the journal and flushes nothing,
+			// which is not an error and is the reason this loop exists.
+			retry.Reset()
+			continue
+		}
+
+		bTime := retry.NextBackOff()
+		if bTime == backoff.Stop {
+			return flushErr
+		}
+		j.log.CDebugf(ctx, "Flush failed for %s: %+v; retrying in %s",
+			j.tlfID, flushErr, bTime)
+		timer := time.NewTimer(bTime)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
 		}
 	}
 }

--- a/go/kbfs/libkbfs/tlf_journal.go
+++ b/go/kbfs/libkbfs/tlf_journal.go
@@ -2737,10 +2737,9 @@ func (j *tlfJournal) waitForCompleteFlush(ctx context.Context) error {
 			continue
 		}
 
+		// MaxElapsedTime is 0 above, so NextBackOff never returns
+		// backoff.Stop; we retry until the caller's context is done.
 		bTime := retry.NextBackOff()
-		if bTime == backoff.Stop {
-			return flushErr
-		}
 		j.log.CDebugf(ctx, "Flush failed for %s: %+v; retrying in %s",
 			j.tlfID, flushErr, bTime)
 		timer := time.NewTimer(bTime)

--- a/go/kbfs/libkbfs/tlf_journal_test.go
+++ b/go/kbfs/libkbfs/tlf_journal_test.go
@@ -895,6 +895,25 @@ type shimMDServer struct {
 	nextGetRange    []*RootMetadataSigned
 	nextErr         error
 	getForTLFCalled bool
+
+	// persistentErr, unlike nextErr, is returned from every Put until it is
+	// cleared, and putCount records how many Puts were attempted. Both are
+	// guarded by lock because they are read from the flusher goroutine.
+	lock          sync.Mutex
+	persistentErr error
+	putCount      int
+}
+
+func (s *shimMDServer) setPersistentErr(err error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.persistentErr = err
+}
+
+func (s *shimMDServer) getPutCount() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.putCount
 }
 
 func (s *shimMDServer) GetRange(
@@ -909,6 +928,13 @@ func (s *shimMDServer) GetRange(
 func (s *shimMDServer) Put(ctx context.Context, rmds *RootMetadataSigned,
 	extra kbfsmd.ExtraMetadata, _ *keybase1.LockContext, _ keybase1.MDPriority,
 ) error {
+	s.lock.Lock()
+	s.putCount++
+	persistentErr := s.persistentErr
+	s.lock.Unlock()
+	if persistentErr != nil {
+		return persistentErr
+	}
 	if s.nextErr != nil {
 		err := s.nextErr
 		s.nextErr = nil
@@ -1893,6 +1919,108 @@ func testTLFJournalSingleOp(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.Len(t, mdserver.rmdses, 1)
 }
 
+// testTLFJournalSingleOpPersistentFlushErr checks that a flush error that never
+// clears does not turn waitForCompleteFlush into a hot loop. It used to
+// re-signal work the instant each failed flush returned, which both spun as
+// fast as the flush could fail and cancelled the background flusher's retry
+// timer, so no backoff ever applied. Seen in the wild as 160k flush attempts in
+// 31 seconds against an unreachable MD server.
+func testTLFJournalSingleOpPersistentFlushErr(
+	t *testing.T, ver kbfsmd.MetadataVer,
+) {
+	tempdir, config, ctx, cancel, tlfJournal, delegate := setupTLFJournalTest(
+		t, ver, TLFJournalSingleOpBackgroundWorkEnabled)
+	defer teardownTLFJournalTest(
+		ctx, tempdir, config, cancel, tlfJournal, delegate)
+
+	var mdserver shimMDServer
+	config.mdserver = &mdserver
+
+	tlfJournal.pauseBackgroundWork()
+	delegate.requireNextState(ctx, bwPaused)
+
+	putBlock(ctx, t, config, tlfJournal, []byte{1, 2})
+	md1 := config.makeMD(kbfsmd.Revision(10), kbfsmd.FakeID(1))
+	irmd, err := tlfJournal.putMD(ctx, md1, tlfJournal.key, nil)
+	require.NoError(t, err)
+	prevRoot := irmd.mdID
+
+	putBlock(ctx, t, config, tlfJournal, []byte{3, 4})
+	md2 := config.makeMD(kbfsmd.Revision(11), prevRoot)
+	_, err = tlfJournal.putMD(ctx, md2, tlfJournal.key, nil)
+	require.NoError(t, err)
+
+	tlfJournal.resumeBackgroundWork()
+	delegate.requireNextState(ctx, bwIdle)
+	delegate.requireNextState(ctx, bwBusy)
+	delegate.requireNextState(ctx, bwIdle)
+	requireJournalEntryCounts(t, tlfJournal, 0, 2)
+
+	finishCtx, finishCancel := context.WithCancel(ctx)
+	defer finishCancel()
+	finishCh := make(chan error, 1)
+	go func() {
+		finishCh <- tlfJournal.finishSingleOp(
+			finishCtx, nil, keybase1.MDPriorityNormal)
+	}()
+
+	// Finishing converts to a conflict branch and pauses; resolving that is
+	// what lets the flusher get as far as putting an MD. See
+	// testTLFJournalSingleOp for why the second state here is racy.
+	delegate.requireNextState(ctx, bwBusy)
+	if delegate.requireNextState(ctx, bwPaused, bwIdle) == bwIdle {
+		delegate.requireNextState(ctx, bwPaused)
+	}
+	require.Equal(
+		t, kbfsmd.PendingLocalSquashBranchID, tlfJournal.mdJournal.getBranchID())
+
+	// Every MD flush fails from here on, so the journal never drains.
+	mdserver.setPersistentErr(errors.New("EOF"))
+
+	// OnNewState blocks on an unbuffered channel, so the background loop
+	// stalls unless somebody keeps reading states for the rest of the test.
+	drainDone := make(chan struct{})
+	defer func() { <-drainDone }()
+	drainCtx, drainCancel := context.WithCancel(ctx)
+	defer drainCancel()
+	go func() {
+		defer close(drainDone)
+		for {
+			select {
+			case <-delegate.stateCh:
+			case <-drainCtx.Done():
+				return
+			}
+		}
+	}()
+
+	resolveMD := config.makeMD(kbfsmd.Revision(10), kbfsmd.FakeID(1))
+	_, err = tlfJournal.resolveBranch(
+		ctx, tlfJournal.mdJournal.getBranchID(), nil, resolveMD, tlfJournal.key,
+		nil)
+	require.NoError(t, err)
+
+	// Let it retry for a while, then count the attempts. The backoff starts at
+	// 500ms, so a correct implementation gets a handful in this window; the hot
+	// loop managed thousands per second.
+	const window = 2 * time.Second
+	const maxAttempts = 20
+	time.Sleep(window)
+	attempts := mdserver.getPutCount()
+
+	finishCancel()
+	select {
+	case err := <-finishCh:
+		require.Error(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("finishSingleOp did not return after its context was canceled")
+	}
+
+	require.NotZero(t, attempts, "flush was never attempted")
+	require.LessOrEqual(t, attempts, maxAttempts,
+		"waitForCompleteFlush spun: %d flush attempts in %s", attempts, window)
+}
+
 func TestTLFJournal(t *testing.T) {
 	tests := []func(*testing.T, kbfsmd.MetadataVer){
 		testTLFJournalBasic,
@@ -1925,6 +2053,7 @@ func TestTLFJournal(t *testing.T) {
 		testTLFJournalSquashByBytes,
 		testTLFJournalFirstRevNoSquash,
 		testTLFJournalSingleOp,
+		testTLFJournalSingleOpPersistentFlushErr,
 	}
 	runTestsOverMetadataVers(t, "testTLFJournal", tests)
 }


### PR DESCRIPTION
## The bug

`waitForCompleteFlush` (`go/kbfs/libkbfs/tlf_journal.go`) loops until the journal drains. It returns `lastFlushErr` only when it is a `ServerErrorLockConflict` and **discards every other error**:

```go
j.signalWork()
err = j.wg.Wait(ctx)
if err != nil { return err }
_, noLock := j.lastFlushErr.(kbfsmd.ServerErrorLockConflict)
if noLock { return j.lastFlushErr }
```

So a flush that keeps failing — an unreachable MD or block server returning EOF — never drains the journal, returns as fast as it can fail, and gets re-signalled immediately.

That `signalWork()` is the second half of it: it cancels the background flusher's retry timer (`tlf_journal.go:629-632`), so the exponential backoff is computed and logged on every pass and **never once waited on**. The `Retrying in 59s` lines describe a wait that does not happen.

## Impact

Seen in the wild: **160,586 flush attempts in 31 seconds** (5,180/s) on one git TLF, which filled the 128MB kbfs log by itself — 39% of the file was these two lines:

```
160,586  tlf_journal.go:664  Background work error for 53ab05b7…: EOF
160,586  tlf_journal.go:670  Retrying in <n>s
```

The log reads like a conflict-resolution loop, but CR ran **exactly once** in that window, and the backoff values grow and cap correctly (`251ms → … → 59.9s`). The backoff object is fine; nothing waits on it. git is what hits this because `waitForCompleteFlush` is the single-op path (`libgit/rpc.go:81`).

## The fix

Keep looping on a nil error — a conflict or squash pauses the journal and flushes nothing, which is the reason the loop exists — and give the loop its own exponential backoff for anything else. Retry-forever semantics are preserved, so a transient failure still recovers; it just no longer spins.

Also reads `lastFlushErr` under `journalLock`. `flush`'s defer writes it under that lock, so the old read was a data race.

## Testing

New `testTLFJournalSingleOpPersistentFlushErr` makes every MD put fail and counts attempts over a 2s window:

| | result |
|---|---|
| without the fix | **FAIL** — 14,093 attempts in 2s (7,046/s) |
| | **FAIL** — 13,644 attempts in 2s (second MD version) |
| with the fix | **ok** |

`TestTLFJournal` passes under `-race` with no data races. `TestJournal*` in libkbfs and all of `kbfs/libgit` pass.

One trap worth knowing for future tests in this file: `testBWDelegate.OnNewState` sends to an unbuffered channel, so the background loop stalls the moment a test stops calling `requireNextState`. An earlier version of this test reported 0 attempts both with and without the fix because of it — a false green in the dangerous direction. The test now drains `delegate.stateCh` in a goroutine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)