### PR TITLE
fix(desktop): stop deep links stranding when the router readies pre-bootstrap

### DIFF
--- a/shared/router-v2/linking.test.ts
+++ b/shared/router-v2/linking.test.ts
@@ -130,3 +130,21 @@ test('uses imperative navigation for URLs outside the linking state config', () 
   expect(useNavigationIntentsState.getState().intent).toBeUndefined()
   unsubscribe()
 })
+
+test('consumes an intent after bootstrap fills in the uid the router readied with', () => {
+  // Desktop mounts its NavigationContainer before the bootstrap RPC returns, so
+  // onReady stamps readiness with an empty uid. The same container then serves
+  // the logged-in user; intents must not be stranded.
+  setCurrentUser('')
+  useNavigationIntentsState.getState().dispatch.setNavigationReady(true, '')
+  setCurrentUser('current-uid')
+
+  const listener = jest.fn()
+  const unsubscribe = subscribeNavigationIntents(listener, jest.fn())
+
+  emitDeepLink('keybase://convid/post-bootstrap-conversation')
+
+  expect(listener).toHaveBeenCalledTimes(1)
+  expect(listener).toHaveBeenCalledWith('keybase://convid/post-bootstrap-conversation')
+  unsubscribe()
+})

--- a/shared/router-v2/linking.tsx
+++ b/shared/router-v2/linking.tsx
@@ -111,7 +111,13 @@ export const subscribeNavigationIntents = (
 
     const {loggedIn, userSwitching} = useConfigState.getState()
     const currentUid = useCurrentUserState.getState().uid
-    if (!navigationReady || navigationReadyForUid !== currentUid || !loggedIn || userSwitching) return
+    if (!navigationReady || !loggedIn || userSwitching) return
+    // Desktop mounts its NavigationContainer before the bootstrap RPC returns, so
+    // onReady stamps readiness with an empty uid. That container goes on to serve
+    // whoever logs in, so an unstamped router matches any account. Real account
+    // switches remount the router (useUserSwitchNavKey) and re-stamp with the new
+    // uid, which still blocks the old container here.
+    if (navigationReadyForUid && navigationReadyForUid !== currentUid) return
     if (intent.targetUid && intent.targetUid !== currentUid) return
 
     consumingID = intent.id


### PR DESCRIPTION
## Problem

Clicking a `keybase://` link inside a chat thread did nothing on desktop release builds — no navigation, no error modal, and re-clicking the same link also no-opped.

## Root cause

`DesktopRouter` mounts its `NavigationContainer` unconditionally, so `onReady` stamps navigation readiness with an empty uid: the bootstrap RPC that fills `useCurrentUserState` hasn't returned yet. The consume gate in `subscribeNavigationIntents` required `navigationReadyForUid === currentUid`, so once the real uid landed the stamp never matched and every queued deep-link intent stayed pending for the life of the session. `enqueue` dedupes against the pending intent, which is why repeat clicks were silent too.

It's a race, which is why debug builds usually looked fine. Mobile was never affected: `NativeRouter` gates its container on `loggedInLoaded && startupLoaded`, so it readies after the uid exists.

## Fix

Treat an unstamped router as matching any account — that container goes on to serve whoever logs in. Real account switches remount the router via `useUserSwitchNavKey` and re-stamp with the new uid, so the guard that keeps an old container from consuming a new account's intent still holds.

## Test

New case in `router-v2/linking.test.ts` covering ready-with-empty-uid → bootstrap → intent consumed. Red before the fix, green after. `yarn lint:all` clean (0 react-compiler bailouts).

Verified by hand in a desktop release build.