### PR TITLE
fix(ci): drop stale shared/ios/ changes before checkout in iOS build

### DIFF
--- a/packaging/ios/build_and_publish.sh
+++ b/packaging/ios/build_and_publish.sh
@@ -56,6 +56,10 @@ if [ -n "$client_commit" ]; then
 	cd "$client_dir"
 	echo "Checking out $client_commit on client (will reset to $client_branch)"
 	git fetch
+	# Builds dirty shared/ios/ (fastlane bumps build numbers, pod install rewrites
+	# Podfile.lock). If a previous run died before its reset trap, that dirt blocks
+	# the checkout below, so drop it first.
+	git checkout -- shared/ios/
 	git checkout "$client_commit"
 	git reset --hard "$client_commit"
 	git pull origin "$client_commit" --ff-only
@@ -63,6 +67,7 @@ else
 	echo "Checking out master on client"
 	cd "$client_dir"
 	git fetch
+	git checkout -- shared/ios/
 	git checkout "master"
 	git reset --hard "origin/master"
 	git pull origin master --ff-only


### PR DESCRIPTION
## Problem

Automated iOS build box fails at startup:

```
Checking out master on client
error: Your local changes to the following files would be overwritten by checkout:
    shared/ios/Podfile.lock
Please commit your changes or stash them before you switch branches.
Aborting
```

Every build dirties `shared/ios/`: fastlane bumps build numbers in `Info.plist` / `project.pbxproj`, and `pod install` rewrites `Podfile.lock`. The EXIT trap in `build_and_publish.sh` cleans that up (`git checkout shared/ios/`), but if a run dies before the trap fires, the dirt survives and blocks the *next* run's `git checkout master`.

## Fix

Discard `shared/ios/` before the checkout, in both the pinned-commit and master paths. The existing `git reset --hard` runs *after* the checkout, so it can't rescue a checkout that was already blocked.

## Test

`bash -n` clean. Behavior is only reachable on the build box; unblocks it without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)