### PR TITLE
feat(chat): show attachment file size in message popup header

### DIFF
--- a/shared/chat/conversation/messages/message-popup/exploding-header.tsx
+++ b/shared/chat/conversation/messages/message-popup/exploding-header.tsx
@@ -3,6 +3,7 @@ import * as Kb from '@/common-adapters'
 import {formatTimeForPopup, formatTimeForRevoked, msToDHMS} from '@/util/timestamp'
 import {addTicker, removeTicker} from '@/util/second-timer'
 import {navToProfile} from '@/constants/router'
+import {humanReadableFileSize} from '@/constants/fs'
 
 type Props = {
   explodesAt: number
@@ -10,6 +11,7 @@ type Props = {
   botUsername?: string
   deviceName: string
   deviceRevokedAt?: number
+  fileSize?: number
   hideTimer: boolean
   timestamp: number
   yourMessage: boolean
@@ -43,7 +45,8 @@ const ExplodingPopupHeader = (props: Props) => {
 
   const [now] = React.useState(() => Date.now())
 
-  const {author, botUsername, deviceName, deviceRevokedAt, hideTimer, timestamp} = props
+  const {author, botUsername, deviceName, deviceRevokedAt, fileSize, hideTimer, timestamp} = props
+  const prettySize = fileSize ? humanReadableFileSize(fileSize) : ''
   const icon = <Kb.ImageIcon style={styles.headerIcon} type={headerIconType} />
   const info = (
     <Kb.Box2 direction="vertical" fullWidth={true} padding="xsmall">
@@ -83,6 +86,11 @@ const ExplodingPopupHeader = (props: Props) => {
         <Kb.Text center={true} type="BodySmall">
           {formatTimeForPopup(timestamp)}
         </Kb.Text>
+        {prettySize ? (
+          <Kb.Text center={true} type="BodySmall">
+            {prettySize}
+          </Kb.Text>
+        ) : null}
         {deviceRevokedAt ? (
           <Kb.Text center={true} type="BodySmallSemibold" style={Kb.Styles.collapseStyles([styles.popupHeaderText, styles.revokedAt])}>
             Device revoked on {formatTimeForRevoked(deviceRevokedAt)}

--- a/shared/chat/conversation/messages/message-popup/header.tsx
+++ b/shared/chat/conversation/messages/message-popup/header.tsx
@@ -2,6 +2,7 @@ import * as Kb from '@/common-adapters'
 import {formatTimeForPopup, formatTimeForRevoked} from '@/util/timestamp'
 import type * as T from '@/constants/types'
 import {navToProfile} from '@/constants/router'
+import {humanReadableFileSize} from '@/constants/fs'
 
 const iconNameForDeviceType = isMobile
   ? (deviceType: string, isRevoked: boolean, isLocation: boolean): Kb.IconType => {
@@ -41,6 +42,7 @@ type Props = {
   deviceName: string
   deviceRevokedAt?: number
   deviceType: T.Devices.DeviceType
+  fileSize?: number
   isLast?: boolean
   isLocation: boolean
   timestamp: number
@@ -48,8 +50,9 @@ type Props = {
   onHidden: () => void
 }
 const MessagePopupHeader = (props: Props) => {
-  const {author, botUsername, deviceName, deviceRevokedAt, deviceType} = props
+  const {author, botUsername, deviceName, deviceRevokedAt, deviceType, fileSize} = props
   const {isLast, isLocation, timestamp, yourMessage, onHidden} = props
+  const prettySize = fileSize ? humanReadableFileSize(fileSize) : ''
   const iconName = iconNameForDeviceType(deviceType, !!deviceRevokedAt, isLocation)
   const whoRevoked = yourMessage ? 'You' : author
 
@@ -100,6 +103,11 @@ const MessagePopupHeader = (props: Props) => {
       <Kb.Text center={true} type="BodySmall">
         {formatTimeForPopup(timestamp)}
       </Kb.Text>
+      {prettySize ? (
+        <Kb.Text center={true} type="BodySmall">
+          {prettySize}
+        </Kb.Text>
+      ) : null}
       {!!deviceRevokedAt && (
         <Kb.Box2
           gap="small"

--- a/shared/chat/conversation/messages/message-popup/hooks.tsx
+++ b/shared/chat/conversation/messages/message-popup/hooks.tsx
@@ -380,6 +380,7 @@ export const useHeaderForMessage = (message: T.Chat.Message, onHidden: () => voi
   const deviceRevokedAt = message.deviceRevokedAt || undefined
   const mapUnfurl = Chat.getMapUnfurl(message)
   const isLocation = !!mapUnfurl
+  const fileSize = message.type === 'attachment' ? message.fileSize : undefined
 
   return exploding ? (
     <ExplodingPopupHeader
@@ -389,6 +390,7 @@ export const useHeaderForMessage = (message: T.Chat.Message, onHidden: () => voi
       botUsername={botUsername}
       deviceName={deviceName ?? ''}
       deviceRevokedAt={deviceRevokedAt}
+      fileSize={fileSize}
       explodesAt={message.exploded ? 0 : (explodingTime ?? 0)}
       timestamp={timestamp}
       yourMessage={yourMessage}
@@ -401,6 +403,7 @@ export const useHeaderForMessage = (message: T.Chat.Message, onHidden: () => voi
       deviceName={deviceName ?? ''}
       deviceRevokedAt={deviceRevokedAt}
       deviceType={deviceType ?? 'desktop'}
+      fileSize={fileSize}
       isLast={false}
       isLocation={isLocation}
       timestamp={timestamp}


### PR DESCRIPTION
## Summary
Right-clicking (or long-pressing) a chat attachment now shows the file size in the popup's header area, under the timestamp.

## Details
- `hooks.tsx`: `useHeaderForMessage` reads `message.fileSize` when the message is an attachment and passes it to the header.
- `header.tsx` / `exploding-header.tsx`: new optional `fileSize` prop rendered as a `BodySmall` line below `formatTimeForPopup`. Formatted with `humanReadableFileSize` from `@/constants/fs`, which returns `''` for 0 — the row is omitted in that case, so non-attachment messages are unchanged.

## Test plan
- `yarn tsc`, `yarn lint`, `yarn lint:bailouts` all clean.
- Visual check pending on desktop + mobile popups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)