### PR TITLE
fix(chat): stop logging pending sends as author errors

### DIFF
--- a/shared/chat/conversation/messages/separator-utils.tsx
+++ b/shared/chat/conversation/messages/separator-utils.tsx
@@ -54,22 +54,13 @@ export const getUsernameToShow = (
     return message.author
   }
 
-  if (
-    !(message.author || message.botUsername) ||
-    !(pMessage.author || pMessage.botUsername) ||
-    !message.timestamp ||
-    !pMessage.timestamp
-  ) {
-    // something totally wrong
-    logger.error('CHATDEBUG: getUsernameToShow FAILED', {
-      authors: message.author === pMessage.author,
-      botUsernames: message.botUsername === pMessage.botUsername,
-      mcollapsible: authorIsCollapsible(message.type),
-      mtime: message.timestamp,
-      pcollapsible: authorIsCollapsible(pMessage.type),
-      ptime: pMessage.timestamp,
+  // A zero timestamp is normal here: pending outbox messages and unbox-error messages carry ctime 0
+  // until the service stamps them, so only a missing author/bot on either side is actually wrong.
+  if (!(message.author || message.botUsername) || !(pMessage.author || pMessage.botUsername)) {
+    logger.error('getUsernameToShow: message with no author', {
+      mtype: message.type,
+      ptype: pMessage.type,
     })
-    return ''
   }
 
   return ''


### PR DESCRIPTION
## Problem

Every message sent from the app logged an error to the console:

```
Error CHATDEBUG: getUsernameToShow FAILED
{authors: true, botUsernames: true, mcollapsible: true, mtime: 0, pcollapsible: true, …}
```

`getUsernameToShow` treated a zero timestamp on either side as "something totally wrong", but `ctime` is legitimately 0 for pending outbox messages and unbox-error messages until the service stamps them. Any local echo collapsed under a previous message from the same author tripped it.

The branch also returned the same `''` as the fallthrough below it, so it never affected what was rendered — it was pure log noise.

## Fix

Narrow the check to a genuinely missing `author`/`botUsername` on either side, drop the redundant `return`, and trim the payload to the two message types.

## Test plan

- `yarn lint:all` — clean (0 bailouts, 0 whole-props deps, tsc green)
- `yarn jest chat/conversation/messages/row-metadata.test.ts` — 8/8 pass