### PR TITLE
fix(login): stop signup push judder; move Create account into header

### DIFF
--- a/shared/login/index.tsx
+++ b/shared/login/index.tsx
@@ -1,16 +1,58 @@
 import * as React from 'react'
+import * as Kb from '@/common-adapters'
 import {useConfigState} from '@/stores/config'
 import {useDaemonState} from '@/stores/daemon'
+import useRequestAutoInvite from '@/signup/use-request-auto-invite'
+import {useNavigation} from '@react-navigation/native'
+import type {ParamListBase} from '@react-navigation/native'
+import type {NativeStackNavigationProp} from '@react-navigation/native-stack'
 
 const Loading = React.lazy(async () => import('./loading'))
 const Relogin = React.lazy(async () => import('./relogin'))
 const JoinOrLogin = React.lazy(async () => import('./join-or-login'))
+
+// This route is a state multiplexer, so "Create account" only exists in relogin mode. A native
+// header takes its actions as options rather than children, so push them up with setOptions.
+// iOS gets a real UIBarButtonItem (UIKit morphs those across pushes instead of sliding them in
+// with the screen); Android has no such API and takes a custom view.
+const useCreateAccountHeaderAction = (show: boolean) => {
+  const navigation = useNavigation() as unknown as NativeStackNavigationProp<ParamListBase>
+  const requestAutoInvite = useRequestAutoInvite()
+  const requestRef = React.useRef(requestAutoInvite)
+  React.useEffect(() => {
+    requestRef.current = requestAutoInvite
+  })
+  React.useEffect(() => {
+    if (!isMobile) return
+    const onPress = () => requestRef.current('')
+    navigation.setOptions(
+      isIOS
+        ? {
+            unstable_headerRightItems: show
+              ? () => [Kb.nativeTextHeaderItem('Create account', onPress)]
+              : () => [],
+          }
+        : {
+            headerRight: show
+              ? () => (
+                  <Kb.Text type="BodyBigLink" style={createAccountStyle} onClick={onPress}>
+                    Create account
+                  </Kb.Text>
+                )
+              : undefined,
+          }
+    )
+  }, [navigation, show])
+}
+
+const createAccountStyle = {paddingRight: Kb.Styles.globalMargins.small} as const
 
 const RootLogin = () => {
   const isLoggedIn = useConfigState(s => s.loggedIn)
   const userSwitching = useConfigState(s => s.userSwitching)
   const showLoading = useDaemonState(s => s.handshakeState !== 'done' || userSwitching)
   const showRelogin = useConfigState(s => !showLoading && s.configuredAccounts.length > 0)
+  useCreateAccountHeaderAction(!isLoggedIn && showRelogin)
   // routing should switch us away so lets not draw anything to speed things up
   if (isLoggedIn) return null
 

--- a/shared/login/relogin/index.tsx
+++ b/shared/login/relogin/index.tsx
@@ -9,13 +9,11 @@ import {errorBanner, SignupScreen} from '@/signup/common'
 import {isAndroidNewerThanM} from '@/constants/platform'
 import {useConfigState} from '@/stores/config'
 import {startRecoverPassword} from '@/login/recover-password/flow'
-import useRequestAutoInvite from '@/signup/use-request-auto-invite'
 import {startProvision} from '@/provision/flow'
 import UserList from './user-list'
 type Props = {
   users: Array<T.Config.ConfiguredAccount>
   onForgotPassword: () => void
-  onSignup: () => void
   onSomeoneElse: () => void
   error: string
   needPassword: boolean
@@ -156,7 +154,6 @@ const NativeLoginRender = (props: Props) => {
     needPassword,
     onFeedback,
     onForgotPassword,
-    onSignup,
     onSomeoneElse,
     password,
     selectedUser,
@@ -184,14 +181,6 @@ const NativeLoginRender = (props: Props) => {
       flex={1}
       style={nativeStyles.container}
     >
-      <Kb.Box2
-        direction="horizontal"
-        fullWidth={true}
-        justifyContent="flex-end"
-        style={nativeStyles.createAccountRow}
-      >
-        <Kb.Button small={true} label="Create account" mode="Secondary" onClick={onSignup} />
-      </Kb.Box2>
       {isAndroid && !C.isDeviceSecureAndroid && !isAndroidNewerThanM && (
         <Kb.Box2 direction="vertical" fullWidth={true} style={nativeStyles.deviceNotSecureContainer}>
           <Kb.Text center={true} type="Body" negative={true} style={nativeStyles.deviceNotSecureText}>
@@ -258,11 +247,6 @@ const useNativeStyles = Kb.Styles.createStyleHook(
       container: {
         backgroundColor: theme.blueGrey,
       },
-      createAccountRow: Kb.Styles.padding(
-        Kb.Styles.globalMargins.tiny,
-        Kb.Styles.globalMargins.small,
-        0
-      ),
       deviceNotSecureContainer: {
         backgroundColor: theme.yellow,
         ...Kb.Styles.paddingV(Kb.Styles.globalMargins.tiny),
@@ -292,8 +276,6 @@ const ReloginContainer = () => {
     C.Router2.navigateAppend({name: 'signupSendFeedbackLoggedOut', params: {}})
   }
   const onLogin = useConfigState(s => s.dispatch.login)
-  const requestAutoInvite = useRequestAutoInvite()
-  const onSignup = () => requestAutoInvite('')
   const onSomeoneElse = () => startProvision()
   const error = perror?.desc || ''
   const loggedInMap = new Map<string, boolean>(
@@ -364,7 +346,6 @@ const ReloginContainer = () => {
       needPassword={!loggedInMap.get(selectedUser) || gotNeedPasswordError}
       onFeedback={onFeedback}
       onForgotPassword={() => startRecoverPassword({username: selectedUser})}
-      onSignup={onSignup}
       onSomeoneElse={onSomeoneElse}
       onSubmit={onSubmit}
       password={password}

--- a/shared/login/routes.tsx
+++ b/shared/login/routes.tsx
@@ -107,8 +107,13 @@ const recoverPasswordGetOptions = {
 export const newRoutes = defineRouteMap({
   feedback: settingsRoutes[settingsFeedbackTab],
   login: {
+    // Keep an empty bar visible instead of hiding the header. Unhiding a hidden bar during a
+    // push makes iOS slide the whole UINavigationBar in from the right as its own animated
+    // plane, desynced from the screen slide (RNS issue #3773) — pushing "Create account" from
+    // here juddered and flashed the target screen. A visible bar on both sides turns it into a
+    // coordinated bar-content transition.
     getOptions: isMobile
-      ? {headerShown: false}
+      ? {headerShown: true, title: ''}
       : {
           headerLeft: () => null,
           headerRightActions: () => <LoginHeaderRight />,

--- a/shared/router-v2/routes.tsx
+++ b/shared/router-v2/routes.tsx
@@ -125,6 +125,22 @@ function toNavOptions(opts: GetOptionsRet): NativeStackNavigationOptions {
   return opts as NativeStackNavigationOptions
 }
 
+// iOS unhides a hidden UINavigationBar mid-push (setNavigationBarHidden:NO animated:YES), which
+// makes UIKit slide the whole bar in from the right as its own animated plane, desynced from the
+// screen slide — the push judders and flashes the target screen (react-native-screens#3773).
+// Only headerless->headered pushes hit it; header->header is fine, and modals present rather than
+// push so they may hide their bar freely. A pushed screen that wants no header must therefore keep
+// an EMPTY bar instead: see the RNS_EMPTY_BAR options on the tabs screen in router.tsx and the
+// `{headerShown: true, title: ''}` login route in login/routes.tsx.
+const assertHeaderShown = (name: string, opts: NativeStackNavigationOptions, isModal: boolean) => {
+  if (!isMobile || isModal || opts.headerShown !== false) return
+  throw new Error(
+    `Route '${name}' sets headerShown:false on a pushed screen. Pushing from it to a headered ` +
+      `screen judders on iOS (react-native-screens#3773). Render an empty bar instead: ` +
+      `{headerShown: true, title: ''}.`
+  )
+}
+
 export function routeMapToStaticScreens<const RS extends Record<string, RouteDef>>(
   rs: RS,
   makeLayoutFn: MakeLayoutFn,
@@ -150,7 +166,11 @@ export function routeMapToStaticScreens<const RS extends Record<string, RouteDef
       options: ({route, navigation}: {route: any; navigation: any}) => {
         const go = rd.getOptions
         const opts = typeof go === 'function' ? go({navigation, route}) : go
-        return toNavOptions(opts)
+        const navOpts = toNavOptions(opts)
+        if (__DEV__) {
+          assertHeaderShown(name, navOpts, isModal)
+        }
+        return navOpts
       },
       screen: rd.screen,
     }

--- a/shared/signup/use-request-auto-invite.tsx
+++ b/shared/signup/use-request-auto-invite.tsx
@@ -5,7 +5,7 @@ import * as T from '@/constants/types'
 
 const useRequestAutoInvite = () => {
   const waiting = C.Waiting.useAnyWaiting(C.waitingKeySignup)
-  const {navigateAppend, navigateUp} = C.Router2
+  const {navigateAppend} = C.Router2
 
   return (username: string) => {
     if (waiting) {
@@ -19,7 +19,6 @@ const useRequestAutoInvite = () => {
       try {
         inviteCode = await T.RPCGen.signupGetInvitationCodeRpcPromise(undefined, C.waitingKeySignup)
       } catch {}
-      navigateUp()
       navigateAppend({name: 'signupEnterUsername', params: {inviteCode, username}})
     }
     ignorePromise(f())

--- a/shared/signup/username.tsx
+++ b/shared/signup/username.tsx
@@ -9,6 +9,9 @@ import {ignorePromise} from '@/constants/utils'
 import logger from '@/logger'
 import {isValidUsername} from '@/util/simple-validators'
 import type {StaticScreenProps} from '@react-navigation/core'
+import {useNavigation} from '@react-navigation/native'
+import type {ParamListBase} from '@react-navigation/native'
+import type {NativeStackNavigationProp} from '@react-navigation/native-stack'
 import {clearSignupDeviceNameDraft} from './device-name-draft'
 
 type Props = StaticScreenProps<{inviteCode?: string; username?: string}>
@@ -94,6 +97,20 @@ const EnterUsername = (props: EnterUsernameProps) => {
     waiting,
   } = props
   const [username, onChangeUsername] = React.useState(initialUsername || '')
+  const inputRef = React.useRef<Kb.Input3Ref>(null)
+
+  // On mobile, autoFocus fires during the push transition, so the keyboard animates up while
+  // the screen is still sliding in and the content thrashes. Wait for the native-stack
+  // transition to finish, then focus. Desktop has no keyboard, so it keeps instant autoFocus.
+  const navigation = useNavigation() as unknown as NativeStackNavigationProp<ParamListBase>
+  React.useEffect(() => {
+    if (!isMobile) return
+    return navigation.addListener('transitionEnd', e => {
+      if (!e.data.closing) {
+        inputRef.current?.focus()
+      }
+    })
+  }, [navigation])
   const [acceptedEULA, setAcceptedEULA] = React.useState(false)
   const eulaUrlProps = Kb.useClickURL('https://keybase.io/docs/acceptable-use-policy')
   const usernameTrimmed = username.trim()
@@ -168,7 +185,8 @@ const EnterUsername = (props: EnterUsernameProps) => {
           <Kb.Box2 direction="vertical" fullWidth={Kb.Styles.isPhone} gap="tiny">
             <Kb.Input3
               textType="BodySemibold"
-              autoFocus={true}
+              autoFocus={!isMobile}
+              ref={inputRef}
               containerStyle={styles.input}
               placeholder="Pick a username"
               maxLength={C.maxUsernameLength}


### PR DESCRIPTION
## Problem

Pushing **Create account** from the relogin screen judders on iOS: the target screen flashes full-screen with no bar, then the stack slides back and forth before settling.

## Cause

The mobile `login` route was `headerShown: false` while `signupEnterUsername` has a header. react-native-screens unhides the bar mid-push (`setNavigationBarHidden:NO animated:YES`), so UIKit slides the whole `UINavigationBar` in from the right as its own animated plane, desynced from the screen slide — [react-native-screens#3773](https://github.com/software-mansion/react-native-screens/issues/3773). Same class of bug already fixed for the tabs screen via the `RNS_EMPTY_BAR` marker in `router-v2/router.tsx`.

## Changes

- **`login/routes.tsx`** — mobile `login` renders an empty header (`headerShown: true, title: ''`). A bar visible on both sides turns the push into a coordinated bar-content transition.
- **`login/index.tsx`** — now that there is a header, **Create account** becomes a header right action. iOS gets a real `UIBarButtonItem` via `Kb.nativeTextHeaderItem` (UIKit morphs those across pushes rather than sliding them in with the screen); Android gets a custom view. Applied through `setOptions` because the route is a state multiplexer and the action only exists in relogin mode.
- **`login/relogin/index.tsx`** — drops the in-body Create account row, its `createAccountRow` style, and the now-unused `onSignup` prop (native-only; desktop never read it).
- **`signup/use-request-auto-invite.tsx`** — drops a dead `navigateUp()` issued right before the push. Nothing to pop from the login stack root, and the extra dispatch raced the push.
- **`signup/username.tsx`** — the username input no longer `autoFocus`es on mobile. It focuses on the native-stack `transitionEnd` event, so the keyboard no longer animates up while the screen is still sliding in and re-laying-out under `LoggedOutScreenWrapper`'s keyboard/header padding.

- **`router-v2/routes.tsx`** — `__DEV__` assert at the single `options()` closure every route flows through: a pushed mobile screen may not set `headerShown: false`, with the empty-bar fix in the message. Skips desktop and skips modals, which present rather than push and may hide their bar freely. Nothing in the tree trips it; a sweep of every mobile `headerShown` site found no other offenders (the two chat `headerShown: false` routes are modals).

Desktop header path is unchanged.

## Testing

`yarn lint:all` clean (0 bailouts, 0 whole-props deps, tsc green). Verified on a physical iOS device: the push reads as one coordinated unit, and the relogin card sits up by the height of the removed row.

