### PR TITLE
fix(chat): show members list in team channels

### DIFF
--- a/shared/constants/chat/helpers.test.tsx
+++ b/shared/constants/chat/helpers.test.tsx
@@ -3,7 +3,15 @@ import {getBotsAndParticipants} from './helpers'
 import {makeConversationMeta} from './meta'
 import type * as T from '@/constants/types'
 
+// Team convs get an empty `name`: the service only sets inConvName for users named in
+// the conv's TLF name, and a team channel's TLF name is the team.
 const participantInfo: T.Chat.ParticipantInfo = {
+  all: ['alice', 'helperbot', 'bob'],
+  contactName: new Map(),
+  name: [],
+}
+
+const adhocParticipantInfo: T.Chat.ParticipantInfo = {
   all: ['alice', 'helperbot', 'bob'],
   contactName: new Map(),
   name: ['alice', 'bob'],
@@ -23,8 +31,20 @@ const teamMeta = {
   teamType: 'small' as const,
 }
 
-test('getBotsAndParticipants excludes known bot participants before team roles load', () => {
-  expect(getBotsAndParticipants(teamMeta, participantInfo, new Map()).participants).toEqual(['alice', 'bob'])
+test('getBotsAndParticipants lists team channel participants before team roles load', () => {
+  expect(getBotsAndParticipants(teamMeta, participantInfo, new Map()).participants).toEqual([
+    'alice',
+    'helperbot',
+    'bob',
+  ])
+})
+
+test('getBotsAndParticipants splits adhoc bots out by conv name membership', () => {
+  const adhocMeta = {...makeConversationMeta(), teamType: 'adhoc' as const}
+  expect(getBotsAndParticipants(adhocMeta, adhocParticipantInfo)).toEqual({
+    bots: ['helperbot'],
+    participants: ['alice', 'bob'],
+  })
 })
 
 test('getBotsAndParticipants keeps using role data after team members load', () => {

--- a/shared/constants/chat/helpers.tsx
+++ b/shared/constants/chat/helpers.tsx
@@ -12,8 +12,12 @@ export const getBotsAndParticipants = (
 ) => {
   const isAdhocTeam = meta.teamType === 'adhoc'
   const members = teamMembers ?? new Map<string, T.Teams.MemberInfo>()
-  const participantBots = participantInfo.all.filter(p => !participantInfo.name.includes(p))
-  let bots = participantBots
+  // participantInfo.name only holds users named in the conv's TLF name, so it's the
+  // participant list for adhoc convs and empty for team channels. Team bots come from
+  // team roles instead, which means no bot filtering until members load.
+  let bots: ReadonlyArray<string> = isAdhocTeam
+    ? participantInfo.all.filter(p => !participantInfo.name.includes(p))
+    : []
   if (!isAdhocTeam && members.size) {
     bots = [...members.values()]
       .filter(
@@ -24,7 +28,7 @@ export const getBotsAndParticipants = (
       .map(p => p.username)
       .sort((l, r) => l.localeCompare(r))
   }
-  let participants: ReadonlyArray<string> = participantInfo.name
+  let participants: ReadonlyArray<string> = isAdhocTeam ? participantInfo.name : participantInfo.all
   if (meta.channelname === 'general') {
     participants = [...members.values()].reduce<Array<string>>((l, mi) => {
       l.push(mi.username)


### PR DESCRIPTION
## Problem

In the desktop info panel, the **Members** tab shows a spinner forever in any team channel. 1:1 conversations are fine.

## Root cause

`getBotsAndParticipants` (`shared/constants/chat/helpers.tsx`) uses `participantInfo.name` as the participant list. `name` is built from `UIParticipant.inConvName`, which the service sets only for users whose username appears in the conversation's TLF name (`ReorderParticipants` in `go/chat/utils/utils.go`); the `ChatParticipantsInfo` notification path never sets it at all. A team channel's TLF name is the *team*, so `name` is always empty there — the members list computes to `[]` and `showSpinner` never clears. 1:1/adhoc convs work because their TLF name *is* the participant list.

Same commit also applied the adhoc `all - name` bot filter to team convs, which on its own zeroes the list for teams regardless of the base.

Confirmed against the running app on a big team channel:

```
all:  ["cnojima106", "cnojima10", "chrisnojima"]
name: []
participants: []
```

## Fix

Gate both the participant source and the pre-role bot filter on `isAdhocTeam`:

- adhoc: unchanged — participants from `name`, bots from `all - name`
- team: participants from `all`, bots from team roles only (so no bot filtering until team members load, which is the pre-regression behavior)

## Test

The existing fixture paired a team meta with `name: ['alice', 'bob']`, which real data can never produce, so it greenlit the regression. Split into a team case (empty `name`) and an adhoc case.

## Verification

- Live app, team channel `#aaa`: members render as `chrisnojima (Owner)`, `cnojima10`, `cnojima106`, matching the 3-member badge
- `yarn jest constants/chat/helpers.test.tsx` — 3 passed
- `yarn lint:all` — clean, 0 bailouts, 0 whole-props deps, tsc OK