### PR TITLE
fix(teams): clear add-members selection on reopen

### DIFF
--- a/shared/team-building/page.tsx
+++ b/shared/team-building/page.tsx
@@ -172,10 +172,11 @@ const ScreenBody = ({
 
   // The store is a per-namespace singleton that outlives this screen; a
   // selection left behind by a previous session (blur can miss when the modal
-  // is removed) would show stale chips. teams intentionally carries the
-  // selection across re-opens for the add-members error path.
+  // is removed) would show stale chips. The one open that must keep the
+  // previous selection is the teams add-members error re-open, which comes
+  // back with initialError set.
   C.useOnMountOnce(() => {
-    if (namespace !== 'teams') {
+    if (!initialError) {
       resetState()
     }
   })


### PR DESCRIPTION
### Problem

Adding people to a team leaves the previous selection in the dialog: invite someone, reopen "Add people to team", and the person you already added is still chipped.

### Cause

The team-building store is a per-namespace singleton that outlives the modal. `finishedTeamBuilding` deliberately preserves `teamSoFar` for the `teams` namespace so the add-members error path can re-open the builder with the chips intact, and the mount reset in `team-building/page.tsx` skipped `teams` for the same reason. Nothing then cleared the selection on a normal reopen.

### Fix

Gate the mount reset on `initialError` rather than on the namespace. The error re-open is the only path that carries `initialError`, so it still restores the selection; every other open resets.

### Verification

- `yarn tsc` clean
- `yarn lint` clean
- `yarn lint:bailouts`: 0 bailouts, 0 whole-props deps
- `stores/tests/team-building.test.ts`: 4 passed

Not visually verified in the app.