### PR TITLE
fix(chat): accept kbfile:// urls in video url check

### DIFF
--- a/shared/common-adapters/video.tsx
+++ b/shared/common-adapters/video.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as Styles from '@/styles'
-import {normalizeFilePathURL} from '@/util/file-url'
+import {localFileHost, localFileScheme, normalizeFilePathURL} from '@/util/file-url'
 import {Box2} from './box'
 import Text from './text'
 import {StatusBar} from 'react-native'
@@ -47,6 +47,10 @@ const isAllowedFilePath = (url: string, allowFile?: boolean) => {
   try {
     const parsed = new URL(url)
     if (parsed.protocol === 'file:' && parsed.hostname === '') {
+      return true
+    }
+    // hot dev serves local files through our own scheme instead of file://
+    if (parsed.protocol === `${localFileScheme}:` && parsed.hostname === localFileHost) {
       return true
     }
   } catch {}

--- a/shared/common-adapters/video.tsx
+++ b/shared/common-adapters/video.tsx
@@ -49,8 +49,9 @@ const isAllowedFilePath = (url: string, allowFile?: boolean) => {
     if (parsed.protocol === 'file:' && parsed.hostname === '') {
       return true
     }
-    // hot dev serves local files through our own scheme instead of file://
-    if (parsed.protocol === `${localFileScheme}:` && parsed.hostname === localFileHost) {
+    // hot dev serves local files through our own scheme instead of file://; the
+    // scheme only exists there, so don't accept it anywhere else
+    if (__HOT__ && parsed.protocol === `${localFileScheme}:` && parsed.hostname === localFileHost) {
       return true
     }
   } catch {}

--- a/shared/util/file-url.tsx
+++ b/shared/util/file-url.tsx
@@ -3,7 +3,7 @@
 // local files through it; see node.desktop.tsx. The dev CSP in vite.config.mts
 // has to allow it too.
 export const localFileScheme = 'kbfile'
-const localFileHost = 'local'
+export const localFileHost = 'local'
 
 // Desktop: normalize absolute file paths (posix or windows) to encoded file:// URLs
 export const normalizeFilePathURL = (url: string) => {


### PR DESCRIPTION
Attaching a video in hot dev rendered `Invalid URL: kbfile://local/...` instead of a preview.

In hot dev the renderer is served over http, so `normalizeFilePathURL` rewrites local paths to our privileged `kbfile://local/...` scheme. `Video`'s allowlist only accepted `file:` with an empty hostname, so every local video preview failed the check.

- accept `kbfile://` + the `local` host in `isAllowedFilePath`
- export `localFileHost` so the check uses the same constant as the encoder

Packaged builds are unaffected (they still emit `file://`).

Validated: `yarn tsc`, `yarn lint`, `yarn lint:bailouts`, `yarn jest util/__tests__/file-url.test.tsx` all green.