### PR TITLE
fix(chat): keep New chat button on desktop empty inbox

### DIFF
--- a/shared/chat/inbox/new-chat-button.tsx
+++ b/shared/chat/inbox/new-chat-button.tsx
@@ -19,7 +19,9 @@ const colorBarCommon = {
 
 const HeaderNewChatButton = () => {
   const styles = useStyles()
-  const hide = useInboxLayoutState(s => s.hasLoaded && isEmptyInboxLayout(s.layout))
+  // mobile's empty inbox draws its own big 'Start a new chat' button, so the header one is
+  // redundant there; desktop has no such affordance and must keep it
+  const hide = useInboxLayoutState(s => isMobile && s.hasLoaded && isEmptyInboxLayout(s.layout))
 
   const onNewChat = C.Router2.appendNewChatBuilder
 


### PR DESCRIPTION
## Problem

On desktop, a new account with an empty inbox has no "New chat" button. `HeaderNewChatButton` returns `null` once the inbox layout has loaded and is empty, and on desktop that header button (via `use-header-portal.tsx` → `SearchRow showNewChatButton`) is the only new-chat affordance. Result: no way to start a conversation.

## Fix

The hide is intentional on mobile — the native empty inbox draws its own full-width "Start a new chat" button, so the header one would be redundant. Gate the hide on `isMobile`.

## Validation

`yarn tsc`, `yarn lint`, `yarn lint:bailouts` all clean (0 bailouts, 0 whole-props deps). Visual check on an empty-inbox account still to be done by hand.