### PR TITLE
fix(chat): restore BodySmall size in reply quote

### DIFF
--- a/shared/chat/conversation/messages/text/reply.tsx
+++ b/shared/chat/conversation/messages/text/reply.tsx
@@ -140,8 +140,10 @@ const useStyles = Kb.Styles.createStyleHook(
       },
       replyEdited: {color: theme.black_35},
       replyText: Kb.Styles.platformStyles({
-        common: {color: theme.black_50, fontSize: 15, lineHeight: 19},
-        isElectron: {whiteSpace: 'pre-wrap'},
+        common: {color: theme.black_50},
+        // match BodySmall, which the quote used before it moved to Markdown
+        isElectron: {fontSize: 13, lineHeight: '17px', whiteSpace: 'pre-wrap'},
+        isMobile: {fontSize: 15, lineHeight: 19},
       }),
       replyTextHighlighted: {color: theme.black_50OrBlack_50},
       replyUsername: {alignSelf: 'center'},


### PR DESCRIPTION
## Problem

#29524 fixed emoji rendering in the reply quote by routing the text through `Kb.Markdown` in `serviceOnly` mode. That replaced `<Kb.Text type="BodySmall">` with a hardcoded `fontSize: 15` / `lineHeight: 19`, which is the *mobile* BodySmall size. Desktop BodySmall is 13/17, so the quote text got noticeably larger on desktop.

## Fix

Split `replyText` per platform: 13/`17px` on electron, 15/19 on mobile — matching the metrics `type="BodySmall"` produced before the Markdown switch.

## Test plan

- `yarn tsc` clean
- Visual check of a reply quote on desktop: emoji still renders, font size back to pre-#29524 size