### PR TITLE
chore(deps): worklets 0.12.1, reanimated 4.6.0 + expo-modules-core patch

### DIFF
--- a/shared/ios/Podfile.lock
+++ b/shared/ios/Podfile.lock
@@ -2276,7 +2276,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets (>= 0.8.0)
     - Yoga
-  - RNReanimated (4.5.3):
+  - RNReanimated (4.6.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2298,36 +2298,12 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/apple (= 4.5.3)
-    - RNReanimated/common (= 4.5.3)
-    - RNReanimated/view (= 4.5.3)
+    - RNReanimated/apple (= 4.6.0)
+    - RNReanimated/common (= 4.6.0)
+    - RNReanimated/view (= 4.6.0)
     - RNWorklets
     - Yoga
-  - RNReanimated/apple (4.5.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - RNWorklets
-    - Yoga
-  - RNReanimated/common (4.5.3):
+  - RNReanimated/apple (4.6.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2351,7 +2327,31 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNReanimated/view (4.5.3):
+  - RNReanimated/common (4.6.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNWorklets
+    - Yoga
+  - RNReanimated/view (4.6.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2422,7 +2422,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.11.3):
+  - RNWorklets (0.12.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2444,10 +2444,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/apple (= 0.11.3)
-    - RNWorklets/common (= 0.11.3)
+    - RNWorklets/apple (= 0.12.1)
+    - RNWorklets/common (= 0.12.1)
     - Yoga
-  - RNWorklets/apple (0.11.3):
+  - RNWorklets/apple (0.12.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2470,7 +2470,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets/common (0.11.3):
+  - RNWorklets/common (0.12.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3010,9 +3010,9 @@ SPEC CHECKSUMS:
   RNCMaskedView: 8069b4d4e23b3d28b4fcac70bf266be43ffc3d2e
   RNCPicker: a3921be99ae291e420e3e8940e5b2b53e572c543
   RNGestureHandler: 85a831012468d1b9af177debae2030d64b4bb610
-  RNReanimated: 41ad1a808a5860d14883872f68ed7cae2efc8635
+  RNReanimated: c57ef141c7843c2849531e7556236d7223b7db1a
   RNScreens: b2e46935230f4877eed4985c259e52bbe0b03aa7
-  RNWorklets: 0e2c906e8e5b043aec4d897ceb4d3226d5e7f6b2
+  RNWorklets: d012a02a4700d0733d525f8c10da9bfae48910a8
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/shared/package.json
+++ b/shared/package.json
@@ -135,12 +135,12 @@
     "react-native-gesture-handler": "3.2.1",
     "react-native-kb": "file:../rnmodules/react-native-kb",
     "react-native-keyboard-controller": "1.22.4",
-    "react-native-reanimated": "4.5.3",
+    "react-native-reanimated": "4.6.0",
     "react-native-safe-area-context": "5.9.1",
     "react-native-screens": "4.27.0",
     "react-native-web": "0.21.2",
     "react-native-webview": "16.0.0",
-    "react-native-worklets": "0.11.3",
+    "react-native-worklets": "0.12.1",
     "zustand": "5.0.15"
   },
   "devDependencies": {

--- a/shared/patches/expo-modules-core+57.0.13.patch
+++ b/shared/patches/expo-modules-core+57.0.13.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp b/node_modules/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
+index a2d707c..be2e3d6 100644
+--- a/node_modules/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
++++ b/node_modules/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
+@@ -24,10 +24,7 @@ namespace expo {
+       return;
+     }
+ 
+-    workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
+-      func(rt);
+-      return jsi::Value::undefined();
+-    });
++    workletRuntime->runSync(func);
+   }
+ } // namespace expo
+ 
+diff --git a/node_modules/expo-modules-core/ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm b/node_modules/expo-modules-core/ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm
+index 126545f..d97163a 100644
+--- a/node_modules/expo-modules-core/ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm
++++ b/node_modules/expo-modules-core/ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm
+@@ -233,7 +233,7 @@ - (void)executeWorkletWithRuntimeHandle:(id)runtimeHandle
+     return;
+   }
+ 
+-  workletRuntime->executeSync([worklet, arguments](jsi::Runtime &rt) -> jsi::Value {
++  workletRuntime->runSync([worklet, arguments](jsi::Runtime &rt) -> jsi::Value {
+     return callWorklet(rt, worklet, arguments);
+   });
+ }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -11639,10 +11639,10 @@ react-native-keyboard-controller@1.22.4:
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 
-react-native-reanimated@4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.5.3.tgz#10ec3f1b2c8d710033d707199cab591a0d410d70"
-  integrity sha512-+owIckpD4sA13XKHaLrr8V1RP4paqoxKvz/jy2wl/ULjMsfcRlfIJdKJxR1kcQr4McBZ6hAoPo01NyLnmy2ycQ==
+react-native-reanimated@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.6.0.tgz#ee6fe5f0dab85f5e746a83669da04acbda1c71d6"
+  integrity sha512-9vbQmok5BPX2J3RLPFt2UnwmK2QQoMDPDi0VB4a9JWIiEc55pdzvwEsdH91V/JXKNErqM6a9fElTBMc/1cbtBA==
   dependencies:
     react-native-is-edge-to-edge "^1.3.1"
     semver "^7.7.3"
@@ -11682,10 +11682,10 @@ react-native-webview@16.0.0:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native-worklets@0.11.3:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.11.3.tgz#b92ca2bd3ea96610e0143a7ef0e386b19b281b0f"
-  integrity sha512-paLRlVFTrrGhkGTi37LHwtaJbrTftA54/zAx1h/ONSBw7XejZn6XUUl1KpM6EOMwsbw7TEGuxJXTAp/wkvuMqQ==
+react-native-worklets@0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.12.1.tgz#2a6956bfd6549e02462b94ef401ae8a1bae153a7"
+  integrity sha512-/u7B+Akrox32IQUi6+0OHwWAfBC/A5LVdt000RL8OKB4L1pHTvIDwVyMP6Nw7ybuuoQYS8PLlpmxTE1Ce7TqWg==
   dependencies:
     "@babel/generator" "^7.27.1"
     "@babel/plugin-transform-arrow-functions" "^7.27.1"


### PR DESCRIPTION
## What

- `react-native-worklets` 0.11.3 → 0.12.1
- `react-native-reanimated` 4.5.3 → 4.6.0
- new `patches/expo-modules-core+57.0.13.patch`

## Why

worklets 0.12 removed `WorkletRuntime::executeSync` in favor of `runSync`. `expo-modules-core@57.0.13` still calls `executeSync` from both worklets bridges, so the native build fails on iOS and Android:

```
ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm:236
  no member named 'executeSync' in 'worklets::WorkletRuntime'
android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp:27
  no member named 'executeSync' in 'worklets::WorkletRuntime'
```

reanimated 4.6.0 hard-peers `react-native-worklets: 0.12.x`, so the two move together or not at all — which is why both were pinned back on the previous pass.

Expo landed the fix on `main` in expo/expo#48691. The sdk-57 backport, expo/expo#49366, is still open, so no published `expo-modules-core@57.x` carries it. The patch here is the same change as that backport, applied locally: `runSync` on iOS, and the Android lambda collapsed to the `RuntimeJob` overload (`WorkletRuntime.h:107`).

Remove the patch once the backport ships in `expo-modules-core@57.0.14+`.

## Rest of the dep pass

Everything else was checked and is either current or deliberately held:

- `react-native 0.86.3 → 0.87.0` — major; expo SDK 57 is tied to the 0.86 line
- `typescript 6.0.3 → 7.0.2` — the classic/native split is intentional; `typescript-native` is already on 7.0.2
- `@babel/* 7.29.7 → 8.x` — major; `babel-preset-expo` still peers `@babel/runtime ^7.20.0`
- `eslint-plugin-react-compiler` — the "newer" version is the hash-tagged rc.1, older than the installed rc.2
- dupes: none actionable. audit: 3 HIGH, all NO-FIX upstream (extract-zip, image-size ×2)
- `protocol/` and `rnmodules/react-native-kb/`: up to date

## Test plan

- [x] `yarn lint:all` — eslint clean, 0 bailouts / 0 whole-props deps, tsc clean
- [x] clean pod install (`rm -rf ios/build ios/Pods` + `yarn ios:pod:install`)
- [ ] iOS native build
- [ ] Android native build