### PR TITLE
fix(ios): avoid NSGenericException in react-native-screens header state update

### DIFF
--- a/shared/patches/react-native-screens+4.27.0.patch
+++ b/shared/patches/react-native-screens+4.27.0.patch
@@ -50,6 +50,25 @@ index c233036..a3f0f36 100644
    if ([self.topViewController isKindOfClass:[RNSScreen class]]) {
      RNSScreen *screenController = (RNSScreen *)self.topViewController;
      BOOL isNotDismissingModal = screenController.presentedViewController == nil ||
+diff --git a/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm b/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
+index 1c84484..462ecee 100644
+--- a/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
++++ b/node_modules/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
+@@ -208,7 +208,13 @@ - (void)updateHeaderStateInShadowTreeInContextOfNavigationBar:(nullable UINaviga
+   [self updateShadowStateWithSize:navigationBar.frame.size
+                        edgeInsets:[self computeEdgeInsetsOfNavigationBar:navigationBar]
+                       frameOrigin:navBarFrameInScreenView.origin];
+-  for (RNSScreenStackHeaderSubview *subview in self.reactSubviews) {
++  // Iterate over a snapshot: `updateShadowStateInContextOfAncestorView:` schedules the state
++  // update with `unstable_Immediate`, which commits AND mounts synchronously, and mounting can
++  // insert or remove header subviews — mutating `_reactSubviews` while it is being enumerated,
++  // which throws NSGenericException. See software-mansion/react-native-screens#4483.
++  // A subview removed mid-loop is harmless because `updateShadowStateWithFrame:` bails out when
++  // its state is null; one added mid-loop is picked up by the next layout pass.
++  for (RNSScreenStackHeaderSubview *subview in [self.reactSubviews copy]) {
+     [subview updateShadowStateInContextOfAncestorView:navigationBar];
+   }
+ }
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.mm b/node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.mm
 index add33c4..8022575 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStackHeaderSubview.mm


### PR DESCRIPTION
### What

Adds one hunk to `patches/react-native-screens+4.27.0.patch`: iterate a snapshot of `reactSubviews` in `-[RNSScreenStackHeaderConfig updateHeaderStateInShadowTreeInContextOfNavigationBar:]`.

### Why

That method iterates `reactSubviews` and calls `updateShadowStateInContextOfAncestorView:` on each one. With `synchronousHeaderConfigUpdatesEnabled`, the state update is scheduled `unstable_Immediate`, so the shadow tree commits **and mounts** synchronously — still inside the loop. Mounting can insert or remove header subviews, which mutates the array being enumerated, and the app aborts:

```
*** Terminating app due to uncaught exception 'NSGenericException',
    reason: '*** Collection <__NSArrayM: ...> was mutated while being enumerated.'

__NSFastEnumerationMutationHandler
-[RNSScreenStackHeaderConfig updateHeaderStateInShadowTreeInContextOfNavigationBar:]  RNSScreenStackHeaderConfig.mm:211
-[RNSNavigationController maybeUpdateHeaderLayoutInfoInShadowTree:]                   RNSScreenStack.mm:117
-[RNSNavigationController viewDidLayoutSubviews]                                      RNSScreenStack.mm:77
CA::Transaction::commit()
```

Our existing patch guards the *layout* re-entrancy on this same path, but not this. Any transition while header options are changing can hit it.

### Verification

Reproduced against **stock** react-native-screens 4.27.0 with a self-driving navigation fuzzer, on both an iOS 26 simulator and a physical device:

| build | result |
| --- | --- |
| stock 4.27.0 | crashed at 21 s, 64 s, 322 s (3 of 3 runs) |
| with this change | ran 36 minutes without crashing, until stopped manually |

Also confirmed the regenerated patch applies from a clean `node_modules`, and that `RNScreens` compiles in our workspace.

Patch regenerated with `yarn patch-package react-native-screens` — the existing `RNS_EMPTY_BAR` and layout-re-entrancy hunks are untouched.

### Upstream

Reported with a public repro and measurements at https://github.com/software-mansion/react-native-screens/issues/4483 — deliberately without prescribing this as the fix, since snapshotting addresses the symptom rather than the underlying re-entrancy, and the maintainers may prefer to defer the commit instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)