### PR TITLE
fix request timeout precedence

### DIFF
--- a/go/avatars/upload.go
+++ b/go/avatars/upload.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"mime/multipart"
 	"os"
-	"time"
 
 	"github.com/keybase/client/go/chat/attachments"
 	"github.com/keybase/client/go/chat/utils"
@@ -125,10 +124,9 @@ func UploadImage(mctx libkb.MetaContext, filename string, teamID *keybase1.TeamI
 	mctx.Debug("Running POST to %s", endpoint)
 
 	arg := libkb.APIArg{
-		Endpoint:       endpoint,
-		SessionType:    libkb.APISessionTypeREQUIRED,
-		InitialTimeout: 5 * time.Minute,
-		RetryCount:     1,
+		Endpoint:    endpoint,
+		SessionType: libkb.APISessionTypeREQUIRED,
+		RetryCount:  1,
 	}
 
 	_, err = mctx.G().API.PostRaw(mctx, arg, mpart.FormDataContentType(), &body)

--- a/go/libkb/api.go
+++ b/go/libkb/api.go
@@ -385,12 +385,12 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (res *ht
 		arg.RetryCount = 0
 	}
 
-	if arg.InitialTimeout == 0 && arg.RetryCount == 0 {
-		res, err = ctxhttp.Do(m.Ctx(), cli.cli, req)
-		return res, nil, err
+	// Determine timeout with precedence: arg.InitialTimeout > config.Timeout > HTTPDefaultTimeout.
+	// This preserves custom timeouts from KEYBASE_API_TIMEOUT env var while allowing per-request overrides.
+	timeout := HTTPDefaultTimeout
+	if cli.config != nil && cli.config.Timeout != 0 {
+		timeout = cli.config.Timeout
 	}
-
-	timeout := cli.cli.Timeout
 	if arg.InitialTimeout != 0 {
 		timeout = arg.InitialTimeout
 	}
@@ -429,7 +429,9 @@ func doRetry(m MetaContext, arg APIArg, cli *Client, req *http.Request) (res *ht
 		}
 	}
 
-	return nil, nil, fmt.Errorf("doRetry failed, attempts: %d, timeout %s, last err: %s", retries, timeout, lastErr)
+	// Return the original error to preserve its type (e.g., *url.Error for TLS errors).
+	// The retry context is already logged via Debug statements above.
+	return nil, nil, lastErr
 }
 
 // doTimeout does the http request with a timeout. It returns the response from making the HTTP request,

--- a/go/libkb/client.go
+++ b/go/libkb/client.go
@@ -218,15 +218,12 @@ func NewClient(g *GlobalContext, config *ClientConfig, needCookie bool) (*Client
 		}
 	}
 
-	var timeout time.Duration
-	if config == nil || config.Timeout == 0 {
-		timeout = HTTPDefaultTimeout
-	} else {
-		timeout = config.Timeout
-	}
-
+	// Don't set client-level timeout - let per-request context timeouts control this.
+	// This allows different endpoints to have different timeouts via APIArg.InitialTimeout.
+	// The doRetry() function ensures all requests get a context timeout, falling back to
+	// config.Timeout (from KEYBASE_API_TIMEOUT env var or config file), then HTTPDefaultTimeout.
 	ret := &Client{
-		cli:    &http.Client{Timeout: timeout},
+		cli:    &http.Client{Timeout: 0},
 		config: config,
 	}
 	if jar != nil {


### PR DESCRIPTION
fix a longstanding bug where the `http.Client.Timeout` took precedence over any request specific timeouts (if they were > 60s)

logsend, avatar upload and DelegatorAggregator all had a 5m timeout that was actually capped at 60s.



@mmaxim 