### PR TITLE
fix(chat): match custom reaction emoji size to native on mobile

### DIFF
--- a/shared/chat/conversation/messages/react-button.tsx
+++ b/shared/chat/conversation/messages/react-button.tsx
@@ -152,9 +152,9 @@ export function NewReactionButton(p: NewReactionButtonProps) {
 const markdownOverride: StyleOverride = isMobile
   ? {
       customEmoji: {
-        height: 20,
-        transform: [{translateY: 4}],
-        width: 20,
+        height: 18,
+        transform: [{translateY: 3}],
+        width: 18,
       },
       emoji: {
         fontSize: 15,

--- a/shared/teams/emojis/add-emoji.tsx
+++ b/shared/teams/emojis/add-emoji.tsx
@@ -11,6 +11,7 @@ import {HeaderLeftButton} from '@/common-adapters/header-buttons'
 import {useNavigation} from '@react-navigation/native'
 import KB2 from '@/util/electron'
 import {ensureError} from '@/util/errors'
+import {normalizeFilePathURL} from '@/util/file-url'
 
 const {getPathForFile} = KB2.functions
 
@@ -335,7 +336,7 @@ const EmojiToAddRow = (p: {item: EmojiToAddOrAddRow}) => {
       ])}
     >
       <Kb.Box2 direction="vertical" style={styles.emojiToAddImageContainer}>
-        <Kb.Image src={item.emojiToAdd.path} style={styles.emojiToAddImage} />
+        <Kb.Image src={normalizeFilePathURL(item.emojiToAdd.path)} style={styles.emojiToAddImage} />
       </Kb.Box2>
       <AliasInput
         error={item.emojiToAdd.error}


### PR DESCRIPTION
Two mobile emoji fixes.

### Custom reaction emoji sizing

Custom emoji art is full-bleed (the artwork touches the edges of its canvas) while Apple glyphs carry internal padding. The reaction pill sized the custom-emoji box like the native glyph's *box*, so the custom one rendered visibly larger and lower, and its bottom collided with the pill border — it read as clipped.

Sized to match the *ink* instead. Measured on an iPhone 17 Pro simulator (device px, 3x):

| | ink | center vs pill center |
|---|---|---|
| native `:thumbsup:` | 52x55 | -2 |
| custom, before (20pt / translateY 4) | 56x57 | +2 |
| custom, after (18pt / translateY 3) | 50x54 | +1 |

Ink height now equals the full 18pt box, so nothing is cut at the top or the bottom, and the rendered art matches the source asset shape exactly.

Ruled out while tracking this down: `styleOverride.paragraph` font size / line height and the `size` prop from `service-decoration.tsx` have no effect on the rendered custom-emoji box; the view is not clipped by the pill (a border on it renders complete on all four sides); the served assets are square.

Buttons did not need to grow — the limiting factor is the inline-emoji clip window inside the pill (~19.3pt), not the pill height (28pt inner).

### Add-emoji preview in hot dev

Also included: the earlier commit fixing the teams add-emoji preview under hot dev.

Verified on the iOS simulator; `yarn lint:all` is clean. The override is shared by Android, which was not verified on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
