### PR TITLE
fix(chat): stop long pasted URLs from widening the desktop layout

### DIFF
--- a/shared/chat/conversation/input-area/normal/input.tsx
+++ b/shared/chat/conversation/input-area/normal/input.tsx
@@ -267,6 +267,9 @@ const desktopInputLowLevelStyles = Kb.Styles.styleSheetCreate(() => ({
   multiline: Kb.Styles.platformStyles({
     isElectron: {
       fieldSizing: 'content',
+      // break anywhere so an unbreakable string (long url) wraps instead of
+      // demanding its full width
+      overflowWrap: 'anywhere',
       ...Kb.Styles.paddingV(0),
       resize: 'none',
       width: '100%',
@@ -903,14 +906,19 @@ const desktopStyles = Kb.Styles.styleSheetCreate(
           minHeight: 22,
         },
       }),
-      inputBox: {
-        minWidth: 0,
-        paddingBottom: Kb.Styles.globalMargins.xtiny,
-        paddingLeft: 6,
-        paddingRight: 6,
-        paddingTop: Kb.Styles.globalMargins.tiny - 2,
-        textAlign: 'left',
-      },
+      inputBox: Kb.Styles.platformStyles({
+        common: {
+          minWidth: 0,
+          paddingBottom: Kb.Styles.globalMargins.xtiny,
+          paddingLeft: 6,
+          paddingRight: 6,
+          paddingTop: Kb.Styles.globalMargins.tiny - 2,
+          textAlign: 'left',
+        },
+        // field-sizing:content on the textarea makes its intrinsic width follow its text,
+        // so containment is what keeps a long unbreakable url from widening the layout
+        isElectron: {contain: 'inline-size'},
+      }),
       inputEditing: {color: Kb.Styles.globalColors.blackOrBlack},
       inputWrapper: {
         alignSelf: 'stretch',

--- a/shared/chat/inbox-and-conversation-shared.tsx
+++ b/shared/chat/inbox-and-conversation-shared.tsx
@@ -56,7 +56,7 @@ export function InboxAndConversationShell(props: Props) {
     <Kb.KeyboardAvoidingView2>
       <Kb.Box2 direction="horizontal" fullWidth={true} fullHeight={true} relative={true}>
         {props.leftPane}
-        <Kb.Box2 direction="vertical" fullHeight={true} flex={1}>
+        <Kb.Box2 direction="vertical" fullHeight={true} flex={1} style={styles.conversation}>
           <Conversation {...props} conversationIDKey={conversationIDKey} />
         </Kb.Box2>
         {infoPanel ? (
@@ -72,6 +72,9 @@ export function InboxAndConversationShell(props: Props) {
 const styles = Kb.Styles.styleSheetCreate(
   () =>
     ({
+      // without this the flex item's automatic min size is its content's min-content
+      // width, so one unbreakable string (a long url) can push the column past the window
+      conversation: {minWidth: 0},
       infoPanel: {
         backgroundColor: Kb.Styles.globalColors.white,
         bottom: 0,

--- a/shared/common-adapters/input3.tsx
+++ b/shared/common-adapters/input3.tsx
@@ -286,6 +286,9 @@ const styles = Styles.styleSheetCreate(
           ...Styles.border(Styles.globalColors.black_10, 1, Styles.borderRadius),
         },
         isElectron: {
+          // multiline inputs use field-sizing:content, whose intrinsic width follows the
+          // text; containment keeps a long unbreakable string from widening the layout
+          contain: 'inline-size',
           width: '100%',
         },
       }),
@@ -312,6 +315,9 @@ const styles = Styles.styleSheetCreate(
       multiline: Styles.platformStyles({
         isElectron: {
           fieldSizing: 'content',
+          // break anywhere so an unbreakable string (long url) wraps instead of
+          // demanding its full width
+          overflowWrap: 'anywhere',
           ...Styles.paddingV(0),
           resize: 'none',
           width: '100%',

--- a/shared/router-v2/left-tab-navigator.desktop.tsx
+++ b/shared/router-v2/left-tab-navigator.desktop.tsx
@@ -35,7 +35,7 @@ function LeftTabNavigator({
             navigation as any
           }
         />
-        <Kb.BoxGrow>
+        <Kb.BoxGrow style={styles.content}>
           {state.routes.map((route, i) => {
             const selected = i === state.index
             const desc = descriptors[route.key]
@@ -60,7 +60,10 @@ function ModalBackdrop(p: {hasModals: boolean}) {
 }
 
 const styles = Kb.Styles.styleSheetCreate(() => ({
-  box: {backgroundColor: Kb.Styles.globalColors.white},
+  // clip + min-width 0 so a misbehaving screen can never widen past the window and shove
+  // the tab bar off screen
+  box: {backgroundColor: Kb.Styles.globalColors.white, overflow: 'hidden'},
+  content: {minWidth: 0, overflow: 'hidden'},
 }))
 
 type NavType = NavigatorTypeBagBase & {


### PR DESCRIPTION
## Problem

Pasting a long URL containing an unbreakable run (a long base64 segment with no break opportunities) into the desktop chat input widened the whole conversation column past the window and broke the app frame.

## Root cause

The multiline textarea uses `field-sizing: content` for auto-grow height. That also makes its *intrinsic* width follow its text, and `width: 100%` does not cap that. The conversation column (`flex={1}`) had `min-width: auto`, so flexbox could not shrink it below that min-content width — measured 1913px in a 1087px window.

Only URLs with a long unbreakable segment hit it. Typing never triggers it (the text wraps at the container edge as it grows); only a one-shot paste does, and Chrome does not re-shrink afterwards.

Verified with an inline repro against the running app: baseline column 1830px inside a 600px frame; each of the three fixes below brings it to 496px on its own.

## Fix

Layered, so a future misbehaving child cannot break the frame either:

- `overflow-wrap: anywhere` on the multiline textarea (`input.tsx`, `input3.tsx`) — long unbreakable strings wrap instead of demanding their full width
- `contain: inline-size` on the textarea's wrapper — its intrinsic width can never leak outward
- `min-width: 0` on the conversation column, and `overflow: hidden` + `min-width: 0` at the desktop shell (`left-tab-navigator.desktop.tsx`) — no screen can widen past the window or shove the tab bar off screen

## Testing

- `yarn lint:all` green (0 react-compiler bailouts)
- Verified live in the running Electron app: computed `overflow-wrap: anywhere`, `contain: inline-size`, `min-width: 0px` all applied; `document.body.scrollWidth === window.innerWidth`
- Paste of a long unbreakable URL confirmed fixed by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)