### PR TITLE
fix(chat): deleted channels in bot settings, and make 'all channels' explicit

### DIFF
--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -4,8 +4,10 @@ import type * as T from '@/constants/types'
 import {makeInsertMatcher} from '@/util/string'
 
 type Props = {
+  allSelected: boolean
   channelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
   installInConvs: ReadonlyArray<string>
+  setAllSelected: (all: boolean) => void
   setChannelPickerScreen: (show: boolean) => void
   setInstallInConvs: (convs: ReadonlyArray<string>) => void
   setDisableDone: (disable: boolean) => void
@@ -87,14 +89,9 @@ const Row = ({description, disabled, name, onToggle, selected}: RowProps) => {
 const ChannelPicker = (props: Props) => {
   const styles = useStyles()
   const theme = Kb.Styles.useTheme()
-  const {installInConvs, setInstallInConvs, setDisableDone} = props
-  const [allSelected, setAllSelected] = React.useState(installInConvs.length === 0)
+  const {allSelected, channelMetas, installInConvs, setAllSelected, setInstallInConvs} = props
+  const {setDisableDone, teamName} = props
   const [searchText, setSearchText] = React.useState('')
-  React.useEffect(() => {
-    if (allSelected) {
-      setInstallInConvs([])
-    }
-  }, [allSelected, setInstallInConvs])
 
   React.useEffect(() => {
     if (!allSelected && installInConvs.length === 0) {
@@ -104,7 +101,7 @@ const ChannelPicker = (props: Props) => {
     setDisableDone(false)
   }, [allSelected, installInConvs, setDisableDone])
 
-  const channels = getChannels(props.channelMetas, searchText)
+  const channels = getChannels(channelMetas, searchText)
   const rows = channels.map(meta => (
     <Row
       disabled={allSelected}
@@ -122,7 +119,7 @@ const ChannelPicker = (props: Props) => {
         <Kb.SearchFilter
           size="full-width"
           icon="iconfont-search"
-          placeholderText={`Search channels in ${props.teamName}`}
+          placeholderText={`Search channels in ${teamName}`}
           placeholderCentered={true}
           onChange={setSearchText}
           style={styles.searchFilter}

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -6,6 +6,7 @@ import {makeInsertMatcher} from '@/util/string'
 type Props = {
   allSelected: boolean
   channelMetas: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
+  channelsKnown: boolean
   installInConvs: ReadonlyArray<string>
   setAllSelected: (all: boolean) => void
   setChannelPickerScreen: (show: boolean) => void
@@ -20,7 +21,7 @@ const getChannels = (
   searchText: string
 ) => {
   const matcher = makeInsertMatcher(searchText)
-  const regex = new RegExp(searchText, 'i')
+  const lowerSearch = searchText.toLowerCase()
   return [...channelMetas.values()]
     .filter(({channelname, description}) => {
       if (!searchText) {
@@ -28,8 +29,9 @@ const getChannels = (
       }
       return (
         // match channel name for search as subsequence (like the identity modal)
-        // match channel desc by strict substring (less noise in results)
-        channelname.search(matcher) !== -1 || description.search(regex) !== -1
+        // match channel desc by strict substring (less noise in results). not a regex:
+        // typing '(' would throw during render
+        channelname.search(matcher) !== -1 || description.toLowerCase().includes(lowerSearch)
       )
     })
     .sort((a, b) => a.channelname.localeCompare(b.channelname))
@@ -89,8 +91,8 @@ const Row = ({description, disabled, name, onToggle, selected}: RowProps) => {
 const ChannelPicker = (props: Props) => {
   const styles = useStyles()
   const theme = Kb.Styles.useTheme()
-  const {allSelected, channelMetas, installInConvs, setAllSelected} = props
-  const {setDisableDone, setInstallInConvs, teamName} = props
+  const {allSelected, channelMetas, channelsKnown, installInConvs} = props
+  const {setAllSelected, setDisableDone, setInstallInConvs, teamName} = props
   const [searchText, setSearchText] = React.useState('')
 
   React.useEffect(() => {
@@ -126,6 +128,11 @@ const ChannelPicker = (props: Props) => {
           focusOnMount={true}
         />
       </Kb.Box2>
+      {!channelsKnown ? (
+        <Kb.Box2 direction="vertical" style={styles.rowsContainer} centerChildren={true}>
+          <Kb.ProgressIndicator type="Large" />
+        </Kb.Box2>
+      ) : (
       <Kb.ScrollView style={styles.rowsContainer}>
         <Kb.Box2 direction="horizontal" style={{backgroundColor: theme.blueGrey}}>
           <Kb.ListItem
@@ -138,6 +145,7 @@ const ChannelPicker = (props: Props) => {
         </Kb.Box2>
         {rows}
       </Kb.ScrollView>
+      )}
     </Kb.Box2>
   )
 }

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -89,8 +89,8 @@ const Row = ({description, disabled, name, onToggle, selected}: RowProps) => {
 const ChannelPicker = (props: Props) => {
   const styles = useStyles()
   const theme = Kb.Styles.useTheme()
-  const {allSelected, channelMetas, installInConvs, setAllSelected, setInstallInConvs} = props
-  const {setDisableDone, teamName} = props
+  const {allSelected, channelMetas, installInConvs, setAllSelected} = props
+  const {setDisableDone, setInstallInConvs, teamName} = props
   const [searchText, setSearchText] = React.useState('')
 
   React.useEffect(() => {

--- a/shared/chat/conversation/bot/channel-picker.tsx
+++ b/shared/chat/conversation/bot/channel-picker.tsx
@@ -114,7 +114,7 @@ const ChannelPicker = (props: Props) => {
   ))
 
   return (
-    <Kb.Box2 direction="vertical" fullWidth={true}>
+    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
       <Kb.Box2 direction="horizontal" fullWidth={true}>
         <Kb.SearchFilter
           size="full-width"
@@ -156,14 +156,18 @@ const useStyles = Kb.Styles.createStyleHook(
           wordBreak: 'break-all',
         },
       }),
-      rowsContainer: Kb.Styles.platformStyles({
-        common: {
-          ...Kb.Styles.padding(0, Kb.Styles.globalMargins.small),
-        },
-        isElectron: {
-          minHeight: 370,
-        },
-      }),
+      // the rows have to scroll inside the modal instead of growing it
+      container: {
+        flexGrow: 1,
+        flexShrink: 1,
+        minHeight: 0,
+      },
+      rowsContainer: {
+        ...Kb.Styles.padding(0, Kb.Styles.globalMargins.small),
+        flexGrow: 1,
+        flexShrink: 1,
+        minHeight: 0,
+      },
       searchFilter: Kb.Styles.platformStyles({
         common: {
           marginBottom: Kb.Styles.globalMargins.xsmall,

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -200,7 +200,7 @@ const InstallBotPopup = (props: Props) => {
     teamname = meta.teamname
   }
 
-  const {channelMetas} = useAllChannelMetas(teamID)
+  const {channelMetas, loadingChannels} = useAllChannelMetas(teamID)
   const mutationWaiting = C.Waiting.useAnyWaiting([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
   const error = C.Waiting.useAnyErrors([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
   const mutationError = C.Waiting.useAnyErrors(C.waitingKeyChatBotAdd)
@@ -357,6 +357,7 @@ const InstallBotPopup = (props: Props) => {
         <PermsList
           channelMetas={channelMetas}
           commands={commands}
+          loadingChannels={loadingChannels}
           settings={settings}
           username={botUsername}
         />
@@ -377,6 +378,7 @@ const InstallBotPopup = (props: Props) => {
       {inTeam && isBot && !inTeamUnrestricted && (
         <PermsList
           channelMetas={channelMetas}
+          loadingChannels={loadingChannels}
           settings={settings}
           commands={commands}
           username={botUsername}
@@ -537,7 +539,11 @@ const InstallBotPopup = (props: Props) => {
         if (settings) {
           setInstallWithCommands(settings.cmds)
           setInstallWithMentions(settings.mentions)
-          setInstallInConvs(settings.convs ?? [])
+          // Drop convs the team no longer has (deleted channels linger in the
+          // server-side bot settings); don't filter while the list is still loading
+          // or we'd save away channels we simply haven't seen yet.
+          const convs = settings.convs ?? []
+          setInstallInConvs(loadingChannels ? convs : convs.filter(c => channelMetas.has(c)))
         }
         setInstallScreen(true)
       }}
@@ -706,36 +712,41 @@ const CommandsLabel = (props: CommandsLabelProps) => {
 type PermsListProps = {
   channelMetas?: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
   commands: T.Chat.BotPublicCommands | undefined
+  loadingChannels?: boolean
   settings?: T.RPCGen.TeamBotSettings
   username: string
 }
 
 const PermsList = (props: PermsListProps) => {
+  const {channelMetas, commands, loadingChannels, settings, username} = props
+  // convs can name channels that were deleted, which have no meta and would
+  // otherwise render as a bare '#'
+  const convs = (settings?.convs ?? []).filter(convID => channelMetas?.has(convID))
   return (
     <Kb.Box2 direction="vertical" gap="small" fullWidth={true}>
       <Kb.Text type="BodySemibold">This bot can currently read:</Kb.Text>
-      {props.settings ? (
+      {settings ? (
         <Kb.Box2 direction="vertical" gap="small" fullWidth={true}>
           <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
-            {!(props.settings.cmds || props.settings.mentions) && (
+            {!(settings.cmds || settings.mentions) && (
               <Kb.Text type="Body">{'• no messages, the bot is in write only mode'}</Kb.Text>
             )}
-            {props.settings.cmds && (
+            {settings.cmds && (
               <Kb.Box2 direction="horizontal" fullWidth={true} gap="xtiny">
                 <Kb.Text type="Body">{'•'}</Kb.Text>
-                <CommandsLabel commands={props.commands} />
+                <CommandsLabel commands={commands} />
               </Kb.Box2>
             )}
-            {props.settings.mentions && (
-              <Kb.Text type="Body">{`• messages it has been mentioned in with @${props.username}`}</Kb.Text>
+            {settings.mentions && (
+              <Kb.Text type="Body">{`• messages it has been mentioned in with @${username}`}</Kb.Text>
             )}
           </Kb.Box2>
-          {props.settings.convs && props.channelMetas && (
+          {!loadingChannels && convs.length > 0 && (
             <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
               <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
-              {props.settings.convs.map(convID => (
+              {convs.map(convID => (
                 <Kb.Text type="Body" key={convID}>{`• #${
-                  props.channelMetas?.get(convID)?.channelname ?? ''
+                  channelMetas?.get(convID)?.channelname ?? ''
                 }`}</Kb.Text>
               ))}
             </Kb.Box2>

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -470,7 +470,7 @@ const InstallBotPopup = (props: Props) => {
   )
 
   const channelPickerContent = channelPickerScreen && teamID && teamname && (
-    <Kb.Box2 direction="vertical" fullWidth={true} gap="small">
+    <Kb.Box2 direction="vertical" fullWidth={true} gap="small" style={styles.pickerContainer}>
       <ChannelPicker
         allSelected={installInAllConvs}
         channelMetas={channelMetas}
@@ -787,6 +787,12 @@ const PermsList = (props: PermsListProps) => {
 }
 
 const useStyles = Kb.Styles.createStyleHook(() => ({
+  // the picker brings its own scroller, so it has to be able to shrink to the modal
+  pickerContainer: {
+    flexGrow: 1,
+    flexShrink: 1,
+    minHeight: 0,
+  },
   bodyScroll: {
     flex: 1,
     minHeight: 0,

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -218,7 +218,7 @@ const InstallBotPopup = (props: Props) => {
   // Only 'All channels' may send an empty list; a restricted bot with no channels
   // selected is not saveable (the picker's Done button enforces the same thing).
   const convsToSave = installInAllConvs ? [] : installInConvs
-  const noConvsChosen = !installInAllConvs && convsToSave.length === 0
+  const noConvsChosen = installWithRestrict && !installInAllConvs && convsToSave.length === 0
   const onInstall = () => {
     if (!conversationIDKey || noConvsChosen) {
       return
@@ -365,7 +365,7 @@ const InstallBotPopup = (props: Props) => {
         <PermsList
           channelMetas={channelMetas}
           commands={commands}
-          loadingChannels={loadingChannels}
+          loadingChannels={!!teamname && loadingChannels}
           settings={settings}
           username={botUsername}
         />
@@ -386,9 +386,9 @@ const InstallBotPopup = (props: Props) => {
       {inTeam && isBot && !inTeamUnrestricted && (
         <PermsList
           channelMetas={channelMetas}
-          loadingChannels={loadingChannels}
-          settings={settings}
           commands={commands}
+          loadingChannels={!!teamname && loadingChannels}
+          settings={settings}
           username={botUsername}
         />
       )}
@@ -438,9 +438,9 @@ const InstallBotPopup = (props: Props) => {
                       {teamname}{' '}
                       {installInAllConvs
                         ? '(all channels)'
-                        : installInConvs.length === 1
+                        : installInConvs.length === 1 && channelMetas.get(installInConvs[0] ?? '')
                           ? `(#${channelMetas.get(installInConvs[0] ?? '')?.channelname ?? ''})`
-                          : `(${installInConvs.length} channels)`}
+                          : `(${installInConvs.length} channel${installInConvs.length === 1 ? '' : 's'})`}
                     </Kb.Text>
                   </Kb.Box2>
                 }
@@ -495,13 +495,15 @@ const InstallBotPopup = (props: Props) => {
   const showInstallButton = installScreen && !inTeam && !channelPickerScreen
   const showReviewButton = !installScreen && !inTeam
   const showRemoveButton = inTeam && isBot && !installScreen
-  const showEditButton = inTeam && isBot && !inTeamUnrestricted && !installScreen
+  // without settings the edit screen would seed from nothing and read as 'all channels'
+  const showEditButton = inTeam && isBot && !inTeamUnrestricted && !installScreen && !!settings
   const showSaveButton = inTeam && installScreen && !channelPickerContent
   const showDoneButton = channelPickerContent
   const installButton = showInstallButton && (
     <Kb.WaitingButton
+      disabled={noConvsChosen}
       fullWidth={true}
-      label="Install"
+      label={noConvsChosen ? 'Select at least one channel' : 'Install'}
       onClick={onInstall}
       mode="Primary"
       type="Default"
@@ -548,18 +550,16 @@ const InstallBotPopup = (props: Props) => {
       fullWidth={true}
       label="Edit settings"
       onClick={() => {
-        if (settings) {
-          setInstallWithCommands(settings.cmds)
-          setInstallWithMentions(settings.mentions)
-          const convs = settings.convs ?? []
-          setInstallInAllConvs(convs.length === 0)
-          // Drop convs the team no longer has (deleted channels linger in the
-          // server-side bot settings), but never let filtering empty the list: that
-          // would flip the bot to 'all channels' if the channel list hasn't loaded,
-          // failed, or came back empty.
-          const known = convs.filter(c => channelMetas.has(c))
-          setInstallInConvs(!loadingChannels && known.length > 0 ? known : convs)
-        }
+        setInstallWithCommands(settings.cmds)
+        setInstallWithMentions(settings.mentions)
+        const convs = settings.convs ?? []
+        setInstallInAllConvs(convs.length === 0)
+        // Drop convs the team no longer has (deleted channels linger in the
+        // server-side bot settings), but never let filtering empty the list: that
+        // would flip the bot to 'all channels' if the channel list hasn't loaded,
+        // failed, or came back empty.
+        const known = convs.filter(c => channelMetas.has(c))
+        setInstallInConvs(!loadingChannels && known.length > 0 ? known : convs)
         setInstallScreen(true)
       }}
       mode="Secondary"
@@ -568,8 +568,9 @@ const InstallBotPopup = (props: Props) => {
   )
   const saveButton = showSaveButton && (
     <Kb.WaitingButton
+      disabled={noConvsChosen}
       fullWidth={true}
-      label="Save"
+      label={noConvsChosen ? 'Select at least one channel' : 'Save'}
       onClick={onEdit}
       mode="Primary"
       type="Default"
@@ -605,7 +606,6 @@ const InstallBotPopup = (props: Props) => {
       botReadOnly: readOnly,
       botSubScreen: channelPickerScreen ? 'channels' : installScreen ? 'install' : '',
       onAction: handleBack,
-      title: channelPickerScreen ? 'Channels' : '',
     })
     return () => {
       useModalHeaderState.setState({
@@ -613,7 +613,6 @@ const InstallBotPopup = (props: Props) => {
         botReadOnly: false,
         botSubScreen: '',
         onAction: undefined,
-        title: '',
       })
     }
   }, [channelPickerScreen, installScreen, inTeam, readOnly, navigateUp, clearModals])
@@ -736,9 +735,9 @@ const PermsList = (props: PermsListProps) => {
   const {channelMetas, commands, loadingChannels, settings, username} = props
   const convs = settings?.convs ?? []
   // convs can name channels that were deleted, which have no meta and would
-  // otherwise render as a bare '#'. An empty convs list is a real state (the bot
-  // reads every channel), so it must stay distinguishable from 'nothing resolved'.
+  // otherwise render as a bare '#'
   const knownConvs = convs.filter(convID => channelMetas?.has(convID))
+  const goneCount = convs.length - knownConvs.length
   return (
     <Kb.Box2 direction="vertical" gap="small" fullWidth={true}>
       <Kb.Text type="BodySemibold">This bot can currently read:</Kb.Text>
@@ -758,24 +757,27 @@ const PermsList = (props: PermsListProps) => {
               <Kb.Text type="Body">{`• messages it has been mentioned in with @${username}`}</Kb.Text>
             )}
           </Kb.Box2>
-          {convs.length > 0 && (
-            <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
-              <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
-              {loadingChannels ? (
-                <Kb.ProgressIndicator />
-              ) : knownConvs.length > 0 ? (
-                knownConvs.map(convID => (
+          <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
+            <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
+            {convs.length === 0 ? (
+              <Kb.Text type="Body">{'• all channels in this team'}</Kb.Text>
+            ) : loadingChannels ? (
+              <Kb.ProgressIndicator />
+            ) : (
+              <>
+                {knownConvs.map(convID => (
                   <Kb.Text type="Body" key={convID}>{`• #${
                     channelMetas?.get(convID)?.channelname ?? ''
                   }`}</Kb.Text>
-                ))
-              ) : (
-                <Kb.Text type="Body">{`• ${convs.length} channel${
-                  convs.length === 1 ? '' : 's'
-                } you don't have access to`}</Kb.Text>
-              )}
-            </Kb.Box2>
-          )}
+                ))}
+                {goneCount > 0 && (
+                  <Kb.Text type="Body">{`• ${goneCount} channel${
+                    goneCount === 1 ? '' : 's'
+                  } that no longer exist${goneCount === 1 ? 's' : ''}`}</Kb.Text>
+                )}
+              </>
+            )}
+          </Kb.Box2>
         </Kb.Box2>
       ) : (
         <Kb.ProgressIndicator type="Large" />

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -454,9 +454,7 @@ const InstallBotPopup = (props: Props) => {
                 toggleOpen={() => setChannelPickerScreen(true)}
               />
               {installInAllConvs && (
-                <Kb.Text type="BodySmall">
-                  {`Every channel in ${teamname}, including channels created later.`}
-                </Kb.Text>
+                <Kb.Text type="BodySmall">{`Every channel in ${teamname}.`}</Kb.Text>
               )}
             </Kb.Box2>
           )}
@@ -784,7 +782,7 @@ const PermsList = (props: PermsListProps) => {
           <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
             <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
             {convs.length === 0 ? (
-              <Kb.Text type="Body">{'• all channels in this team, including new ones'}</Kb.Text>
+              <Kb.Text type="Body">{'• all channels in this team'}</Kb.Text>
             ) : !channelsKnown ? (
               <Kb.ProgressIndicator />
             ) : (

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -453,10 +453,17 @@ const InstallBotPopup = (props: Props) => {
                 }
                 toggleOpen={() => setChannelPickerScreen(true)}
               />
+              {installInAllConvs && (
+                <Kb.Text type="BodySmall">
+                  {`Every channel in ${teamname}, including channels created later.`}
+                </Kb.Text>
+              )}
             </Kb.Box2>
           )}
           <Kb.Text type="BodySmall">
-            This bot will not be able to read any other messages, channels, files, or repositories.
+            {installInAllConvs
+              ? 'This bot will not be able to read any other messages, files, or repositories.'
+              : 'This bot will not be able to read any other messages, channels, files, or repositories.'}
           </Kb.Text>
         </Kb.Box2>
       ) : (
@@ -777,7 +784,7 @@ const PermsList = (props: PermsListProps) => {
           <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
             <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
             {convs.length === 0 ? (
-              <Kb.Text type="Body">{'• all channels in this team'}</Kb.Text>
+              <Kb.Text type="Body">{'• all channels in this team, including new ones'}</Kb.Text>
             ) : !channelsKnown ? (
               <Kb.ProgressIndicator />
             ) : (

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -158,6 +158,10 @@ const InstallBotPopup = (props: Props) => {
   const [installWithMentions, setInstallWithMentions] = React.useState(true)
   const [installWithRestrict, setInstallWithRestrict] = React.useState(true)
   const [installInConvs, setInstallInConvs] = React.useState<ReadonlyArray<string>>([])
+  // An empty convs list means 'every channel in the team' on the wire, so that has to
+  // be an explicit choice ('All channels' in the picker) and never something we fall
+  // into by filtering or by failing to load the channel list.
+  const [installInAllConvs, setInstallInAllConvs] = React.useState(true)
   const [disableDone, setDisableDone] = React.useState(false)
   const [loadedBotPublicCommands, setLoadedBotPublicCommands] = React.useState<
     | {
@@ -211,8 +215,12 @@ const InstallBotPopup = (props: Props) => {
   const onLearn = () => {
     void openURL('https://book.keybase.io/docs/chat/restricted-bots')
   }
+  // Only 'All channels' may send an empty list; a restricted bot with no channels
+  // selected is not saveable (the picker's Done button enforces the same thing).
+  const convsToSave = installInAllConvs ? [] : installInConvs
+  const noConvsChosen = !installInAllConvs && convsToSave.length === 0
   const onInstall = () => {
-    if (!conversationIDKey) {
+    if (!conversationIDKey || noConvsChosen) {
       return
     }
     dispatchClearWaiting([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
@@ -221,7 +229,7 @@ const InstallBotPopup = (props: Props) => {
       addBotMember({
         botUsername,
         conversationIDKey,
-        installInConvs,
+        installInConvs: convsToSave,
         installWithCommands,
         installWithMentions,
         installWithRestrict,
@@ -229,7 +237,7 @@ const InstallBotPopup = (props: Props) => {
     )
   }
   const onEdit = () => {
-    if (!conversationIDKey) {
+    if (!conversationIDKey || noConvsChosen) {
       return
     }
     dispatchClearWaiting([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
@@ -238,7 +246,7 @@ const InstallBotPopup = (props: Props) => {
       try {
         await T.RPCChat.localSetBotMemberSettingsRpcPromise(
           {
-            botSettings: {cmds: installWithCommands, convs: installInConvs, mentions: installWithMentions},
+            botSettings: {cmds: installWithCommands, convs: convsToSave, mentions: installWithMentions},
             convID: T.Chat.keyToConversationID(conversationIDKey),
             username: botUsername,
           },
@@ -428,9 +436,11 @@ const InstallBotPopup = (props: Props) => {
                     />
                     <Kb.Text type="BodySemibold">
                       {teamname}{' '}
-                      {installInConvs.length === 1
-                        ? `(#${channelMetas.get(installInConvs[0] ?? '')?.channelname ?? ''})`
-                        : `(${installInConvs.length > 0 ? installInConvs.length : 'all'} channels)`}
+                      {installInAllConvs
+                        ? '(all channels)'
+                        : installInConvs.length === 1
+                          ? `(#${channelMetas.get(installInConvs[0] ?? '')?.channelname ?? ''})`
+                          : `(${installInConvs.length} channels)`}
                     </Kb.Text>
                   </Kb.Box2>
                 }
@@ -462,8 +472,10 @@ const InstallBotPopup = (props: Props) => {
   const channelPickerContent = channelPickerScreen && teamID && teamname && (
     <Kb.Box2 direction="vertical" fullWidth={true} gap="small">
       <ChannelPicker
+        allSelected={installInAllConvs}
         channelMetas={channelMetas}
         installInConvs={installInConvs}
+        setAllSelected={setInstallInAllConvs}
         setChannelPickerScreen={setChannelPickerScreen}
         setDisableDone={setDisableDone}
         setInstallInConvs={setInstallInConvs}
@@ -539,12 +551,12 @@ const InstallBotPopup = (props: Props) => {
         if (settings) {
           setInstallWithCommands(settings.cmds)
           setInstallWithMentions(settings.mentions)
-          // Drop convs the team no longer has (deleted channels linger in the
-          // server-side bot settings). An empty convs list means 'every channel' on
-          // the wire, so never let filtering produce one: if the channel list hasn't
-          // loaded, failed, or came back empty we'd otherwise save away the
-          // restriction entirely and hand the bot the whole team.
           const convs = settings.convs ?? []
+          setInstallInAllConvs(convs.length === 0)
+          // Drop convs the team no longer has (deleted channels linger in the
+          // server-side bot settings), but never let filtering empty the list: that
+          // would flip the bot to 'all channels' if the channel list hasn't loaded,
+          // failed, or came back empty.
           const known = convs.filter(c => channelMetas.has(c))
           setInstallInConvs(!loadingChannels && known.length > 0 ? known : convs)
         }

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -540,10 +540,13 @@ const InstallBotPopup = (props: Props) => {
           setInstallWithCommands(settings.cmds)
           setInstallWithMentions(settings.mentions)
           // Drop convs the team no longer has (deleted channels linger in the
-          // server-side bot settings); don't filter while the list is still loading
-          // or we'd save away channels we simply haven't seen yet.
+          // server-side bot settings). An empty convs list means 'every channel' on
+          // the wire, so never let filtering produce one: if the channel list hasn't
+          // loaded, failed, or came back empty we'd otherwise save away the
+          // restriction entirely and hand the bot the whole team.
           const convs = settings.convs ?? []
-          setInstallInConvs(loadingChannels ? convs : convs.filter(c => channelMetas.has(c)))
+          const known = convs.filter(c => channelMetas.has(c))
+          setInstallInConvs(!loadingChannels && known.length > 0 ? known : convs)
         }
         setInstallScreen(true)
       }}
@@ -719,9 +722,11 @@ type PermsListProps = {
 
 const PermsList = (props: PermsListProps) => {
   const {channelMetas, commands, loadingChannels, settings, username} = props
+  const convs = settings?.convs ?? []
   // convs can name channels that were deleted, which have no meta and would
-  // otherwise render as a bare '#'
-  const convs = (settings?.convs ?? []).filter(convID => channelMetas?.has(convID))
+  // otherwise render as a bare '#'. An empty convs list is a real state (the bot
+  // reads every channel), so it must stay distinguishable from 'nothing resolved'.
+  const knownConvs = convs.filter(convID => channelMetas?.has(convID))
   return (
     <Kb.Box2 direction="vertical" gap="small" fullWidth={true}>
       <Kb.Text type="BodySemibold">This bot can currently read:</Kb.Text>
@@ -741,14 +746,22 @@ const PermsList = (props: PermsListProps) => {
               <Kb.Text type="Body">{`• messages it has been mentioned in with @${username}`}</Kb.Text>
             )}
           </Kb.Box2>
-          {!loadingChannels && convs.length > 0 && (
+          {convs.length > 0 && (
             <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
               <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
-              {convs.map(convID => (
-                <Kb.Text type="Body" key={convID}>{`• #${
-                  channelMetas?.get(convID)?.channelname ?? ''
-                }`}</Kb.Text>
-              ))}
+              {loadingChannels ? (
+                <Kb.ProgressIndicator />
+              ) : knownConvs.length > 0 ? (
+                knownConvs.map(convID => (
+                  <Kb.Text type="Body" key={convID}>{`• #${
+                    channelMetas?.get(convID)?.channelname ?? ''
+                  }`}</Kb.Text>
+                ))
+              ) : (
+                <Kb.Text type="Body">{`• ${convs.length} channel${
+                  convs.length === 1 ? '' : 's'
+                } you don't have access to`}</Kb.Text>
+              )}
             </Kb.Box2>
           )}
         </Kb.Box2>

--- a/shared/chat/conversation/bot/install.tsx
+++ b/shared/chat/conversation/bot/install.tsx
@@ -118,6 +118,8 @@ type Props = {
 
 const blankCommands: Array<T.RPCChat.ConversationCommand> = []
 
+const pickChannelsLabel = 'Select at least one channel'
+
 const addBotMember = async (p: {
   botUsername: string
   conversationIDKey: T.Chat.ConversationIDKey
@@ -194,7 +196,7 @@ const InstallBotPopup = (props: Props) => {
 
   const {yourOperations} = useChatTeam(meta.teamID, meta.teamname)
   const readOnly = meta.teamname ? !yourOperations.manageBots : false
-  const {settings} = useBotSettings(conversationIDKey, botUsername, !!inTeam)
+  const {failed: settingsFailed, settings} = useBotSettings(conversationIDKey, botUsername, !!inTeam)
   let teamname: string | undefined
   let teamID: T.Teams.TeamID = T.Teams.noTeamID
   let refreshTeamID: T.Teams.TeamID | undefined
@@ -204,7 +206,8 @@ const InstallBotPopup = (props: Props) => {
     teamname = meta.teamname
   }
 
-  const {channelMetas, loadingChannels} = useAllChannelMetas(teamID)
+  const {channelMetas} = useAllChannelMetas(teamID)
+  const channelsKnown = channelMetas.size > 0
   const mutationWaiting = C.Waiting.useAnyWaiting([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
   const error = C.Waiting.useAnyErrors([C.waitingKeyChatBotAdd, C.waitingKeyChatBotRemove])
   const mutationError = C.Waiting.useAnyErrors(C.waitingKeyChatBotAdd)
@@ -364,9 +367,11 @@ const InstallBotPopup = (props: Props) => {
       {inTeam && isBot && !inTeamUnrestricted && (
         <PermsList
           channelMetas={channelMetas}
+          channelsKnown={channelsKnown}
           commands={commands}
-          loadingChannels={!!teamname && loadingChannels}
+          hasTeam={!!teamname}
           settings={settings}
+          settingsFailed={settingsFailed}
           username={botUsername}
         />
       )}
@@ -386,9 +391,11 @@ const InstallBotPopup = (props: Props) => {
       {inTeam && isBot && !inTeamUnrestricted && (
         <PermsList
           channelMetas={channelMetas}
+          channelsKnown={channelsKnown}
           commands={commands}
-          loadingChannels={!!teamname && loadingChannels}
+          hasTeam={!!teamname}
           settings={settings}
+          settingsFailed={settingsFailed}
           username={botUsername}
         />
       )}
@@ -474,6 +481,7 @@ const InstallBotPopup = (props: Props) => {
       <ChannelPicker
         allSelected={installInAllConvs}
         channelMetas={channelMetas}
+        channelsKnown={channelsKnown}
         installInConvs={installInConvs}
         setAllSelected={setInstallInAllConvs}
         setChannelPickerScreen={setChannelPickerScreen}
@@ -495,15 +503,17 @@ const InstallBotPopup = (props: Props) => {
   const showInstallButton = installScreen && !inTeam && !channelPickerScreen
   const showReviewButton = !installScreen && !inTeam
   const showRemoveButton = inTeam && isBot && !installScreen
-  // without settings the edit screen would seed from nothing and read as 'all channels'
-  const showEditButton = inTeam && isBot && !inTeamUnrestricted && !installScreen && !!settings
+  const showEditButton = inTeam && isBot && !inTeamUnrestricted && !installScreen
+  // without settings the edit screen would seed from nothing and read as 'all channels';
+  // without the channel list it can't tell a deleted channel from an unloaded one
+  const editDisabled = !settings || !channelsKnown
   const showSaveButton = inTeam && installScreen && !channelPickerContent
   const showDoneButton = channelPickerContent
   const installButton = showInstallButton && (
     <Kb.WaitingButton
       disabled={noConvsChosen}
       fullWidth={true}
-      label={noConvsChosen ? 'Select at least one channel' : 'Install'}
+      label={noConvsChosen ? pickChannelsLabel : 'Install'}
       onClick={onInstall}
       mode="Primary"
       type="Default"
@@ -547,19 +557,19 @@ const InstallBotPopup = (props: Props) => {
   )
   const editButton = showEditButton && (
     <Kb.Button
+      disabled={editDisabled}
       fullWidth={true}
       label="Edit settings"
       onClick={() => {
+        if (!settings) return
         setInstallWithCommands(settings.cmds)
         setInstallWithMentions(settings.mentions)
         const convs = settings.convs ?? []
         setInstallInAllConvs(convs.length === 0)
-        // Drop convs the team no longer has (deleted channels linger in the
-        // server-side bot settings), but never let filtering empty the list: that
-        // would flip the bot to 'all channels' if the channel list hasn't loaded,
-        // failed, or came back empty.
-        const known = convs.filter(c => channelMetas.has(c))
-        setInstallInConvs(!loadingChannels && known.length > 0 ? known : convs)
+        // the button waits for the channel list, so anything that doesn't resolve here
+        // is a deleted channel: drop it rather than carry an id the user can't see or
+        // deselect. An empty result blocks save, it can't widen the bot.
+        setInstallInConvs(convs.filter(c => channelMetas.has(c)))
         setInstallScreen(true)
       }}
       mode="Secondary"
@@ -570,7 +580,7 @@ const InstallBotPopup = (props: Props) => {
     <Kb.WaitingButton
       disabled={noConvsChosen}
       fullWidth={true}
-      label={noConvsChosen ? 'Select at least one channel' : 'Save'}
+      label={noConvsChosen ? pickChannelsLabel : 'Save'}
       onClick={onEdit}
       mode="Primary"
       type="Default"
@@ -580,8 +590,11 @@ const InstallBotPopup = (props: Props) => {
   const doneButton = showDoneButton && (
     <Kb.Button
       fullWidth={true}
-      label={disableDone ? 'Select at least one channel' : 'Done'}
-      onClick={() => setChannelPickerScreen(false)}
+      label={disableDone ? pickChannelsLabel : 'Done'}
+      onClick={() => {
+        setDisableDone(false)
+        setChannelPickerScreen(false)
+      }}
       disabled={disableDone}
       mode="Primary"
       type="Default"
@@ -725,14 +738,17 @@ const CommandsLabel = (props: CommandsLabelProps) => {
 
 type PermsListProps = {
   channelMetas?: ReadonlyMap<T.Chat.ConversationIDKey, T.Chat.ConversationMeta>
+  channelsKnown: boolean
   commands: T.Chat.BotPublicCommands | undefined
-  loadingChannels?: boolean
+  hasTeam: boolean
   settings?: T.RPCGen.TeamBotSettings
+  settingsFailed: boolean
   username: string
 }
 
 const PermsList = (props: PermsListProps) => {
-  const {channelMetas, commands, loadingChannels, settings, username} = props
+  const {channelMetas, channelsKnown, commands, hasTeam} = props
+  const {settings, settingsFailed, username} = props
   const convs = settings?.convs ?? []
   // convs can name channels that were deleted, which have no meta and would
   // otherwise render as a bare '#'
@@ -757,11 +773,12 @@ const PermsList = (props: PermsListProps) => {
               <Kb.Text type="Body">{`• messages it has been mentioned in with @${username}`}</Kb.Text>
             )}
           </Kb.Box2>
+          {hasTeam && (
           <Kb.Box2 direction="vertical" gap="tiny" fullWidth={true}>
             <Kb.Text type="BodySemibold">In these channels:</Kb.Text>
             {convs.length === 0 ? (
               <Kb.Text type="Body">{'• all channels in this team'}</Kb.Text>
-            ) : loadingChannels ? (
+            ) : !channelsKnown ? (
               <Kb.ProgressIndicator />
             ) : (
               <>
@@ -778,7 +795,10 @@ const PermsList = (props: PermsListProps) => {
               </>
             )}
           </Kb.Box2>
+          )}
         </Kb.Box2>
+      ) : settingsFailed ? (
+        <Kb.Text type="BodySmallError">{`Couldn't load this bot's settings.`}</Kb.Text>
       ) : (
         <Kb.ProgressIndicator type="Large" />
       )}

--- a/shared/chat/conversation/bot/settings.tsx
+++ b/shared/chat/conversation/bot/settings.tsx
@@ -12,6 +12,7 @@ export const useBotSettings = (
     | {
         botUsername: string
         conversationIDKey: T.Chat.ConversationIDKey
+        failed?: boolean
         settings?: T.RPCGen.TeamBotSettings
       }
     | undefined
@@ -38,7 +39,7 @@ export const useBotSettings = (
           return
         }
         logger.info(`useBotSettings: failed to refresh settings for ${botUsername}: ${error.message}`)
-        setLoaded({botUsername, conversationIDKey})
+        setLoaded({botUsername, conversationIDKey, failed: true})
       }
     )
     return () => {
@@ -48,13 +49,17 @@ export const useBotSettings = (
     }
   }, [botUsername, conversationIDKey, enabled, loadBotSettings])
 
-  const settings =
+  const current =
     enabled &&
     loaded &&
     loaded.conversationIDKey === conversationIDKey &&
     loaded.botUsername === botUsername
-      ? loaded.settings
+      ? loaded
       : undefined
+  const settings = current?.settings
+  // nothing retries this load, so callers have to be able to tell a failure from a
+  // load still in flight
+  const failed = !!current?.failed
   const setSettings = React.useCallback(
     (settings: T.RPCGen.TeamBotSettings) => {
       if (conversationIDKey) {
@@ -63,5 +68,5 @@ export const useBotSettings = (
     },
     [botUsername, conversationIDKey]
   )
-  return {setSettings, settings}
+  return {failed, setSettings, settings}
 }

--- a/shared/chat/conversation/info-panel/bot.tsx
+++ b/shared/chat/conversation/info-panel/bot.tsx
@@ -43,18 +43,21 @@ const AddToChannel = (props: AddToChannelProps) => {
   const theme = Kb.Styles.useTheme()
   const {conversationIDKey, username} = props
   const {settings, setSettings} = useBotSettings(conversationIDKey, username)
+  // empty convs means the bot already reads every channel in the team; writing
+  // [thisConv] over that would revoke the rest, not add one
+  const readsAllChannels = !settings?.convs?.length
   const editBotSettings = C.useRPC(T.RPCChat.localSetBotMemberSettingsRpcPromise)
   const previewConversationByID = C.useRPC(T.RPCChat.localPreviewConversationByIDLocalRpcPromise)
   return (
     <Kb.WaitingButton
-      disabled={!settings}
+      disabled={!settings || readsAllChannels}
       type="Dim"
       mode="Secondary"
-      tooltip="Add to this channel"
+      tooltip={readsAllChannels ? 'Already in all channels' : 'Add to this channel'}
       onClick={e => {
         e.preventDefault()
         // if settings aren't loaded, don't even try to do anything
-        if (settings && !settings.convs?.includes(conversationIDKey)) {
+        if (settings && !readsAllChannels && !settings.convs.includes(conversationIDKey)) {
           const nextSettings = {
             cmds: settings.cmds,
             convs: [conversationIDKey].concat(settings.convs ?? []),

--- a/shared/chat/routes.tsx
+++ b/shared/chat/routes.tsx
@@ -54,7 +54,14 @@ const PDFShareButton = ({url}: {url?: string}) => {
 
 const BotInstallHeaderTitle = () => {
   const subScreen = useModalHeaderState(s => s.botSubScreen)
-  return <>{subScreen === 'channels' ? 'Channels' : ''}</>
+  // has to be a Text: the desktop modal header only wraps a bare string title, and a
+  // component that renders one lands in the header unstyled
+  if (subScreen !== 'channels') return null
+  return (
+    <Kb.Text type="Header" lineClamp={1} center={true}>
+      Channels
+    </Kb.Text>
+  )
 }
 
 const BotInstallHeaderLeft = () => {


### PR DESCRIPTION
## Problem

A restricted bot's settings dialog could list a channel with no name — a bare `• #` row — and count it in the `(N channels)` label.

`TeamBotSettings.convs` is a list of conversation IDs and is not pruned when a channel is deleted. The UI mapped every id through the team's channel metas and fell back to an empty string when the lookup missed, so a dead id rendered as `#`. Confirmed against a live service: the offending id is absent from the team's channel list and `chat api read` on it returns `no conversations matched`.

Fixing that surfaced a sharper problem. An empty `convs` list means **every conversation in the team** on the wire — `keybase1.TeamBotSettings.ConvIDAllowed` returns `true` when `len(Convs) == 0` — but the client only ever inferred that state from the list happening to be empty. So any path that emptied the list silently handed the bot the whole team.

## Changes

**Don't render unresolvable channels.** `PermsList` filters `settings.convs` to convs present in `channelMetas`, and no longer collapses distinct states into "render nothing": it says "all channels in this team" when `convs` is empty (the widest grant, previously shown as silence), shows a spinner while channels load, lists what resolves, and counts what doesn't instead of silently truncating. A conversation with no team never loads channels, so it doesn't sit on a spinner forever.

**Make "all channels" an explicit choice.** `installInAllConvs` is now real state. The picker's "All channels" row is its only writer (lifted out of `ChannelPicker`'s local state so it survives the round-trip), install/edit send `convs: []` only when that flag is set, and a restricted bot with nothing selected can't be saved — the Install/Save buttons are disabled with the same label the picker's Done button uses, since the header's Back link can leave the picker with an empty selection. Toggling "All channels" no longer discards the previous selection.

**Never let filtering empty the list.** The channel list can be loaded-but-empty — a rejected load, or the offline path where `handleOfflineError` squashes the error and returns no convs, both settle with `loading` false and no metas. So `!loadingChannels` is not proof we know the team's channels, and the filter falls back to the original convs whenever it would produce an empty list.

**"Edit settings" needs loaded settings.** The button is gated on the team-role RPC, a different call from the one that fetches bot settings, and that call can also fail outright. Clicking in that window skipped the seed entirely, so the screen read "(all channels)" and Save widened the bot to the whole team. It now requires settings to be present.

**Scrolling.** The picker's list grew to its full content height (5184px inside a 439px modal body) and painted outside the modal, so it couldn't be scrolled. The boxes between the modal body and the scroller were `flex: 0 1 auto` with no `min-height: 0`, and a `minHeight: 370` could only push the scroller taller. Pre-existing, fixed here since the picker is being touched anyway.

**Header font.** The "Channels" modal title rendered in Times. The desktop modal header wraps a title in a `Text` only when it is a bare string; `BotInstallHeaderTitle` was a component that rendered a bare string of its own, so it landed unstyled.

## Follow-up (service side)

This stops the client from displaying and re-persisting ids it cannot resolve; the stale grants remain in the stored settings. `convs` is what the server enforces when deciding which conversations a restricted bot may read, so entries pointing at conversations the team no longer has are unauditable permission grants. The client cannot prune them, because it cannot tell "deleted" from "not visible to me". Deletion is the one point where that is known, so channel delete should strip the id from the team's bot settings, plus a one-shot pass for settings that already carry stale ids.

Separately and not touched here: the modal's save path builds `botSettings` without `triggers`, so any `--allow-trigger` regexes set from the CLI are erased on save. Pre-existing.

## Test plan

- `yarn lint:all` — clean (0 bailouts, 0 whole-props deps, tsc clean).
- Verified in the running desktop app: the nameless row is gone, real channels still render, and the Channels header renders in the right font. Layout measured in the live DOM before and after the scroll fix.