### PR TITLE
fix(chat): select right bot command when pasting

### DIFF
--- a/shared/chat/conversation/input-area/normal/input.test.tsx
+++ b/shared/chat/conversation/input-area/normal/input.test.tsx
@@ -1,0 +1,45 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as React from 'react'
+import * as TestIDs from '@/tests/e2e/shared/test-ids'
+import {cleanup, fireEvent, render} from '@testing-library/react'
+import {Input} from './input'
+import type {RefType} from './input.shared'
+
+// input.tsx pulls in the native-only halves of the input bar at module scope;
+// none of them are involved in the desktop caret path under test
+jest.mock('@/chat/audio/audio-recorder.native', () => ({__esModule: true, default: () => null}))
+jest.mock('@/chat/audio/audio-send.native', () => ({AudioSendWrapper: () => null}))
+jest.mock('@/util/expo-document-picker.native', () => ({pickDocumentsAsync: jest.fn()}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const renderInput = () => {
+  const ref = React.createRef<RefType>()
+  const utils = render(<Input multiline={true} onChangeText={jest.fn()} ref={ref} />)
+  const input = utils.getByTestId(TestIDs.CHAT_INPUT)
+  return {input, ref}
+}
+
+// the browser dispatches selectionchange (our onSelect) asynchronously, so a paste
+// never updates the caret before the suggestors read it. the change event has to
+// carry it instead, otherwise a pasted `!keybot cancel` looks like a caret at 0 and
+// the suggestors match on the first word only
+test('getSelection reflects the caret carried by the change event', () => {
+  const {input, ref} = renderInput()
+
+  fireEvent.change(input, {target: {selectionEnd: 14, selectionStart: 14, value: '!keybot cancel'}})
+
+  expect(ref.current?.value).toBe('!keybot cancel')
+  expect(ref.current?.getSelection()).toEqual({end: 14, start: 14})
+})
+
+test('getSelection keeps a range selection from the change event', () => {
+  const {input, ref} = renderInput()
+
+  fireEvent.change(input, {target: {selectionEnd: 7, selectionStart: 1, value: '!keybot cancel'}})
+
+  expect(ref.current?.getSelection()).toEqual({end: 7, start: 1})
+})

--- a/shared/chat/conversation/input-area/normal/input.tsx
+++ b/shared/chat/conversation/input-area/normal/input.tsx
@@ -103,11 +103,20 @@ function DesktopInput(p: InputLowLevelProps) {
   React.useEffect(() => {
     onChangeTextRef.current = _onChangeText
   }, [_onChangeText])
-  const [onChange] = React.useState(() => (e: {target: {value: string}}) => {
-    const s = e.target.value
-    setValue(s)
-    onChangeTextRef.current?.(s)
-  })
+  const [onChange] = React.useState(
+    () => (e: {target: {value: string; selectionStart?: number | null; selectionEnd?: number | null}}) => {
+      const s = e.target.value
+      // the browser dispatches selectionchange (our onSelect) asynchronously, so on
+      // paste selectionRef still holds the pre-paste caret when the suggestors read
+      // it. the change event's target already has the settled caret, so take it here
+      const {selectionStart, selectionEnd} = e.target
+      if (typeof selectionStart === 'number') {
+        selectionRef.current = {end: selectionEnd ?? selectionStart, start: selectionStart}
+      }
+      setValue(s)
+      onChangeTextRef.current?.(s)
+    }
+  )
   const onSelect = (e: {currentTarget: {selectionEnd: number | null; selectionStart: number | null}}) => {
     selectionRef.current = {
       end: e.currentTarget.selectionEnd || 0,

--- a/shared/chat/conversation/input-area/suggestors/index.test.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.test.tsx
@@ -1,0 +1,117 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import type * as React from 'react'
+import {act, cleanup, render, renderHook} from '@testing-library/react'
+import type {RefType as InputRef, Selection} from '../normal/input.shared'
+import {useSuggestors} from '.'
+
+const mockCommandsList = jest.fn((_p: {filter: string}) => null)
+const mockUsersList = jest.fn((_p: {filter: string}) => null)
+
+jest.mock('./commands', () => ({
+  List: (p: {filter: string}) => mockCommandsList(p),
+  transformer: jest.fn(),
+  useBotCommandsUpdateState: () => ({
+    conversationIDKey: 'conv',
+    settings: new Map<string, unknown>(),
+    status: 0,
+  }),
+}))
+jest.mock('./channels', () => ({List: () => null, transformer: jest.fn()}))
+jest.mock('./emoji', () => ({List: () => null, transformer: jest.fn()}))
+jest.mock('./users', () => ({UsersList: (p: {filter: string}) => mockUsersList(p), transformer: jest.fn()}))
+jest.mock('../../thread-context', () => ({useConversationThreadID: () => 'conv'}))
+jest.mock('../input-state', () => ({useConversationInput: () => false}))
+jest.mock('@/common-adapters', () => {
+  const actual = jest.requireActual<Record<string, unknown>>('@/common-adapters')
+  return {...actual, Popup: (p: {children: React.ReactNode}) => <>{p.children}</>}
+})
+
+// the suggestors read the caret through the input ref; drive it directly so the
+// test exercises the word-splitting rather than a real textarea
+const makeInputRef = (getSelection: () => Selection | undefined) => ({
+  current: {
+    getSelection,
+    isFocused: () => true,
+    transformText: jest.fn(),
+  } as unknown as InputRef,
+})
+
+const renderSuggestors = (getSelection: () => Selection | undefined) => {
+  const inputRef = makeInputRef(getSelection)
+  const {result} = renderHook(() =>
+    useSuggestors({
+      inputRef,
+      onChangeText: jest.fn(),
+      suggestionListStyle: {},
+      suggestionOverlayStyle: {},
+      suggestionSpinnerStyle: {},
+    })
+  )
+  return result
+}
+
+// mirrors what the input does: one change event carrying the whole text, then the
+// suggestors' settle timeout. a paste only ever gets one of these
+const typeText = (result: {current: ReturnType<typeof useSuggestors>}, text: string) => {
+  act(() => {
+    result.current.onChangeText(text)
+  })
+  act(() => {
+    jest.advanceTimersByTime(5)
+  })
+}
+
+const renderPopup = (result: {current: ReturnType<typeof useSuggestors>}) => {
+  render(<>{result.current.popup}</>)
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  mockCommandsList.mockClear()
+  mockUsersList.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  jest.useRealTimers()
+})
+
+// bot command names contain a space (`keybot cancel`), so the command-mode word
+// split has to be on for the very first trigger. pasted text arrives in a single
+// change event and never gets a follow-up keystroke to widen the word
+test('a pasted multi-word bot command filters on the whole command name', () => {
+  const text = '!keybot cancel'
+  const result = renderSuggestors(() => ({end: text.length, start: text.length}))
+
+  typeText(result, text)
+  renderPopup(result)
+
+  expect(mockCommandsList).toHaveBeenCalled()
+  expect(mockCommandsList.mock.calls.at(-1)?.[0].filter).toBe('keybot cancel')
+})
+
+test('typing a multi-word bot command a character at a time ends on the same filter', () => {
+  const full = '!keybot cancel'
+  let text = ''
+  const result = renderSuggestors(() => ({end: text.length, start: text.length}))
+
+  for (const c of full) {
+    text += c
+    typeText(result, text)
+  }
+  renderPopup(result)
+
+  expect(mockCommandsList.mock.calls.at(-1)?.[0].filter).toBe('keybot cancel')
+})
+
+test('non-command text still splits on plain spaces', () => {
+  const text = 'hello there @test'
+  const result = renderSuggestors(() => ({end: text.length, start: text.length}))
+
+  typeText(result, text)
+  renderPopup(result)
+
+  expect(mockUsersList).toHaveBeenCalled()
+  expect(mockUsersList.mock.calls.at(-1)?.[0].filter).toBe('test')
+})

--- a/shared/chat/conversation/input-area/suggestors/index.tsx
+++ b/shared/chat/conversation/input-area/suggestors/index.tsx
@@ -96,9 +96,8 @@ const useSyncInput = (p: UseSyncInputProps) => {
     text: lastTextRef.current,
   })
 
-  const getWordAtCursor = (inputSnapshot: Commands.CommandInputSnapshot) => {
+  const getWordAtCursor = (inputSnapshot: Commands.CommandInputSnapshot, useSpaces: boolean) => {
     if (inputRef.current) {
-      const useSpaces = active === 'commands'
       const {selection, text} = inputSnapshot
       // eslint-disable-next-line
       if (!selection || selection.start === null) {
@@ -142,7 +141,13 @@ const useSyncInput = (p: UseSyncInputProps) => {
       // desktop would get the previous selection on arrowleft / arrowright
       const inputSnapshot = getInputSnapshot()
       setCommandInputSnapshot(inputSnapshot)
-      const cursorInfo = getWordAtCursor(inputSnapshot)
+      // bot command names contain spaces (`!keybot cancel`), so the command-mode
+      // word split has to be on before `active` catches up: pasted text arrives in
+      // one change event and never gets a follow-up keystroke to correct the word
+      const cursorInfo = getWordAtCursor(
+        inputSnapshot,
+        active === 'commands' || /^\s*[!/]/.test(inputSnapshot.text)
+      )
       if (!cursorInfo) {
         setInactive()
         return
@@ -192,7 +197,7 @@ const useSyncInput = (p: UseSyncInputProps) => {
     const input = inputRef.current
     const inputSnapshot = getInputSnapshot()
     setCommandInputSnapshot(inputSnapshot)
-    const cursorInfo = getWordAtCursor(inputSnapshot)
+    const cursorInfo = getWordAtCursor(inputSnapshot, active === 'commands')
     const matchInfo = matchesMarker(cursorInfo?.word ?? '', suggestorToMarker[active])
 
     let transformedText: {


### PR DESCRIPTION
## Problem

Pasting `!keybot cancel keybase.build.ios` into the chat input left the suggestion HUD highlighting `!keybot build <ios>`. Enter at that point replaced the pasted message with the wrong command. Typing the same text worked.

## Causes

**Stale caret on desktop.** `selectionRef` was only updated from `onSelect`, and browsers dispatch `selectionchange` asynchronously, so the suggestors' settle timeout read the pre-paste caret (0). The word came out `!keybot`, filter `keybot`, and the list defaulted to index 0.

**`useSpaces` read stale state.** `getWordAtCursor` derived `useSpaces` from the `active` state, which is a render behind. Bot command names contain spaces (`keybot cancel`), so the first trigger after a paste split on plain spaces and never got a follow-up keystroke to widen the word. Typing works only because every keystroke re-runs the check.

## Fix

- Take the caret off the change event's target, where it has already settled.
- Pass `useSpaces` into `getWordAtCursor`, computed from the snapshot text rather than from `active`.

Paste now matches typing: `!keybot cancel` shows that command, and the full line with args hides the HUD (caret is past `maxCmdLength`) instead of offering a wrong item.

## Tests

New `input.test.tsx` and `suggestors/index.test.tsx`. Both fail with their half of the fix reverted.