### PR TITLE
chore(deps): routine dep bump + security re-resolves

### DIFF
--- a/protocol/package.json
+++ b/protocol/package.json
@@ -22,7 +22,7 @@
     "json5": "2.2.3"
   },
   "devDependencies": {
-    "@types/node": "26.1.2",
+    "@types/node": "26.2.0",
     "typescript": "7.0.2"
   },
   "resolutions": {

--- a/protocol/yarn.lock
+++ b/protocol/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@types/node@26.1.2":
-  version "26.1.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.2.tgz#da79708f1f9c6294f4cdec8f455a3032b028808a"
-  integrity sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==
+"@types/node@26.2.0":
+  version "26.2.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.2.0.tgz#5a4875a862fda8fdc57de8faa579bb81ecba1685"
+  integrity sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==
   dependencies:
     undici-types "~8.3.0"
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -96,7 +96,7 @@
     "@gorhom/bottom-sheet": "5.2.14",
     "@gorhom/portal": "1.0.14",
     "@khanacademy/simple-markdown": "3.0.0",
-    "@legendapp/list": "3.3.3",
+    "@legendapp/list": "3.3.4",
     "@msgpack/msgpack": "3.1.3",
     "@react-native-community/netinfo": "12.0.1",
     "@react-native-masked-view/masked-view": "0.3.2",
@@ -189,7 +189,7 @@
     "babel-preset-expo": "57.0.6",
     "cross-env": "10.1.0",
     "electron": "43.3.0",
-    "eslint": "10.8.0",
+    "eslint": "10.8.1",
     "eslint-plugin-deprecation": "3.0.0",
     "eslint-plugin-promise": "7.3.0",
     "eslint-plugin-react": "7.37.5",
@@ -208,7 +208,7 @@
   },
   "resolutions": {
     "**/@types/react": "19.2.18",
-    "**/serialize-javascript": "7.0.7",
+    "**/serialize-javascript": "7.1.0",
     "**/xcode/uuid": "14.0.1"
   },
   "typecoverage": {

--- a/shared/patches/@legendapp+list+3.3.4.patch
+++ b/shared/patches/@legendapp+list+3.3.4.patch
@@ -1,5 +1,33 @@
+diff --git a/node_modules/@legendapp/list/react-native.js b/node_modules/@legendapp/list/react-native.js
+index ca99e71..32720c3 100644
+--- a/node_modules/@legendapp/list/react-native.js
++++ b/node_modules/@legendapp/list/react-native.js
+@@ -6402,7 +6402,8 @@ var ScheduledWork = class {
+     const work = this.work.get(key);
+     if (work) {
+       this.work.delete(key);
+-      work[1](work[0]);
++      const [handle, cancelWork] = work;
++      cancelWork(handle);
+     }
+   }
+   has(key) {
+diff --git a/node_modules/@legendapp/list/react-native.mjs b/node_modules/@legendapp/list/react-native.mjs
+index 5315f44..5faff3c 100644
+--- a/node_modules/@legendapp/list/react-native.mjs
++++ b/node_modules/@legendapp/list/react-native.mjs
+@@ -6381,7 +6381,8 @@ var ScheduledWork = class {
+     const work = this.work.get(key);
+     if (work) {
+       this.work.delete(key);
+-      work[1](work[0]);
++      const [handle, cancelWork] = work;
++      cancelWork(handle);
+     }
+   }
+   has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.web.js b/node_modules/@legendapp/list/react-native.web.js
-index ea03488..3efcb9c 100644
+index ea03488..96edeb9 100644
 --- a/node_modules/@legendapp/list/react-native.web.js
 +++ b/node_modules/@legendapp/list/react-native.web.js
 @@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
@@ -57,8 +85,18 @@ index ea03488..3efcb9c 100644
        resizeObserver.disconnect();
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
+@@ -7054,7 +7066,8 @@ var ScheduledWork = class {
+     const work = this.work.get(key);
+     if (work) {
+       this.work.delete(key);
+-      work[1](work[0]);
++      const [handle, cancelWork] = work;
++      cancelWork(handle);
+     }
+   }
+   has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.web.mjs b/node_modules/@legendapp/list/react-native.web.mjs
-index c96345b..9549a9c 100644
+index c96345b..a696431 100644
 --- a/node_modules/@legendapp/list/react-native.web.mjs
 +++ b/node_modules/@legendapp/list/react-native.web.mjs
 @@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
@@ -116,8 +154,18 @@ index c96345b..9549a9c 100644
        resizeObserver.disconnect();
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
+@@ -7033,7 +7045,8 @@ var ScheduledWork = class {
+     const work = this.work.get(key);
+     if (work) {
+       this.work.delete(key);
+-      work[1](work[0]);
++      const [handle, cancelWork] = work;
++      cancelWork(handle);
+     }
+   }
+   has(key) {
 diff --git a/node_modules/@legendapp/list/react.js b/node_modules/@legendapp/list/react.js
-index ea03488..3efcb9c 100644
+index ea03488..96edeb9 100644
 --- a/node_modules/@legendapp/list/react.js
 +++ b/node_modules/@legendapp/list/react.js
 @@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
@@ -175,8 +223,18 @@ index ea03488..3efcb9c 100644
        resizeObserver.disconnect();
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
+@@ -7054,7 +7066,8 @@ var ScheduledWork = class {
+     const work = this.work.get(key);
+     if (work) {
+       this.work.delete(key);
+-      work[1](work[0]);
++      const [handle, cancelWork] = work;
++      cancelWork(handle);
+     }
+   }
+   has(key) {
 diff --git a/node_modules/@legendapp/list/react.mjs b/node_modules/@legendapp/list/react.mjs
-index c96345b..9549a9c 100644
+index c96345b..a696431 100644
 --- a/node_modules/@legendapp/list/react.mjs
 +++ b/node_modules/@legendapp/list/react.mjs
 @@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
@@ -234,3 +292,13 @@ index c96345b..9549a9c 100644
        resizeObserver.disconnect();
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
+@@ -7033,7 +7045,8 @@ var ScheduledWork = class {
+     const work = this.work.get(key);
+     if (work) {
+       this.work.delete(key);
+-      work[1](work[0]);
++      const [handle, cancelWork] = work;
++      cancelWork(handle);
+     }
+   }
+   has(key) {

--- a/shared/patches/@legendapp+list+3.3.4.patch
+++ b/shared/patches/@legendapp+list+3.3.4.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@legendapp/list/react-native.web.js b/node_modules/@legendapp/list/react-native.web.js
-index 544cca8..a119caa 100644
+index ea03488..3efcb9c 100644
 --- a/node_modules/@legendapp/list/react-native.web.js
 +++ b/node_modules/@legendapp/list/react-native.web.js
-@@ -5230,17 +5230,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
+@@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
    if (!globalResizeObserver) {
@@ -37,7 +37,7 @@ index 544cca8..a119caa 100644
      });
    }
    return globalResizeObserver;
-@@ -6193,8 +6202,10 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
+@@ -6242,8 +6251,10 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
        });
      };
      fireLayout();
@@ -49,7 +49,7 @@ index 544cca8..a119caa 100644
      });
      resizeObserver.observe(element);
      const onWindowResize = () => {
-@@ -6204,6 +6215,7 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
+@@ -6253,6 +6264,7 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
        window.addEventListener("resize", onWindowResize);
      }
      return () => {
@@ -58,10 +58,10 @@ index 544cca8..a119caa 100644
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
 diff --git a/node_modules/@legendapp/list/react-native.web.mjs b/node_modules/@legendapp/list/react-native.web.mjs
-index 6b2d901..b566c94 100644
+index c96345b..9549a9c 100644
 --- a/node_modules/@legendapp/list/react-native.web.mjs
 +++ b/node_modules/@legendapp/list/react-native.web.mjs
-@@ -5209,17 +5209,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
+@@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
    if (!globalResizeObserver) {
@@ -96,7 +96,7 @@ index 6b2d901..b566c94 100644
      });
    }
    return globalResizeObserver;
-@@ -6172,8 +6181,10 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
+@@ -6221,8 +6230,10 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
        });
      };
      fireLayout();
@@ -108,7 +108,7 @@ index 6b2d901..b566c94 100644
      });
      resizeObserver.observe(element);
      const onWindowResize = () => {
-@@ -6183,6 +6194,7 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
+@@ -6232,6 +6243,7 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
        window.addEventListener("resize", onWindowResize);
      }
      return () => {
@@ -117,10 +117,10 @@ index 6b2d901..b566c94 100644
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
 diff --git a/node_modules/@legendapp/list/react.js b/node_modules/@legendapp/list/react.js
-index 544cca8..a119caa 100644
+index ea03488..3efcb9c 100644
 --- a/node_modules/@legendapp/list/react.js
 +++ b/node_modules/@legendapp/list/react.js
-@@ -5230,17 +5230,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
+@@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
    if (!globalResizeObserver) {
@@ -155,7 +155,7 @@ index 544cca8..a119caa 100644
      });
    }
    return globalResizeObserver;
-@@ -6193,8 +6202,10 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
+@@ -6242,8 +6251,10 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
        });
      };
      fireLayout();
@@ -167,7 +167,7 @@ index 544cca8..a119caa 100644
      });
      resizeObserver.observe(element);
      const onWindowResize = () => {
-@@ -6204,6 +6215,7 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
+@@ -6253,6 +6264,7 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
        window.addEventListener("resize", onWindowResize);
      }
      return () => {
@@ -176,10 +176,10 @@ index 544cca8..a119caa 100644
        if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
          window.removeEventListener("resize", onWindowResize);
 diff --git a/node_modules/@legendapp/list/react.mjs b/node_modules/@legendapp/list/react.mjs
-index 6b2d901..b566c94 100644
+index c96345b..9549a9c 100644
 --- a/node_modules/@legendapp/list/react.mjs
 +++ b/node_modules/@legendapp/list/react.mjs
-@@ -5209,17 +5209,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
+@@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
    if (!globalResizeObserver) {
@@ -214,7 +214,7 @@ index 6b2d901..b566c94 100644
      });
    }
    return globalResizeObserver;
-@@ -6172,8 +6181,10 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
+@@ -6221,8 +6230,10 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
        });
      };
      fireLayout();
@@ -226,7 +226,7 @@ index 6b2d901..b566c94 100644
      });
      resizeObserver.observe(element);
      const onWindowResize = () => {
-@@ -6183,6 +6194,7 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
+@@ -6232,6 +6243,7 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
        window.addEventListener("resize", onWindowResize);
      }
      return () => {

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -2661,10 +2661,10 @@
   dependencies:
     "@khanacademy/perseus-utils" "2.1.5"
 
-"@legendapp/list@3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@legendapp/list/-/list-3.3.3.tgz#219531d71d0020a8e521827f072002224df8cfaa"
-  integrity sha512-p3g4xG6f//s4XQKhuus2189GCQgOHEIbJXHePqeDxj+6UQQQyij4YBjyArNSCgqoP0c03sxDPSOuCFB128Ql6g==
+"@legendapp/list@3.3.4":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/@legendapp/list/-/list-3.3.4.tgz#6d71d46d1026d92015116f00492839a629cc50b8"
+  integrity sha512-XsKCM7F8Fmy1jE7dZ9UEBCihouVOJ6B5pbAI1ssooadBu+YQHGoSQdxHs5dPXHb4qkGOIfUIAljIXnDzMYUCCQ==
   dependencies:
     use-sync-external-store "^1.5.0"
 
@@ -6941,10 +6941,10 @@ eslint-visitor-keys@^5.0.0, eslint-visitor-keys@^5.0.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
   integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
 
-eslint@10.8.0:
-  version "10.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.8.0.tgz#e6d19907a3f090a53a022261ba34c5ff6d04908b"
-  integrity sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==
+eslint@10.8.1:
+  version "10.8.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-10.8.1.tgz#fb37d514c19b6dd5b2d6b70169fd26fddfa97967"
+  integrity sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.8.0"
     "@eslint-community/regexpp" "^4.12.2"
@@ -9164,17 +9164,17 @@ joi@^17.2.1:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -10229,15 +10229,10 @@ mute-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-2.0.0.tgz#a5446fc0c512b71c83c44d908d5c7b7b4c493b2b"
   integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
 
-nanoid@^3.3.1:
-  version "3.3.12"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
-  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
-
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.1, nanoid@^3.3.16:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 nanoid@^3.3.17:
   version "3.3.17"
@@ -10245,9 +10240,9 @@ nanoid@^3.3.17:
   integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 nanoid@^5.1.11:
-  version "5.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.11.tgz#559dbdbc41737da341ac938c25514563d2dd94c7"
-  integrity sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
 
 napi-postinstall@^0.3.4:
   version "0.3.4"
@@ -11958,10 +11953,10 @@ serialize-error@^2.1.0:
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
   integrity sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==
 
-serialize-javascript@7.0.7, serialize-javascript@^6.0.2:
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.7.tgz#06ec40576d4cea96d68010a534520bff1f948a72"
-  integrity sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==
+serialize-javascript@7.1.0, serialize-javascript@^6.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.1.0.tgz#9e462c5c6dec5dbc8b55d90c52a4ad6aff985b9f"
+  integrity sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==
 
 serve-favicon@2.5.1:
   version "2.5.1"


### PR DESCRIPTION
Routine dependency pass.

## Updates
- `@legendapp/list` 3.3.3 → 3.3.4 — patch regenerated against the new source; the resize-observer debounce fix is still not upstream, so the patch is still needed.
- `eslint` 10.8.0 → 10.8.1
- `protocol/`: `@types/node` 26.1.2 → 26.2.0

## Security
- Deleted stale `yarn.lock` entries so `js-yaml` (3.15.1 / 4.3.1) and `nanoid` (3.3.18 / 5.1.16) re-resolve to patched versions. No `package.json` change needed — the requiring ranges already accept them.
- Ran the resolutions removal test on `**/serialize-javascript` and `**/xcode/uuid`. Both advisories returned, so both entries stay. `serialize-javascript` bumped 7.0.7 → 7.1.0 (latest patched).

Remaining audit findings are the two `image-size` advisories ([GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq)) — transitive via metro, no patched version published.

## Deliberately skipped
- `@babel/*` 7.29.7 → 8.x — major version line, opt-in.
- `typescript` 7.0.2 — the bare `typescript` package must stay on 6.x for `typescript-eslint` and `analyze-styles.mts` (classic JS compiler API). `typescript-native` is already on 7.0.2.
- `eslint-plugin-react-compiler` — npm's highest-sorting version is a hash-tagged rc.1, older than the installed rc.2.
- `@types/react-dom` 19.2.4 — runtime `react-dom` is unchanged at 19.2.3.

## Verification
- `yarn lint:all` clean — 0 bailouts, 0 whole-props deps, tsc green on both desktop and native configs
- No duplicate installs (`check-dupes.py`)
- `protocol/`: `make clean && make` exits 0 and regenerates byte-identical output
- No native deps changed, so pods are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)