### PR TITLE
fix(chat): stop duplicate username headers on scroll-back load

### DIFF
--- a/shared/chat/conversation/list-area/index.tsx
+++ b/shared/chat/conversation/list-area/index.tsx
@@ -51,7 +51,8 @@ const keyExtractor = (ordinal: ItemType) => String(ordinal)
 // avatar + username header (~40px taller) than a grouped follow-on of the same render type. Without
 // splitting the pool, recycleItems reuses one container across both heights, so a recycled view
 // paints at the wrong height for a frame before re-measure — visible as rows overlapping during
-// scroll. Append ':hdr' so header and grouped rows pool separately.
+// scroll. Append ':hdr' so header and grouped rows pool separately. A row that reserves header
+// space after a scroll-back load is as tall as a headered one, so it belongs in the same pool.
 const useGetItemType = () => {
   const threadStore = useConversationThreadStore()
   const you = useCurrentUserState(s => s.username)
@@ -70,7 +71,7 @@ const useGetItemType = () => {
         return messageTypeMap.get(ordinal) ?? 'text'
       }
       const base = getMessageRowType(message, messageTypeMap.get(ordinal))
-      const showUsername = getMessageShowUsername({
+      const {reserveHeader, showUsername} = getMessageShowUsername({
         message,
         messageMap,
         messageOrdinals: messageOrdinals ?? noOrdinals,
@@ -78,7 +79,7 @@ const useGetItemType = () => {
         shownCache,
         you,
       })
-      return showUsername ? `${base}:hdr` : base
+      return showUsername || reserveHeader ? `${base}:hdr` : base
     },
     [threadStore, you, shownCache]
   )

--- a/shared/chat/conversation/messages/row-metadata.test.ts
+++ b/shared/chat/conversation/messages/row-metadata.test.ts
@@ -127,8 +127,9 @@ test('a header hides but keeps its space once a real previous message groups the
 
   // oldest row of the loaded window: nothing above it yet, so it leads a group
   expect(
-    showUsernameFor({message, messageMap, messageOrdinals: [ordinal], ordinal, shownCache, you: 'alice'})
-  ).toBe('bob')
+    getMessageHeader({message, messageMap, messageOrdinals: [ordinal], ordinal, shownCache, you: 'alice'})
+  ).toEqual({reserveHeader: false, showUsername: 'bob'})
+  expect(shownCache.get(ordinal)).toBe('bob')
 
   // an unboxing placeholder above is not an answer, so the header stays
   messageMap.set(
@@ -140,7 +141,7 @@ test('a header hides but keeps its space once a real previous message groups the
     })
   )
   expect(
-    showUsernameFor({
+    getMessageHeader({
       message,
       messageMap,
       messageOrdinals: [olderOrdinal, ordinal],
@@ -148,7 +149,7 @@ test('a header hides but keeps its space once a real previous message groups the
       shownCache,
       you: 'alice',
     })
-  ).toBe('bob')
+  ).toEqual({reserveHeader: false, showUsername: 'bob'})
 
   // it resolves to a same-author message close in time: the row groups, so the header stops showing
   // but keeps its space so the row height doesn't change under the load
@@ -201,6 +202,7 @@ test('a header forced by an unresolved previous is not remembered', () => {
   expect(
     getMessageHeader({message, messageMap, messageOrdinals, ordinal, shownCache, you: 'alice'})
   ).toEqual({reserveHeader: false, showUsername: 'bob'})
+  expect(shownCache.has(ordinal)).toBe(false)
 
   // the placeholder unboxes into a same-author message: no header, and no space held for one — the
   // neighbor's own height was about to change anyway, so there is nothing to keep stable
@@ -216,6 +218,72 @@ test('a header forced by an unresolved previous is not remembered', () => {
   )
   expect(
     getMessageHeader({message, messageMap, messageOrdinals, ordinal, shownCache, you: 'alice'})
+  ).toEqual({reserveHeader: false, showUsername: ''})
+})
+
+test('a header shown for an ordinal outside the loaded window is not remembered', () => {
+  // list churn can ask about an ordinal the window no longer holds. That looks the same as "oldest
+  // row, nothing above it" from the previous ordinal alone, but it is not a real gap, so nothing
+  // about it should be recorded and reserved later.
+  const staleOrdinal = T.Chat.numberToOrdinal(901)
+  const liveOrdinal = T.Chat.numberToOrdinal(902)
+  const message = makeTextMessage({
+    author: 'bob',
+    id: T.Chat.numberToMessageID(901),
+    ordinal: staleOrdinal,
+    outboxID: T.Chat.stringToOutboxID('stale'),
+    timestamp: 101,
+  })
+  const messageMap = new Map<T.Chat.Ordinal, T.Chat.Message>([[staleOrdinal, message]])
+  const shownCache = new Map<T.Chat.Ordinal, string>()
+
+  expect(
+    getMessageHeader({
+      message,
+      messageMap,
+      messageOrdinals: [liveOrdinal],
+      ordinal: staleOrdinal,
+      shownCache,
+      you: 'alice',
+    })
+  ).toEqual({reserveHeader: false, showUsername: 'bob'})
+  expect(shownCache.has(staleOrdinal)).toBe(false)
+})
+
+test('without a cache nothing is recorded and no space is ever reserved', () => {
+  const olderOrdinal = T.Chat.numberToOrdinal(1001)
+  const ordinal = T.Chat.numberToOrdinal(1002)
+  const message = makeTextMessage({
+    author: 'bob',
+    id: T.Chat.numberToMessageID(1002),
+    ordinal,
+    outboxID: T.Chat.stringToOutboxID('current'),
+    timestamp: 101,
+  })
+  const messageMap = new Map<T.Chat.Ordinal, T.Chat.Message>([[ordinal, message]])
+
+  expect(
+    getMessageHeader({message, messageMap, messageOrdinals: [ordinal], ordinal, you: 'alice'})
+  ).toEqual({reserveHeader: false, showUsername: 'bob'})
+
+  messageMap.set(
+    olderOrdinal,
+    makeTextMessage({
+      author: 'bob',
+      id: T.Chat.numberToMessageID(1001),
+      ordinal: olderOrdinal,
+      outboxID: T.Chat.stringToOutboxID('older'),
+      timestamp: 100,
+    })
+  )
+  expect(
+    getMessageHeader({
+      message,
+      messageMap,
+      messageOrdinals: [olderOrdinal, ordinal],
+      ordinal,
+      you: 'alice',
+    })
   ).toEqual({reserveHeader: false, showUsername: ''})
 })
 

--- a/shared/chat/conversation/messages/row-metadata.test.ts
+++ b/shared/chat/conversation/messages/row-metadata.test.ts
@@ -4,9 +4,11 @@ import * as T from '@/constants/types'
 import HiddenString from '@/util/hidden-string'
 import {
   getMessageRowType,
-  getMessageShowUsername,
+  getMessageShowUsername as getMessageHeader,
   getPreviousOrdinal,
 } from './row-metadata'
+
+const showUsernameFor = (p: Parameters<typeof getMessageHeader>[0]) => getMessageHeader(p).showUsername
 
 const convID = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
 const outboxID = T.Chat.stringToOutboxID('outbox-1')
@@ -69,7 +71,7 @@ test('showUsername is derived from the previous ordinal and current message data
 
   expect(getPreviousOrdinal(messageOrdinals, secondOrdinal)).toBe(firstOrdinal)
   expect(
-    getMessageShowUsername({
+    showUsernameFor({
       message: messageMap.get(secondOrdinal)!,
       messageMap,
       messageOrdinals,
@@ -90,7 +92,7 @@ test('showUsername is derived from the previous ordinal and current message data
   )
 
   expect(
-    getMessageShowUsername({
+    showUsernameFor({
       message: messageMap.get(secondOrdinal)!,
       messageMap,
       messageOrdinals,
@@ -100,7 +102,7 @@ test('showUsername is derived from the previous ordinal and current message data
   ).toBe('bob')
 
   expect(
-    getMessageShowUsername({
+    showUsernameFor({
       message: messageMap.get(secondOrdinal)!,
       messageMap,
       messageOrdinals: [secondOrdinal],
@@ -108,6 +110,113 @@ test('showUsername is derived from the previous ordinal and current message data
       you: 'alice',
     })
   ).toBe('bob')
+})
+
+test('a header hides but keeps its space once a real previous message groups the row', () => {
+  const olderOrdinal = T.Chat.numberToOrdinal(701)
+  const ordinal = T.Chat.numberToOrdinal(702)
+  const message = makeTextMessage({
+    author: 'bob',
+    id: T.Chat.numberToMessageID(702),
+    ordinal,
+    outboxID: T.Chat.stringToOutboxID('current'),
+    timestamp: 101,
+  })
+  const messageMap = new Map<T.Chat.Ordinal, T.Chat.Message>([[ordinal, message]])
+  const shownCache = new Map<T.Chat.Ordinal, string>()
+
+  // oldest row of the loaded window: nothing above it yet, so it leads a group
+  expect(
+    showUsernameFor({message, messageMap, messageOrdinals: [ordinal], ordinal, shownCache, you: 'alice'})
+  ).toBe('bob')
+
+  // an unboxing placeholder above is not an answer, so the header stays
+  messageMap.set(
+    olderOrdinal,
+    Message.makeMessagePlaceholder({
+      conversationIDKey: convID,
+      id: T.Chat.numberToMessageID(701),
+      ordinal: olderOrdinal,
+    })
+  )
+  expect(
+    showUsernameFor({
+      message,
+      messageMap,
+      messageOrdinals: [olderOrdinal, ordinal],
+      ordinal,
+      shownCache,
+      you: 'alice',
+    })
+  ).toBe('bob')
+
+  // it resolves to a same-author message close in time: the row groups, so the header stops showing
+  // but keeps its space so the row height doesn't change under the load
+  messageMap.set(
+    olderOrdinal,
+    makeTextMessage({
+      author: 'bob',
+      id: T.Chat.numberToMessageID(701),
+      ordinal: olderOrdinal,
+      outboxID: T.Chat.stringToOutboxID('older'),
+      timestamp: 100,
+    })
+  )
+  expect(
+    getMessageHeader({
+      message,
+      messageMap,
+      messageOrdinals: [olderOrdinal, ordinal],
+      ordinal,
+      shownCache,
+      you: 'alice',
+    })
+  ).toEqual({reserveHeader: true, showUsername: ''})
+})
+
+test('a header forced by an unresolved previous is not remembered', () => {
+  const olderOrdinal = T.Chat.numberToOrdinal(801)
+  const ordinal = T.Chat.numberToOrdinal(802)
+  const message = makeTextMessage({
+    author: 'bob',
+    id: T.Chat.numberToMessageID(802),
+    ordinal,
+    outboxID: T.Chat.stringToOutboxID('current'),
+    timestamp: 101,
+  })
+  const messageOrdinals = [olderOrdinal, ordinal]
+  const messageMap = new Map<T.Chat.Ordinal, T.Chat.Message>([
+    [
+      olderOrdinal,
+      Message.makeMessagePlaceholder({
+        conversationIDKey: convID,
+        id: T.Chat.numberToMessageID(801),
+        ordinal: olderOrdinal,
+      }),
+    ],
+    [ordinal, message],
+  ])
+  const shownCache = new Map<T.Chat.Ordinal, string>()
+
+  expect(
+    getMessageHeader({message, messageMap, messageOrdinals, ordinal, shownCache, you: 'alice'})
+  ).toEqual({reserveHeader: false, showUsername: 'bob'})
+
+  // the placeholder unboxes into a same-author message: no header, and no space held for one — the
+  // neighbor's own height was about to change anyway, so there is nothing to keep stable
+  messageMap.set(
+    olderOrdinal,
+    makeTextMessage({
+      author: 'bob',
+      id: T.Chat.numberToMessageID(801),
+      ordinal: olderOrdinal,
+      outboxID: T.Chat.stringToOutboxID('older'),
+      timestamp: 100,
+    })
+  )
+  expect(
+    getMessageHeader({message, messageMap, messageOrdinals, ordinal, shownCache, you: 'alice'})
+  ).toEqual({reserveHeader: false, showUsername: ''})
 })
 
 test('row type only uses suffixes that are stable for the message lifetime', () => {
@@ -172,7 +281,7 @@ test('showUsername recomputes from the current neighboring ordinal after inserts
   ])
 
   expect(
-    getMessageShowUsername({
+    showUsernameFor({
       message: messageMap.get(currentOrdinal)!,
       messageMap,
       messageOrdinals: [firstOrdinal, currentOrdinal],
@@ -191,7 +300,7 @@ test('showUsername recomputes from the current neighboring ordinal after inserts
   )
 
   expect(
-    getMessageShowUsername({
+    showUsernameFor({
       message: messageMap.get(currentOrdinal)!,
       messageMap,
       messageOrdinals: [firstOrdinal, insertedOrdinal, currentOrdinal],
@@ -203,7 +312,7 @@ test('showUsername recomputes from the current neighboring ordinal after inserts
   messageMap.delete(insertedOrdinal)
 
   expect(
-    getMessageShowUsername({
+    showUsernameFor({
       message: messageMap.get(currentOrdinal)!,
       messageMap,
       messageOrdinals: [firstOrdinal, currentOrdinal],

--- a/shared/chat/conversation/messages/row-metadata.tsx
+++ b/shared/chat/conversation/messages/row-metadata.tsx
@@ -18,13 +18,22 @@ const findOrdinalIndex = (ordinals: ReadonlyArray<T.Chat.Ordinal>, ordinal: T.Ch
   return low
 }
 
-export const getPreviousOrdinal = (
+// `inWindow` tells apart "this row is the oldest thing loaded" (previous is a real gap that a
+// scroll-back load can fill) from "we were asked about an ordinal the loaded window doesn't have"
+// (a stale item id during list churn), which looks identical from the previous ordinal alone.
+const getPreviousOrdinalInfo = (
   messageOrdinals: ReadonlyArray<T.Chat.Ordinal>,
   ordinal: T.Chat.Ordinal
 ) => {
   const idx = findOrdinalIndex(messageOrdinals, ordinal)
-  return messageOrdinals[idx] === ordinal && idx > 0 ? messageOrdinals[idx - 1]! : emptyOrdinal
+  const inWindow = messageOrdinals[idx] === ordinal
+  return {inWindow, previous: inWindow && idx > 0 ? messageOrdinals[idx - 1]! : emptyOrdinal}
 }
+
+export const getPreviousOrdinal = (
+  messageOrdinals: ReadonlyArray<T.Chat.Ordinal>,
+  ordinal: T.Chat.Ordinal
+) => getPreviousOrdinalInfo(messageOrdinals, ordinal).previous
 
 export const getPreviousMessage = (
   messageOrdinals: ReadonlyArray<T.Chat.Ordinal>,
@@ -35,13 +44,21 @@ export const getPreviousMessage = (
   return previousOrdinal ? messageMap.get(previousOrdinal) : undefined
 }
 
-// Sticky username-header behavior. Whether a row shows the author header depends on its PREVIOUS
-// message (author grouping). When older messages load in (scroll-back pagination), a row's previous
-// changes from missing/placeholder to a real same-author message, which would collapse the header
-// and shrink the row — making the thread jump. Once a row has shown the header we keep showing it,
-// even if a later-loaded previous would group it away, so already-rendered rows never change height.
-// The cache is owned per-conversation by the thread provider (ShownUsernameCacheContext) and passed
-// in; omitting it (e.g. in tests) just disables stickiness.
+// Username-header behavior. Whether a row shows the author header depends on its PREVIOUS message
+// (author grouping), so the oldest row of the loaded window has no previous and must assume it
+// leads a group. A scroll-back load then hands it a same-author previous and the header has to go —
+// but dropping the header outright shrinks the row ~40px mid-load and the thread jumps. So the row
+// keeps the SPACE and loses the CONTENT: `showUsername` is always the currently correct answer
+// (empty once the row groups) while `reserveHeader` says a header was already painted here, so the
+// row renders it invisibly and its height never changes. shownCache records which rows painted one.
+//
+// Only non-provisional decisions are recorded. A row whose previous ordinal is in the window but
+// whose message is missing or still an unboxing placeholder reads as a different author and shows a
+// header it will lose a moment later; that neighbor's own height is about to change anyway, so
+// reserving space for it would leave a permanent blank gap where an avatar never belonged. Ditto a
+// stale ordinal that isn't in the window at all. The cache is owned per-conversation by the thread
+// provider (ShownUsernameCacheContext) and passed in; omitting it (e.g. in tests) disables both the
+// recording and the reservation.
 export const getMessageShowUsername = (p: {
   message: T.Chat.Message
   messageMap: ReadonlyMap<T.Chat.Ordinal, T.Chat.Message>
@@ -49,16 +66,20 @@ export const getMessageShowUsername = (p: {
   ordinal: T.Chat.Ordinal
   you: string
   shownCache?: Map<T.Chat.Ordinal, string>
-}) => {
+}): {reserveHeader: boolean; showUsername: string} => {
   const {message, messageMap, messageOrdinals, ordinal, you, shownCache} = p
-  const result = getUsernameToShow(message, getPreviousMessage(messageOrdinals, messageMap, ordinal), you)
-  if (!shownCache) return result
-  if (result) {
-    shownCache.set(ordinal, result)
-    return result
+  const {inWindow, previous} = getPreviousOrdinalInfo(messageOrdinals, ordinal)
+  const previousMessage = previous ? messageMap.get(previous) : undefined
+  const showUsername = getUsernameToShow(message, previousMessage, you)
+  if (!shownCache) return {reserveHeader: false, showUsername}
+  const provisional = !inWindow || (!!previous && (!previousMessage || previousMessage.type === 'placeholder'))
+  if (showUsername) {
+    if (!provisional) {
+      shownCache.set(ordinal, showUsername)
+    }
+    return {reserveHeader: false, showUsername}
   }
-  // sticky: if this row previously showed the author, keep it rather than collapsing on load
-  return shownCache.get(ordinal) ?? result
+  return {reserveHeader: shownCache.has(ordinal), showUsername}
 }
 
 export const getMessageRowRecycleType = (

--- a/shared/chat/conversation/messages/separator.tsx
+++ b/shared/chat/conversation/messages/separator.tsx
@@ -35,7 +35,7 @@ const useSeparatorData = (trailingItem: T.Chat.Ordinal) => {
       // only pay for the time label when an orange line will actually render
       let orangeTime = ''
       if (orangeLineAbove && !isMobile) {
-        const showUsername = RowMetadata.getMessageShowUsername({
+        const {showUsername} = RowMetadata.getMessageShowUsername({
           message: m,
           messageMap: s.messageMap,
           messageOrdinals,

--- a/shared/chat/conversation/messages/wrapper/wrapper.tsx
+++ b/shared/chat/conversation/messages/wrapper/wrapper.tsx
@@ -73,6 +73,7 @@ const missingMessage = Chat.makeMessageDeleted({})
 type AuthorProps = {
   author: string
   botAlias: string
+  hiddenHeader: boolean
   isAdhocBot: boolean
   teamID: T.Teams.TeamID
   teamType: T.Chat.TeamType
@@ -95,6 +96,7 @@ type EditCancelRetryData = {
 type FlatAuthorData = {
   author: string
   botAlias: string
+  hiddenHeader: boolean
   isAdhocBot: boolean
   showUsername: string
   teamID: T.Teams.TeamID
@@ -106,6 +108,7 @@ type FlatAuthorData = {
 const emptyAuthorData: FlatAuthorData = {
   author: '',
   botAlias: '',
+  hiddenHeader: false,
   isAdhocBot: false,
   showUsername: '',
   teamID: '' as T.Teams.TeamID,
@@ -125,7 +128,8 @@ const getRowActions = (
 }
 
 function AuthorSection(p: AuthorProps) {
-  const {author, botAlias, isAdhocBot, teamID, teamType, teamname, timestamp, showUsername} = p
+  const {author, botAlias, hiddenHeader, isAdhocBot, teamID, teamType, teamname, timestamp} = p
+  const {showUsername} = p
 
   const authorRoleInTeam = useChatTeamMemberRole(teamID, author)
   const onAuthorClick = () => navToProfile(showUsername)
@@ -174,16 +178,20 @@ function AuthorSection(p: AuthorProps) {
     usernameNode
   )
 
+  // hidden: the header keeps its space so the row height never changes, but nothing of it shows.
+  // The avatar is absolutely positioned, so dropping it (and its image fetch) costs no height.
   return (
     <>
-      <Kb.Avatar size={32} username={showUsername} onClick={onAuthorClick} style={styles.avatar} />
+      {hiddenHeader ? null : (
+        <Kb.Avatar size={32} username={showUsername} onClick={onAuthorClick} style={styles.avatar} />
+      )}
       <Kb.Box2
-        pointerEvents="box-none"
+        pointerEvents={hiddenHeader ? 'none' : 'box-none'}
         key="author"
         direction="horizontal"
         alignItems="flex-start"
         alignSelf="flex-start"
-        style={styles.authorContainer}
+        style={hiddenHeader ? styles.authorContainerHidden : styles.authorContainer}
         gap="tiny"
       >
         <Kb.Box2
@@ -209,9 +217,10 @@ const getAuthorData = (
   message: T.Chat.Message,
   meta: Pick<T.Chat.ConversationMeta, 'botAliases' | 'teamID' | 'teamType' | 'teamname'>,
   participants: T.Chat.ParticipantInfo,
-  showUsername: string
+  showUsername: string,
+  reserveHeader: boolean
 ): FlatAuthorData => {
-  if (!showUsername) {
+  if (!showUsername && !reserveHeader) {
     return emptyAuthorData
   }
   const {author, timestamp} = message
@@ -222,8 +231,11 @@ const getAuthorData = (
   return {
     author,
     botAlias: botAliases[author] ?? '',
+    hiddenHeader: !showUsername,
     isAdhocBot,
-    showUsername,
+    // the hidden header still renders the author line, it just doesn't show; it needs a name to
+    // lay out the same way the visible one did
+    showUsername: showUsername || author,
     teamID,
     teamType,
     teamname,
@@ -402,7 +414,7 @@ export const useMessageData = (ordinal: T.Chat.Ordinal, isCenteredHighlight?: bo
         unfurlPrompt: s.unfurlPrompt,
         you,
       })
-      const showUsername = RowMetadata.getMessageShowUsername({
+      const {reserveHeader, showUsername} = RowMetadata.getMessageShowUsername({
         message,
         messageMap: s.messageMap,
         messageOrdinals: s.messageOrdinals ?? [],
@@ -414,7 +426,7 @@ export const useMessageData = (ordinal: T.Chat.Ordinal, isCenteredHighlight?: bo
         ...commonData,
         ...getEditCancelRetryData(commonData.ecrType, message),
         ...getRowActions(messageActions, uiDispatch, retryMessage),
-        ...getAuthorData(message, authorMeta, participantInfo, showUsername),
+        ...getAuthorData(message, authorMeta, participantInfo, showUsername, reserveHeader),
         message,
       }
     })
@@ -929,7 +941,8 @@ export function WrapperMessage(p: WrapperMessageProps) {
   const {showCoinsIcon, botname, hasBeenEdited, hasUnfurlList, showCenteredHighlight} = mdata
   const {failureDescription, messageDelete, messageRetry, outboxID} = mdata
   const {setEditing, setReplyTo, toggleMessageReaction} = mdata
-  const {author, botAlias, isAdhocBot, showUsername, teamID, teamType, teamname, timestamp} = mdata
+  const {author, botAlias, hiddenHeader, isAdhocBot, showUsername, teamID, teamType, teamname} = mdata
+  const {timestamp} = mdata
 
   // Both pieces of per-row state are keyed to messageKey and reset when it changes: with
   // recycleItems the component instance is REUSED for a different message, so plain mount-captured
@@ -1000,6 +1013,7 @@ export function WrapperMessage(p: WrapperMessageProps) {
       <AuthorHeader
         author={author}
         botAlias={botAlias}
+        hiddenHeader={hiddenHeader}
         isAdhocBot={isAdhocBot}
         showUsername={showUsername}
         teamID={teamID}
@@ -1030,6 +1044,17 @@ const styles = Kb.Styles.styleSheetCreate(
         },
         isElectron: {
           ...Kb.Styles.marginV(0),
+        },
+        isMobile: {marginTop: 8},
+      }),
+      authorContainerHidden: Kb.Styles.platformStyles({
+        common: {
+          marginLeft: isMobile ? 48 : 56,
+          opacity: 0,
+        },
+        isElectron: {
+          ...Kb.Styles.marginV(0),
+          visibility: 'hidden',
         },
         isMobile: {marginTop: 8},
       }),


### PR DESCRIPTION
## Problem

The oldest row of the loaded window has no previous message, so it assumes it leads a group and paints an author header. A scroll-back load then hands it a same-author previous, and the header should collapse — but dropping it shrinks the row ~40px mid-load and the thread jumps.

The previous fix made the header sticky: once shown, always shown. That kept the height stable but left a **duplicate header** sitting above the newly loaded same-author message.

## Fix

The row now keeps the *space* and loses the *content*.

`getMessageShowUsername` returns `{showUsername, reserveHeader}`:

- `showUsername` is always the currently correct answer — empty once the row groups.
- `reserveHeader` says a header was already painted here, so the row renders the author line invisibly and its height never changes.

The avatar is absolutely positioned, so it's dropped outright along with its image fetch; only the author line holds the space.

Only non-provisional decisions get recorded in `shownCache`. A row whose previous ordinal is in the window but whose message is missing or still an unboxing placeholder reads as a different author and shows a header it will lose a moment later — that neighbor's own height is about to change anyway, so reserving space for it would leave a permanent blank gap where an avatar never belonged. Same for a stale ordinal that isn't in the window at all.

`getItemType` pools reserved-header rows with headered ones, since they're the same height.

## Test plan

- `yarn jest chat/conversation/messages/row-metadata.test.ts` — 6 passed, including two new cases covering the reserve-vs-provisional split
- `yarn lint:all` — eslint clean, 0 react-compiler bailouts, tsc clean
- Needs a visual pass: scroll back in a conversation with a run of same-author messages at the window boundary and confirm no duplicate header and no jump.