### PR TITLE
fix(mobile): stop full tab bar relayout on badge changes

### DIFF
--- a/shared/router-v2/router.tsx
+++ b/shared/router-v2/router.tsx
@@ -465,9 +465,9 @@ const getBadgeNumber = (
 
 const appTabsScreenOptions = (
   routeName: Tabs.Tab,
-  navBadges: ReadonlyMap<Tabs.Tab, number>,
-  hasPermissions: boolean,
-  isDarkMode: boolean, theme: Kb.Styles.Theme
+  badge: number | undefined,
+  isDarkMode: boolean,
+  theme: Kb.Styles.Theme
 ) => {
   return {
     headerShown: false,
@@ -475,7 +475,7 @@ const appTabsScreenOptions = (
     // hidden tab shortly after startup; only mount tabs on first focus
     lazy: true,
     overrideScrollViewContentInsetAdjustmentBehavior: true,
-    tabBarBadge: getBadgeNumber(routeName, navBadges, hasPermissions),
+    tabBarBadge: badge,
     tabBarBadgeStyle: {
       backgroundColor: theme.orange,
     },
@@ -516,6 +516,27 @@ if (isMobile) {
   // aliased to the null module, so calling it at module scope would crash startup.
   const NativeTab = createBottomTabNavigator()
 
+  // Options objects are cached per tab and only replaced when that tab's own inputs
+  // change: handing the native tab bar a new options object recreates its UITabBarItem,
+  // and recreating all of them at once makes UIKit re-lay-out the whole bar, which can
+  // leave labels stuck truncated ('Peo...') until something else forces another pass.
+  const tabOptionsCache = new Map<Tabs.Tab, {key: string; options: ReturnType<typeof appTabsScreenOptions>}>()
+  const getCachedTabOptions = (
+    tab: Tabs.Tab,
+    badge: number | undefined,
+    isDarkMode: boolean,
+    theme: Kb.Styles.Theme
+  ) => {
+    const key = `${badge ?? ''}:${isDarkMode ? 1 : 0}:${theme.orange}`
+    const cached = tabOptionsCache.get(tab)
+    if (cached?.key === key) {
+      return cached.options
+    }
+    const options = appTabsScreenOptions(tab, badge, isDarkMode, theme)
+    tabOptionsCache.set(tab, {key, options})
+    return options
+  }
+
   function AppTabsNative() {
     const theme = Kb.Styles.useTheme()
     const navBadges = useNotifState(s => s.navBadges)
@@ -529,7 +550,12 @@ if (isMobile) {
             key={tab}
             name={tab}
             component={nativeTabComponents[tab]!}
-            options={appTabsScreenOptions(tab, navBadges, hasPermissions, isDarkMode, theme)}
+            options={getCachedTabOptions(
+              tab,
+              getBadgeNumber(tab, navBadges, hasPermissions),
+              isDarkMode,
+              theme
+            )}
           />
         ))}
       </NativeTab.Navigator>


### PR DESCRIPTION
## Problem

iOS tab bar labels sometimes get stuck truncated (`Peo...` instead of `People`) and stay that way until some later layout pass fixes them.

## Cause

`appTabsScreenOptions` took the whole `navBadges` map plus `hasPermissions`, so **any** badge change produced a new options object for **every** tab. Native bottom-tabs (`react-native-screens`) recreates a screen's `UITabBarItem` when its options change, so a single badge update rebuilt all five items at once and made UIKit re-lay-out the entire tab bar. Labels can come out of that relayout truncated and stay truncated.

## Fix

- `appTabsScreenOptions` now takes a plain `badge: number | undefined`.
- Per-tab options cache keyed on that tab's badge, dark mode, and badge color, so a badge change only recreates the item it belongs to.

## Notes

This removes the churn that triggers the bad relayout; it does not change UIKit's truncation math. If the stuck label reappears, the next suspect is a layout landing while the liquid-glass bar is at a transient width (launch or minimize animation), which is `react-native-screens`-side.

## Validation

`yarn tsc`, `yarn lint`, `yarn lint:bailouts` all clean (0 bailouts, 0 whole-props deps). Visual behavior not yet confirmed on device.