### PR TITLE
fix(chat): show inbox unread bar off liquid glass

### DIFF
--- a/shared/.gitignore
+++ b/shared/.gitignore
@@ -2,6 +2,9 @@
 android/local.properties
 android/.gradle
 android/keybaselib/keybaselib.aar
+# gobuild-if-needed's freshness stamp for the .aar above
+android/keybaselib/.gobuild-stamp
+android/.kotlin
 android/.idea
 android/app/.externalNativeBuild
 android/**/build/

--- a/shared/chat/inbox/index.tsx
+++ b/shared/chat/inbox/index.tsx
@@ -278,6 +278,21 @@ const NativeNoChatsWrapper = ({children}: {children: React.ReactNode}) => {
     )
 }
 
+// The bottom-anchored bars (unread shortcut, big teams divider) position themselves
+// absolutely against this box. On iOS the tab screen draws edge-to-edge under the
+// native tab bar, so inset the bottom edge to clear it; Android already insets the
+// whole tab screen. box-none so the rest of the fill doesn't eat list touches.
+const NativeBottomBarsWrapper = ({children}: {children: React.ReactNode}) => {
+  const nativeStyles = useNativeStyles()
+  return isIOS ? (
+    <ScreensSafeAreaView edges={{bottom: true}} pointerEvents="box-none" style={nativeStyles.bottomBars}>
+      {children}
+    </ScreensSafeAreaView>
+  ) : (
+    <>{children}</>
+  )
+}
+
 const NativeNoRowsBuildTeam = () => {
   const isLoading = C.useWaitingState(s => [...s.counts.keys()].some(k => k.startsWith('chat:')))
   return isLoading ? null : <BuildTeam />
@@ -595,18 +610,35 @@ function NativeInboxBody(p: ControlledInboxProps) {
             </NativeNoChatsWrapper>
           )}
           {showFloatingDivider || showUnreadBanner ? (
-            <Kb.BottomAccessory>
-              {showUnreadBanner && (
-                <UnreadShortcut inlineLayout={true} onClick={scrollToUnread} unreadCount={unreadCount} />
-              )}
-              {showFloatingDivider && (
-                <BigTeamsDivider
-                  inlineLayout={true}
-                  toggle={scrollToBigTeams}
-                  onEdit={isIOS ? promptSmallTeamsNum : undefined}
-                />
-              )}
-            </Kb.BottomAccessory>
+            Kb.isBottomAccessoryHosted ? (
+              // Hosted in the tab bar accessory row: both bars sit side by side.
+              <Kb.BottomAccessory>
+                {showUnreadBanner && (
+                  <UnreadShortcut inlineLayout={true} onClick={scrollToUnread} unreadCount={unreadCount} />
+                )}
+                {showFloatingDivider && (
+                  <BigTeamsDivider
+                    inlineLayout={true}
+                    toggle={scrollToBigTeams}
+                    onEdit={isIOS ? promptSmallTeamsNum : undefined}
+                  />
+                )}
+              </Kb.BottomAccessory>
+            ) : (
+              // No accessory host: each bar pins itself to the bottom of the inbox, so
+              // only one can show at a time.
+              <NativeBottomBarsWrapper>
+                {showUnreadBanner && !showFloatingDivider && (
+                  <UnreadShortcut onClick={scrollToUnread} unreadCount={unreadCount} />
+                )}
+                {showFloatingDivider && (
+                  <BigTeamsDivider
+                    toggle={scrollToBigTeams}
+                    onEdit={isIOS ? promptSmallTeamsNum : undefined}
+                  />
+                )}
+              </NativeBottomBarsWrapper>
+            )
           ) : (
             !noChats && rows.length === 0 && !neverLoaded && <NativeNoRowsBuildTeam />
           )}
@@ -773,6 +805,9 @@ const useNativeStyles = Kb.Styles.createStyleHook(
       // below it. On iOS the RNS SafeAreaView (forced flex: 1) applies the bottom inset as
       // margin, which lifts the buttons above the tab bar within this fill box.
       noChatsWrapper: {
+        ...Kb.Styles.globalStyles.fillAbsolute,
+      },
+      bottomBars: {
         ...Kb.Styles.globalStyles.fillAbsolute,
       },
     }) as const

--- a/shared/common-adapters/bottom-accessory.tsx
+++ b/shared/common-adapters/bottom-accessory.tsx
@@ -10,6 +10,10 @@ import type {RootParamList} from '@/router-v2/route-params'
 
 const isLiquidGlassActive = (isIOS && C.isPhone && _isLiquidGlassSupported) as boolean
 
+// True when BottomAccessory hosts its children in the tab bar's accessory row.
+// When false children render inline and must lay themselves out (no row context).
+export const isBottomAccessoryHosted = isLiquidGlassActive
+
 const useStyles = Styles.createStyleHook(() => ({
   container: {
     ...Styles.globalStyles.fillAbsolute,

--- a/shared/common-adapters/index.tsx
+++ b/shared/common-adapters/index.tsx
@@ -12,7 +12,7 @@ export const LayoutAnimation: typeof NativeLayoutAnimation = isMobile
 export {default as Animation} from './animation'
 export {default as Avatar} from './avatar/index'
 export {default as AvatarLine} from './avatar/avatar-line'
-export {BottomAccessory} from './bottom-accessory'
+export {BottomAccessory, isBottomAccessoryHosted} from './bottom-accessory'
 export {default as BackButton} from './back-button'
 export {default as Badge} from './badge'
 export {Banner, BannerParagraph, ErrorBanner} from './banner'


### PR DESCRIPTION
## Problem

The orange "N unread messages" bar (and the big teams divider) never showed in the chat inbox on Android and on pre-liquid-glass iOS. It worked on modern iOS phones.

## Cause

Two independent bugs:

1. **Collapsed layout.** `Kb.BottomAccessory` only mounts its children into the tab bar accessory row when `isIOS && isPhone && isLiquidGlassSupported`; otherwise it renders them raw. The inbox always passed `inlineLayout={true}`, whose styles (`flex: 1; height: '100%'`) are written for that horizontal host. Dropped into the inbox's vertical container, `flex: 1` means `flexBasis: 0`, and the LegendList sibling's content leaves no free space — so both bars shrank to zero height.

2. **Tab bar occlusion.** With absolute `bottom: 0` restored, the bar rendered *under* the native tab bar on iOS: tab screens draw edge-to-edge, `useBottomTabBarHeight()` reports 0 with the native tabs impl, and `useSafeAreaInsets().bottom` only covers the home indicator.

## Fix

- Export `isBottomAccessoryHosted` from `bottom-accessory.tsx`.
- Inbox uses the inline row bars when hosted, and otherwise falls back to the pre-670 bottom-pinned bars, showing only one at a time since they overlap.
- Wrap that fallback in `NativeBottomBarsWrapper` — an iOS-only `SafeAreaView edges={{bottom: true}}` fill with `pointerEvents="box-none"`, the same pattern as `NativeNoChatsWrapper`. Android tab screens are already inset, so children pass through untouched.

## Testing

- `yarn lint:all` clean (0 bailouts, 0 whole-props deps, tsc green).
- Verified in the iOS 16.4 simulator (bar now sits above the tab bar) and the iOS 26 simulator (glass accessory path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)