### PR TITLE
fix(chat): stop info panel content shifting when tabs toggle a scrollbar

### DIFF
--- a/shared/common-adapters/section-list.tsx
+++ b/shared/common-adapters/section-list.tsx
@@ -1,3 +1,4 @@
+import * as Styles from '@/styles'
 import type * as React from 'react'
 import {
   SectionList as NativeSectionList,
@@ -64,10 +65,15 @@ function SectionListImpl<ItemT, SectionT>(
       keyboardDismissMode="on-drag"
       ref={ref}
       {...rest}
+      style={[stableScrollbarGutter, rest.style]}
       renderSectionHeader={resolvedRenderSectionHeader}
     />
   )
 }
+
+// desktop scrollbars are obtrusive off macOS, so reserve the gutter: without it a
+// list that gains or loses its scrollbar reflows every child sideways
+const stableScrollbarGutter = Styles.platformStyles({isElectron: {scrollbarGutter: 'stable'}})
 
 export type SectionListRef<ItemT, SectionT> = NativeSectionList<ItemT, SectionT>
 


### PR DESCRIPTION
## Problem

Reported: clicking the info panel tabs (members / attachments / bots / settings) on Electron makes the right panel jump around horizontally.

The panel container itself can't change width — it's absolutely positioned at a fixed 320 (`inbox-and-conversation-shared.tsx`). What moves is the content inside it.

Each tab renders its own `Kb.SectionList` (members, bot, attachments, settings), which becomes an RNW ScrollView with `overflow-y: auto`. None of them reserved a scrollbar gutter. So:

- members (long list) → scrollbar present
- bots / settings (short) → no scrollbar
- switching tabs adds or removes the bar and reflows every child sideways, every click

This only shows where scrollbars consume layout width: Windows, Linux, or macOS with "always show scrollbars". macOS overlay scrollbars take 0 width, which is why it doesn't reproduce there. The repo already detects the obtrusive case (`layout-scrollbar-obtrusive` in `styles/index.tsx`).

## Fix

Default `scrollbar-gutter: stable` on desktop `SectionList`, matching what `common-adapters/list.tsx`, the chat thread list, and `input3.tsx` already do. Electron-only, no-op on mobile; a caller-supplied `style` still wins.

## Known leftover

`attachments.tsx` sizes media thumbs off a hardcoded `infoPanelWidth()` of 320, ignoring the gutter, so that grid runs slightly wide. It's now constant instead of jumping; left for a separate change.

## Test plan

- `yarn tsc`, `yarn lint`, `yarn lint:bailouts` (1717 compiled, 0 bailed out, 0 whole-props deps) all clean
- Visual check needed on a platform with obtrusive scrollbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)