### PR TITLE
refactor(chat): retire LegendList workarounds fixed upstream

### DIFF
--- a/shared/chat/conversation/list-area/index.tsx
+++ b/shared/chat/conversation/list-area/index.tsx
@@ -219,9 +219,12 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
   const {clearVersion, containsLatestMessage, messageOrdinals, loaded} = data
 
   // Centered loads (search hit, reply-quote jump, pinned message) clear the thread before
-  // refetching, so the list sees a non-empty -> empty -> non-empty transition. dataKey tells it
-  // that is a new logical dataset, which resets layout readiness and re-runs the initial scroll
-  // without throwing away measurement caches the way a remount does.
+  // refetching, so the list sees a non-empty -> empty -> non-empty transition. dataKey is the
+  // library's answer to that, but it cannot be used here: the fresh-data reset drops
+  // readyToRender and restores it inside one layout-effect pass, so the containers never render
+  // in the not-ready state that useFreshDataTransitionVisibility waits for before clearing its
+  // pending flag. The wrapper then stays at opacity 0 with the thread fully measured behind it.
+  // Remounting sidesteps it because a fresh mount seeds that flag from the current epoch.
   const datasetKey = `${conversationIDKey}:${clearVersion}`
 
   const listRef = React.useRef<LegendListRef | null>(null)
@@ -526,7 +529,7 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
         ref={wrapperRef}
       >
         <LegendList
-          dataKey={datasetKey}
+          key={datasetKey}
           ref={listRef as React.Ref<LegendListRef>}
           data={messageOrdinals as unknown as T.Chat.Ordinal[]}
           renderItem={renderItem}

--- a/shared/chat/conversation/list-area/index.tsx
+++ b/shared/chat/conversation/list-area/index.tsx
@@ -218,29 +218,11 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
   const {centeredOrdinal} = useConversationCenter()
   const {clearVersion, containsLatestMessage, messageOrdinals, loaded} = data
 
-  // LegendList cannot recover from a non-empty -> empty -> non-empty data transition: it resets
-  // its layout state and then waits on a container layout event that never arrives, so
-  // readyToRender stays false and the thread renders blank forever. Centered loads (search hit,
-  // reply-quote jump, pinned message) clear the thread before refetching, so remount the list on
-  // every clear and let it take its fresh-mount path instead.
-  const listKey = `${conversationIDKey}:${clearVersion}`
-
-  // LegendList deadlock fix: when initialScrollAtEnd=true, data must not arrive
-  // before LegendList's internal ResizeObserver fires (sets queuedInitialLayout).
-  // If data arrives first, handleInitialScrollDataChange returns early and
-  // didFinishInitialScroll never becomes true, leaving readyToRender=false forever.
-  // Delaying data by one rAF ensures layout fires before data is fed in.
-  // We track which list instance has had its layout settle rather than using
-  // a boolean state, so the reset on remount is derived (no synchronous
-  // setState inside an effect).
-  const [layoutReadyKey, setLayoutReadyKey] = React.useState('')
-  const layoutReady = layoutReadyKey === listKey
-  React.useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      setLayoutReadyKey(listKey)
-    })
-    return () => cancelAnimationFrame(id)
-  }, [listKey])
+  // Centered loads (search hit, reply-quote jump, pinned message) clear the thread before
+  // refetching, so the list sees a non-empty -> empty -> non-empty transition. dataKey tells it
+  // that is a new logical dataset, which resets layout readiness and re-runs the initial scroll
+  // without throwing away measurement caches the way a remount does.
+  const datasetKey = `${conversationIDKey}:${clearVersion}`
 
   const listRef = React.useRef<LegendListRef | null>(null)
   const wrapperRef = React.useRef<HTMLDivElement | null>(null)
@@ -321,12 +303,12 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
   // Scroll to centered ordinal when it changes (search / thread navigation).
   // Use a "last scrolled to" ref rather than a "did it change" ref so we still
   // scroll when loaded becomes true after centeredOrdinal was already set.
-  // Reset per list instance, not per conversation: re-centering on the ordinal we
-  // are already parked on still remounts the list, so it has to scroll again.
+  // Reset per dataset, not per conversation: re-centering on the ordinal we are already parked
+  // on still reloads the thread, so the list has to scroll to it again.
   const lastScrolledCenteredRef = React.useRef<T.Chat.Ordinal | undefined>(undefined)
   React.useLayoutEffect(() => {
     lastScrolledCenteredRef.current = undefined
-  }, [listKey])
+  }, [datasetKey])
 
   // Owns the in-flight centering loop. It has to outlive re-renders: the messages that make
   // centering accurate arrive after it starts, so the loop must not be torn down by an effect
@@ -449,28 +431,12 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
     markedReadRef.current = false
   }, [conversationIDKey])
 
-  // LegendList only re-pins to the bottom while the gap is within
-  // maintainScrollAtEndThreshold * viewport (default 0.1). While the thread is still settling,
-  // rows re-measure and the content size can jump by several viewports in a single frame; the
-  // gap lands outside that threshold, the deferred re-pin bails, and the thread is left parked
-  // short of the last message. Widen the threshold for the settle window only — restoring the
-  // default afterwards keeps an arriving message from yanking a user who has scrolled up.
-  const [settledKey, setSettledKey] = React.useState('')
-  const settled = settledKey === listKey
-  const endSettle = React.useCallback(() => {
-    setSettledKey(listKey)
-  }, [listKey])
-  const settleTimerRef = React.useRef<ReturnType<typeof setTimeout>>(undefined)
-  React.useEffect(() => () => clearTimeout(settleTimerRef.current), [])
-
   const onLoad = React.useCallback(() => {
     if (!markedReadRef.current) {
       markedReadRef.current = true
       markInitiallyLoadedThreadAsRead()
     }
-    clearTimeout(settleTimerRef.current)
-    settleTimerRef.current = setTimeout(endSettle, 1000)
-  }, [endSettle, markInitiallyLoadedThreadAsRead])
+  }, [markInitiallyLoadedThreadAsRead])
 
   const renderItem = React.useCallback(
     ({item: ordinal}: {item: T.Chat.Ordinal}) => <HighlightableRow ordinal={ordinal} />,
@@ -542,13 +508,11 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
 
   const initialScrollIndex = useInitialScrollIndex(messageOrdinals, centeredOrdinal)
 
-  // A wheel during the settle window means the user took over: stop centering and narrow the
-  // maintainScrollAtEnd threshold back down so we don't scroll them away from where they landed.
+  // A wheel means the user took over: stop centering so we don't scroll them away from where
+  // they landed.
   const onWheel = React.useCallback(() => {
     abortCentering()
-    clearTimeout(settleTimerRef.current)
-    endSettle()
-  }, [abortCentering, endSettle])
+  }, [abortCentering])
 
   return (
     <Kb.ErrorBoundary>
@@ -562,9 +526,9 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
         ref={wrapperRef}
       >
         <LegendList
-          key={listKey}
+          dataKey={datasetKey}
           ref={listRef as React.Ref<LegendListRef>}
-          data={(layoutReady ? messageOrdinals : noOrdinals) as unknown as T.Chat.Ordinal[]}
+          data={messageOrdinals as unknown as T.Chat.Ordinal[]}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           getItemType={getItemType}
@@ -581,7 +545,6 @@ const DesktopThreadWrapper = function DesktopThreadWrapper() {
               ? false
               : {on: {dataChange: true, footerLayout: true, itemLayout: true}}
           }
-          maintainScrollAtEndThreshold={settled ? undefined : 5}
           // Stays on while centered: the full thread response lands after the cached one and
           // re-measures rows above the target, which slides it out of view unless anchored.
           maintainVisibleContentPosition={{data: true}}

--- a/shared/common-adapters/list.shared.tsx
+++ b/shared/common-adapters/list.shared.tsx
@@ -1,6 +1,8 @@
 import type * as React from 'react'
 import type {CustomStyles} from '@/styles'
-import type {LegendListRef as _LegendListRef} from '@legendapp/list/react'
+import type {LegendListRef} from '@legendapp/list/react'
+
+export type {LegendListRef}
 
 export type FixedHeight = {
   height: number
@@ -10,17 +12,6 @@ export type FixedHeight = {
 export type FixedListItemAuto = {
   sizeType: 'Small' | 'Large'
   type: 'fixedListItemAuto'
-}
-
-export type LegendListRef = _LegendListRef & {
-  getState: () => LegendListState
-}
-
-export type LegendListState = {
-  end: number
-  scroll: number
-  scrollLength: number
-  start: number
 }
 
 export type TrueVariable = {

--- a/shared/patches/@legendapp+list+3.3.4.patch
+++ b/shared/patches/@legendapp+list+3.3.4.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@legendapp/list/react-native.js b/node_modules/@legendapp/list/react-native.js
-index ca99e71..6124734 100644
+index ca99e71..9127b2d 100644
 --- a/node_modules/@legendapp/list/react-native.js
 +++ b/node_modules/@legendapp/list/react-native.js
 @@ -4833,7 +4833,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
@@ -11,7 +11,25 @@ index ca99e71..6124734 100644
        shouldMaintainScrollAtEnd = true;
      }
      onItemSizeChanged == null ? void 0 : onItemSizeChanged({
-@@ -6402,7 +6402,8 @@ var ScheduledWork = class {
+@@ -5683,13 +5683,11 @@ var ContainerSlot = typedMemo(function ContainerSlot2(props) {
+   return /* @__PURE__ */ React2__namespace.createElement(ContainerSlotBase, { ...props });
+ });
+ function useFreshDataTransitionVisibility(readyToRender, transitionEpoch) {
+-  const completedTransitionEpoch = React2.useRef(transitionEpoch);
+-  const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
++  const [completedTransitionEpoch, setCompletedTransitionEpoch] = React2.useState(transitionEpoch);
++  const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
+   React2.useLayoutEffect(() => {
+-    if (!readyToRender) {
+-      completedTransitionEpoch.current = transitionEpoch;
+-    }
+-  }, [readyToRender, transitionEpoch]);
++    setCompletedTransitionEpoch(transitionEpoch);
++  }, [transitionEpoch]);
+   return readyToRender && !isTransitionPending;
+ }
+ 
+@@ -6402,7 +6400,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
        this.work.delete(key);
@@ -22,7 +40,7 @@ index ca99e71..6124734 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.mjs b/node_modules/@legendapp/list/react-native.mjs
-index 5315f44..a6bdaa8 100644
+index 5315f44..5776876 100644
 --- a/node_modules/@legendapp/list/react-native.mjs
 +++ b/node_modules/@legendapp/list/react-native.mjs
 @@ -4812,7 +4812,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
@@ -34,7 +52,25 @@ index 5315f44..a6bdaa8 100644
        shouldMaintainScrollAtEnd = true;
      }
      onItemSizeChanged == null ? void 0 : onItemSizeChanged({
-@@ -6381,7 +6381,8 @@ var ScheduledWork = class {
+@@ -5662,13 +5662,11 @@ var ContainerSlot = typedMemo(function ContainerSlot2(props) {
+   return /* @__PURE__ */ React2.createElement(ContainerSlotBase, { ...props });
+ });
+ function useFreshDataTransitionVisibility(readyToRender, transitionEpoch) {
+-  const completedTransitionEpoch = useRef(transitionEpoch);
+-  const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
++  const [completedTransitionEpoch, setCompletedTransitionEpoch] = useState(transitionEpoch);
++  const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
+   useLayoutEffect(() => {
+-    if (!readyToRender) {
+-      completedTransitionEpoch.current = transitionEpoch;
+-    }
+-  }, [readyToRender, transitionEpoch]);
++    setCompletedTransitionEpoch(transitionEpoch);
++  }, [transitionEpoch]);
+   return readyToRender && !isTransitionPending;
+ }
+ 
+@@ -6381,7 +6379,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
        this.work.delete(key);
@@ -45,7 +81,7 @@ index 5315f44..a6bdaa8 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.web.js b/node_modules/@legendapp/list/react-native.web.js
-index ea03488..ebb54ae 100644
+index ea03488..e70e58c 100644
 --- a/node_modules/@legendapp/list/react-native.web.js
 +++ b/node_modules/@legendapp/list/react-native.web.js
 @@ -4850,7 +4850,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
@@ -57,62 +93,25 @@ index ea03488..ebb54ae 100644
        shouldMaintainScrollAtEnd = true;
      }
      onItemSizeChanged == null ? void 0 : onItemSizeChanged({
-@@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
- var globalResizeObserver = null;
- function getGlobalResizeObserver() {
-   if (!globalResizeObserver) {
-+    let pending = [];
-+    let timer = null;
-     globalResizeObserver = new ResizeObserver((entries) => {
--      batchItemSizeUpdates(() => {
--        for (const entry of entries) {
--          const callbacks = callbackMap.get(entry.target);
--          if (callbacks) {
--            for (const callback of callbacks) {
--              callback(entry);
-+      pending = pending.concat(entries);
-+      clearTimeout(timer);
-+      timer = setTimeout(() => {
-+        const toProcess = pending;
-+        pending = [];
-+        timer = null;
-+        batchItemSizeUpdates(() => {
-+          for (const entry of toProcess) {
-+            const callbacks = callbackMap.get(entry.target);
-+            if (callbacks) {
-+              for (const callback of callbacks) {
-+                callback(entry);
-+              }
-             }
-           }
--        }
--      });
-+        });
-+      }, 0);
-     });
-   }
-   return globalResizeObserver;
-@@ -6242,8 +6251,10 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
-       });
-     };
-     fireLayout();
-+    let layoutTimer = null;
-     const resizeObserver = new ResizeObserver(() => {
--      fireLayout();
-+      clearTimeout(layoutTimer);
-+      layoutTimer = setTimeout(() => fireLayout(), 0);
-     });
-     resizeObserver.observe(element);
-     const onWindowResize = () => {
-@@ -6253,6 +6264,7 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
-       window.addEventListener("resize", onWindowResize);
-     }
-     return () => {
-+      clearTimeout(layoutTimer);
-       resizeObserver.disconnect();
-       if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
-         window.removeEventListener("resize", onWindowResize);
-@@ -7054,7 +7066,8 @@ var ScheduledWork = class {
+@@ -5750,13 +5750,11 @@ function useDOMOrder(ref) {
+   }, [ctx]);
+ }
+ function useFreshDataTransitionVisibility(readyToRender, transitionEpoch) {
+-  const completedTransitionEpoch = React3.useRef(transitionEpoch);
+-  const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
++  const [completedTransitionEpoch, setCompletedTransitionEpoch] = React3.useState(transitionEpoch);
++  const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
+   React3.useLayoutEffect(() => {
+-    if (!readyToRender) {
+-      completedTransitionEpoch.current = transitionEpoch;
+-    }
+-  }, [readyToRender, transitionEpoch]);
++    setCompletedTransitionEpoch(transitionEpoch);
++  }, [transitionEpoch]);
+   return readyToRender && !isTransitionPending;
+ }
+ 
+@@ -7054,7 +7052,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
        this.work.delete(key);
@@ -123,7 +122,7 @@ index ea03488..ebb54ae 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.web.mjs b/node_modules/@legendapp/list/react-native.web.mjs
-index c96345b..1926b4c 100644
+index c96345b..e93d72d 100644
 --- a/node_modules/@legendapp/list/react-native.web.mjs
 +++ b/node_modules/@legendapp/list/react-native.web.mjs
 @@ -4829,7 +4829,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
@@ -135,62 +134,25 @@ index c96345b..1926b4c 100644
        shouldMaintainScrollAtEnd = true;
      }
      onItemSizeChanged == null ? void 0 : onItemSizeChanged({
-@@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
- var globalResizeObserver = null;
- function getGlobalResizeObserver() {
-   if (!globalResizeObserver) {
-+    let pending = [];
-+    let timer = null;
-     globalResizeObserver = new ResizeObserver((entries) => {
--      batchItemSizeUpdates(() => {
--        for (const entry of entries) {
--          const callbacks = callbackMap.get(entry.target);
--          if (callbacks) {
--            for (const callback of callbacks) {
--              callback(entry);
-+      pending = pending.concat(entries);
-+      clearTimeout(timer);
-+      timer = setTimeout(() => {
-+        const toProcess = pending;
-+        pending = [];
-+        timer = null;
-+        batchItemSizeUpdates(() => {
-+          for (const entry of toProcess) {
-+            const callbacks = callbackMap.get(entry.target);
-+            if (callbacks) {
-+              for (const callback of callbacks) {
-+                callback(entry);
-+              }
-             }
-           }
--        }
--      });
-+        });
-+      }, 0);
-     });
-   }
-   return globalResizeObserver;
-@@ -6221,8 +6230,10 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
-       });
-     };
-     fireLayout();
-+    let layoutTimer = null;
-     const resizeObserver = new ResizeObserver(() => {
--      fireLayout();
-+      clearTimeout(layoutTimer);
-+      layoutTimer = setTimeout(() => fireLayout(), 0);
-     });
-     resizeObserver.observe(element);
-     const onWindowResize = () => {
-@@ -6232,6 +6243,7 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
-       window.addEventListener("resize", onWindowResize);
-     }
-     return () => {
-+      clearTimeout(layoutTimer);
-       resizeObserver.disconnect();
-       if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
-         window.removeEventListener("resize", onWindowResize);
-@@ -7033,7 +7045,8 @@ var ScheduledWork = class {
+@@ -5729,13 +5729,11 @@ function useDOMOrder(ref) {
+   }, [ctx]);
+ }
+ function useFreshDataTransitionVisibility(readyToRender, transitionEpoch) {
+-  const completedTransitionEpoch = useRef(transitionEpoch);
+-  const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
++  const [completedTransitionEpoch, setCompletedTransitionEpoch] = useState(transitionEpoch);
++  const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
+   useLayoutEffect(() => {
+-    if (!readyToRender) {
+-      completedTransitionEpoch.current = transitionEpoch;
+-    }
+-  }, [readyToRender, transitionEpoch]);
++    setCompletedTransitionEpoch(transitionEpoch);
++  }, [transitionEpoch]);
+   return readyToRender && !isTransitionPending;
+ }
+ 
+@@ -7033,7 +7031,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
        this.work.delete(key);
@@ -201,7 +163,7 @@ index c96345b..1926b4c 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react.js b/node_modules/@legendapp/list/react.js
-index ea03488..ebb54ae 100644
+index ea03488..e70e58c 100644
 --- a/node_modules/@legendapp/list/react.js
 +++ b/node_modules/@legendapp/list/react.js
 @@ -4850,7 +4850,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
@@ -213,62 +175,25 @@ index ea03488..ebb54ae 100644
        shouldMaintainScrollAtEnd = true;
      }
      onItemSizeChanged == null ? void 0 : onItemSizeChanged({
-@@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
- var globalResizeObserver = null;
- function getGlobalResizeObserver() {
-   if (!globalResizeObserver) {
-+    let pending = [];
-+    let timer = null;
-     globalResizeObserver = new ResizeObserver((entries) => {
--      batchItemSizeUpdates(() => {
--        for (const entry of entries) {
--          const callbacks = callbackMap.get(entry.target);
--          if (callbacks) {
--            for (const callback of callbacks) {
--              callback(entry);
-+      pending = pending.concat(entries);
-+      clearTimeout(timer);
-+      timer = setTimeout(() => {
-+        const toProcess = pending;
-+        pending = [];
-+        timer = null;
-+        batchItemSizeUpdates(() => {
-+          for (const entry of toProcess) {
-+            const callbacks = callbackMap.get(entry.target);
-+            if (callbacks) {
-+              for (const callback of callbacks) {
-+                callback(entry);
-+              }
-             }
-           }
--        }
--      });
-+        });
-+      }, 0);
-     });
-   }
-   return globalResizeObserver;
-@@ -6242,8 +6251,10 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
-       });
-     };
-     fireLayout();
-+    let layoutTimer = null;
-     const resizeObserver = new ResizeObserver(() => {
--      fireLayout();
-+      clearTimeout(layoutTimer);
-+      layoutTimer = setTimeout(() => fireLayout(), 0);
-     });
-     resizeObserver.observe(element);
-     const onWindowResize = () => {
-@@ -6253,6 +6264,7 @@ var ListComponentScrollView = React3.forwardRef(function ListComponentScrollView
-       window.addEventListener("resize", onWindowResize);
-     }
-     return () => {
-+      clearTimeout(layoutTimer);
-       resizeObserver.disconnect();
-       if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
-         window.removeEventListener("resize", onWindowResize);
-@@ -7054,7 +7066,8 @@ var ScheduledWork = class {
+@@ -5750,13 +5750,11 @@ function useDOMOrder(ref) {
+   }, [ctx]);
+ }
+ function useFreshDataTransitionVisibility(readyToRender, transitionEpoch) {
+-  const completedTransitionEpoch = React3.useRef(transitionEpoch);
+-  const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
++  const [completedTransitionEpoch, setCompletedTransitionEpoch] = React3.useState(transitionEpoch);
++  const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
+   React3.useLayoutEffect(() => {
+-    if (!readyToRender) {
+-      completedTransitionEpoch.current = transitionEpoch;
+-    }
+-  }, [readyToRender, transitionEpoch]);
++    setCompletedTransitionEpoch(transitionEpoch);
++  }, [transitionEpoch]);
+   return readyToRender && !isTransitionPending;
+ }
+ 
+@@ -7054,7 +7052,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
        this.work.delete(key);
@@ -279,7 +204,7 @@ index ea03488..ebb54ae 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react.mjs b/node_modules/@legendapp/list/react.mjs
-index c96345b..1926b4c 100644
+index c96345b..e93d72d 100644
 --- a/node_modules/@legendapp/list/react.mjs
 +++ b/node_modules/@legendapp/list/react.mjs
 @@ -4829,7 +4829,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
@@ -291,62 +216,25 @@ index c96345b..1926b4c 100644
        shouldMaintainScrollAtEnd = true;
      }
      onItemSizeChanged == null ? void 0 : onItemSizeChanged({
-@@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
- var globalResizeObserver = null;
- function getGlobalResizeObserver() {
-   if (!globalResizeObserver) {
-+    let pending = [];
-+    let timer = null;
-     globalResizeObserver = new ResizeObserver((entries) => {
--      batchItemSizeUpdates(() => {
--        for (const entry of entries) {
--          const callbacks = callbackMap.get(entry.target);
--          if (callbacks) {
--            for (const callback of callbacks) {
--              callback(entry);
-+      pending = pending.concat(entries);
-+      clearTimeout(timer);
-+      timer = setTimeout(() => {
-+        const toProcess = pending;
-+        pending = [];
-+        timer = null;
-+        batchItemSizeUpdates(() => {
-+          for (const entry of toProcess) {
-+            const callbacks = callbackMap.get(entry.target);
-+            if (callbacks) {
-+              for (const callback of callbacks) {
-+                callback(entry);
-+              }
-             }
-           }
--        }
--      });
-+        });
-+      }, 0);
-     });
-   }
-   return globalResizeObserver;
-@@ -6221,8 +6230,10 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
-       });
-     };
-     fireLayout();
-+    let layoutTimer = null;
-     const resizeObserver = new ResizeObserver(() => {
--      fireLayout();
-+      clearTimeout(layoutTimer);
-+      layoutTimer = setTimeout(() => fireLayout(), 0);
-     });
-     resizeObserver.observe(element);
-     const onWindowResize = () => {
-@@ -6232,6 +6243,7 @@ var ListComponentScrollView = forwardRef(function ListComponentScrollView2({
-       window.addEventListener("resize", onWindowResize);
-     }
-     return () => {
-+      clearTimeout(layoutTimer);
-       resizeObserver.disconnect();
-       if (isWindowScroll && typeof window !== "undefined" && typeof window.removeEventListener === "function") {
-         window.removeEventListener("resize", onWindowResize);
-@@ -7033,7 +7045,8 @@ var ScheduledWork = class {
+@@ -5729,13 +5729,11 @@ function useDOMOrder(ref) {
+   }, [ctx]);
+ }
+ function useFreshDataTransitionVisibility(readyToRender, transitionEpoch) {
+-  const completedTransitionEpoch = useRef(transitionEpoch);
+-  const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
++  const [completedTransitionEpoch, setCompletedTransitionEpoch] = useState(transitionEpoch);
++  const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
+   useLayoutEffect(() => {
+-    if (!readyToRender) {
+-      completedTransitionEpoch.current = transitionEpoch;
+-    }
+-  }, [readyToRender, transitionEpoch]);
++    setCompletedTransitionEpoch(transitionEpoch);
++  }, [transitionEpoch]);
+   return readyToRender && !isTransitionPending;
+ }
+ 
+@@ -7033,7 +7031,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
        this.work.delete(key);

--- a/shared/patches/@legendapp+list+3.3.4.patch
+++ b/shared/patches/@legendapp+list+3.3.4.patch
@@ -1,7 +1,16 @@
 diff --git a/node_modules/@legendapp/list/react-native.js b/node_modules/@legendapp/list/react-native.js
-index ca99e71..32720c3 100644
+index ca99e71..6124734 100644
 --- a/node_modules/@legendapp/list/react-native.js
 +++ b/node_modules/@legendapp/list/react-native.js
+@@ -4833,7 +4833,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
+     if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
+       needsRecalculate = true;
+     }
+-    if (prevSizeKnown !== void 0 && Math.abs(prevSizeKnown - size) > 5) {
++    if (prevSizeKnown === void 0 || Math.abs(prevSizeKnown - size) > 5) {
+       shouldMaintainScrollAtEnd = true;
+     }
+     onItemSizeChanged == null ? void 0 : onItemSizeChanged({
 @@ -6402,7 +6402,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
@@ -13,9 +22,18 @@ index ca99e71..32720c3 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.mjs b/node_modules/@legendapp/list/react-native.mjs
-index 5315f44..5faff3c 100644
+index 5315f44..a6bdaa8 100644
 --- a/node_modules/@legendapp/list/react-native.mjs
 +++ b/node_modules/@legendapp/list/react-native.mjs
+@@ -4812,7 +4812,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
+     if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
+       needsRecalculate = true;
+     }
+-    if (prevSizeKnown !== void 0 && Math.abs(prevSizeKnown - size) > 5) {
++    if (prevSizeKnown === void 0 || Math.abs(prevSizeKnown - size) > 5) {
+       shouldMaintainScrollAtEnd = true;
+     }
+     onItemSizeChanged == null ? void 0 : onItemSizeChanged({
 @@ -6381,7 +6381,8 @@ var ScheduledWork = class {
      const work = this.work.get(key);
      if (work) {
@@ -27,9 +45,18 @@ index 5315f44..5faff3c 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.web.js b/node_modules/@legendapp/list/react-native.web.js
-index ea03488..96edeb9 100644
+index ea03488..ebb54ae 100644
 --- a/node_modules/@legendapp/list/react-native.web.js
 +++ b/node_modules/@legendapp/list/react-native.web.js
+@@ -4850,7 +4850,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
+     if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
+       needsRecalculate = true;
+     }
+-    if (prevSizeKnown !== void 0 && Math.abs(prevSizeKnown - size) > 5) {
++    if (prevSizeKnown === void 0 || Math.abs(prevSizeKnown - size) > 5) {
+       shouldMaintainScrollAtEnd = true;
+     }
+     onItemSizeChanged == null ? void 0 : onItemSizeChanged({
 @@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
@@ -96,9 +123,18 @@ index ea03488..96edeb9 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react-native.web.mjs b/node_modules/@legendapp/list/react-native.web.mjs
-index c96345b..a696431 100644
+index c96345b..1926b4c 100644
 --- a/node_modules/@legendapp/list/react-native.web.mjs
 +++ b/node_modules/@legendapp/list/react-native.web.mjs
+@@ -4829,7 +4829,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
+     if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
+       needsRecalculate = true;
+     }
+-    if (prevSizeKnown !== void 0 && Math.abs(prevSizeKnown - size) > 5) {
++    if (prevSizeKnown === void 0 || Math.abs(prevSizeKnown - size) > 5) {
+       shouldMaintainScrollAtEnd = true;
+     }
+     onItemSizeChanged == null ? void 0 : onItemSizeChanged({
 @@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
@@ -165,9 +201,18 @@ index c96345b..a696431 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react.js b/node_modules/@legendapp/list/react.js
-index ea03488..96edeb9 100644
+index ea03488..ebb54ae 100644
 --- a/node_modules/@legendapp/list/react.js
 +++ b/node_modules/@legendapp/list/react.js
+@@ -4850,7 +4850,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
+     if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
+       needsRecalculate = true;
+     }
+-    if (prevSizeKnown !== void 0 && Math.abs(prevSizeKnown - size) > 5) {
++    if (prevSizeKnown === void 0 || Math.abs(prevSizeKnown - size) > 5) {
+       shouldMaintainScrollAtEnd = true;
+     }
+     onItemSizeChanged == null ? void 0 : onItemSizeChanged({
 @@ -5254,17 +5254,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {
@@ -234,9 +279,18 @@ index ea03488..96edeb9 100644
    }
    has(key) {
 diff --git a/node_modules/@legendapp/list/react.mjs b/node_modules/@legendapp/list/react.mjs
-index c96345b..a696431 100644
+index c96345b..1926b4c 100644
 --- a/node_modules/@legendapp/list/react.mjs
 +++ b/node_modules/@legendapp/list/react.mjs
+@@ -4829,7 +4829,7 @@ function applyItemSize(ctx, itemKey, sizeObj, resolvedMeasurementItem) {
+     if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
+       needsRecalculate = true;
+     }
+-    if (prevSizeKnown !== void 0 && Math.abs(prevSizeKnown - size) > 5) {
++    if (prevSizeKnown === void 0 || Math.abs(prevSizeKnown - size) > 5) {
+       shouldMaintainScrollAtEnd = true;
+     }
+     onItemSizeChanged == null ? void 0 : onItemSizeChanged({
 @@ -5233,17 +5233,26 @@ function Separator({ ItemSeparatorComponent, leadingItem }) {
  var globalResizeObserver = null;
  function getGlobalResizeObserver() {


### PR DESCRIPTION
Stacked on #29517 (the dep bump that brought in `@legendapp/list` 3.3.4). Review that one first; this PR's diff is against it, not `master`.

`@legendapp/list` has moved a long way since several of our workarounds were written, so this revisits each one against the current library, keeps what still earns its place, and files the rest upstream.

## Workarounds removed

**Redundant ref/state types** (`common-adapters/list.shared.tsx`). `getState()` is published on `LegendListRef` as of 3.3.x, and its `LegendListState` is a superset of the four fields we declared. Re-export the library type instead of intersecting our own onto it.

**rAF data gate** (desktop thread). Guarded `handleInitialScrollDataChange` bailing on `!queuedInitialLayout`. That branch is unreachable for us now: passing `initialScrollAtEnd` or `initialScrollIndex` selects the bootstrap path, which returns before the check, and the desktop list always passes one of them.

**`maintainScrollAtEndThreshold` widening + settle timer.** 3.3.4 changed the deferred re-pin to run when the user has not scrolled since the request, rather than requiring the gap to still be within the threshold. Tracing the flow it was meant to protect also showed the settle window closing about 1.5s before the event that actually strands the list, so it was mistimed regardless.

**Both ResizeObserver patch hunks.** These date from 3.0.3, when the global observer ran callbacks in a bare loop with no batching; 3.3.3 added `batchItemSizeUpdates` around that same loop for the same reason. What our version still added was a macrotask of deferral, pushing measurement past paint — the same shape as the bugs fixed below.

## Workaround kept

**Remount on clear** (`key={datasetKey}`). `dataKey` is the library's answer to a non-empty → empty → non-empty swap and would let us keep measurement caches across centered loads, but it is unusable until LegendApp/legend-list#519 lands: the fresh-data reset drops `readyToRender` and restores it inside one layout-effect pass, so the containers never render in the not-ready state that `useFreshDataTransitionVisibility` waits for, and the wrapper stays at `opacity: 0` with the thread fully measured behind it. The comment now records that mechanism instead of the earlier guess about a container layout event that never arrives.

## Upstream fixes carried in `patches/`

Three bugs found along the way, each filed with a regression test that fails on the library's `main`:

| PR | Fix | Symptom |
|---|---|---|
| LegendApp/legend-list#518 | `ScheduledWork.cancel` invoked native `clearTimeout`/`cancelAnimationFrame` with its bookkeeping tuple as the receiver | `Uncaught TypeError: Illegal invocation` on every thread open |
| LegendApp/legend-list#519 | `useFreshDataTransitionVisibility` pending flag outliving the transition | a `dataKey` change left the list permanently at `opacity: 0` |
| LegendApp/legend-list#520 | `maintainScrollAtEnd` ignored first measurements, so prepended rows' growth was never followed | thread parked short of the newest message after loading older messages |

The patch is now exactly these three and nothing else, so every hunk has a tracking PR and an obvious removal trigger. #519 is carried even though the remount sidesteps it, to keep the local tree honest against what we reported.

## Verification

`yarn lint:all` clean — 0 bailouts, 0 whole-props deps, tsc green on both configs.

Everything here was checked against a running desktop client rather than by reading source, after two of my early theories turned out wrong:

- Cold-open a busy thread, scroll-up-while-a-message-arrives, and search → cancel → jump all behave.
- The `maintainScrollAtEnd` fix was confirmed by instrumenting the library in-app: the failing flow recorded 285 item measurements, every one a first measurement, against 3 `doMaintainScrollAtEnd` calls; afterwards 9 calls, and the thread settles at the pinned baseline (`gap = -116`) instead of 57–94px short.
- ResizeObserver removal was exercised across window resizes, info panel and search bar toggles, conversation switches and hard scrolling, with a collector installed for `window.onerror`, unhandled rejections and `console.error`: zero captured.

## Risk

The ResizeObserver hunks were originally added against runtime errors whose exact identity is no longer recorded, so their removal rests on the analysis above plus a clean error hunt, not on reproducing the original failure. Kept as its own commit (`872c353067`) so it can be reverted alone if something surfaces around resizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)