### PR TITLE
fix(chat): stop the giphy popup resizing when results land

### DIFF
--- a/shared/chat/conversation/giphy/index.tsx
+++ b/shared/chat/conversation/giphy/index.tsx
@@ -43,6 +43,7 @@ const DesktopGiphySearch = () => {
     <Kb.Box2 direction="vertical" alignSelf="stretch" relative={true} style={styles.outerContainer}>
       <Kb.Box2
         direction="vertical"
+        alignSelf="stretch"
         ref={divRef as React.RefObject<DivRef>}
         style={Kb.Styles.collapseStyles([
           styles.scrollContainer,
@@ -158,7 +159,7 @@ const useStyles = Kb.Styles.createStyleHook(
         },
       }),
       loadingContainer: {
-        minHeight: 200,
+        flexGrow: 1,
       },
       outerContainer: {
         marginBottom: Kb.Styles.globalMargins.xtiny,
@@ -174,7 +175,7 @@ const useStyles = Kb.Styles.createStyleHook(
           ...Kb.Styles.desktopStyles.boxShadow,
           border: `1px solid ${theme.black_20}`,
           borderRadius: Kb.Styles.borderRadius,
-          maxHeight: 300,
+          height: 300,
           ...Kb.Styles.padding(0, Kb.Styles.globalMargins.tiny, Kb.Styles.globalMargins.tiny),
         },
       }),


### PR DESCRIPTION
The `/giphy` popup on desktop grew twice on open: first wider, then taller.

**Width.** The bordered scroll container is a `Box2` with neither `fullWidth` nor `fullHeight`, so it took Box2's `align-self: center` default and shrink-wrapped its content. #29483 stretched the outer wrapper, but that wrapper is not the visible box — the inner one kept sizing itself to the tip line until previews arrived. Stretched it as well.

**Height.** Same cause in the other direction: the loading state was a 200px minimum plus the tip line, while filled content ran into the 300px maximum. The container is now a fixed 300 and the loading state grows into it, so the box is one size from the first frame.

Verified visually on the desktop app.