### PR TITLE
fix(ios): restore 6.6.3 image compression

### DIFF
--- a/rnmodules/kb-common/src/MediaUtils.swift
+++ b/rnmodules/kb-common/src/MediaUtils.swift
@@ -4,8 +4,11 @@ import ImageIO
 import UIKit
 
 struct MediaProcessingConfig {
-    static let imageMaxPixelSize: Int = 1200
-    static let imageCompressionQuality: CGFloat = 0.85
+    // Images keep their original dimensions: 6.6.3's in-chat attach re-encoded at
+    // this quality without resizing, and downscaling to a thumbnail-sized long
+    // edge is the visible regression users noticed when the share extension's
+    // policy took over both flows.
+    static let imageCompressionQuality: CGFloat = 0.4
 }
 
 enum MediaUtilsError: Error, LocalizedError {
@@ -28,11 +31,13 @@ typealias ProcessMediaCompletion = (Result<URL, Error>) -> Void
 
 @objc(MediaUtils)
 public class MediaUtils: NSObject {
-    private static var scaledImageOptions: CFDictionary {
+    // No max pixel size, so this decodes at full resolution; it stays a thumbnail
+    // request only because that's the call that bakes the EXIF orientation into
+    // the pixels, which the re-encoded JPEG no longer carries as metadata.
+    private static var fullSizeImageOptions: CFDictionary {
         return [
             kCGImageSourceCreateThumbnailWithTransform: true,
             kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceThumbnailMaxPixelSize: MediaProcessingConfig.imageMaxPixelSize,
         ] as CFDictionary
     }
 
@@ -84,17 +89,18 @@ public class MediaUtils: NSObject {
 
         try stripImageExif(at: url)
 
-        // Create scaled version
+        // Re-encode at the shared quality. Same dimensions, JPEG out, so a HEIC
+        // pick still lands as something every platform can render.
         let basename = url.deletingPathExtension().lastPathComponent
         let parent = url.deletingLastPathComponent()
-        let scaledURL = parent.appendingPathComponent("\(basename).scaled.jpg")
+        let compressedURL = parent.appendingPathComponent("\(basename).compressed.jpg")
 
         guard let cgSource = CGImageSourceCreateWithURL(url as CFURL, nil) else {
             throw MediaUtilsError.imageProcessingFailed("Failed to create image source")
         }
 
-        try scaleDownCGImageSource(cgSource, dstURL: scaledURL, options: scaledImageOptions)
-        return scaledURL
+        try recompressCGImageSource(cgSource, dstURL: compressedURL, options: fullSizeImageOptions)
+        return compressedURL
     }
 
     // edit carries the user's trim range and audio choice; nil means "the whole
@@ -280,25 +286,25 @@ public class MediaUtils: NSObject {
         }
     }
 
-    private static func scaleDownCGImageSource(
+    private static func recompressCGImageSource(
         _ img: CGImageSource, dstURL: URL, options: CFDictionary
     ) throws {
-        guard let scaledRef = CGImageSourceCreateThumbnailAtIndex(img, 0, options) else {
-            throw MediaUtilsError.imageProcessingFailed("Failed to create thumbnail")
+        guard let fullRef = CGImageSourceCreateThumbnailAtIndex(img, 0, options) else {
+            throw MediaUtilsError.imageProcessingFailed("Failed to decode image")
         }
 
         guard
-            let scaled = UIImage(cgImage: scaledRef).jpegData(
+            let data = UIImage(cgImage: fullRef).jpegData(
                 compressionQuality: MediaProcessingConfig.imageCompressionQuality)
         else {
             throw MediaUtilsError.imageProcessingFailed("Failed to create JPEG data")
         }
 
         do {
-            try scaled.write(to: dstURL)
+            try data.write(to: dstURL)
         } catch {
             throw MediaUtilsError.fileOperationFailed(
-                "Failed to write scaled image: \(error.localizedDescription)")
+                "Failed to write compressed image: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Problem

Unifying the share extension and in-chat attach onto `MediaUtils` (#29485) also handed in-chat attach the share extension's image policy: a 1200px long edge at quality 0.85. In 6.6.3, in-chat attach went through `expo-image-picker` at `quality: 0.4` with **no resize**, so a photo that used to arrive at full resolution now arrives thumbnail-sized. A user reported it.

| | dimensions | bytes |
|---|---|---|
| source | 4032x3024 | 4,028,880 |
| 6.6.3 | 4032x3024 | 1,670,062 |
| this branch before | 1200x900 | 631,988 |
| this branch after | 4032x3024 | ~1,672,898 |

## Change

`rnmodules/kb-common/src/MediaUtils.swift` only:

- drop `imageMaxPixelSize` — no downscale
- `imageCompressionQuality` 0.85 → 0.4
- rename `scaledImageOptions`/`scaleDownCGImageSource`/`.scaled.jpg` to the `fullSize`/`recompress`/`.compressed.jpg` equivalents, since nothing is being scaled anymore. Nothing outside this file referenced those names.

The full-size decode is still a `CGImageSourceCreateThumbnailAtIndex` call rather than a plain decode: that call is what bakes EXIF orientation into the pixels, and the re-encoded JPEG no longer carries orientation as metadata.

The share extension and in-chat attach still share exactly one policy — it's just 6.6.3's now instead of the share extension's.

## Scope

- Android unaffected: `processPaths` early-returns off iOS, and the Android picker already used `quality: 0.4` at full resolution, which is the 6.6.3 behavior.
- No podspec change, so no `pod install`; `kb-common` is referenced by path and needs no `yarn sync:kb-modules`.
- Video handling untouched.

## Testing

Verified the quality figure out-of-band with `sips -s format jpeg -s formatOptions 40` against the reporter's source image: 1,672,898 bytes vs 6.6.3's 1,670,062, same dimensions. Needs an iOS build to confirm end to end through both the share extension and in-chat attach.

## Note, not addressed here

`stripImageExif` still rewrites the source file before the re-encode. It was already redundant (`jpegData` emits no EXIF/GPS) and now costs a full-size rewrite of the original. Left alone to keep this diff to the compression change.