### PR TITLE
fix(android): dark mode — live repaint, splash flash, system setting

### DIFF
--- a/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
+++ b/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
@@ -145,7 +145,8 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
         constants.putBoolean("androidIsTestDevice", misTestDevice)
         constants.putString("appVersionCode", c.versionCode)
         constants.putString("appVersionName", c.versionName)
-        constants.putBoolean("darkModeSupported", false)
+        // System dark mode (uiMode night mask) exists on Q+.
+        constants.putBoolean("darkModeSupported", Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
         constants.putString("fsCacheDir", c.cacheDir)
         constants.putString("fsDownloadDir", c.downloadDir)
         // gui_config.json changes at runtime (route persistence), and JS re-reads

--- a/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.kt
+++ b/shared/android/app/src/main/java/io/keybase/ossifrage/MainActivity.kt
@@ -63,15 +63,16 @@ class MainActivity : ReactActivity() {
         setupKBRuntime(this, true)
         captureIntent(intent)
 
+        // Before super.onCreate so the first frame after the splash already has the
+        // right background; a delayed call here shows a white flash in dark mode.
+        try {
+            val gc = GuiConfig.getInstance(filesDir)
+            gc?.let { setBackgroundColor(it.getDarkMode()) }
+        } catch (e: Exception) {
+            NativeLogger.warn("Error reading GuiConfig in onCreate", e)
+        }
+
         super.onCreate(null)
-        Handler(Looper.getMainLooper()).postDelayed({
-            try {
-                val gc = GuiConfig.getInstance(filesDir)
-                gc?.let { setBackgroundColor(it.getDarkMode()) }
-            } catch (e: Exception) {
-                NativeLogger.warn("Error reading GuiConfig in onCreate", e)
-            }
-        }, 300)
         KeybasePushNotificationListenerService.createNotificationChannel(this)
         updateIsUsingHardwareKeyboard()
 
@@ -395,9 +396,11 @@ class MainActivity : ReactActivity() {
             DarkModePreference.AlwaysLight -> R.color.white
         }
         val mainWindow = this.window
-        val handler = Handler(Looper.getMainLooper())
-        // Run this on the main thread.
-        handler.post { mainWindow.setBackgroundDrawableResource(bgColor) }
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            mainWindow.setBackgroundDrawableResource(bgColor)
+        } else {
+            Handler(Looper.getMainLooper()).post { mainWindow.setBackgroundDrawableResource(bgColor) }
+        }
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {

--- a/shared/android/app/src/main/res/values-night/styles.xml
+++ b/shared/android/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,9 @@
+<resources>
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="android:windowBackground">@color/black</item>
+        <item name="android:colorBackground">@color/black</item>
+    </style>
+
+    <color name="splash_background">#191919</color>
+</resources>

--- a/shared/android/app/src/main/res/values-v31/styles.xml
+++ b/shared/android/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,8 @@
+<resources>
+    <!-- API 31+ ignores the legacy splash windowBackground drawable and draws the
+         system splash screen instead, which otherwise falls back to colorBackground. -->
+    <style name="SplashTheme" parent="AppTheme">
+        <item name="android:windowBackground">@drawable/splash_screen</item>
+        <item name="android:windowSplashScreenBackground">@color/splash_background</item>
+    </style>
+</resources>

--- a/shared/android/app/src/main/res/values/styles.xml
+++ b/shared/android/app/src/main/res/values/styles.xml
@@ -14,4 +14,5 @@
     <color name="white">#ffffff</color>
     <color name="blue">#4c8eff</color>
     <color name="black">#191919</color>
+    <color name="splash_background">#ffffff</color>
 </resources>

--- a/shared/router-v2/common.tsx
+++ b/shared/router-v2/common.tsx
@@ -15,10 +15,17 @@ import Header from './header/index'
 // creates two different bar types; pushing between them slides two opaque slabs (visible seam
 // riding the header during the transition) instead of morphing one native bar. The native
 // appearance already draws the theme card color (same palette value as globalColors.white).
+// Colors go through getters: this object lives at module scope, so a plain read would
+// bake in whatever the theme was at import time (before initDarkMode runs) and Android
+// resolves the palette at read time.
 export const headerDefaultStyle = isAndroid
   ? {
-      backgroundColor: Kb.Styles.globalColors.white,
-      borderBottomColor: Kb.Styles.globalColors.black_10,
+      get backgroundColor() {
+        return Kb.Styles.globalColors.white
+      },
+      get borderBottomColor() {
+        return Kb.Styles.globalColors.black_10
+      },
       borderBottomWidth: Kb.Styles.hairlineWidth,
       height: 44,
     }
@@ -92,7 +99,9 @@ export const defaultNavigationOptions = isMobile
         ...(DEBUGCOLORS ? {backgroundColor: 'orange'} : {}),
       },
       headerStyle: headerDefaultStyle,
-      headerTintColor: Kb.Styles.globalColors.black_50,
+      get headerTintColor() {
+        return Kb.Styles.globalColors.black_50
+      },
       headerTitle: (hp: {children: React.ReactNode}) => (
         <Kb.Text type="BodyBig" style={styles.headerTitle} lineClamp={1} center={true}>
           {hp.children}

--- a/shared/router-v2/router.tsx
+++ b/shared/router-v2/router.tsx
@@ -30,7 +30,7 @@ import {usePushState} from '@/stores/push'
 import {colors, darkColors} from '@/styles/colors'
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs'
 import {isLiquidGlassSupported as _isLiquidGlassSupported} from '@callstack/liquid-glass'
-import {Platform, StatusBar, View, useColorScheme} from 'react-native'
+import {Platform, StatusBar, View} from 'react-native'
 import AccountSwitchHeaderAvatar from './account-switch-header-avatar'
 import {clearPendingAccountSwitch, consumePendingAccountSwitchTab} from './account-switch'
 import {useCurrentUserState} from '@/stores/current-user'
@@ -490,8 +490,10 @@ const appTabsScreenOptions = (
       : {
           tabBarActiveIndicatorColor: 'rgba(255,255,255,0.15)',
           tabBarActiveIndicatorEnabled: true,
-          tabBarActiveTintColor: Kb.Styles.globalColors.white,
-          tabBarInactiveTintColor: Kb.Styles.globalColors.blueLighter,
+          // The bar is dark in both themes (greyDarkest/blueDark below), so the tints
+          // must not flip with the theme or the labels invert onto a dark background.
+          tabBarActiveTintColor: Kb.Styles.globalColors.whiteOrWhite,
+          tabBarInactiveTintColor: colors.blueLighter,
         }),
     tabBarIcon: getNativeTabIcon(routeName),
     tabBarLabel: tabToLabel.get(routeName) ?? routeName,
@@ -663,11 +665,12 @@ function NativeRouter() {
   )
 
   const bar = barStyle === 'default' ? null : <StatusBar barStyle={barStyle} />
-  // Android also remounts on dark mode changes
-  const nativeIsDarkMode = useColorScheme() === 'dark'
+  // Android resolves palette colors at read time, so a theme flip only reaches a
+  // component that happens to re-render; remount the whole tree instead. The suffix
+  // must not be gated on navKey (empty unless a user switch already happened).
   const navKey = Common.useUserSwitchNavKey()
-  const nativeDarkSuffix = isAndroid ? (nativeIsDarkMode ? '-dark' : '-light') : ''
-  const rootKey = navKey ? `${navKey}${nativeDarkSuffix}` : ''
+  const nativeDarkSuffix = isAndroid ? (isDarkMode ? '-dark' : '-light') : ''
+  const rootKey = `${navKey}${nativeDarkSuffix}`
   const setNavigationReady = useNavigationIntentsState(s => s.dispatch.setNavigationReady)
   const setNativeNavRef = (ref: typeof C.Router2.navigationRef.current) => {
     setNavRef(ref)

--- a/shared/router-v2/router.tsx
+++ b/shared/router-v2/router.tsx
@@ -666,11 +666,12 @@ function NativeRouter() {
 
   const bar = barStyle === 'default' ? null : <StatusBar barStyle={barStyle} />
   // Android resolves palette colors at read time, so a theme flip only reaches a
-  // component that happens to re-render; remount the whole tree instead. The suffix
+  // component that happens to re-render; remount the navigators instead. The suffix
   // must not be gated on navKey (empty unless a user switch already happened).
+  // Keyed inside NavigationContainer, not around it: the container owns the nav
+  // state, so remounting only its child repaints without losing where you were.
   const navKey = Common.useUserSwitchNavKey()
   const nativeDarkSuffix = isAndroid ? (isDarkMode ? '-dark' : '-light') : ''
-  const rootKey = `${navKey}${nativeDarkSuffix}`
   const setNavigationReady = useNavigationIntentsState(s => s.dispatch.setNavigationReady)
   const setNativeNavRef = (ref: typeof C.Router2.navigationRef.current) => {
     setNavRef(ref)
@@ -704,7 +705,7 @@ function NativeRouter() {
   }
 
   return (
-    <Kb.Box2 direction="vertical" pointerEvents="box-none" fullWidth={true} fullHeight={true} key={rootKey}>
+    <Kb.Box2 direction="vertical" pointerEvents="box-none" fullWidth={true} fullHeight={true} key={navKey}>
       {bar}
       <NavigationContainer
         fallback={<View style={{backgroundColor: Kb.Styles.globalColors.white, flex: 1}} />}
@@ -719,7 +720,7 @@ function NativeRouter() {
         theme={isDarkMode ? darkTheme : lightTheme}
       >
         <LoadedTeamsListProvider>
-          <NativeRootComponent />
+          <NativeRootComponent key={nativeDarkSuffix} />
         </LoadedTeamsListProvider>
       </NavigationContainer>
     </Kb.Box2>


### PR DESCRIPTION
Android dark mode was broken end to end: white startup flash, white header, wrong text colors, unreadable tab bar, and no way to follow the system setting. iOS was unaffected.

## Why Android only

`themed` in `shared/styles/colors.tsx` is platform-split. iOS returns a `DynamicColorIOS` object and desktop returns a `var(--color-x)` string — both stay live no matter when they're read. Android returns a concrete hex **at read time**, so a component only picks up a theme flip when it re-renders, and dark mode isn't part of most components' subscribed state. The app has always covered that with a whole-tree remount keyed on the theme.

`PlatformColor` is not an escape hatch. `ColorPropConverter.kt` resolves `resource_paths` to an `int` when props are applied, so those views go stale exactly the same way ours do. With ~2900 `globalColors.*` read sites, making leaves resolve lazily isn't realistic — the remount stays.

## The remount was dead

It used to live in `router-v2/hooks.native.tsx`:

```js
export const useRootKey = () => {
  const [rootKey, setRootKey] = React.useState('')
  const isDarkMode = useColorScheme() === 'dark'
  React.useEffect(() => {
    if (!C.isAndroid) return
    setRootKey(isDarkMode ? 'android-dark' : 'android-light')
  }, [isDarkMode])
  return rootKey
}
```

The router rewrite folded it into the user-switch nav key:

```js
const rootKey = navKey ? `${navKey}${nativeDarkSuffix}` : ''
```

`navKey` comes from `useUserSwitchNavKey()`, which is `''` unless a user switch already happened — so `rootKey` was permanently `''` and the dark suffix never reached the key. Launching with `alwaysDark` while the system is light left light-mode rows and text painted over the dark root, and toggling the preference changed nothing.

This ungates the suffix and derives it from the darkmode store's `isDarkMode` instead of `useColorScheme()`, so the remount tracks the same source the palette reads.

## …and then it reset your navigation

Restoring the remount exposed the next problem: the key sat on the `Kb.Box2` **wrapping** `NavigationContainer`, so a theme flip tore down the container and the whole nav state went with it. Toggling dark mode from Settings → Display dumped you back on the Teams tab root.

The key now sits on `NativeRootComponent`, **inside** the container. The container owns the nav state, so remounting only its child repaints every screen while the route stack survives. Component state below it (scroll offsets, local `useState`) still resets — unavoidable, since repainting Android *is* re-rendering.

## Header froze separately

`headerDefaultStyle` lost its `get backgroundColor()` accessor and became a plain object literal. Module scope evaluates once at import, before `initDarkMode()` runs, so the header background froze at light `#FFFFFF` — and no remount fixes that, since module scope never re-evaluates. Getters restored, and `headerTintColor` gets the same treatment.

## Tab bar tints

The Android tab bar is dark in both themes (`greyDarkest`/`blueDark`), but its tints used theme-flipping `white`/`blueLighter`, so in dark mode the active label rendered near-black on a dark bar. Now uses the fixed variants, matching what iOS already does on its non-glass path.

## White splash flash on launch

Cold launch in dark mode flashed white with the logo, from three separate causes:

- API 31+ ignores `SplashTheme`'s legacy layer-list `android:windowBackground` and draws the system splash instead, falling back to `colorBackground` (white). New `res/values-v31/styles.xml` sets `android:windowSplashScreenBackground`.
- `res/values-night/` didn't exist at all, so `AppTheme`'s `windowBackground`/`colorBackground` stayed white in dark. Added a night `AppTheme`.
- `MainActivity.onCreate` read the GuiConfig dark preference inside `postDelayed(…, 300)`, leaving 300ms of white after the splash dismissed. Now read above `super.onCreate`, and `setBackgroundColor` applies inline when it's already on the main thread.

Two knowingly-unfixed residuals: pre-API-31 devices still get the old blue `mipmap/splash.png` (background baked into the bitmap), and an `alwaysDark` preference under a light system still gets a light system splash, since that background is a resource resolved before any app code runs.

## "Respect system settings" was hidden on Android

`settings/display.tsx` gates that radio on the native `darkModeSupported` constant. iOS returns `@YES`; `KbModule.kt` hardcoded `false`, so Android never showed the option — even though the `DayNight` theme, `colorSchemeForCurrentConfiguration()` and RN `Appearance` all already worked. Now gated on API 29+, matching where the uiMode night mask exists.

## iOS

Untouched by construction: `nativeDarkSuffix` is still `isAndroid ? … : ''`, `headerDefaultStyle`'s iOS branch is still `{}`, the tint change is in the non-iOS arm, and the `headerTintColor` getter returns the identical `DynamicColorIOS` value, just read later. The splash and `darkModeSupported` changes are Android resources and Android native.

## Verification

Measured pixel colors from `adb screencap` on a Pixel 6a, preference `alwaysDark` with system night mode off:

| | before | after |
|---|---|---|
| header bg | `#ffffff` | `#303030`, native header `#191919` |
| rows | `#ffffff` | `#191919` |
| tab bar active label | dark on dark | white |
| live Dark→Light | no change | full repaint, bar `#3663ea` |
| live Light→Dark | — | full repaint back |

Then on the same device, driving the system setting with `adb shell cmd uimode night yes|no`:

- Cold launch in dark: splash is `#191919`, no white frame.
- Settings → Display now lists "Respect system settings", and selecting it tracks the system live with no restart.
- Flipping the theme while on Settings → Display leaves you on Display, fully repainted, with the back stack intact.
- Same flip from inside an open conversation leaves the conversation open and repainted.

`yarn lint:all` clean — 0 bailouts, 0 whole-props deps, tsc green. Not yet checked on an iOS device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
