### PR TITLE
test(chat): unit tests for message conversion, thread engine and inbox rows

### DIFF
--- a/shared/chat/audio/amptracker.test.tsx
+++ b/shared/chat/audio/amptracker.test.tsx
@@ -1,0 +1,80 @@
+/// <reference types="jest" />
+import {AmpTracker} from './amptracker'
+import {maxAmpsLength} from '@/constants/chat/message'
+
+const minBars = 20
+
+const trackerWith = (amps: ReadonlyArray<number>) => {
+  const tracker = new AmpTracker()
+  amps.forEach(a => {
+    tracker.addAmp(a)
+  })
+  return tracker
+}
+
+// amps arrive one per 100ms, so n amps cover n*100ms of audio
+const ampsFor = (count: number, value: number) => new Array<number>(count).fill(value)
+
+test('no amps means no bars', () => {
+  expect(new AmpTracker().getBucketedAmps(1000)).toEqual([])
+})
+
+test('reset drops everything recorded so far', () => {
+  const tracker = trackerWith(ampsFor(10, 5))
+  expect(tracker.getBucketedAmps(1000).length).toBeGreaterThan(0)
+  tracker.reset()
+  expect(tracker.getBucketedAmps(1000)).toEqual([])
+})
+
+test('a constant amplitude survives rescaling', () => {
+  const amps = trackerWith(ampsFor(10, 7)).getBucketedAmps(1000)
+  expect(amps).toHaveLength(minBars)
+  expect(amps.every(a => a === 7)).toBe(true)
+})
+
+test('short clips get the minimum number of bars', () => {
+  // 10 amps = 1s of audio; a 1s duration snaps to minBars, so each bar is 50ms
+  expect(trackerWith(ampsFor(10, 1)).getBucketedAmps(1000)).toHaveLength(minBars)
+  // durations under the low snap point still ask for minBars
+  expect(trackerWith(ampsFor(5, 1)).getBucketedAmps(500)).toHaveLength(minBars)
+})
+
+test('bar width comes from the duration, so a short duration over-produces bars', () => {
+  // the bar width is duration/bars, but bars are emitted until the recorded audio runs
+  // out: 1s of audio reported as 500ms yields twice minBars
+  expect(trackerWith(ampsFor(10, 1)).getBucketedAmps(500)).toHaveLength(minBars * 2)
+})
+
+test('long clips get the maximum number of bars', () => {
+  // 30s+ snaps to maxBars, so a 3s clip of audio is spread over 500ms bars
+  expect(trackerWith(ampsFor(30, 1)).getBucketedAmps(30000)).toHaveLength(
+    Math.ceil(3000 / (30000 / maxAmpsLength))
+  )
+  expect(trackerWith(ampsFor(30, 1)).getBucketedAmps(60000)).toHaveLength(
+    Math.ceil(3000 / (60000 / maxAmpsLength))
+  )
+})
+
+test('bar count scales along the curve between the snap points', () => {
+  // halfway between the snaps the curve is sqrt(0.5), not 0.5
+  const duration = 15500
+  const expectedBars = Math.floor(minBars + (maxAmpsLength - minBars) * Math.sqrt(0.5))
+  const barWidth = duration / expectedBars
+  expect(trackerWith(ampsFor(100, 1)).getBucketedAmps(duration)).toHaveLength(
+    Math.ceil(10000 / barWidth)
+  )
+})
+
+test('bars average the amps they cover', () => {
+  // 4 amps = 400ms of audio; a 30s duration gives 500ms bars, so all four land in one bar
+  const amps = trackerWith([0, 10, 0, 10]).getBucketedAmps(30000)
+  expect(amps).toHaveLength(1)
+  expect(amps[0]).toBeCloseTo(5)
+})
+
+test('bars keep the shape of the signal', () => {
+  // silence then noise, bucketed 1:1 (10 amps = 1s of audio, 1s duration, 20 bars)
+  const amps = trackerWith([...ampsFor(5, 0), ...ampsFor(5, 10)]).getBucketedAmps(1000)
+  expect(amps.slice(0, 10).every(a => a === 0)).toBe(true)
+  expect(amps.slice(-8).every(a => a === 10)).toBe(true)
+})

--- a/shared/chat/conversation/attachment-get-titles.test.tsx
+++ b/shared/chat/conversation/attachment-get-titles.test.tsx
@@ -1,0 +1,35 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import {isKbfsPath, pathToAttachmentType} from './attachment-get-titles'
+
+describe('pathToAttachmentType', () => {
+  test('common image extensions preview as images, case insensitively', () => {
+    for (const path of ['/tmp/a.jpg', '/tmp/a.JPEG', '/tmp/a.png', '/tmp/a.gif', '/tmp/a.bmp']) {
+      expect(pathToAttachmentType(path)).toBe('image')
+    }
+  })
+
+  test('videos preview as video', () => {
+    expect(pathToAttachmentType('/tmp/a.mp4')).toBe('video')
+    expect(pathToAttachmentType('/tmp/a.mov')).toBe('video')
+  })
+
+  test('everything else previews as a file', () => {
+    // heic is deliberately a file here even though it is processed like an image
+    expect(pathToAttachmentType('/tmp/a.heic')).toBe('file')
+    expect(pathToAttachmentType('/tmp/a.pdf')).toBe('file')
+    expect(pathToAttachmentType('/tmp/noextension')).toBe('file')
+  })
+
+  test('the extension has to be on the file name, not the directory', () => {
+    expect(pathToAttachmentType('/tmp/a.png/notanimage')).toBe('file')
+  })
+})
+
+describe('isKbfsPath', () => {
+  test('only /keybase/ paths count', () => {
+    expect(isKbfsPath('/keybase/private/testuser/a.png')).toBe(true)
+    expect(isKbfsPath('/tmp/a.png')).toBe(false)
+    expect(isKbfsPath('keybase/private/testuser/a.png')).toBe(false)
+  })
+})

--- a/shared/chat/conversation/attachment-get-titles.tsx
+++ b/shared/chat/conversation/attachment-get-titles.tsx
@@ -38,7 +38,7 @@ type Info = {
 // which is deliberately a different set (heic previews as a file but is
 // processed, gif previews as an image but is passed through untouched).
 const imageFileNameRegex = /[^/]+\.(jpg|png|gif|jpeg|bmp)$/i
-const pathToAttachmentType = (path: string) => {
+export const pathToAttachmentType = (path: string) => {
   if (imageFileNameRegex.test(path)) {
     return 'image'
   }
@@ -48,7 +48,7 @@ const pathToAttachmentType = (path: string) => {
   return 'file'
 }
 
-const isKbfsPath = (path: string) => path.startsWith('/keybase/')
+export const isKbfsPath = (path: string) => path.startsWith('/keybase/')
 
 const ContainerInner = (ownProps: OwnProps) => {
   const styles = useStyles()

--- a/shared/chat/conversation/data-hooks.test.tsx
+++ b/shared/chat/conversation/data-hooks.test.tsx
@@ -1,0 +1,212 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as Meta from '@/constants/chat/meta'
+import * as OrangeLine from './orange-line-context'
+import * as T from '@/constants/types'
+import * as ThreadRpc from './thread-rpc'
+import {act, cleanup, renderHook} from '@testing-library/react'
+import {metasReceived} from '@/chat/inbox/metadata'
+import {resetAllStores} from '@/util/zustand'
+import {useConfigState} from '@/stores/config'
+import {useCurrentUserState} from '@/stores/current-user'
+import {
+  getConversationClientPrev,
+  markConversationAsUnread,
+  useConversationExplodingMode,
+} from './data-hooks'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const messageID = (n: number) => T.Chat.numberToMessageID(n)
+
+const flushPromises = async () => {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+}
+
+const setMeta = (over: Partial<T.Chat.ConversationMeta>) => {
+  metasReceived([{...Meta.makeConversationMeta(), conversationIDKey, ...over}], undefined, {force: true})
+}
+
+// the walk-back load returns whatever messages the service had around the unread line
+const mockAroundMessages = (ids: ReadonlyArray<number>) =>
+  jest.spyOn(ThreadRpc, 'loadThreadNonblock').mockImplementation(async p => {
+    const messages = ids.map(id => ({
+      placeholder: {hidden: false, messageID: messageID(id)},
+      state: T.RPCChat.MessageUnboxedState.placeholder,
+    }))
+    await Promise.resolve()
+    p.onFullThread?.(JSON.stringify({messages}))
+    return undefined as never
+  })
+
+beforeEach(() => {
+  useConfigState.setState({loggedIn: true})
+  useCurrentUserState.getState().dispatch.setBootstrap({
+    deviceID: 'device-id',
+    deviceName: 'testuser-mac',
+    uid: 'uid',
+    username: 'testuser',
+  })
+  jest.spyOn(ThreadRpc, 'markConversationRead').mockResolvedValue(undefined as never)
+  jest.spyOn(OrangeLine, 'setConversationOrangeLine').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  cleanup()
+  jest.restoreAllMocks()
+  resetAllStores()
+})
+
+describe('markConversationAsUnread', () => {
+  test('does nothing when the caller opts out with false', async () => {
+    mockAroundMessages([])
+    markConversationAsUnread(conversationIDKey, false)
+    await flushPromises()
+    expect(ThreadRpc.markConversationRead).not.toHaveBeenCalled()
+  })
+
+  test('does nothing for an invalid conversation', async () => {
+    mockAroundMessages([])
+    markConversationAsUnread(T.Chat.noConversationIDKey, messageID(5))
+    await flushPromises()
+    expect(ThreadRpc.markConversationRead).not.toHaveBeenCalled()
+  })
+
+  test('bails when logged out', async () => {
+    useConfigState.setState({loggedIn: false})
+    mockAroundMessages([])
+    markConversationAsUnread(conversationIDKey, messageID(5))
+    await flushPromises()
+    expect(ThreadRpc.markConversationRead).not.toHaveBeenCalled()
+    expect(OrangeLine.setConversationOrangeLine).not.toHaveBeenCalled()
+  })
+
+  test('bails when there is no id to unread from', async () => {
+    mockAroundMessages([])
+    markConversationAsUnread(conversationIDKey)
+    await flushPromises()
+    expect(ThreadRpc.markConversationRead).not.toHaveBeenCalled()
+  })
+
+  test('falls back to the conversation maxVisibleMsgID', async () => {
+    setMeta({maxVisibleMsgID: messageID(9)})
+    mockAroundMessages([])
+    markConversationAsUnread(conversationIDKey)
+    await flushPromises()
+    expect(OrangeLine.setConversationOrangeLine).toHaveBeenCalledWith(
+      conversationIDKey,
+      T.Chat.numberToOrdinal(9)
+    )
+  })
+
+  test('sets the orange line and marks read at the message before the unread line', async () => {
+    mockAroundMessages([3, 4, 5, 6])
+    markConversationAsUnread(conversationIDKey, messageID(5))
+    await flushPromises()
+
+    expect(OrangeLine.setConversationOrangeLine).toHaveBeenCalledWith(
+      conversationIDKey,
+      T.Chat.numberToOrdinal(5)
+    )
+    // 4 is the newest message older than the unread line
+    expect(ThreadRpc.markConversationRead).toHaveBeenCalledWith({
+      conversationIDKey,
+      forceUnread: true,
+      msgID: messageID(4),
+    })
+  })
+
+  test('keeps the unread line id when nothing older came back', async () => {
+    mockAroundMessages([5, 6, 7])
+    markConversationAsUnread(conversationIDKey, messageID(5))
+    await flushPromises()
+    expect(ThreadRpc.markConversationRead).toHaveBeenCalledWith({
+      conversationIDKey,
+      forceUnread: true,
+      msgID: messageID(5),
+    })
+  })
+
+  test('still marks read when the walk-back load fails', async () => {
+    jest.spyOn(ThreadRpc, 'loadThreadNonblock').mockRejectedValue(new Error('offline'))
+    markConversationAsUnread(conversationIDKey, messageID(5))
+    await flushPromises()
+    expect(ThreadRpc.markConversationRead).toHaveBeenCalledWith({
+      conversationIDKey,
+      forceUnread: true,
+      msgID: messageID(5),
+    })
+  })
+})
+
+describe('getConversationClientPrev', () => {
+  test('is 0 without a meta', () => {
+    expect(getConversationClientPrev(conversationIDKey)).toBe(0)
+  })
+
+  test('reads maxVisibleMsgID off the meta', () => {
+    setMeta({maxVisibleMsgID: messageID(12)})
+    expect(getConversationClientPrev(conversationIDKey)).toBe(12)
+  })
+})
+
+describe('useConversationExplodingMode', () => {
+  const gregorPushState = (category: string, body: string) =>
+    [{item: {body: new TextEncoder().encode(body), category}}] as unknown as ReturnType<
+      typeof useConfigState.getState
+    >['gregorPushState']
+
+  test('is off with no gregor state', () => {
+    const {result} = renderHook(() => useConversationExplodingMode(conversationIDKey))
+    expect(result.current).toBe(0)
+  })
+
+  test('follows the gregor exploding item for this conversation', () => {
+    const {result} = renderHook(() => useConversationExplodingMode(conversationIDKey))
+    act(() => {
+      useConfigState.setState({
+        gregorPushState: gregorPushState(`exploding:${conversationIDKey}`, '300'),
+      })
+    })
+    expect(result.current).toBe(300)
+  })
+
+  test('a dirty value reads as off rather than undefined', () => {
+    const {result} = renderHook(() => useConversationExplodingMode(conversationIDKey))
+    act(() => {
+      useConfigState.setState({
+        gregorPushState: gregorPushState(`exploding:${conversationIDKey}`, 'garbage'),
+      })
+    })
+    expect(result.current).toBe(0)
+  })
+})
+
+describe('parsed thread messages', () => {
+  test('the walk-back load dedupes and sorts by message id', async () => {
+    // the service can send the same message in the cached and full thread callbacks
+    jest.spyOn(ThreadRpc, 'loadThreadNonblock').mockImplementation(async p => {
+      const thread = (ids: ReadonlyArray<number>) =>
+        JSON.stringify({
+          messages: ids.map(id => ({
+            placeholder: {hidden: false, messageID: messageID(id)},
+            state: T.RPCChat.MessageUnboxedState.placeholder,
+          })),
+        })
+      await Promise.resolve()
+      p.onCachedThread?.(thread([6, 4]))
+      p.onFullThread?.(thread([4, 5]))
+      return undefined as never
+    })
+
+    markConversationAsUnread(conversationIDKey, messageID(6))
+    await flushPromises()
+    // 5 is the newest id below the unread line across both callbacks
+    expect(ThreadRpc.markConversationRead).toHaveBeenCalledWith({
+      conversationIDKey,
+      forceUnread: true,
+      msgID: messageID(5),
+    })
+  })
+})

--- a/shared/chat/conversation/input-area/suggestors/users.test.tsx
+++ b/shared/chat/conversation/input-area/suggestors/users.test.tsx
@@ -1,0 +1,94 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import {filterAndJoin, transformer} from './users'
+import type {TeamListItem, UserListItem} from './users'
+
+const user = (username: string, fullName = ''): UserListItem => ({fullName, username})
+const channel = (teamname: string, channelname: string): TeamListItem => ({channelname, teamname})
+const team = (teamname: string): TeamListItem => ({channelname: '', teamname})
+
+const tData = {position: {end: 3, start: 0}, text: '@al'}
+
+describe('transformer', () => {
+  test('inserts a username and a trailing space', () => {
+    expect(transformer({fullName: 'Alice', username: 'alice'}, '@', tData, false)).toEqual({
+      selection: {end: 7, start: 7},
+      text: '@alice ',
+    })
+  })
+
+  test('preview mode inserts without the trailing space', () => {
+    expect(transformer({fullName: 'Alice', username: 'alice'}, '@', tData, true)).toEqual({
+      selection: {end: 6, start: 6},
+      text: '@alice',
+    })
+  })
+
+  test('a team without a channel inserts just the team', () => {
+    expect(
+      transformer({fullName: '', teamname: 'acme', username: 'ignored'}, '@', tData, true).text
+    ).toBe('@acme')
+  })
+
+  test('a team with a channel inserts team#channel', () => {
+    expect(
+      transformer(
+        {channelname: 'general', fullName: '', teamname: 'acme', username: 'ignored'},
+        '@',
+        tData,
+        true
+      ).text
+    ).toBe('@acme#general')
+  })
+})
+
+describe('filterAndJoin', () => {
+  const users = [user('alice', 'Alice Anderson'), user('bob', 'Bob Baker'), user('carol', 'Alice Carter')]
+  const teams = [team('acme'), team('acmecorp')]
+  const allChannels = [channel('acme', 'general'), channel('acme', 'random'), channel('acmecorp', 'general')]
+
+  test('an empty filter returns everyone with teams sorted by name', () => {
+    const result = filterAndJoin(users, [team('zebra'), team('acme')], allChannels, '')
+    expect(result).toEqual([...users, team('acme'), team('zebra')])
+  })
+
+  test('username prefix outranks fullname prefix, which outranks a substring match', () => {
+    // 'al': alice matches username prefix (3), carol matches fullname prefix (2)
+    const result = filterAndJoin(users, [], allChannels, 'al')
+    expect(result).toEqual([user('alice', 'Alice Anderson'), user('carol', 'Alice Carter')])
+  })
+
+  test('non-matching users are dropped', () => {
+    expect(filterAndJoin(users, [], allChannels, 'zzz')).toEqual([])
+  })
+
+  test('teams match on a plain substring', () => {
+    const result = filterAndJoin([], teams, allChannels, 'acmec')
+    // a lone team result also offers its channels
+    expect(result).toEqual([team('acmecorp'), channel('acmecorp', 'general')])
+  })
+
+  test('a lone team result only expands when no users matched', () => {
+    const result = filterAndJoin([user('acmebot', '')], [team('acmecorp')], allChannels, 'acme')
+    expect(result).toEqual([user('acmebot', ''), team('acmecorp')])
+  })
+
+  test('team# lists every channel in that team', () => {
+    expect(filterAndJoin(users, teams, allChannels, 'acme#')).toEqual([
+      channel('acme', 'general'),
+      channel('acme', 'random'),
+    ])
+  })
+
+  test('team#partial ranks channel prefix matches first', () => {
+    const channels = [channel('acme', 'general'), channel('acme', 'ungeneral'), channel('acme', 'random')]
+    expect(filterAndJoin(users, teams, channels, 'acme#gen')).toEqual([
+      channel('acme', 'general'),
+      channel('acme', 'ungeneral'),
+    ])
+  })
+
+  test('a team# filter for an unknown team yields nothing, not a user search', () => {
+    expect(filterAndJoin(users, teams, allChannels, 'nosuchteam#')).toEqual([])
+  })
+})

--- a/shared/chat/conversation/input-area/suggestors/users.tsx
+++ b/shared/chat/conversation/input-area/suggestors/users.tsx
@@ -107,7 +107,7 @@ const filterUsersAndTeams = (
   return [...sortedUsers, ...sortedTeams]
 }
 
-const filterAndJoin = (
+export const filterAndJoin = (
   users: Array<UserListItem>,
   teams: Array<TeamListItem>,
   allChannels: Array<TeamListItem>,
@@ -183,12 +183,12 @@ const useDataSource = (conversationIDKey: T.Chat.ConversationIDKey, filter: stri
   return filterAndJoin(users, teams, allChannels, fl)
 }
 
-type UserListItem = {
+export type UserListItem = {
   username: string
   fullName: string
 }
 
-type TeamListItem = {
+export type TeamListItem = {
   teamname: string
   channelname: string
 }

--- a/shared/chat/conversation/messages/account-payment/container.test.tsx
+++ b/shared/chat/conversation/messages/account-payment/container.test.tsx
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {makeChatPaymentInfo, makeChatRequestInfo, makeMessageRequestPayment} from '@/constants/chat/message'
+import {getRequestMessageInfo, makeSendPaymentVerb} from './container'
+
+describe('makeSendPaymentVerb', () => {
+  test('pending reads the same for both sides', () => {
+    expect(makeSendPaymentVerb('pending', true)).toBe('sending')
+    expect(makeSendPaymentVerb('pending', false)).toBe('sending')
+  })
+
+  test('canceled and claimable soften for the recipient', () => {
+    for (const status of ['canceled', 'claimable'] as const) {
+      expect(makeSendPaymentVerb(status, true)).toBe('sending')
+      expect(makeSendPaymentVerb(status, false)).toBe('attempting to send')
+    }
+  })
+
+  test('errors read as attempted for both sides', () => {
+    expect(makeSendPaymentVerb('error', true)).toBe('attempted to send')
+    expect(makeSendPaymentVerb('error', false)).toBe('attempted to send')
+  })
+
+  test('anything else is a completed send', () => {
+    expect(makeSendPaymentVerb('completed', true)).toBe('sent')
+    expect(makeSendPaymentVerb('none', false)).toBe('sent')
+  })
+})
+
+describe('getRequestMessageInfo', () => {
+  const messageID = T.Chat.numberToMessageID(4)
+  const message = makeMessageRequestPayment({
+    conversationIDKey: T.Chat.stringToConversationIDKey('conv1'),
+    id: messageID,
+    requestInfo: makeChatRequestInfo({amount: 'from the message'}),
+  })
+
+  test('falls back to the info already on the message', () => {
+    expect(getRequestMessageInfo(new Map(), message)?.amount).toBe('from the message')
+  })
+
+  test('a later info from the accounts map wins', () => {
+    const fresher = makeChatRequestInfo({amount: 'from the map'})
+    expect(getRequestMessageInfo(new Map([[messageID, fresher]]), message)).toBe(fresher)
+  })
+
+  test('throws when the map holds a payment info for a request message', () => {
+    const wrongType = makeChatPaymentInfo()
+    expect(() => getRequestMessageInfo(new Map([[messageID, wrongType]]), message)).toThrow()
+  })
+})

--- a/shared/chat/conversation/messages/account-payment/container.tsx
+++ b/shared/chat/conversation/messages/account-payment/container.tsx
@@ -27,7 +27,7 @@ const failedProps = {
 }
 
 // Get action phrase for sendPayment msg
-const makeSendPaymentVerb = (status: T.Wallets.StatusSimplified, youAreSender: boolean) => {
+export const makeSendPaymentVerb = (status: T.Wallets.StatusSimplified, youAreSender: boolean) => {
   switch (status) {
     case 'pending':
       return 'sending'
@@ -47,7 +47,7 @@ type OwnProps = {
 
 type AccountsInfoMap = ReadonlyMap<T.RPCChat.MessageID, T.Chat.ChatRequestInfo | T.Chat.ChatPaymentInfo>
 
-const getRequestMessageInfo = (
+export const getRequestMessageInfo = (
   accountsInfoMap: AccountsInfoMap,
   message: T.Chat.MessageRequestPayment
 ) => {

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.test.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.test.tsx
@@ -1,0 +1,90 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import {getLoopInterval, makeInitialTimerState} from './exploding-meta'
+
+const second = 1000
+const minute = 60 * second
+const hour = 60 * minute
+const day = 24 * hour
+
+describe('getLoopInterval', () => {
+  test('under a minute it ticks twice a second', () => {
+    expect(getLoopInterval(0)).toBe(500)
+    expect(getLoopInterval(30 * second)).toBe(500)
+    expect(getLoopInterval(minute)).toBe(500)
+  })
+
+  test('within half a unit of the boundary it wakes exactly on the boundary', () => {
+    // the remainder is returned so the displayed unit flips on time
+    expect(getLoopInterval(70 * second)).toBe(10 * second)
+    expect(getLoopInterval(90 * second)).toBe(30 * second)
+    expect(getLoopInterval(hour + 20 * minute)).toBe(20 * minute)
+    expect(getLoopInterval(day + 8 * hour)).toBe(8 * hour)
+  })
+
+  test('further into a unit it wakes on the next half-unit mark', () => {
+    // 100s = 1m40s; past the half-minute mark, so wake 10s later at 1m30s
+    expect(getLoopInterval(100 * second)).toBe(10 * second)
+    // exactly 2 units in: half a unit until the next half mark
+    expect(getLoopInterval(2 * hour)).toBe(hour / 2)
+    expect(getLoopInterval(3 * day)).toBe(day / 2)
+  })
+})
+
+describe('makeInitialTimerState', () => {
+  const now = 1_700_000_000_000
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('a pending send shows nothing yet', () => {
+    expect(makeInitialTimerState({exploded: false, explodesAt: now + hour, pending: true})).toEqual({
+      exploded: false,
+      inter: 0,
+      mode: 'none',
+      now,
+    })
+  })
+
+  test('an already exploded message is hidden', () => {
+    expect(makeInitialTimerState({exploded: true, explodesAt: now + hour, pending: false})).toEqual({
+      exploded: true,
+      inter: 0,
+      mode: 'hidden',
+      now,
+    })
+  })
+
+  test('a message past its explode time is hidden', () => {
+    expect(makeInitialTimerState({exploded: false, explodesAt: now - 1, pending: false})).toEqual({
+      exploded: false,
+      inter: 0,
+      mode: 'hidden',
+      now,
+    })
+  })
+
+  test('a live message counts down on the loop interval', () => {
+    expect(makeInitialTimerState({exploded: false, explodesAt: now + 90 * second, pending: false})).toEqual({
+      exploded: false,
+      inter: minute / 2,
+      mode: 'countdown',
+      now,
+    })
+  })
+
+  test('the countdown interval is capped at a minute for long fuses', () => {
+    const {inter, mode} = makeInitialTimerState({
+      exploded: false,
+      explodesAt: now + 7 * day,
+      pending: false,
+    })
+    expect(mode).toBe('countdown')
+    expect(inter).toBe(minute)
+  })
+})

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.tsx
@@ -26,7 +26,7 @@ function ExplodingMetaContainer(p: OwnProps) {
 
 type ExplodingMetaInnerProps = OwnProps & {pending: boolean}
 type Mode = 'none' | 'countdown' | 'boom' | 'hidden'
-type TimerState = {
+export type TimerState = {
   exploded: boolean
   inter: number
   mode: Mode
@@ -38,7 +38,7 @@ const isPendingSubmitState = (submitState?: T.Chat.Message['submitState']) =>
 
 const cappedLoopInterval = (difference: number) => Math.min(getLoopInterval(difference), 60000)
 
-const makeInitialTimerState = (p: {exploded: boolean; explodesAt: number; pending: boolean}): TimerState => {
+export const makeInitialTimerState = (p: {exploded: boolean; explodesAt: number; pending: boolean}): TimerState => {
   const now = Date.now()
   if (p.pending) {
     return {exploded: p.exploded, inter: 0, mode: 'none', now}
@@ -224,7 +224,7 @@ const oneMinuteInMs = 60 * 1000
 const oneHourInMs = oneMinuteInMs * 60
 const oneDayInMs = oneHourInMs * 24
 
-const getLoopInterval = (diff: number) => {
+export const getLoopInterval = (diff: number) => {
   let nearestUnit: number = 0
 
   // If diff is less than half a unit away,

--- a/shared/chat/conversation/thread-engine.test.tsx
+++ b/shared/chat/conversation/thread-engine.test.tsx
@@ -1,0 +1,465 @@
+/// <reference types="jest" />
+import * as Common from '@/constants/chat/common'
+import * as T from '@/constants/types'
+import {makeMessageText} from '@/constants/chat/message'
+import {resetAllStores} from '@/util/zustand'
+import {useConfigState} from '@/stores/config'
+import {useCurrentUserState} from '@/stores/current-user'
+import {
+  applyEphemeralPurgeToThread,
+  applyExpungeToThread,
+  applyFailedMessageToThread,
+  applyIncomingMessageToThread,
+  applyIncomingMutationToThread,
+  applyMessagesUpdatedToThread,
+  applyReactionUpdateToThread,
+} from './thread-engine'
+import type {ConversationThreadActions, ConversationThreadState} from './thread-context'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const otherConversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([9, 9, 9, 9]))
+const username = 'testuser'
+const devicename = 'testuser-mac'
+
+const ordinal = (n: number) => T.Chat.numberToOrdinal(n)
+const messageID = (n: number) => T.Chat.numberToMessageID(n)
+
+type Actions = {
+  [K in keyof ConversationThreadActions]: jest.Mock
+}
+
+const makeSnapshot = (
+  messages: ReadonlyArray<T.Chat.Message>,
+  over: Partial<ConversationThreadState> = {}
+) =>
+  ({
+    loaded: true,
+    messageIDToOrdinal: new Map(messages.map(m => [m.id, m.ordinal])),
+    messageMap: new Map(messages.map(m => [m.ordinal, m])),
+    messageOrdinals: messages.map(m => m.ordinal),
+    moreToLoadForward: false,
+    pendingOutboxToOrdinal: new Map(),
+    ...over,
+  }) as unknown as ConversationThreadState
+
+const makeActions = (snapshot = makeSnapshot([])) => {
+  const actions = {
+    addMessages: jest.fn(),
+    deleteMessages: jest.fn(),
+    explodeMessages: jest.fn(),
+    getSnapshot: jest.fn(() => snapshot),
+    setMessageErrored: jest.fn(),
+    updateOptimisticReactionDecorated: jest.fn(),
+    updateReactions: jest.fn(),
+  } as unknown as Actions
+  return actions
+}
+
+const asActions = (a: Actions) => a as unknown as ConversationThreadActions
+
+const noReactions: T.RPCChat.UIReactionMap = {reactions: undefined}
+
+const makeValid = (over: Partial<T.RPCChat.UIMessageValid> = {}): T.RPCChat.UIMessageValid => ({
+  botUsername: '',
+  bodySummary: '',
+  channelMention: T.RPCChat.ChannelMention.none,
+  ctime: 1000 as T.RPCGen.Gregor1.Time,
+  etime: 0 as T.RPCGen.Gregor1.Time,
+  explodedBy: '',
+  hasPairwiseMacs: false,
+  isCollapsed: false,
+  isDeleteable: true,
+  isEditable: true,
+  isEphemeral: false,
+  isEphemeralExpired: false,
+  messageBody: {messageType: T.RPCChat.MessageType.text, text: {body: 'hello'}},
+  messageID: messageID(5),
+  reactions: noReactions,
+  senderDeviceID: 'devID' as unknown as T.RPCGen.Gregor1.DeviceID,
+  senderDeviceName: devicename,
+  senderDeviceType: 'desktop',
+  senderUID: 'uid' as unknown as T.RPCGen.Gregor1.UID,
+  senderUsername: username,
+  superseded: false,
+  ...over,
+})
+
+const validUIMessage = (over: Partial<T.RPCChat.UIMessageValid> = {}): T.RPCChat.UIMessage => ({
+  state: T.RPCChat.MessageUnboxedState.valid,
+  valid: makeValid(over),
+})
+
+const setActivelyLooking = (looking: boolean) => {
+  jest.spyOn(Common, 'isUserActivelyLookingAtThisThread').mockReturnValue(looking)
+}
+
+beforeEach(() => {
+  useCurrentUserState.getState().dispatch.setBootstrap({
+    deviceID: 'device-id',
+    deviceName: devicename,
+    uid: 'uid',
+    username,
+  })
+  setActivelyLooking(true)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  resetAllStores()
+})
+
+describe('applyMessagesUpdatedToThread', () => {
+  test('ignores an empty update', () => {
+    const actions = makeActions()
+    applyMessagesUpdatedToThread(conversationIDKey, {convID: new Uint8Array(), updates: undefined}, asActions(actions))
+    expect(actions.addMessages).not.toHaveBeenCalled()
+  })
+
+  test('bails on an unloaded thread the user is not looking at', () => {
+    setActivelyLooking(false)
+    const actions = makeActions(makeSnapshot([], {loaded: false}))
+    applyMessagesUpdatedToThread(
+      conversationIDKey,
+      {convID: new Uint8Array(), updates: [validUIMessage()]},
+      asActions(actions)
+    )
+    expect(actions.addMessages).not.toHaveBeenCalled()
+  })
+
+  test('still applies to an unloaded thread the user is looking at', () => {
+    const actions = makeActions(makeSnapshot([], {loaded: false}))
+    applyMessagesUpdatedToThread(
+      conversationIDKey,
+      {convID: new Uint8Array(), updates: [validUIMessage()]},
+      asActions(actions)
+    )
+    expect(actions.addMessages).toHaveBeenCalledTimes(1)
+  })
+
+  test('converts updates and marks read only when actively looking', () => {
+    const actions = makeActions()
+    applyMessagesUpdatedToThread(
+      conversationIDKey,
+      {convID: new Uint8Array(), updates: [validUIMessage()]},
+      asActions(actions)
+    )
+    const [messages, opts] = actions.addMessages.mock.calls[0] as [Array<T.Chat.Message>, object]
+    expect(messages.map(m => m.id)).toEqual([5])
+    expect(opts).toEqual({liveUpdate: true, markAsRead: true})
+
+    setActivelyLooking(false)
+    actions.addMessages.mockClear()
+    applyMessagesUpdatedToThread(
+      conversationIDKey,
+      {convID: new Uint8Array(), updates: [validUIMessage()]},
+      asActions(actions)
+    )
+    expect(actions.addMessages.mock.calls[0]?.[1]).toEqual({liveUpdate: true, markAsRead: false})
+  })
+
+  test('does not call addMessages when nothing converted', () => {
+    const actions = makeActions()
+    applyMessagesUpdatedToThread(
+      conversationIDKey,
+      {
+        convID: new Uint8Array(),
+        updates: [validUIMessage({messageBody: {messageType: T.RPCChat.MessageType.none}})],
+      },
+      asActions(actions)
+    )
+    expect(actions.addMessages).not.toHaveBeenCalled()
+  })
+})
+
+describe('applyIncomingMutationToThread', () => {
+  test('drops an existing message at the mutation ordinal first', () => {
+    const existing = makeMessageText({conversationIDKey, id: messageID(5), ordinal: ordinal(5)})
+    const actions = makeActions(makeSnapshot([existing]))
+    applyIncomingMutationToThread(
+      conversationIDKey,
+      makeValid({messageBody: {edit: {body: 'new', messageID: messageID(4)}, messageType: T.RPCChat.MessageType.edit}}),
+      undefined,
+      asActions(actions)
+    )
+    expect(actions.deleteMessages).toHaveBeenCalledWith({liveUpdate: true, ordinals: [ordinal(5)]})
+  })
+
+  test('an edit adds the modified message and reports handled', () => {
+    const actions = makeActions()
+    const handled = applyIncomingMutationToThread(
+      conversationIDKey,
+      makeValid({messageBody: {edit: {body: 'new', messageID: messageID(4)}, messageType: T.RPCChat.MessageType.edit}}),
+      validUIMessage({messageBody: {messageType: T.RPCChat.MessageType.text, text: {body: 'edited'}}, messageID: messageID(4)}),
+      asActions(actions)
+    )
+    expect(handled).toBe(true)
+    const [messages] = actions.addMessages.mock.calls[0] as [Array<T.Chat.Message>]
+    expect(messages[0]?.id).toBe(4)
+  })
+
+  test('a delete of a plain message deletes by message id', () => {
+    const target = makeMessageText({conversationIDKey, id: messageID(4), ordinal: ordinal(4)})
+    const actions = makeActions(makeSnapshot([target]))
+    const handled = applyIncomingMutationToThread(
+      conversationIDKey,
+      makeValid({
+        messageBody: {delete: {messageIDs: [4]}, messageType: T.RPCChat.MessageType.delete},
+      } as Partial<T.RPCChat.UIMessageValid>),
+      undefined,
+      asActions(actions)
+    )
+    expect(handled).toBe(true)
+    expect(actions.explodeMessages).not.toHaveBeenCalled()
+    expect(actions.deleteMessages).toHaveBeenCalledWith({liveUpdate: true, messageIDs: [messageID(4)]})
+  })
+
+  test('a delete of an exploding message explodes it instead', () => {
+    const target = makeMessageText({
+      conversationIDKey,
+      exploding: true,
+      id: messageID(4),
+      ordinal: ordinal(4),
+    })
+    const actions = makeActions(makeSnapshot([target]))
+    applyIncomingMutationToThread(
+      conversationIDKey,
+      makeValid({
+        messageBody: {delete: {messageIDs: [4]}, messageType: T.RPCChat.MessageType.delete},
+        senderUsername: 'testuser-two',
+      } as Partial<T.RPCChat.UIMessageValid>),
+      undefined,
+      asActions(actions)
+    )
+    expect(actions.explodeMessages).toHaveBeenCalledWith([messageID(4)], 'testuser-two', true)
+    expect(actions.deleteMessages).not.toHaveBeenCalled()
+  })
+
+  test('other message types are not handled here', () => {
+    const actions = makeActions()
+    expect(applyIncomingMutationToThread(conversationIDKey, makeValid(), undefined, asActions(actions))).toBe(
+      false
+    )
+  })
+})
+
+describe('applyIncomingMessageToThread', () => {
+  const incoming = (message: T.RPCChat.UIMessage, modifiedMessage?: T.RPCChat.UIMessage) =>
+    ({message, modifiedMessage} as T.RPCChat.IncomingMessage)
+
+  test('bails on an unloaded thread the user is not looking at', () => {
+    setActivelyLooking(false)
+    const actions = makeActions(makeSnapshot([], {loaded: false}))
+    applyIncomingMessageToThread(conversationIDKey, incoming(validUIMessage()), asActions(actions))
+    expect(actions.addMessages).not.toHaveBeenCalled()
+  })
+
+  test('an outbox reaction only updates the optimistic decoration', () => {
+    const actions = makeActions()
+    applyIncomingMessageToThread(
+      conversationIDKey,
+      incoming({
+        outbox: {
+          body: ':+1:',
+          decoratedTextBody: ':+1: decorated',
+          messageType: T.RPCChat.MessageType.reaction,
+          outboxID: 'outbox1',
+        } as T.RPCChat.UIMessageOutbox,
+        state: T.RPCChat.MessageUnboxedState.outbox,
+      }),
+      asActions(actions)
+    )
+    expect(actions.updateOptimisticReactionDecorated).toHaveBeenCalledWith(
+      T.Chat.stringToOutboxID('outbox1'),
+      ':+1: decorated'
+    )
+    expect(actions.addMessages).not.toHaveBeenCalled()
+  })
+
+  test('an outbox reaction falls back to the raw body', () => {
+    const actions = makeActions()
+    applyIncomingMessageToThread(
+      conversationIDKey,
+      incoming({
+        outbox: {
+          body: ':+1:',
+          messageType: T.RPCChat.MessageType.reaction,
+          outboxID: 'outbox1',
+        } as T.RPCChat.UIMessageOutbox,
+        state: T.RPCChat.MessageUnboxedState.outbox,
+      }),
+      asActions(actions)
+    )
+    expect(actions.updateOptimisticReactionDecorated).toHaveBeenCalledWith(
+      T.Chat.stringToOutboxID('outbox1'),
+      ':+1:'
+    )
+  })
+
+  test('an incoming edit is routed to the mutation path', () => {
+    const actions = makeActions()
+    applyIncomingMessageToThread(
+      conversationIDKey,
+      incoming(
+        validUIMessage({
+          messageBody: {edit: {body: 'new', messageID: messageID(4)}, messageType: T.RPCChat.MessageType.edit},
+        }),
+        validUIMessage({messageID: messageID(4)})
+      ),
+      asActions(actions)
+    )
+    const [messages] = actions.addMessages.mock.calls[0] as [Array<T.Chat.Message>]
+    expect(messages[0]?.id).toBe(4)
+    expect(actions.addMessages).toHaveBeenCalledTimes(1)
+  })
+
+  test('adds a plain new message', () => {
+    const actions = makeActions()
+    applyIncomingMessageToThread(conversationIDKey, incoming(validUIMessage()), asActions(actions))
+    expect(actions.addMessages).toHaveBeenCalledWith([expect.objectContaining({id: 5})], {
+      liveUpdate: true,
+      markAsRead: true,
+    })
+  })
+
+  test('drops new messages while there is still newer history to load', () => {
+    const actions = makeActions(makeSnapshot([], {moreToLoadForward: true}))
+    applyIncomingMessageToThread(conversationIDKey, incoming(validUIMessage()), asActions(actions))
+    expect(actions.addMessages).not.toHaveBeenCalled()
+  })
+})
+
+describe('applyFailedMessageToThread', () => {
+  const outboxRecord = (
+    over: Partial<T.RPCChat.OutboxRecord> = {}
+  ): T.RPCChat.OutboxRecord =>
+    ({
+      convID: T.Chat.keyToConversationID(conversationIDKey),
+      outboxID: new Uint8Array([1, 2, 3]),
+      state: {
+        error: {message: 'boom', typ: T.RPCChat.OutboxErrorType.misc},
+        state: T.RPCChat.OutboxStateType.error,
+      },
+      ...over,
+    }) as T.RPCChat.OutboxRecord
+
+  const failed = (outboxRecords?: ReadonlyArray<T.RPCChat.OutboxRecord>): T.RPCChat.FailedMessageInfo => ({
+    isEphemeralPurge: false,
+    outboxRecords,
+  })
+
+  test('ignores an empty payload', () => {
+    const actions = makeActions()
+    applyFailedMessageToThread(conversationIDKey, failed(), asActions(actions))
+    expect(actions.setMessageErrored).not.toHaveBeenCalled()
+  })
+
+  test('ignores records for other conversations', () => {
+    const actions = makeActions()
+    applyFailedMessageToThread(
+      conversationIDKey,
+      failed([outboxRecord({convID: T.Chat.keyToConversationID(otherConversationIDKey)})]),
+      asActions(actions)
+    )
+    expect(actions.setMessageErrored).not.toHaveBeenCalled()
+  })
+
+  test('ignores records that are not in an error state', () => {
+    const actions = makeActions()
+    applyFailedMessageToThread(
+      conversationIDKey,
+      failed([outboxRecord({state: {state: T.RPCChat.OutboxStateType.sending} as T.RPCChat.OutboxState})]),
+      asActions(actions)
+    )
+    expect(actions.setMessageErrored).not.toHaveBeenCalled()
+  })
+
+  test('reports the error string and type for this conversation', () => {
+    const actions = makeActions()
+    applyFailedMessageToThread(conversationIDKey, failed([outboxRecord()]), asActions(actions))
+    expect(actions.setMessageErrored).toHaveBeenCalledWith(
+      T.Chat.rpcOutboxIDToOutboxID(new Uint8Array([1, 2, 3])),
+      'boom',
+      T.RPCChat.OutboxErrorType.misc
+    )
+  })
+})
+
+describe('applyReactionUpdateToThread', () => {
+  test('ignores an empty update', () => {
+    const actions = makeActions()
+    applyReactionUpdateToThread({convID: new Uint8Array(), reactionUpdates: []} as never, asActions(actions))
+    expect(actions.updateReactions).not.toHaveBeenCalled()
+  })
+
+  test('maps the reaction map per target message', () => {
+    const actions = makeActions()
+    applyReactionUpdateToThread(
+      {
+        convID: new Uint8Array(),
+        reactionUpdates: [
+          {
+            reactions: {
+              reactions: {':+1:': {decorated: 'd', users: {testuser: {ctime: 3}}}},
+            },
+            targetMsgID: 4,
+          },
+        ],
+      } as never,
+      asActions(actions)
+    )
+    const [updates] = actions.updateReactions.mock.calls[0] as [
+      Array<{reactions?: Map<string, T.Chat.ReactionDesc>; targetMsgID: T.Chat.MessageID}>,
+    ]
+    expect(updates[0]?.targetMsgID).toBe(4)
+    expect(updates[0]?.reactions?.get(':+1:')).toEqual({
+      decorated: 'd',
+      users: [{timestamp: 3, username: 'testuser'}],
+    })
+  })
+})
+
+describe('applyExpungeToThread', () => {
+  test('deletes up to the expunge point with the default deletable types', () => {
+    const actions = makeActions()
+    applyExpungeToThread(
+      {convID: new Uint8Array(), expunge: {basis: 0, upto: 7}} as T.RPCChat.ExpungeInfo,
+      asActions(actions)
+    )
+    expect(actions.deleteMessages).toHaveBeenCalledWith({
+      deletableMessageTypes: Common.allMessageTypes,
+      liveUpdate: true,
+      upToMessageID: messageID(7),
+    })
+  })
+
+  test('uses the server-provided deletable types when config has them', () => {
+    const chatDeletableByDeleteHistory = new Set<T.Chat.MessageType>(['text'])
+    useConfigState.setState({chatDeletableByDeleteHistory})
+    const actions = makeActions()
+    applyExpungeToThread(
+      {convID: new Uint8Array(), expunge: {basis: 0, upto: 7}} as T.RPCChat.ExpungeInfo,
+      asActions(actions)
+    )
+    expect(actions.deleteMessages.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({deletableMessageTypes: chatDeletableByDeleteHistory})
+    )
+  })
+})
+
+describe('applyEphemeralPurgeToThread', () => {
+  test('explodes every purged message that has an id', () => {
+    const actions = makeActions()
+    applyEphemeralPurgeToThread(
+      {
+        convID: new Uint8Array(),
+        msgs: [
+          validUIMessage({messageID: messageID(4)}),
+          {outbox: {} as T.RPCChat.UIMessageOutbox, state: T.RPCChat.MessageUnboxedState.outbox},
+          validUIMessage({messageID: messageID(6)}),
+        ],
+      } as T.RPCChat.EphemeralPurgeNotifInfo,
+      asActions(actions)
+    )
+    expect(actions.explodeMessages).toHaveBeenCalledWith([messageID(4), messageID(6)], undefined, true)
+  })
+})

--- a/shared/chat/conversation/thread-load.test.tsx
+++ b/shared/chat/conversation/thread-load.test.tsx
@@ -1,0 +1,157 @@
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {makeMessageText} from '@/constants/chat/message'
+import {
+  getClientPrevFromSnapshot,
+  getExplodingModeFromGregorItems,
+  getLastOrdinalFromSnapshot,
+  getOrdinalForMessageIDInSnapshot,
+  scrollDirectionToPagination,
+} from './thread-load'
+import type {ConversationThreadState} from './thread-context'
+
+const conversationIDKey = T.Chat.stringToConversationIDKey('conv1')
+const otherConversationIDKey = T.Chat.stringToConversationIDKey('conv2')
+
+const gregorItem = (category: string, body: string) => ({
+  item: {
+    body: new TextEncoder().encode(body),
+    category,
+  } as T.RPCGen.Gregor1.Item,
+})
+
+describe('getExplodingModeFromGregorItems', () => {
+  test('no exploding items at all means no exploding mode', () => {
+    expect(getExplodingModeFromGregorItems(conversationIDKey, [])).toBe(0)
+    expect(getExplodingModeFromGregorItems(conversationIDKey, [gregorItem('other:thing', '60')])).toBe(0)
+  })
+
+  test('reads the seconds for this conversation', () => {
+    const items = [
+      gregorItem(`exploding:${otherConversationIDKey}`, '3600'),
+      gregorItem(`exploding:${conversationIDKey}`, '300'),
+    ]
+    expect(getExplodingModeFromGregorItems(conversationIDKey, items)).toBe(300)
+  })
+
+  test('a dismissed category with other conversations present means off', () => {
+    const items = [gregorItem(`exploding:${otherConversationIDKey}`, '3600')]
+    expect(getExplodingModeFromGregorItems(conversationIDKey, items)).toBe(0)
+  })
+
+  test('unparseable seconds yield undefined so callers can fall back', () => {
+    const items = [gregorItem(`exploding:${conversationIDKey}`, 'garbage')]
+    expect(getExplodingModeFromGregorItems(conversationIDKey, items)).toBeUndefined()
+  })
+})
+
+describe('scrollDirectionToPagination', () => {
+  test('none sends no cursor', () => {
+    expect(scrollDirectionToPagination('none', 20)).toEqual({last: false, next: '', num: 20, previous: ''})
+  })
+
+  test('back pages older, forward pages newer', () => {
+    expect(scrollDirectionToPagination('back', 100)).toEqual({
+      last: false,
+      next: 'deadbeef',
+      num: 100,
+      previous: '',
+    })
+    expect(scrollDirectionToPagination('forward', 100)).toEqual({
+      last: false,
+      next: '',
+      num: 100,
+      previous: 'deadbeef',
+    })
+  })
+})
+
+describe('snapshot helpers', () => {
+  const ordinal = (n: number) => T.Chat.numberToOrdinal(n)
+  const messageID = (n: number) => T.Chat.numberToMessageID(n)
+
+  const makeSnapshot = (
+    messages: ReadonlyArray<{id: number; ordinal: number}>,
+    extra: Partial<ConversationThreadState> = {}
+  ) =>
+    ({
+      messageIDToOrdinal: new Map(messages.map(m => [messageID(m.id), ordinal(m.ordinal)])),
+      messageMap: new Map(
+        messages.map(m => [
+          ordinal(m.ordinal),
+          makeMessageText({
+            conversationIDKey,
+            id: messageID(m.id),
+            ordinal: ordinal(m.ordinal),
+          }),
+        ])
+      ),
+      messageOrdinals: messages.map(m => ordinal(m.ordinal)),
+      pendingOutboxToOrdinal: new Map(),
+      ...extra,
+    }) as unknown as ConversationThreadState
+
+  test('getClientPrevFromSnapshot returns 0 for an empty thread', () => {
+    expect(getClientPrevFromSnapshot(makeSnapshot([]))).toBe(0)
+  })
+
+  test('getClientPrevFromSnapshot skips trailing pending messages with no id', () => {
+    const snapshot = makeSnapshot([
+      {id: 1, ordinal: 1},
+      {id: 2, ordinal: 2},
+    ])
+    // a pending (outbox) message has id 0 and a fractional ordinal
+    const pendingOrdinal = ordinal(2.001)
+    snapshot.messageMap.set(
+      pendingOrdinal,
+      makeMessageText({conversationIDKey, id: messageID(0), ordinal: pendingOrdinal})
+    )
+    const withPending = {
+      ...snapshot,
+      messageOrdinals: [...(snapshot.messageOrdinals ?? []), pendingOrdinal],
+    } as ConversationThreadState
+
+    expect(getClientPrevFromSnapshot(withPending)).toBe(2)
+  })
+
+  test('getLastOrdinalFromSnapshot returns the last ordinal or 0', () => {
+    expect(getLastOrdinalFromSnapshot(makeSnapshot([]))).toBe(0)
+    expect(
+      getLastOrdinalFromSnapshot(
+        makeSnapshot([
+          {id: 1, ordinal: 1},
+          {id: 4, ordinal: 4},
+        ])
+      )
+    ).toBe(4)
+  })
+
+  test('getOrdinalForMessageIDInSnapshot finds messages by id', () => {
+    const snapshot = makeSnapshot([
+      {id: 1, ordinal: 1},
+      {id: 4, ordinal: 4},
+    ])
+    expect(getOrdinalForMessageIDInSnapshot(snapshot, messageID(4))).toBe(4)
+    expect(getOrdinalForMessageIDInSnapshot(snapshot, messageID(99))).toBeNull()
+  })
+
+  test('getOrdinalForMessageIDInSnapshot finds sent outbox messages at fractional ordinals', () => {
+    const outboxID = T.Chat.stringToOutboxID('outbox1')
+    const pendingOrdinal = ordinal(4.001)
+    const snapshot = makeSnapshot([{id: 1, ordinal: 1}])
+    snapshot.messageMap.set(
+      pendingOrdinal,
+      makeMessageText({conversationIDKey, id: messageID(5), ordinal: pendingOrdinal, outboxID})
+    )
+    snapshot.pendingOutboxToOrdinal.set(outboxID, pendingOrdinal)
+
+    expect(getOrdinalForMessageIDInSnapshot(snapshot, messageID(5))).toBe(pendingOrdinal)
+  })
+
+  test('getOrdinalForMessageIDInSnapshot ignores a stale index entry', () => {
+    const snapshot = makeSnapshot([{id: 1, ordinal: 1}])
+    // index claims 7 lives at ordinal 1, but ordinal 1 holds message 1
+    snapshot.messageIDToOrdinal.set(messageID(7), ordinal(1))
+    expect(getOrdinalForMessageIDInSnapshot(snapshot, messageID(7))).toBeNull()
+  })
+})

--- a/shared/chat/inbox/rows-state.test.ts
+++ b/shared/chat/inbox/rows-state.test.ts
@@ -9,7 +9,7 @@ import {metasReceived, participantInfoReceived} from './metadata'
 import {syncInboxBadgeState} from './badge-state'
 import {updateInboxTyping} from './typing-state'
 import {useInboxLayoutState} from './layout-state'
-import {useInboxRowBig, useInboxRowSmall} from './rows-state'
+import {useInboxRowBig, useInboxRowIsMuted, useInboxRowSmall} from './rows-state'
 
 const convID = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
 
@@ -174,4 +174,81 @@ test('layout fills gaps until a trusted meta wins; participant store overrides n
     participantInfoReceived(convID, {all: ['alice', 'dave'], contactName: new Map(), name: ['alice', 'dave']})
   })
   expect(small.current.participants).toEqual(['dave'])
+})
+
+test('useInboxRowIsMuted follows the same layout/meta precedence as the full row', () => {
+  const {result} = renderHook(() => useInboxRowIsMuted(convID))
+  // nothing loaded yet
+  expect(result.current).toBe(false)
+
+  // untrusted: the layout row decides
+  act(() => {
+    setLayout({
+      smallTeams: [
+        {
+          convID: T.Chat.conversationIDKeyToString(convID),
+          draft: '',
+          isMuted: true,
+          isTeam: false,
+          lastSendTime: 0,
+          name: 'alice,bob',
+          snippet: '',
+          snippetDecoration: T.RPCChat.SnippetDecoration.none,
+          time: 0,
+        },
+      ],
+      totalSmallTeams: 1,
+    })
+  })
+  expect(result.current).toBe(true)
+
+  // a trusted meta wins over the layout row
+  act(() => {
+    metasReceived([
+      {
+        ...Meta.makeConversationMeta(),
+        conversationIDKey: convID,
+        isMuted: false,
+        trustedState: 'trusted',
+      },
+    ])
+  })
+  expect(result.current).toBe(false)
+})
+
+test('big rows drop non-pending snippet decorations and flag the error state', () => {
+  const {result} = renderHook(() => useInboxRowBig(convID))
+
+  act(() => {
+    metasReceived([
+      {
+        ...Meta.makeConversationMeta(),
+        conversationIDKey: convID,
+        snippetDecorated: 'snip',
+        snippetDecoration: T.RPCChat.SnippetDecoration.explodingMessage,
+        trustedState: 'trusted',
+      },
+    ])
+  })
+  expect(result.current.snippetDecoration).toBe(0)
+  expect(result.current.isError).toBe(false)
+
+  act(() => {
+    metasReceived(
+      [
+        {
+          ...Meta.makeConversationMeta(),
+          channelname: 'general',
+          conversationIDKey: convID,
+          snippetDecoration: T.RPCChat.SnippetDecoration.failedPendingMessage,
+          trustedState: 'error',
+        },
+      ],
+      undefined,
+      {force: true}
+    )
+  })
+  expect(result.current.snippetDecoration).toBe(T.RPCChat.SnippetDecoration.failedPendingMessage)
+  expect(result.current.isError).toBe(true)
+  expect(result.current.channelname).toBe('general')
 })

--- a/shared/constants/chat/common.test.tsx
+++ b/shared/constants/chat/common.test.tsx
@@ -1,0 +1,119 @@
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import * as Router from '@/constants/router'
+import {resetAllStores} from '@/util/zustand'
+import {useShellState} from '@/stores/shell'
+import {
+  generateOutboxID,
+  getSelectedConversation,
+  isUserActivelyLookingAtThisThread,
+  threadRouteName,
+  uiParticipantsToParticipantInfo,
+} from './common'
+
+const convID = T.Chat.stringToConversationIDKey('conv1')
+const otherConvID = T.Chat.stringToConversationIDKey('conv2')
+
+// the thread route holds the selected conversation in its params
+const mockVisibleScreen = (screen?: {name: string; params?: object}) => {
+  jest.spyOn(Router, 'getVisibleScreen').mockReturnValue(screen as never)
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  resetAllStores()
+})
+
+describe('getSelectedConversation', () => {
+  test('is none when no screen is visible', () => {
+    mockVisibleScreen(undefined)
+    expect(getSelectedConversation()).toBe(T.Chat.noConversationIDKey)
+  })
+
+  test('is none when the visible screen is not the thread', () => {
+    mockVisibleScreen({name: 'someOtherRoute', params: {conversationIDKey: convID}})
+    expect(getSelectedConversation()).toBe(T.Chat.noConversationIDKey)
+  })
+
+  test('is none when the thread route carries no conversation', () => {
+    mockVisibleScreen({name: threadRouteName})
+    expect(getSelectedConversation()).toBe(T.Chat.noConversationIDKey)
+  })
+
+  test('reads the conversation out of the thread route params', () => {
+    mockVisibleScreen({name: threadRouteName, params: {conversationIDKey: convID}})
+    expect(getSelectedConversation()).toBe(convID)
+  })
+})
+
+describe('isUserActivelyLookingAtThisThread', () => {
+  beforeEach(() => {
+    mockVisibleScreen({name: threadRouteName, params: {conversationIDKey: convID}})
+    useShellState.setState({active: true, appFocused: true})
+  })
+
+  test('true for the selected conversation with a focused, active app', () => {
+    expect(isUserActivelyLookingAtThisThread(convID)).toBe(true)
+  })
+
+  test('false for another conversation', () => {
+    expect(isUserActivelyLookingAtThisThread(otherConvID)).toBe(false)
+  })
+
+  test('false when the app is not focused', () => {
+    useShellState.setState({appFocused: false})
+    expect(isUserActivelyLookingAtThisThread(convID)).toBe(false)
+  })
+
+  test('false when the user is idle', () => {
+    useShellState.setState({active: false})
+    expect(isUserActivelyLookingAtThisThread(convID)).toBe(false)
+  })
+
+  test('false when the thread route is not visible', () => {
+    mockVisibleScreen({name: 'someOtherRoute'})
+    expect(isUserActivelyLookingAtThisThread(convID)).toBe(false)
+  })
+})
+
+describe('uiParticipantsToParticipantInfo', () => {
+  test('empty in, empty out', () => {
+    expect(uiParticipantsToParticipantInfo([])).toEqual({all: [], contactName: new Map(), name: []})
+  })
+
+  test('only inConvName participants land in name, contact names are indexed', () => {
+    const participant = (
+      assertion: string,
+      inConvName: boolean,
+      contactName?: string
+    ): T.RPCChat.UIParticipant => ({
+      assertion,
+      contactName,
+      inConvName,
+      type: T.RPCChat.UIParticipantType.user,
+    })
+    const participants = [
+      participant('testuser', true),
+      participant('testuser-two', false),
+      participant('1-555-0100@phone', true, 'Some Contact'),
+    ]
+
+    expect(uiParticipantsToParticipantInfo(participants)).toEqual({
+      all: ['testuser', 'testuser-two', '1-555-0100@phone'],
+      contactName: new Map([['1-555-0100@phone', 'Some Contact']]),
+      name: ['testuser', '1-555-0100@phone'],
+    })
+  })
+})
+
+describe('generateOutboxID', () => {
+  test('is 8 random bytes', () => {
+    const id = generateOutboxID()
+    expect(id).toHaveLength(8)
+    expect(id.every(b => b >= 0 && b <= 255)).toBe(true)
+    // two ids in a row should not collide
+    expect(T.Chat.rpcOutboxIDToOutboxID(generateOutboxID())).not.toBe(
+      T.Chat.rpcOutboxIDToOutboxID(generateOutboxID())
+    )
+  })
+})

--- a/shared/constants/chat/helpers.test.tsx
+++ b/shared/constants/chat/helpers.test.tsx
@@ -1,7 +1,16 @@
 /// <reference types="jest" />
-import {getBotsAndParticipants} from './helpers'
+import * as T from '@/constants/types'
+import {makeMessageText} from './message'
+import {
+  clampImageSize,
+  getBotsAndParticipants,
+  getMessageKey,
+  getTeamMentionName,
+  isAssertion,
+  isBigTeam,
+  zoomImage,
+} from './helpers'
 import {makeConversationMeta} from './meta'
-import type * as T from '@/constants/types'
 
 // Team convs get an empty `name`: the service only sets inConvName for users named in
 // the conv's TLF name, and a team channel's TLF name is the team.
@@ -57,5 +66,79 @@ test('getBotsAndParticipants keeps using role data after team members load', () 
   expect(getBotsAndParticipants(teamMeta, participantInfo, members)).toEqual({
     bots: ['helperbot'],
     participants: ['alice', 'bob'],
+  })
+})
+
+test('getMessageKey is conversation + ordinal', () => {
+  const message = makeMessageText({
+    conversationIDKey: T.Chat.stringToConversationIDKey('conv1'),
+    ordinal: T.Chat.numberToOrdinal(4.001),
+  })
+  expect(getMessageKey(message)).toBe('conv1:4.001')
+})
+
+test('getTeamMentionName only appends a channel when there is one', () => {
+  expect(getTeamMentionName('acme', '')).toBe('acme')
+  expect(getTeamMentionName('acme', 'general')).toBe('acme#general')
+})
+
+test('isAssertion looks for a service separator', () => {
+  expect(isAssertion('testuser')).toBe(false)
+  expect(isAssertion('testuser@twitter')).toBe(true)
+})
+
+describe('clampImageSize', () => {
+  test('leaves images that already fit alone', () => {
+    expect(clampImageSize(100, 50, 200, 200)).toEqual({height: 50, width: 100})
+  })
+
+  test('clamps by width and keeps the aspect ratio', () => {
+    expect(clampImageSize(400, 200, 200, 400)).toEqual({height: 100, width: 200})
+  })
+
+  test('clamps by height and keeps the aspect ratio', () => {
+    expect(clampImageSize(200, 400, 400, 200)).toEqual({height: 200, width: 100})
+  })
+
+  test('clamps both dimensions, height wins last', () => {
+    expect(clampImageSize(400, 800, 200, 200)).toEqual({height: 200, width: 100})
+  })
+})
+
+describe('zoomImage', () => {
+  test('falls back to a square when there are no dimensions', () => {
+    expect(zoomImage(0, 100, 80)).toEqual({
+      dims: {height: 80, width: 80},
+      margins: {marginBottom: 0, marginLeft: 0, marginRight: 0, marginTop: 0},
+    })
+  })
+
+  test('tall images fill the width and bleed vertically', () => {
+    const {dims, margins} = zoomImage(50, 100, 80)
+    expect(dims).toEqual({height: 160, width: 80})
+    expect(margins).toEqual({marginBottom: -40, marginLeft: -0, marginRight: -0, marginTop: -40})
+  })
+
+  test('wide images fill the height and bleed horizontally', () => {
+    const {dims, margins} = zoomImage(100, 50, 80)
+    expect(dims).toEqual({height: 80, width: 160})
+    expect(margins).toEqual({marginBottom: -0, marginLeft: -40, marginRight: -40, marginTop: -0})
+  })
+})
+
+describe('isBigTeam', () => {
+  const label = (id: string): T.RPCChat.UIInboxBigTeamRow => ({
+    label: {id: id, name: id},
+    state: T.RPCChat.UIInboxBigTeamRowTyp.label,
+  })
+
+  test('false without a layout', () => {
+    expect(isBigTeam(undefined, 'teamID')).toBe(false)
+  })
+
+  test('true only when the team has a label row', () => {
+    const layout = {bigTeams: [label('teamID')], smallTeams: [], totalSmallTeams: 0}
+    expect(isBigTeam(layout, 'teamID')).toBe(true)
+    expect(isBigTeam(layout, 'otherTeamID')).toBe(false)
   })
 })

--- a/shared/constants/chat/message.test.tsx
+++ b/shared/constants/chat/message.test.tsx
@@ -1,0 +1,615 @@
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {
+  getMapUnfurl,
+  getMessageID,
+  getMessageRenderType,
+  getPaymentMessageInfo,
+  getReactionOrder,
+  isImageViewable,
+  isMessageWithReactions,
+  isPathHEIC,
+  makeMessageAttachment,
+  makeMessageDeleted,
+  makeMessagePlaceholder,
+  makeMessageSendPayment,
+  makeMessageText,
+  parseUIMessagesJSON,
+  reactionMapToReactions,
+  rpcErrorToString,
+  serviceMessageTypeToMessageTypes,
+  systemGitBranchName,
+  uiMessageToMessage,
+  uiPaymentInfoToChatPaymentInfo,
+  uiRequestInfoToChatRequestInfo,
+} from './message'
+
+const conversationIDKey = T.Chat.stringToConversationIDKey('conv1')
+const getLastOrdinal = () => T.Chat.numberToOrdinal(0)
+const username = 'testuser'
+const devicename = 'testuser-mac'
+
+const noReactions: T.RPCChat.UIReactionMap = {reactions: undefined}
+
+const makeTextBody = (body: string): T.RPCChat.MessageBody => ({
+  messageType: T.RPCChat.MessageType.text,
+  text: {body},
+})
+
+const makeValid = (overrides: Partial<T.RPCChat.UIMessageValid> = {}): T.RPCChat.UIMessageValid => ({
+  botUsername: '',
+  bodySummary: 'summary',
+  channelMention: T.RPCChat.ChannelMention.none,
+  ctime: 1000,
+  etime: 0,
+  explodedBy: '',
+  hasPairwiseMacs: false,
+  isCollapsed: false,
+  isDeleteable: true,
+  isEditable: true,
+  isEphemeral: false,
+  isEphemeralExpired: false,
+  messageBody: makeTextBody('hello'),
+  messageID: 5,
+  reactions: noReactions,
+  senderDeviceID: 'devID' as unknown as T.RPCGen.Gregor1.DeviceID,
+  senderDeviceName: devicename,
+  senderDeviceType: 'desktop',
+  senderUID: 'uid' as unknown as T.RPCGen.Gregor1.UID,
+  senderUsername: username,
+  superseded: false,
+  ...overrides,
+})
+
+const validMessage = (overrides: Partial<T.RPCChat.UIMessageValid> = {}): T.RPCChat.UIMessage => ({
+  state: T.RPCChat.MessageUnboxedState.valid,
+  valid: makeValid(overrides),
+})
+
+describe('image/render type helpers', () => {
+  test('isPathHEIC is case insensitive', () => {
+    expect(isPathHEIC('/tmp/a.HEIC')).toBe(true)
+    expect(isPathHEIC('/tmp/a.heic')).toBe(true)
+    expect(isPathHEIC('/tmp/a.png')).toBe(false)
+  })
+
+  test('isImageViewable only for image attachments (heic is ios only)', () => {
+    expect(isImageViewable(makeMessageAttachment({attachmentType: 'image'}))).toBe(true)
+    // desktop test env: isIOS is false so heic files are not viewable
+    expect(isImageViewable(makeMessageAttachment({attachmentType: 'file', fileName: 'a.heic'}))).toBe(false)
+    expect(isImageViewable(makeMessageText())).toBe(false)
+  })
+
+  test('getMessageRenderType maps attachments by kind', () => {
+    expect(getMessageRenderType(makeMessageText())).toBe('text')
+    expect(getMessageRenderType(makeMessageAttachment({attachmentType: 'image'}))).toBe('attachment:image')
+    expect(getMessageRenderType(makeMessageAttachment({attachmentType: 'file'}))).toBe('attachment:file')
+    expect(
+      getMessageRenderType(makeMessageAttachment({attachmentType: 'file', inlineVideoPlayable: true}))
+    ).toBe('attachment:video')
+    // audio never becomes video even when marked inline playable
+    expect(
+      getMessageRenderType(makeMessageAttachment({attachmentType: 'audio', inlineVideoPlayable: true}))
+    ).toBe('attachment:audio')
+  })
+})
+
+describe('reactions', () => {
+  test('isMessageWithReactions excludes non-reactable, exploded and errored messages', () => {
+    expect(isMessageWithReactions(makeMessageText())).toBe(true)
+    expect(isMessageWithReactions(makeMessagePlaceholder())).toBe(false)
+    expect(isMessageWithReactions(makeMessageDeleted())).toBe(false)
+    expect(isMessageWithReactions(makeMessageText({exploded: true}))).toBe(false)
+    expect(isMessageWithReactions(makeMessageText({errorReason: 'nope'}))).toBe(false)
+  })
+
+  test('getReactionOrder sorts by earliest reaction timestamp', () => {
+    const reactions = new Map<string, T.Chat.ReactionDesc>([
+      [':wave:', {decorated: '', users: [{timestamp: 30, username: 'a'}]}],
+      [':+1:', {decorated: '', users: [{timestamp: 50, username: 'b'}, {timestamp: 10, username: 'c'}]}],
+      [':tada:', {decorated: '', users: [{timestamp: 20, username: 'd'}]}],
+    ])
+    expect(getReactionOrder(reactions)).toEqual([':+1:', ':tada:', ':wave:'])
+  })
+
+  test('reactionMapToReactions returns undefined when empty', () => {
+    expect(reactionMapToReactions({reactions: undefined})).toBeUndefined()
+    expect(reactionMapToReactions({reactions: {}})).toBeUndefined()
+  })
+
+  test('reactionMapToReactions maps users and ctimes', () => {
+    const res = reactionMapToReactions({
+      reactions: {
+        ':+1:': {
+          decorated: 'decorated',
+          users: {
+            testuser: {ctime: 7} as T.RPCChat.Reaction,
+          },
+        },
+      },
+    })
+    expect(res?.get(':+1:')).toEqual({decorated: 'decorated', users: [{timestamp: 7, username: 'testuser'}]})
+  })
+})
+
+describe('getMessageID', () => {
+  test('reads the id out of every state that has one', () => {
+    expect(getMessageID(validMessage({messageID: 9}))).toBe(9)
+    expect(
+      getMessageID({
+        error: {messageID: 11} as T.RPCChat.MessageUnboxedError,
+        state: T.RPCChat.MessageUnboxedState.error,
+      })
+    ).toBe(11)
+    expect(
+      getMessageID({
+        placeholder: {hidden: false, messageID: 12},
+        state: T.RPCChat.MessageUnboxedState.placeholder,
+      })
+    ).toBe(12)
+    expect(
+      getMessageID({
+        outbox: {} as T.RPCChat.UIMessageOutbox,
+        state: T.RPCChat.MessageUnboxedState.outbox,
+      })
+    ).toBeNull()
+  })
+})
+
+describe('serviceMessageTypeToMessageTypes', () => {
+  test('maps service types to our types', () => {
+    expect(serviceMessageTypeToMessageTypes(T.RPCChat.MessageType.text)).toEqual(['text'])
+    expect(serviceMessageTypeToMessageTypes(T.RPCChat.MessageType.attachment)).toEqual(['attachment'])
+    expect(serviceMessageTypeToMessageTypes(T.RPCChat.MessageType.attachmentuploaded)).toEqual(['attachment'])
+    expect(serviceMessageTypeToMessageTypes(T.RPCChat.MessageType.metadata)).toEqual(['setDescription'])
+    expect(serviceMessageTypeToMessageTypes(T.RPCChat.MessageType.headline)).toEqual(['setChannelname'])
+    expect(serviceMessageTypeToMessageTypes(T.RPCChat.MessageType.join)).toEqual(['systemJoined'])
+  })
+})
+
+describe('payments', () => {
+  const paymentInfo = (
+    overrides: Partial<T.RPCChat.UIPaymentInfo> = {}
+  ): T.RPCChat.UIPaymentInfo => ({
+    accountID: 'acctID',
+    amountDescription: '1 XLM',
+    delta: T.RPCStellar.BalanceDelta.increase,
+    fromUsername: 'testuser',
+    issuerDescription: '',
+    note: 'a note',
+    paymentID: 'payID',
+    showCancel: false,
+    sourceAmount: '',
+    sourceAsset: {code: '', issuer: '', issuerName: '', type: 'native', verifiedDomain: ''} as T.RPCStellar.Asset,
+    status: T.RPCStellar.PaymentStatus.completed,
+    statusDescription: 'completed',
+    statusDetail: '',
+    toUsername: 'testuser-two',
+    worth: '$1',
+    worthAtSendTime: '$1',
+    ...overrides,
+  })
+
+  test('uiPaymentInfoToChatPaymentInfo requires exactly one payment', () => {
+    expect(uiPaymentInfoToChatPaymentInfo(undefined)).toBeUndefined()
+    expect(uiPaymentInfoToChatPaymentInfo([])).toBeUndefined()
+    expect(uiPaymentInfoToChatPaymentInfo([paymentInfo(), paymentInfo()])).toBeUndefined()
+  })
+
+  test('uiPaymentInfoToChatPaymentInfo stringifies status and delta', () => {
+    const res = uiPaymentInfoToChatPaymentInfo([paymentInfo()])
+    expect(res?.status).toBe('completed')
+    expect(res?.delta).toBe('increase')
+    expect(res?.accountID).toBe('acctID')
+    expect(res?.note.stringValue()).toBe('a note')
+    expect(res?.type).toBe('paymentInfo')
+  })
+
+  test('getPaymentMessageInfo prefers the accounts map, falls back to the message', () => {
+    const message = makeMessageSendPayment({
+      id: T.Chat.numberToMessageID(3),
+      paymentInfo: undefined,
+    })
+    expect(getPaymentMessageInfo(new Map(), message)).toBeUndefined()
+
+    const info = uiPaymentInfoToChatPaymentInfo([paymentInfo()])!
+    expect(getPaymentMessageInfo(new Map([[T.Chat.numberToMessageID(3), info]]), message)).toBe(info)
+  })
+
+  test('getPaymentMessageInfo throws when the map holds a request info', () => {
+    const message = makeMessageSendPayment({id: T.Chat.numberToMessageID(3)})
+    const requestInfo = uiRequestInfoToChatRequestInfo({
+      amount: '1',
+      amountDescription: '1 XLM',
+      currency: 'USD',
+      status: T.RPCStellar.RequestStatus.ok,
+      worthAtRequestTime: '$1',
+    })!
+    expect(() =>
+      getPaymentMessageInfo(new Map([[T.Chat.numberToMessageID(3), requestInfo]]), message)
+    ).toThrow()
+  })
+})
+
+describe('uiRequestInfoToChatRequestInfo', () => {
+  const base = {
+    amount: '1',
+    amountDescription: '1 XLM',
+    status: T.RPCStellar.RequestStatus.ok,
+    worthAtRequestTime: '$1',
+  }
+
+  test('undefined in, undefined out', () => {
+    expect(uiRequestInfoToChatRequestInfo(undefined)).toBeUndefined()
+  })
+
+  test('requires an asset or a currency', () => {
+    expect(uiRequestInfoToChatRequestInfo({...base})).toBeUndefined()
+  })
+
+  test('currency requests become currency assets', () => {
+    const res = uiRequestInfoToChatRequestInfo({
+      ...base,
+      currency: 'USD',
+    })
+    expect(res?.asset).toBe('currency')
+    expect(res?.currencyCode).toBe('USD')
+    expect(res?.canceled).toBe(false)
+    expect(res?.done).toBe(false)
+  })
+
+  test('native assets stay native and status flags are derived', () => {
+    const canceled = uiRequestInfoToChatRequestInfo({
+      ...base,
+      asset: {code: '', issuer: '', type: 'native'} as T.RPCStellar.Asset,
+      status: T.RPCStellar.RequestStatus.canceled,
+    })
+    expect(canceled?.asset).toBe('native')
+    expect(canceled?.canceled).toBe(true)
+
+    const done = uiRequestInfoToChatRequestInfo({
+      ...base,
+      asset: {code: '', issuer: '', type: 'native'} as T.RPCStellar.Asset,
+      status: T.RPCStellar.RequestStatus.done,
+    })
+    expect(done?.done).toBe(true)
+  })
+
+  test('non-native assets become asset descriptions', () => {
+    const res = uiRequestInfoToChatRequestInfo({
+      ...base,
+      asset: {
+        code: 'KEYZ',
+        issuer: 'issuerAccountID',
+        issuerName: 'Keyz Inc',
+        type: 'credit_alphanum4',
+        verifiedDomain: 'keyz.example',
+      } as T.RPCStellar.Asset,
+    })
+    expect(res?.asset).toEqual(
+      expect.objectContaining({
+        code: 'KEYZ',
+        issuerAccountID: 'issuerAccountID',
+        issuerName: 'Keyz Inc',
+        issuerVerifiedDomain: 'keyz.example',
+      })
+    )
+  })
+})
+
+describe('rpcErrorToString', () => {
+  const err = (typ: T.RPCChat.OutboxErrorType, message = '') =>
+    ({message, typ}) as T.RPCChat.OutboxStateError
+
+  test('known types get friendly strings', () => {
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.offline))).toBe('disconnected from chat server')
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.identify))).toBe('proofs failed for recipient user')
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.toolong))).toBe('message is too long')
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.duplicate))).toBe('message already sent')
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.expired))).toBe('took too long to send')
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.restrictedbot))).toBe(
+      'bot is restricted from sending to this conversation'
+    )
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.minwriter))).toBe(
+      'not high enough team role to post in this conversation'
+    )
+  })
+
+  test('misc uses the message and falls back', () => {
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.misc, 'boom'))).toBe('boom')
+    expect(rpcErrorToString(err(T.RPCChat.OutboxErrorType.misc))).toBe('unknown error')
+  })
+
+  test('unknown types include the code', () => {
+    expect(rpcErrorToString(err(999 as T.RPCChat.OutboxErrorType, 'weird'))).toBe('weird (code: 999)')
+  })
+})
+
+describe('systemGitBranchName', () => {
+  test('strips the refs/heads prefix only', () => {
+    expect(systemGitBranchName({refName: 'refs/heads/main'} as T.RPCGen.GitRefMetadata)).toBe('main')
+    expect(systemGitBranchName({refName: 'refs/tags/v1'} as T.RPCGen.GitRefMetadata)).toBe('refs/tags/v1')
+  })
+})
+
+describe('getMapUnfurl', () => {
+  const mapInfo = {
+    coord: {accuracy: 0, lat: 1, lon: 2},
+    isLiveLocationDone: false,
+    time: 0,
+  } as T.RPCChat.UnfurlGenericMapInfo
+
+  const unfurl = (generic: Partial<T.RPCChat.UnfurlGenericDisplay>): T.RPCChat.UIMessageUnfurlInfo =>
+    ({
+      unfurl: {
+        generic: {siteName: 'maps', title: '', url: 'u', ...generic},
+        unfurlType: T.RPCChat.UnfurlType.generic,
+      },
+      url: 'u',
+    }) as T.RPCChat.UIMessageUnfurlInfo
+
+  test('undefined when there are no unfurls', () => {
+    expect(getMapUnfurl(makeMessageText())).toBeUndefined()
+    expect(getMapUnfurl(makeMessageAttachment())).toBeUndefined()
+  })
+
+  test('undefined when the unfurl has no map info', () => {
+    const message = makeMessageText({unfurls: new Map([['u', unfurl({})]])})
+    expect(getMapUnfurl(message)).toBeUndefined()
+  })
+
+  test('returns the generic display for map unfurls', () => {
+    const message = makeMessageText({unfurls: new Map([['u', unfurl({mapInfo})]])})
+    expect(getMapUnfurl(message)?.mapInfo).toBe(mapInfo)
+  })
+})
+
+describe('uiMessageToMessage', () => {
+  const convert = (m: T.RPCChat.UIMessage) =>
+    uiMessageToMessage(conversationIDKey, m, username, getLastOrdinal, devicename)
+
+  test('valid text messages carry text, author and ordinal from the message id', () => {
+    const message = convert(validMessage({decoratedTextBody: 'hello *world*'}))
+    expect(message?.type).toBe('text')
+    if (message?.type !== 'text') throw new Error('expected text')
+    expect(message.text.stringValue()).toBe('hello')
+    expect(message.decoratedText?.stringValue()).toBe('hello *world*')
+    expect(message.author).toBe(username)
+    expect(message.id).toBe(5)
+    expect(message.ordinal).toBe(5)
+    expect(message.timestamp).toBe(1000)
+    expect(message.conversationIDKey).toBe(conversationIDKey)
+  })
+
+  test('flip messages become text', () => {
+    const message = convert(
+      validMessage({
+        messageBody: {
+          flip: {
+            flipConvID: new Uint8Array(),
+            gameID: 'g' as unknown as T.RPCChat.FlipGameID,
+            text: '/flip',
+          },
+          messageType: T.RPCChat.MessageType.flip,
+        } as T.RPCChat.MessageBody,
+      })
+    )
+    if (message?.type !== 'text') throw new Error('expected text')
+    expect(message.text.stringValue()).toBe('/flip')
+  })
+
+  test('replyTo is converted recursively', () => {
+    const message = convert(
+      validMessage({
+        messageBody: makeTextBody('the reply'),
+        messageID: 6,
+        replyTo: validMessage({messageBody: makeTextBody('the original')}),
+      })
+    )
+    if (message?.type !== 'text') throw new Error('expected text')
+    expect(message.replyTo?.id).toBe(5)
+    if (message.replyTo?.type !== 'text') throw new Error('expected text reply')
+    expect(message.replyTo.text?.stringValue()).toBe('the original')
+  })
+
+  test('expired ephemerals become empty text', () => {
+    const message = convert(
+      validMessage({
+        explodedBy: 'testuser-two',
+        isEphemeral: true,
+        isEphemeralExpired: true,
+      })
+    )
+    if (message?.type !== 'text') throw new Error('expected text')
+    expect(message.text.stringValue()).toBe('')
+    expect(message.exploded).toBe(true)
+    expect(message.explodedBy).toBe('testuser-two')
+    expect(message.exploding).toBe(true)
+  })
+
+  test('inline payment success is derived from the payment status descriptions', () => {
+    const withStatus = (statusDescription: string) =>
+      convert(
+        validMessage({
+          paymentInfos: [{statusDescription} as T.RPCChat.UIPaymentInfo],
+        })
+      )
+    const completed = withStatus('completed')
+    const pending = withStatus('pending')
+    if (completed?.type !== 'text' || pending?.type !== 'text') throw new Error('expected text')
+    expect(completed.inlinePaymentSuccessful).toBe(true)
+    expect(pending.inlinePaymentSuccessful).toBe(false)
+  })
+
+  test('edit/delete/deletehistory collapse to deleted', () => {
+    for (const messageType of [
+      T.RPCChat.MessageType.edit,
+      T.RPCChat.MessageType.delete,
+      T.RPCChat.MessageType.deletehistory,
+    ]) {
+      const message = convert(validMessage({messageBody: {messageType} as T.RPCChat.MessageBody}))
+      expect(message?.type).toBe('deleted')
+    }
+  })
+
+  test('headline and metadata become setDescription/setChannelname', () => {
+    const headline = convert(
+      validMessage({
+        messageBody: {
+          headline: {headline: 'the topic'},
+          messageType: T.RPCChat.MessageType.headline,
+        } as T.RPCChat.MessageBody,
+      })
+    )
+    if (headline?.type !== 'setDescription') throw new Error('expected setDescription')
+    expect(headline.newDescription.stringValue()).toBe('the topic')
+
+    const metadata = convert(
+      validMessage({
+        messageBody: {
+          messageType: T.RPCChat.MessageType.metadata,
+          metadata: {conversationTitle: 'general'},
+        } as T.RPCChat.MessageBody,
+      })
+    )
+    if (metadata?.type !== 'setChannelname') throw new Error('expected setChannelname')
+    expect(metadata.newChannelname).toBe('general')
+  })
+
+  test('pin falls back to its own message id', () => {
+    const withPinned = convert(
+      validMessage({
+        messageBody: {messageType: T.RPCChat.MessageType.pin, pin: {}} as T.RPCChat.MessageBody,
+        pinnedMessageID: 3,
+      })
+    )
+    if (withPinned?.type !== 'pin') throw new Error('expected pin')
+    expect(withPinned.pinnedMessageID).toBe(3)
+
+    const withoutPinned = convert(
+      validMessage({
+        messageBody: {messageType: T.RPCChat.MessageType.pin, pin: {}} as T.RPCChat.MessageBody,
+      })
+    )
+    if (withoutPinned?.type !== 'pin') throw new Error('expected pin')
+    expect(withoutPinned.pinnedMessageID).toBe(5)
+  })
+
+  test('join carries joiners and leavers', () => {
+    const message = convert(
+      validMessage({
+        messageBody: {
+          join: {joiners: ['a'], leavers: ['b']},
+          messageType: T.RPCChat.MessageType.join,
+        } as T.RPCChat.MessageBody,
+      })
+    )
+    if (message?.type !== 'systemJoined') throw new Error('expected systemJoined')
+    expect(message.joiners).toEqual(['a'])
+    expect(message.leavers).toEqual(['b'])
+  })
+
+  test('unsupported bodies convert to nothing', () => {
+    expect(
+      convert(validMessage({messageBody: {messageType: T.RPCChat.MessageType.none} as T.RPCChat.MessageBody}))
+    ).toBeUndefined()
+  })
+
+  test('placeholders become placeholder or deleted when hidden', () => {
+    const shown = convert({
+      placeholder: {hidden: false, messageID: 4},
+      state: T.RPCChat.MessageUnboxedState.placeholder,
+    })
+    expect(shown?.type).toBe('placeholder')
+    expect(shown?.ordinal).toBe(4)
+
+    const hidden = convert({
+      placeholder: {hidden: true, messageID: 4},
+      state: T.RPCChat.MessageUnboxedState.placeholder,
+    })
+    expect(hidden?.type).toBe('deleted')
+  })
+
+  test('errors become text with an errorReason', () => {
+    const message = convert({
+      error: {
+        botUsername: '',
+        ctime: 10,
+        errMsg: 'could not decrypt',
+        errType: T.RPCChat.MessageUnboxedErrorType.misc,
+        etime: 0,
+        explodedBy: '',
+        isEphemeral: false,
+        messageID: 7,
+        senderDeviceName: devicename,
+        senderDeviceType: 'desktop',
+        senderUsername: username,
+      } as T.RPCChat.MessageUnboxedError,
+      state: T.RPCChat.MessageUnboxedState.error,
+    })
+    if (message?.type !== 'text') throw new Error('expected text')
+    expect(message.errorReason).toBe('could not decrypt')
+    expect(message.id).toBe(7)
+    expect(message.explodingUnreadable).toBe(false)
+  })
+
+  test('journeycards are only supported for welcome and popularChannels', () => {
+    const welcome = convert({
+      journeycard: {
+        cardType: T.RPCChat.JourneycardType.welcome,
+        highlightMsgID: 2,
+        openTeam: true,
+        ordinal: 1,
+      },
+      state: T.RPCChat.MessageUnboxedState.journeycard,
+    })
+    expect(welcome?.type).toBe('journeycard')
+
+    const unsupported = convert({
+      journeycard: {
+        cardType: T.RPCChat.JourneycardType.addPeople,
+        highlightMsgID: 2,
+        openTeam: false,
+        ordinal: 1,
+      },
+      state: T.RPCChat.MessageUnboxedState.journeycard,
+    })
+    expect(unsupported).toBeUndefined()
+  })
+})
+
+describe('parseUIMessagesJSON', () => {
+  const parse = (json: string, onMessage?: (m: T.Chat.Message) => void) =>
+    parseUIMessagesJSON(conversationIDKey, json, username, devicename, getLastOrdinal, onMessage)
+
+  test('bad json yields no messages instead of throwing', () => {
+    expect(parse('not json')).toEqual({messages: []})
+  })
+
+  test('empty payloads yield no messages', () => {
+    expect(parse(JSON.stringify({}))).toEqual({messages: [], pagination: undefined})
+  })
+
+  test('converts messages, keeps pagination and skips unconvertible ones', () => {
+    const pagination = {last: false, next: 'n', num: 10, previous: 'p'}
+    const seen: Array<T.Chat.Message> = []
+    const res = parse(
+      JSON.stringify({
+        messages: [
+          validMessage({messageBody: makeTextBody('one'), messageID: 1}),
+          validMessage({
+            messageBody: {messageType: T.RPCChat.MessageType.none},
+            messageID: 2,
+          }),
+          validMessage({messageBody: makeTextBody('three'), messageID: 3}),
+        ],
+        pagination,
+      }),
+      m => seen.push(m)
+    )
+    expect(res.messages.map(m => m.id)).toEqual([1, 3])
+    expect(res.pagination).toEqual(pagination)
+    // onMessage runs per converted message, in order, before the next conversion
+    expect(seen.map(m => m.id)).toEqual([1, 3])
+  })
+})


### PR DESCRIPTION
Stacked on #29578. Tests only, plus a handful of `export` keywords so module-private helpers are reachable from tests. No behavior changes.

Unit test count goes from 584 to 664 across 101 suites.

## New test files

- `constants/chat/message.test.tsx` — the largest untested file in chat (1406 lines). `uiMessageToMessage` across every unboxed state (valid text/flip/replyTo, expired ephemeral, edit/delete collapse, headline, metadata, pin, join, error, placeholder, journeycard), `parseUIMessagesJSON` (bad JSON, pagination, skipped messages, `onMessage` ordering), payment and request info conversion, reaction map conversion and ordering, render types, `rpcErrorToString`.
- `chat/conversation/thread-engine.test.tsx` — every `apply*ToThread` function, driven through a spy `actions` object: the unloaded-and-not-looking bail, `markAsRead` following actively-looking, edits routed through the mutation path, a delete of an exploding message becoming an explode, outbox reaction decoration with its raw-body fallback, `moreToLoadForward` dropping live adds, failed-message filtering by conversation and error state, expunge deletable types, ephemeral purge skipping id-less messages.
- `chat/conversation/data-hooks.test.tsx` — `markConversationAsUnread` end to end: opt-out, invalid conversation, logged-out, no-id bail, `maxVisibleMsgID` fallback, orange line placement, the walk-back to the newest message below the unread line, the load-failure fallback, and dedupe/sort across the cached and full thread callbacks.
- `chat/conversation/thread-load.test.tsx` — exploding mode from gregor items (dismissed category reads as off, a dirty value reads as undefined), scroll direction pagination, and the snapshot helpers for clientPrev, last ordinal and ordinal-for-message-id (including fractional outbox ordinals and a stale index entry).
- `chat/audio/amptracker.test.tsx` — bucket rescaling, bar snapping at both ends, the sqrt curve between the snap points, averaging and signal shape.
- `chat/conversation/messages/wrapper/exploding-meta.test.tsx` — countdown loop intervals at the second/minute/hour/day scales and the initial timer state for pending, exploded, expired and live messages.
- `chat/conversation/input-area/suggestors/users.test.tsx` — transformer output and the filter ranking rules (username prefix beats fullname prefix beats substring), lone-team channel expansion and when it does not fire, `team#` and `team#partial` channel filtering.
- `chat/conversation/attachment-get-titles.test.tsx` — preview type by path.
- `chat/conversation/messages/account-payment/container.test.tsx` — send verb per status and sender, request info lookup.
- `constants/chat/common.test.tsx` — selected conversation, the actively-looking checks, participant info conversion.

## Extended

- `constants/chat/helpers.test.tsx` — image clamp and zoom, mention name, `isBigTeam`.
- `chat/inbox/rows-state.test.ts` — `useInboxRowIsMuted` layout/meta precedence, big row decoration filtering and error state.

## Notes

Two behaviors the tests pin down that were not obvious from reading the code:

- `AmpTracker.getBucketedAmps` takes its bar *width* from the reported duration but keeps emitting bars until the recorded audio runs out, so a duration shorter than the audio produces more bars than `maxBars`.
- `getLoopInterval` has two distinct paths that can return the same value: the within-half-a-unit remainder and the next-half-unit-mark calculation. They are covered separately.

## Verification

- `yarn test:unit` — 101 suites, 664 tests pass
- `yarn tsc` — clean
- `yarn lint` — clean
- `yarn lint:bailouts` — 0 bailed out, 0 whole-props deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)