### PR TITLE
fix(ios): attach the real file when a share vends only public.file-url

### DIFF
--- a/rnmodules/kb-common/src/ItemProviderHelper.swift
+++ b/rnmodules/kb-common/src/ItemProviderHelper.swift
@@ -364,7 +364,10 @@ public class ItemProviderHelper: NSObject {
         sendMedia(url, isVideo: false)
         return
       }
-      if !type.conforms(to: .text) {
+      // Only inline honest plain text. Plenty of document types (crash reports,
+      // logs, source) conform to public.text but are files the user meant to
+      // attach, extension and all.
+      if !type.conforms(to: .plainText) {
         sendFile(url)
         return
       }
@@ -623,10 +626,24 @@ public class ItemProviderHelper: NSObject {
               forTypeIdentifier: "public.vcard", completionHandler: contactHandler))
         // PDF and generic files
         case .file:
-          reserveItemProgress(loaderReportsProgress: true)
-          attachLoaderProgress(
-            item.loadFileRepresentation(
-              forTypeIdentifier: "public.item", completionHandler: fileHandler))
+          // A provider whose only file-ish representation is `public.file-url`
+          // has no file representation to load: asking for one writes the URL's
+          // property-list encoding to a temp file, and we would attach that
+          // 200-byte blob instead of the document. Take the URL and copy what it
+          // points at.
+          if UTType(best.stype)?.conforms(to: .fileURL) == true {
+            reserveItemProgress(loaderReportsProgress: false)
+            item.loadItem(
+              forTypeIdentifier: best.stype, options: nil,
+              completionHandler: { (loaded: NSSecureCoding?, error: Error?) in
+                self.sendURLItem(loaded as? URL)
+              })
+          } else {
+            reserveItemProgress(loaderReportsProgress: true)
+            attachLoaderProgress(
+              item.loadFileRepresentation(
+                forTypeIdentifier: best.stype, completionHandler: fileHandler))
+          }
         case .text:
           reserveItemProgress(loaderReportsProgress: false)
           item.loadItem(


### PR DESCRIPTION
## Problem

Sharing a crash report (`.ips`) into a conversation — via the share extension **or** via open-in from the app — attached a 207-byte Apple binary property list containing a `file://` URL instead of the crash report itself. The attachment even arrived named `file URL`, which is the suggested name of the URL representation.

## Cause

Both paths run through `ItemProviderHelper`.

1. The `.file` branch of `startProcessing` called `loadFileRepresentation(forTypeIdentifier: "public.item")`. `public.file-url` conforms to `public.item`, so when a provider's only file-ish representation is the file URL, iOS matched *that*, serialized the `NSURL` to a plist, wrote it to a temp file, and we copied the plist through as the payload.

2. Even once routed as a URL, `sendURLItem` inlined anything conforming to `public.text`. `com.apple.ips` conforms to `public.text` but not `public.plain-text`, so the crash report would have been read in as a text payload and lost its extension.

## Fix

- `.file` now checks whether the chosen type conforms to `.fileURL`. If so it uses `loadItem` and hands the resulting URL to `sendURLItem`, which security-scopes it and copies what it points at. Otherwise it loads a file representation for the type actually selected instead of a hardcoded `public.item` — the same mis-match could have hit PDFs.
- The text sniff in `sendURLItem` narrowed from `.text` to `.plainText`, so crash reports, logs, and source files attach as files while `.txt` and `.md` still inline as message text.

## Testing

Typechecks clean against the iphonesimulator SDK. Needs a device/simulator pass: share an `.ips` and a `.txt` through both the share extension and open-in, plus a photo, video, PDF, and plain link to confirm nothing else regressed.