### PR TITLE
fix(chat): render emoji in reply quote preview

### DIFF
--- a/shared/chat/conversation/messages/text/reply.tsx
+++ b/shared/chat/conversation/messages/text/reply.tsx
@@ -58,13 +58,18 @@ const ReplyText = () => {
         : ''
 
   return text ? (
-    <Kb.Text
-      type="BodySmall"
-      style={showCenteredHighlight ? styles.textHighlighted : undefined}
+    <Kb.Markdown
+      serviceOnly={true}
       lineClamp={3}
+      context={`reply-${replyTo.id}`}
+      style={
+        showCenteredHighlight
+          ? Kb.Styles.collapseStyles([styles.replyText, styles.replyTextHighlighted])
+          : styles.replyText
+      }
     >
       {text}
-    </Kb.Text>
+    </Kb.Markdown>
   ) : null
 }
 
@@ -134,8 +139,12 @@ const useStyles = Kb.Styles.createStyleHook(
         paddingTop: Kb.Styles.globalMargins.xtiny,
       },
       replyEdited: {color: theme.black_35},
+      replyText: Kb.Styles.platformStyles({
+        common: {color: theme.black_50, fontSize: 15, lineHeight: 19},
+        isElectron: {whiteSpace: 'pre-wrap'},
+      }),
+      replyTextHighlighted: {color: theme.black_50OrBlack_50},
       replyUsername: {alignSelf: 'center'},
       replyUsernameHighlighted: {color: theme.blackOrBlack},
-      textHighlighted: {color: theme.black_50OrBlack_50},
     }) as const
 )


### PR DESCRIPTION
## Problem

In a reply, the quoted original message renders as raw text. Emoji shortcodes stored on the message (e.g. `:sunglasses:`) leak through as the literal `:sunglasses:` even though the message body itself shows the emoji.

Cause: the message body renders through `Kb.Markdown` (which owns the `emoji` rule), but `ReplyText` in `chat/conversation/messages/text/reply.tsx` rendered the text straight into a `Kb.Text`. Same reason custom emoji and other service decorations didn't show in the quote.

## Fix

Render the quote through `Kb.Markdown` in `serviceOnly` mode — resolves emoji, custom emoji, and service decorations, while leaving block markdown (quotes, code blocks, bold/italic) flattened, which is what a quote preview wants.

- `lineClamp={3}` preserved.
- `context` passed for spoiler keying.
- New `replyText` style replicates `BodySmall` (15/19, `black_50`) plus `whiteSpace: pre-wrap` on desktop, so the Markdown root's `pre` doesn't break wrapping.

## Test

`yarn lint`, `yarn lint:bailouts` (0 bailouts), `yarn tsc` clean. Visual check pending.