### PR TITLE
fix(chat): gap between input and keyboard after picking a bot command

### DIFF
--- a/shared/chat/conversation/command-markdown.tsx
+++ b/shared/chat/conversation/command-markdown.tsx
@@ -1,13 +1,30 @@
 import * as Kb from '@/common-adapters'
+import * as React from 'react'
 import * as InputState from './input-area/input-state'
+import {MaxInputAreaContext} from './input-area/normal/max-input-area-context'
+
+// used until the conversation reports its height; the markdown mounts long after layout, so this
+// is only a backstop against an unbounded body
+const fallbackMaxHeight = 250
 
 const CommandMarkdown = () => {
   const styles = useStyles()
   const md = InputState.useConversationInput(s => s.commandMarkdown)
   const body = md?.body ?? ''
   const title = md?.title ?? undefined
+  // a percentage maxHeight has no definite-height ancestor here, so yoga re-resolves it at
+  // every nesting level and each box ends up taller than its content: the leftover slack shows
+  // as a gap between the input's buttons and the keyboard. clamp in points instead.
+  const maxInputArea = React.useContext(MaxInputAreaContext)
+  const maxHeightStyle = isMobile
+    ? {maxHeight: maxInputArea ? Math.floor(maxInputArea * 0.35) : fallbackMaxHeight}
+    : undefined
   return (
-    <Kb.Box2 direction="vertical" fullWidth={true} style={styles.container}>
+    <Kb.Box2
+      direction="vertical"
+      fullWidth={true}
+      style={Kb.Styles.collapseStyles([styles.container, maxHeightStyle])}
+    >
       {!!title && (
         <Kb.Box2 direction="horizontal" fullWidth={true} style={styles.title}>
           <Kb.Markdown>{title}</Kb.Markdown>
@@ -39,8 +56,8 @@ const useStyles = Kb.Styles.createStyleHook(
         isMobile: {
           backgroundColor: theme.white,
           flexShrink: 1,
-          // if this is not constrained it pushes the rest of the input down
-          maxHeight: '70%',
+          // constrained in points by the caller (percentages cascade badly here); without any
+          // constraint this pushes the rest of the input down
         },
       }),
       scrollContainer: Kb.Styles.platformStyles({


### PR DESCRIPTION
## Problem

On iOS, with the bot-command HUD open, tapping a command left a ~50pt gap between the buttons under the message input and the top of the keyboard. Typing with the HUD open looked fine — only selecting an item got into the bad state.

## Cause

Selecting a command mounts the command-markdown panel, which was sized with `maxHeight: '70%'` on mobile. Nothing in that stack has a definite height (the input rides a `KeyboardStickyView`), so Yoga re-resolves the percentage at each nesting level. Measured steady state with the keyboard up:

```
stickyView       h=416     bottom=566   <- correct, sits at keyboard top
stickyChild      h=386.33  bottom=536.33
inputBox         h=365.33  bottom=515.33
commandMarkdown  h=255.67  = 0.7 * 365.33
```

416 = 0.7·458+95, 386.33 = 0.7·416+95, 365.33 = 0.7·386.33+95. Every box ends up taller than its content, the content is pinned to the top, and the accumulated slack (29.67 + 21 + 14.67) is the gap.

## Fix

Clamp the panel in points off `MaxInputAreaContext` instead of a percentage, with a fixed fallback for the window before the conversation reports its height. `0.35` matches the height the cascading percentage was effectively resolving to, so the panel looks the same size as before.

## Test

Verified on the iOS simulator: `!` command HUD, tap an item — input buttons now sit flush on the keyboard, panel height unchanged. `yarn lint:all` clean.