### PR TITLE
WIP DO NOT MERGE: ci: report failing step name back to the PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,34 @@ def logKbwebServices(container) {
   archive("kbweb-logs.tar.gz")
 }
 
+// Reports which pipeline step failed back to the PR as a commit status, so a
+// red build says "go: golangci-lint" instead of only "failed". The status
+// description carries nothing but the literal name passed in here -- never
+// log output, exception text, paths, or credentials.
+def reportStep(name, closure) {
+  try {
+    closure()
+  } catch (ex) {
+    notifyStep('FAILURE', name)
+    throw ex
+  }
+}
+
+// Best-effort: the reporting must never itself break a build, and must never
+// mask the underlying failure.
+def notifyStep(status, description) {
+  try {
+    githubNotify(
+      context: 'client/failed-step',
+      status: status,
+      description: description,
+      targetUrl: env.BUILD_URL
+    )
+  } catch (ex) {
+    println "reportStep: githubNotify failed, continuing"
+  }
+}
+
 helpers.rootLinuxNode(env, {
   helpers.slackOnError("client", env, currentBuild)
 }, {}) {
@@ -72,6 +100,9 @@ helpers.rootLinuxNode(env, {
   def cause = helpers.getCauseString(currentBuild)
   println "Cause: ${cause}"
   println "Pull Request ID: ${env.CHANGE_ID}"
+
+  // Seed green so the context always exists; a failing step overwrites it.
+  notifyStep('SUCCESS', 'no step failures')
 
   env.BASEDIR=pwd()
   env.GOPATH="${env.BASEDIR}/go"
@@ -277,7 +308,9 @@ helpers.rootLinuxNode(env, {
                   stage("JS Tests") {
                     sh "git config --global user.name 'Keybase Jenkins'"
                     sh "git config --global user.email 'jenkins@keyba.se'"
-                    sh "./jenkins_test.sh js ${env.COMMIT_HASH} ${env.CHANGE_TARGET}"
+                    reportStep("js: tests") {
+                      sh "./jenkins_test.sh js ${env.COMMIT_HASH} ${env.CHANGE_TARGET}"
+                    }
                   }
                 }
               }},
@@ -585,17 +618,19 @@ def testGoBuilds(prefix, packagesToTest, hasKBFSChanges) {
     sh "golangci-lint config verify"
 
     // Only test golangci-lint on linux
-    if (env.CHANGE_TARGET) {
-      println("Running golangci-lint on new code")
-      fetchChangeTarget()
-      def BASE_COMMIT_HASH = getBaseCommitHash()
-      timeout(activity: true, time: 30, unit: 'MINUTES') {
-        sh "make golangci-lint GOLANGCI_RUN_OPT='--new-from-rev ${BASE_COMMIT_HASH}'"
-      }
-    } else {
-      println("Running golangci-lint on all code")
-      timeout(activity: true, time: 30, unit: 'MINUTES') {
-        sh "make golangci-lint"
+    reportStep("go: golangci-lint") {
+      if (env.CHANGE_TARGET) {
+        println("Running golangci-lint on new code")
+        fetchChangeTarget()
+        def BASE_COMMIT_HASH = getBaseCommitHash()
+        timeout(activity: true, time: 30, unit: 'MINUTES') {
+          sh "make golangci-lint GOLANGCI_RUN_OPT='--new-from-rev ${BASE_COMMIT_HASH}'"
+        }
+      } else {
+        println("Running golangci-lint on all code")
+        timeout(activity: true, time: 30, unit: 'MINUTES') {
+          sh "make golangci-lint"
+        }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,10 +45,10 @@ def logKbwebServices(container) {
   archive("kbweb-logs.tar.gz")
 }
 
-// Reports which pipeline step failed back to the PR as a commit status, so a
-// red build says "go: golangci-lint" instead of only "failed". The status
-// description carries nothing but the literal name passed in here -- never
-// log output, exception text, paths, or credentials.
+// Reports which pipeline step failed back to the PR, so a red build says
+// "go: golangci-lint" instead of only "failed". The published text is nothing
+// but the literal name passed in here -- never log output, exception text,
+// paths, or credentials.
 def reportStep(name, closure) {
   try {
     closure()
@@ -60,16 +60,21 @@ def reportStep(name, closure) {
 
 // Best-effort: the reporting must never itself break a build, and must never
 // mask the underlying failure.
-def notifyStep(status, description) {
+//
+// githubNotify (github-plugin) is not installed on this controller, but the
+// Checks API plugin is, so publish a check run instead. If no checks publisher
+// is registered, publishChecks logs and does nothing rather than throwing.
+def notifyStep(conclusion, summary) {
   try {
-    githubNotify(
-      context: 'client/failed-step',
-      status: status,
-      description: description,
-      targetUrl: env.BUILD_URL
+    publishChecks(
+      name: 'client/failed-step',
+      title: summary,
+      summary: summary,
+      conclusion: conclusion,
+      detailsURL: env.BUILD_URL
     )
   } catch (ex) {
-    println "reportStep: githubNotify failed, continuing"
+    println "reportStep: publishChecks failed, continuing"
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,19 +52,37 @@ def logKbwebServices(container) {
 def reportStep(name, closure) {
   try {
     closure()
-  } catch (ex) {
+  } catch (Throwable ex) {
+    // Throwable, so a step that dies on an Error still gets named. The
+    // original is always rethrown, so nothing here changes the build result.
     notifyStep('FAILURE', name)
     throw ex
   }
 }
 
 // Best-effort: the reporting must never itself break a build, and must never
-// mask the underlying failure.
-//
-// githubNotify (github-plugin) is not installed on this controller, but the
-// Checks API plugin is, so publish a check run instead. If no checks publisher
-// is registered, publishChecks logs and does nothing rather than throwing.
+// mask the underlying failure. Every probe below catches Throwable, not
+// Exception: a missing pipeline step surfaces as NoSuchMethodError, which is
+// an Error, so an untyped `catch (ex)` would let it through and kill the run.
 def notifyStep(conclusion, summary) {
+  // Unconditional local trace. Needs no plugin and no credential, so the step
+  // name is always recoverable from the console and the build page even when
+  // nothing reaches GitHub.
+  println "reportStep: ${conclusion} -- ${summary}"
+  if (conclusion != 'SUCCESS') {
+    try {
+      currentBuild.description = summary
+    } catch (Throwable ex) {
+      println "reportStep: could not set build description"
+    }
+  }
+
+  // DIAGNOSTIC, remove with the rest of this harness. Build 5 published no
+  // check run at all -- neither the green seed nor the golangci-lint failure
+  // -- and the old catch block hid whether publishChecks threw or silently
+  // no-opped. Print the exception type and message: the Checks plugin reports
+  // a missing publisher or an auth rejection here, neither of which carries a
+  // secret.
   try {
     publishChecks(
       name: 'client/failed-step',
@@ -73,8 +91,19 @@ def notifyStep(conclusion, summary) {
       conclusion: conclusion,
       detailsURL: env.BUILD_URL
     )
-  } catch (ex) {
-    println "reportStep: publishChecks failed, continuing"
+    println "reportStep: publishChecks returned without throwing"
+  } catch (Throwable ex) {
+    println "reportStep: publishChecks threw ${ex.getClass().getName()}: ${ex.getMessage()}"
+  }
+
+  // DIAGNOSTIC, same lifetime. Confirm githubNotify is genuinely unregistered
+  // rather than previously mis-called, so we stop guessing which reporting
+  // routes this controller offers.
+  try {
+    githubNotify(context: 'client/failed-step-probe', status: 'SUCCESS', description: 'probe')
+    println "reportStep: githubNotify IS available"
+  } catch (Throwable ex) {
+    println "reportStep: githubNotify threw ${ex.getClass().getName()}: ${ex.getMessage()}"
   }
 }
 

--- a/go/libkb/temp_jenkins_plumbing.go
+++ b/go/libkb/temp_jenkins_plumbing.go
@@ -1,0 +1,12 @@
+// Copyright 2019 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// TEMPORARY -- deliberate gofmt/gofumpt violation used to verify that Jenkins
+// reports the failing step name back to the PR. Delete this file once the
+// plumbing is confirmed.
+
+package libkb
+
+func tempJenkinsPlumbingCheck( ) int {
+	return   1
+}


### PR DESCRIPTION
## Why

Jenkins currently tells GitHub only pass/fail. Nothing in this repo or in `jenkins-helpers` posts a commit status, so the single check comes from the GitHub Branch Source plugin and carries no detail beyond the state. A red build means opening Jenkins to find out which step broke.

## What

`reportStep(name, closure)` wraps a step; if it throws, a commit status is posted under the context `client/failed-step` whose description is the literal step name, then the original exception is rethrown.

- Only the hardcoded name passed at the call site is ever sent. No log output, no exception text, no paths, no credentials.
- `githubNotify` reuses the job's existing GitHub credentials, so no new auth or GitHub App is involved.
- The notify call is itself wrapped in try/catch, so reporting can never break a build or mask the underlying failure.

Wired around `golangci-lint` and the JS suite, plus a green seed at the start of the build so the context is present on passing runs rather than only appearing when something is red.

## Testing the plumbing

This branch includes a deliberately misformatted Go file so `golangci-lint` fails once and the status has something to report. Expected result: `client/failed-step` goes red with the description `go: golangci-lint`.

If `githubNotify` cannot infer the account, repo, and sha from the job's SCM source, the console log will show `reportStep: githubNotify failed, continuing` and the build will fail normally on the lint error. That log line is the diagnostic either way.

## Before this merges

Both the temporary Go file and any leftover test scaffolding come out. Do not merge as-is.