### PR TITLE
Fix tests in teams/audit_test.go

### DIFF
--- a/go/teams/audit_test.go
+++ b/go/teams/audit_test.go
@@ -320,10 +320,6 @@ func TestAuditFailsIfDataIsInconsistent(t *testing.T) {
 	headMerkleSeqno := int64(team.MainChain().Chain.HeadMerkle.Seqno)
 	t.Logf("headMerkleSeqno: %v", headMerkleSeqno)
 
-	firstWithHiddenS, err := m[A].G().GetMerkleClient().FirstMainRootWithHiddenRootHash(m[A])
-	require.NoError(t, err)
-	firstWithHidden := int64(firstWithHiddenS)
-	t.Logf("firstWithHidden: %v", firstWithHidden)
 	root := m[A].G().GetMerkleClient().LastRoot(m[A])
 	require.NotNil(t, root)
 	high := int64(*root.Seqno())
@@ -500,10 +496,6 @@ func TestFailedProbesAreRetried(t *testing.T) {
 	t.Logf("latest root: %v %X", root.Seqno(), root.HashMeta())
 	headMerkleSeqno := team.MainChain().Chain.HeadMerkle.Seqno
 	t.Logf("headMerkleSeqno: %v", headMerkleSeqno)
-	firstWithHiddenS, err := m[A].G().GetMerkleClient().FirstMainRootWithHiddenRootHash(m[A])
-	require.NoError(t, err)
-	firstWithHidden := firstWithHiddenS
-	t.Logf("firstWithHidden: %v", firstWithHidden)
 	firstExaminable := m[B].G().GetMerkleClient().FirstExaminableHistoricalRoot(m[B])
 	require.NotNil(t, firstExaminable)
 	firstPreProbe := *firstExaminable

--- a/go/teams/audit_test.go
+++ b/go/teams/audit_test.go
@@ -329,6 +329,23 @@ func TestAuditFailsIfDataIsInconsistent(t *testing.T) {
 	high := int64(*root.Seqno())
 	t.Logf("latest root: %v %X", root.Seqno(), root.HashMeta())
 
+	firstExaminable := m[B].G().GetMerkleClient().FirstExaminableHistoricalRoot(m[B])
+	require.NotNil(t, firstExaminable)
+	firstExaminableSeqno := int64(*firstExaminable)
+	t.Logf("firstExaminable: %v", firstExaminableSeqno)
+	require.LessOrEqual(t, firstExaminableSeqno+2, headMerkleSeqno)
+	require.LessOrEqual(t, headMerkleSeqno+2, high)
+	mockAuditRandom := func() *MockRandom {
+		return &MockRandom{t: t, nextOutputs: []int64{
+			firstExaminableSeqno,
+			firstExaminableSeqno + 1,
+			firstExaminableSeqno + 2,
+			headMerkleSeqno,
+			headMerkleSeqno + 1,
+			high,
+		}}
+	}
+
 	for i := headMerkleSeqno; i <= high; i++ {
 		leaf, _, hiddenResp, err := m[B].G().GetMerkleClient().LookupLeafAtSeqnoForAudit(m[B], teamID.AsUserOrTeam(), keybase1.Seqno(i), hidden.ProcessHiddenResponseFunc)
 		require.NoError(t, err)
@@ -355,7 +372,7 @@ func TestAuditFailsIfDataIsInconsistent(t *testing.T) {
 		},
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{firstWithHidden - 1, firstWithHidden, firstWithHidden + 1, headMerkleSeqno, headMerkleSeqno + 1, high - 1}})
+	m[B].G().SetRandom(mockAuditRandom())
 
 	auditor := m[B].G().GetTeamAuditor().(*Auditor)
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
@@ -364,7 +381,7 @@ func TestAuditFailsIfDataIsInconsistent(t *testing.T) {
 	require.Contains(t, err.Error(), "team chain linkID mismatch")
 
 	// repeat a second time to ensure that a failed audit is not cached (and thus skipped the second time)
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{firstWithHidden - 1, firstWithHidden, firstWithHidden + 1, headMerkleSeqno, headMerkleSeqno + 1, high - 1}})
+	m[B].G().SetRandom(mockAuditRandom())
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
 	require.Error(t, err)
 	require.ErrorAs(t, err, new(AuditError))
@@ -382,7 +399,7 @@ func TestAuditFailsIfDataIsInconsistent(t *testing.T) {
 		},
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{firstWithHidden - 1, firstWithHidden, firstWithHidden + 1, headMerkleSeqno, headMerkleSeqno + 1, high - 1}})
+	m[B].G().SetRandom(mockAuditRandom())
 
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
 	require.Error(t, err)
@@ -410,7 +427,7 @@ func TestAuditFailsIfDataIsInconsistent(t *testing.T) {
 		},
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{firstWithHidden - 1, firstWithHidden, firstWithHidden + 1, headMerkleSeqno, headMerkleSeqno + 1, high - 1}})
+	m[B].G().SetRandom(mockAuditRandom())
 
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
 	require.Error(t, err)
@@ -487,6 +504,13 @@ func TestFailedProbesAreRetried(t *testing.T) {
 	require.NoError(t, err)
 	firstWithHidden := firstWithHiddenS
 	t.Logf("firstWithHidden: %v", firstWithHidden)
+	firstExaminable := m[B].G().GetMerkleClient().FirstExaminableHistoricalRoot(m[B])
+	require.NotNil(t, firstExaminable)
+	firstPreProbe := *firstExaminable
+	secondPreProbe := firstPreProbe + 1
+	t.Logf("firstExaminable: %v", firstPreProbe)
+	require.LessOrEqual(t, secondPreProbe, headMerkleSeqno)
+	require.LessOrEqual(t, headMerkleSeqno+4, latestRootSeqno)
 
 	for i := headMerkleSeqno; i <= latestRootSeqno; i++ {
 		leaf, _, hiddenResp, err := m[B].G().GetMerkleClient().LookupLeafAtSeqnoForAudit(m[B], teamID.AsUserOrTeam(), i, hidden.ProcessHiddenResponseFunc)
@@ -531,7 +555,7 @@ func TestFailedProbesAreRetried(t *testing.T) {
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
 	// the first two are for preprobes, the last for post probes
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstWithHidden) - 1, int64(firstWithHidden + 1), int64(headMerkleSeqno) + 1, int64(headMerkleSeqno) + 2}})
+	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstPreProbe), int64(secondPreProbe), int64(headMerkleSeqno) + 1, int64(headMerkleSeqno) + 2}})
 
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
 	require.Error(t, err)
@@ -580,8 +604,8 @@ func TestFailedProbesAreRetried(t *testing.T) {
 		},
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
-	// note that the postProbes we will sample now are different from the ones which we failed on the first time, so we can test we are actually retrying those.
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstWithHidden) - 1, int64(firstWithHidden + 1), int64(headMerkleSeqno) + 3, int64(headMerkleSeqno) + 4}})
+	// Include different post-probe candidates so the check below verifies that the failed probes are retried.
+	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstPreProbe), int64(secondPreProbe), int64(headMerkleSeqno) + 3, int64(headMerkleSeqno) + 4}})
 
 	// repeat a second time and make sure that we retry the same probes
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
@@ -610,7 +634,7 @@ func TestFailedProbesAreRetried(t *testing.T) {
 		},
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstWithHidden) - 1, int64(firstWithHidden + 1), int64(headMerkleSeqno) + 3, int64(headMerkleSeqno) + 4}})
+	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstPreProbe), int64(secondPreProbe), int64(headMerkleSeqno) + 3, int64(headMerkleSeqno) + 4}})
 
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
 	require.Error(t, err)
@@ -620,8 +644,8 @@ func TestFailedProbesAreRetried(t *testing.T) {
 	history, err = auditor.getFromCache(m[B], teamID, lru)
 	require.NoError(t, err)
 	require.Len(t, history.PreProbesToRetry, 2)
-	require.Contains(t, history.PreProbesToRetry, firstWithHidden-1)
-	require.Contains(t, history.PreProbesToRetry, firstWithHidden+1)
+	require.Contains(t, history.PreProbesToRetry, firstPreProbe)
+	require.Contains(t, history.PreProbesToRetry, secondPreProbe)
 
 	// the old failed postprobes are still in the cache
 	require.Len(t, history.PostProbesToRetry, 2)
@@ -630,8 +654,8 @@ func TestFailedProbesAreRetried(t *testing.T) {
 
 	probesToTest = make(map[keybase1.Seqno]bool)
 	probesToTestLock.Lock()
-	probesToTest[firstWithHidden-1] = true
-	probesToTest[firstWithHidden+1] = true
+	probesToTest[firstPreProbe] = true
+	probesToTest[secondPreProbe] = true
 	probesToTestLock.Unlock()
 	numProbes = 2
 
@@ -665,7 +689,7 @@ func TestFailedProbesAreRetried(t *testing.T) {
 		},
 	}
 	m[B].G().SetMerkleClient(corruptMerkle)
-	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstWithHidden) - 2, int64(firstWithHidden) + 2, int64(headMerkleSeqno) + 3, int64(headMerkleSeqno) + 4}})
+	m[B].G().SetRandom(&MockRandom{t: t, nextOutputs: []int64{int64(firstPreProbe) + 2, int64(firstPreProbe) + 3, int64(headMerkleSeqno) + 3, int64(headMerkleSeqno) + 4}})
 
 	err = auditor.AuditTeam(m[B], teamID, false, team.MainChain().Chain.HeadMerkle.Seqno, team.MainChain().Chain.LinkIDs, team.HiddenChain().GetOuter(), team.MainChain().Chain.LastSeqno, team.HiddenChain().GetLastCommittedSeqno(), root, keybase1.AuditMode_STANDARD)
 	require.Error(t, err)
@@ -675,8 +699,8 @@ func TestFailedProbesAreRetried(t *testing.T) {
 	history, err = auditor.getFromCache(m[B], teamID, lru)
 	require.NoError(t, err)
 	require.Len(t, history.PreProbesToRetry, 2)
-	require.Contains(t, history.PreProbesToRetry, firstWithHidden-1)
-	require.Contains(t, history.PreProbesToRetry, firstWithHidden+1)
+	require.Contains(t, history.PreProbesToRetry, firstPreProbe)
+	require.Contains(t, history.PreProbesToRetry, secondPreProbe)
 
 	// the old failed postprobes are still in the cache
 	require.Len(t, history.PostProbesToRetry, 2)


### PR DESCRIPTION
Fix two tests in go/teams/audit_test.go:

- TestAuditFailsIfDataIsInconsistent
- TestFailedProbesAreRetried

The breakage was caused by a test setup change in commit `1bed523ded`:

```
- requestNewBlindTreeFromArchitectAndWaitUntilDone(t, tcs[A])
+ publishNewMainMerkleRoot(t, tcs[A])
```

That changed the Merkle timeline produced during the tests, but the tests still used old hard-coded MockRandom values.

Fix:

- Derive mock pre-probe values from FirstExaminableHistoricalRoot.
- Keep post-probe values derived from headMerkleSeqno / high.
- Update retry assertions in TestFailedProbesAreRetried to expect the corrected pre-probe seqnos.
- Add range assertions so future Merkle timeline changes fail clearly instead of producing confusing mock-random errors.
- Deduplicate the repeated mock-random setup in TestAuditFailsIfDataIsInconsistent.