### PR TITLE
fix(chat): refresh channel participants after membership changes

### DIFF
--- a/shared/chat/conversation/info-panel/add-to-channel.test.tsx
+++ b/shared/chat/conversation/info-panel/add-to-channel.test.tsx
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {addMembersToChannel} from './add-to-channel'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convID = T.Chat.keyToConversationID(conversationIDKey)
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('adding members refreshes the conversation participants', async () => {
+  jest.spyOn(T.RPCChat, 'localBulkAddToConvRpcPromise').mockResolvedValue(undefined)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await addMembersToChannel(conversationIDKey, ['testuser', 'testuser-mac'])
+
+  expect(T.RPCChat.localBulkAddToConvRpcPromise).toHaveBeenCalledWith({
+    convID,
+    usernames: ['testuser', 'testuser-mac'],
+  })
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('a failed add never claims the participants are fresh', async () => {
+  jest.spyOn(T.RPCChat, 'localBulkAddToConvRpcPromise').mockRejectedValue(new Error('nope'))
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await expect(addMembersToChannel(conversationIDKey, ['testuser'])).rejects.toThrow('nope')
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})
+
+test('a failed refresh does not fail the add', async () => {
+  jest.spyOn(T.RPCChat, 'localBulkAddToConvRpcPromise').mockResolvedValue(undefined)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockRejectedValue(new Error('offline'))
+
+  await expect(addMembersToChannel(conversationIDKey, ['testuser'])).resolves.toBeUndefined()
+})

--- a/shared/chat/conversation/info-panel/add-to-channel.tsx
+++ b/shared/chat/conversation/info-panel/add-to-channel.tsx
@@ -6,8 +6,22 @@ import {useSafeNavigation} from '@/util/safe-navigation'
 import {pluralize} from '@/util/string'
 import {useChatTeamMembers} from '../team-hooks'
 import {useConversationMetadata} from '../data-hooks'
+import {refreshConversationParticipants} from '@/chat/inbox/refresh-participants'
 
 type Props = {conversationIDKey?: T.Chat.ConversationIDKey; teamID: T.Teams.TeamID}
+
+// bulkAddToConv only posts a system message - nothing recomputes the channel's
+// participants, so the refresh is what makes every open members list show the new members.
+export const addMembersToChannel = async (
+  conversationIDKey: T.Chat.ConversationIDKey,
+  usernames: ReadonlyArray<string>
+) => {
+  await T.RPCChat.localBulkAddToConvRpcPromise({
+    convID: T.Chat.keyToConversationID(conversationIDKey),
+    usernames: [...usernames],
+  })
+  await refreshConversationParticipants([conversationIDKey])
+}
 
 const AddToChannel = (props: Props) => {
   const conversationIDKey = props.conversationIDKey ?? T.Chat.noConversationIDKey
@@ -37,7 +51,7 @@ const AddToChannelInner = (props: Props & {conversationIDKey: T.Chat.Conversatio
 
   const [waiting, setWaiting] = React.useState(false)
   const [error, setError] = React.useState('')
-  const addToChannel = C.useRPC(T.RPCChat.localBulkAddToConvRpcPromise)
+  const addToChannel = C.useRPC(addMembersToChannel)
 
   const onClose = React.useCallback(() => {
     nav.safeNavigateUp()
@@ -45,7 +59,7 @@ const AddToChannelInner = (props: Props & {conversationIDKey: T.Chat.Conversatio
   const onAdd = React.useCallback(() => {
     setWaiting(true)
     addToChannel(
-      [{convID: T.Chat.keyToConversationID(conversationIDKey), usernames: [...toAdd]}],
+      [conversationIDKey, [...toAdd]],
       () => {
         setWaiting(false)
         onClose()

--- a/shared/chat/conversation/info-panel/members.test.tsx
+++ b/shared/chat/conversation/info-panel/members.test.tsx
@@ -1,0 +1,186 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {act, cleanup, renderHook} from '@testing-library/react'
+import {makeConversationMeta} from '@/constants/chat/meta'
+import {notifyEngineActionListeners} from '@/engine/action-listener'
+import {resetAllStores} from '@/util/zustand'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convID = T.Chat.keyToConversationID(conversationIDKey)
+const teamID = 'team-1' as T.Teams.TeamID
+
+let mockMembers = new Map<string, T.Teams.MemberInfo>()
+let mockMeta: T.Chat.ConversationMeta = makeConversationMeta()
+let mockParticipants: T.Chat.ParticipantInfo = {all: [], contactName: new Map(), name: []}
+
+jest.mock('../team-hooks', () => ({
+  useChatTeamMembers: () => ({loading: false, members: mockMembers}),
+}))
+jest.mock('../data-hooks', () => ({
+  useConversationMetadata: () => ({meta: mockMeta, participants: mockParticipants}),
+}))
+
+import {useChannelMembers} from './members'
+
+const member = (username: string, type: T.Teams.TeamRoleType): [string, T.Teams.MemberInfo] => [
+  username,
+  {fullName: `${username} fullname`, needsPUK: false, status: 'active', type, username},
+]
+
+const teamChannelMeta = (over: Partial<T.Chat.ConversationMeta> = {}): T.Chat.ConversationMeta => ({
+  ...makeConversationMeta(),
+  channelname: 'random',
+  conversationIDKey,
+  teamID,
+  teamType: 'big',
+  teamname: 'acme',
+  ...over,
+})
+
+const noChanges = {keyRotated: false, membershipChanged: false, misc: false, renamed: false}
+
+const teamChangedByID = (changes = {...noChanges, membershipChanged: true}) =>
+  ({
+    payload: {
+      params: {
+        changes,
+        implicitTeam: false,
+        latestHiddenSeqno: 0,
+        latestOffchainSeqno: 0,
+        latestSeqno: 1,
+        source: 0,
+        teamID,
+      },
+    },
+    type: 'keybase.1.NotifyTeam.teamChangedByID',
+  }) as never
+
+beforeEach(() => {
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  jest.restoreAllMocks()
+  resetAllStores()
+  mockMembers = new Map()
+  mockMeta = makeConversationMeta()
+  mockParticipants = {all: [], contactName: new Map(), name: []}
+})
+
+test('opening a team channel asks the service for its participants', () => {
+  mockMeta = teamChannelMeta()
+  renderHook(() => useChannelMembers(conversationIDKey))
+
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('an adhoc conversation has no team participants to refresh', () => {
+  mockMeta = {...makeConversationMeta(), conversationIDKey, teamType: 'adhoc'}
+  renderHook(() => useChannelMembers(conversationIDKey))
+
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})
+
+test('a membership change in the team refreshes the open list', () => {
+  mockMeta = teamChannelMeta()
+  renderHook(() => useChannelMembers(conversationIDKey))
+  ;(T.RPCChat.localRefreshParticipantsRpcPromise as jest.Mock).mockClear()
+
+  act(() => {
+    notifyEngineActionListeners(teamChangedByID())
+  })
+
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+// teamChangedByID also fires for every message in the team
+test('team activity that did not change membership does not refresh the open list', () => {
+  mockMeta = teamChannelMeta()
+  renderHook(() => useChannelMembers(conversationIDKey))
+  ;(T.RPCChat.localRefreshParticipantsRpcPromise as jest.Mock).mockClear()
+
+  act(() => {
+    notifyEngineActionListeners(teamChangedByID({...noChanges, misc: true}))
+  })
+
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})
+
+test('a re-render of the same channel does not re-ask for participants', () => {
+  mockMeta = teamChannelMeta()
+  const {rerender} = renderHook(() => useChannelMembers(conversationIDKey))
+  rerender()
+  rerender()
+
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledTimes(1)
+})
+
+test('the list shows the channel participants, owners and admins first', () => {
+  mockMembers = new Map([
+    member('testuser', 'writer'),
+    member('testuser-mac', 'admin'),
+    member('zeta', 'owner'),
+  ])
+  mockMeta = teamChannelMeta()
+  mockParticipants = {all: ['testuser', 'testuser-mac', 'zeta'], contactName: new Map(), name: []}
+
+  const {participantsItems, showSpinner} = renderHook(() =>
+    useChannelMembers(conversationIDKey)
+  ).result.current
+
+  expect(showSpinner).toBe(false)
+  expect(participantsItems.map(i => i.username)).toEqual(['testuser-mac', 'zeta', 'testuser'])
+  expect(participantsItems.map(i => i.isOwner)).toEqual([false, true, false])
+  expect(participantsItems.map(i => i.isAdmin)).toEqual([true, false, false])
+})
+
+test('a member added to the channel appears in the list', () => {
+  mockMembers = new Map([member('testuser', 'writer'), member('testuser-mac', 'writer')])
+  mockMeta = teamChannelMeta()
+  mockParticipants = {all: ['testuser'], contactName: new Map(), name: []}
+
+  const {rerender, result} = renderHook(() => useChannelMembers(conversationIDKey))
+  expect(result.current.participantsItems.map(i => i.username)).toEqual(['testuser'])
+
+  mockParticipants = {all: ['testuser', 'testuser-mac'], contactName: new Map(), name: []}
+  rerender()
+
+  expect(result.current.participantsItems.map(i => i.username)).toEqual(['testuser', 'testuser-mac'])
+})
+
+test('bots on the team are not listed as members', () => {
+  mockMembers = new Map([
+    member('testuser', 'writer'),
+    member('chatbot', 'bot'),
+    member('limitedbot', 'restrictedbot'),
+  ])
+  mockMeta = teamChannelMeta()
+  mockParticipants = {all: ['testuser', 'chatbot', 'limitedbot'], contactName: new Map(), name: []}
+
+  const {participantsItems} = renderHook(() => useChannelMembers(conversationIDKey)).result.current
+
+  expect(participantsItems.map(i => i.username)).toEqual(['testuser'])
+})
+
+test('a channel with no participants yet shows a spinner instead of an empty list', () => {
+  mockMeta = teamChannelMeta()
+
+  const {participantsItems, showSpinner} = renderHook(() =>
+    useChannelMembers(conversationIDKey)
+  ).result.current
+
+  expect(showSpinner).toBe(true)
+  expect(participantsItems).toEqual([])
+})
+
+test('general lists the whole team rather than the conversation participants', () => {
+  mockMembers = new Map([member('testuser', 'writer'), member('testuser-mac', 'writer')])
+  mockMeta = teamChannelMeta({channelname: 'general'})
+  mockParticipants = {all: ['testuser'], contactName: new Map(), name: []}
+
+  const {participantsItems} = renderHook(() => useChannelMembers(conversationIDKey)).result.current
+
+  expect(participantsItems.map(i => i.username)).toEqual(['testuser', 'testuser-mac'])
+})

--- a/shared/chat/conversation/info-panel/members.tsx
+++ b/shared/chat/conversation/info-panel/members.tsx
@@ -9,6 +9,7 @@ import {useUsersState} from '@/stores/users'
 import {navToProfile} from '@/constants/router'
 import {useChatTeamMembers} from '../team-hooks'
 import {useConversationMetadata} from '../data-hooks'
+import {useRefreshParticipantsOnTeamMembershipChange} from '@/chat/inbox/refresh-participants'
 
 type Props = {
   commonSections: ReadonlyArray<Section>
@@ -32,9 +33,11 @@ type Item =
 
 type Section = Kb.SectionType<Item>
 
-const MembersTab = (props: Props) => {
-  const styles = useStyles()
-  const {conversationIDKey} = props
+type MemberItem = Extract<Item, {type: 'member'}>
+
+// The list the info panel renders, and everything that keeps it current. Extracted so the
+// refresh wiring can be exercised without standing up the whole section list.
+export const useChannelMembers = (conversationIDKey: T.Chat.ConversationIDKey) => {
   const infoMap = useUsersState(s => s.infoMap)
   const {meta, participants: participantInfo} = useConversationMetadata(conversationIDKey)
   const {channelname, teamID, teamname} = meta
@@ -59,8 +62,12 @@ const MembersTab = (props: Props) => {
     }
   }, [conversationIDKey, refreshParticipants, teamname])
 
+  // a kick, an add-to-team or a reset user let back in changes this channel's members
+  // too, including when another client does it
+  useRefreshParticipantsOnTeamMembershipChange(teamID, conversationIDKey)
+
   const showSpinner = !participants.length
-  const participantsItems = participants
+  const participantsItems: ReadonlyArray<MemberItem> = participants
     .map(
       p =>
         ({
@@ -86,6 +93,14 @@ const MembersTab = (props: Props) => {
       }
       return l.username.localeCompare(r.username)
     })
+
+  return {participantsItems, showAuditingBanner, showSpinner}
+}
+
+const MembersTab = (props: Props) => {
+  const styles = useStyles()
+  const {conversationIDKey} = props
+  const {participantsItems, showAuditingBanner, showSpinner} = useChannelMembers(conversationIDKey)
 
   const participantSection: Section = {
     data: showSpinner

--- a/shared/chat/conversation/messages/reset-user.test.tsx
+++ b/shared/chat/conversation/messages/reset-user.test.tsx
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {addTeamMemberAfterReset} from './reset-user'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convID = T.Chat.keyToConversationID(conversationIDKey)
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('letting a reset user back in refreshes the conversation participants', async () => {
+  jest.spyOn(T.RPCChat, 'localAddTeamMemberAfterResetRpcPromise').mockResolvedValue(undefined)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await addTeamMemberAfterReset(conversationIDKey, 'testuser')
+
+  expect(T.RPCChat.localAddTeamMemberAfterResetRpcPromise).toHaveBeenCalledWith({
+    convID,
+    username: 'testuser',
+  })
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('a failed re-add never claims the participants are fresh', async () => {
+  jest
+    .spyOn(T.RPCChat, 'localAddTeamMemberAfterResetRpcPromise')
+    .mockRejectedValue(new Error('still reset'))
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await expect(addTeamMemberAfterReset(conversationIDKey, 'testuser')).rejects.toThrow('still reset')
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})

--- a/shared/chat/conversation/messages/reset-user.tsx
+++ b/shared/chat/conversation/messages/reset-user.tsx
@@ -4,6 +4,20 @@ import * as T from '@/constants/types'
 import {navToProfile} from '@/constants/router'
 import {useConversationThreadID, useThreadMeta} from '../thread-context'
 import {useConversationParticipants} from '../data-hooks'
+import {refreshConversationParticipants} from '@/chat/inbox/refresh-participants'
+
+// Letting a reset user back in puts them back in the conversation, and nothing
+// recomputes its participants on its own - see refreshConversationParticipants.
+export const addTeamMemberAfterReset = async (
+  conversationIDKey: T.Chat.ConversationIDKey,
+  username: string
+) => {
+  await T.RPCChat.localAddTeamMemberAfterResetRpcPromise({
+    convID: T.Chat.keyToConversationID(conversationIDKey),
+    username,
+  })
+  await refreshConversationParticipants([conversationIDKey])
+}
 
 const ResetUser = () => {
   const styles = useStyles()
@@ -23,13 +37,7 @@ const ResetUser = () => {
     })
   }
   const letThemIn = () => {
-    const f = async () => {
-      await T.RPCChat.localAddTeamMemberAfterResetRpcPromise({
-        convID: T.Chat.keyToConversationID(conversationIDKey),
-        username,
-      })
-    }
-    C.ignorePromise(f())
+    C.ignorePromise(addTeamMemberAfterReset(conversationIDKey, username))
   }
   const viewProfile = () => _viewProfile(username)
 

--- a/shared/chat/conversation/status-actions.test.tsx
+++ b/shared/chat/conversation/status-actions.test.tsx
@@ -1,0 +1,40 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {joinConversation} from './status-actions'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convID = T.Chat.keyToConversationID(conversationIDKey)
+
+const flushPromises = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('joining a conversation refreshes its participants', async () => {
+  jest.spyOn(T.RPCChat, 'localJoinConversationByIDLocalRpcPromise').mockResolvedValue({} as never)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  joinConversation(conversationIDKey)
+  await flushPromises()
+
+  expect(T.RPCChat.localJoinConversationByIDLocalRpcPromise).toHaveBeenCalledWith({convID})
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('a failed join never claims the participants are fresh', async () => {
+  jest
+    .spyOn(T.RPCChat, 'localJoinConversationByIDLocalRpcPromise')
+    .mockRejectedValue(new Error('cannot join'))
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  joinConversation(conversationIDKey)
+  await flushPromises()
+
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})

--- a/shared/chat/conversation/status-actions.tsx
+++ b/shared/chat/conversation/status-actions.tsx
@@ -4,6 +4,7 @@ import {isPhone} from '@/constants/platform'
 import {navigateToInbox, setChatRootParams} from '@/constants/router'
 import logger from '@/logger'
 import {getInboxConversationMeta} from '@/chat/inbox/metadata'
+import {refreshConversationParticipants} from '@/chat/inbox/refresh-participants'
 import {setConversationOrangeLine} from './orange-line-context'
 import {loadThreadMessageIDAtIndex, markConversationRead} from './thread-rpc'
 
@@ -43,6 +44,8 @@ export const joinConversation = (conversationIDKey: T.Chat.ConversationIDKey) =>
     await T.RPCChat.localJoinConversationByIDLocalRpcPromise({
       convID: T.Chat.keyToConversationID(conversationIDKey),
     })
+    // joining adds you to the participants, which nothing else recomputes
+    await refreshConversationParticipants([conversationIDKey])
   }
   C.ignorePromise(f())
 }

--- a/shared/chat/inbox/metadata.test.tsx
+++ b/shared/chat/inbox/metadata.test.tsx
@@ -9,6 +9,9 @@ import {
   getInboxConversationMeta,
   metasReceived,
   participantInfoReceived,
+  syncInboxParticipantsFromParticipantMap,
+  unboxRows,
+  useInboxMetadataState,
 } from './metadata'
 
 const convID = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
@@ -59,6 +62,74 @@ const makeMeta = (over: Partial<T.Chat.ConversationMeta>): T.Chat.ConversationMe
   ...Meta.makeConversationMeta(),
   conversationIDKey: convID,
   ...over,
+})
+
+// Why every membership change has to ask for a participant refresh: the conversation
+// you are looking at is already trusted, so the ordinary reload is dropped here and
+// no fresh participants ever come back. See chat/inbox/refresh-participants.
+test('an ordinary reload of a trusted conversation never reaches the service', async () => {
+  jest.spyOn(T.RPCChat, 'localRequestInboxUnboxRpcPromise').mockResolvedValue(undefined)
+  metasReceived([makeMeta({inboxVersion: 1, trustedState: 'trusted'})])
+
+  unboxRows([convID])
+  await flushPromises()
+
+  expect(T.RPCChat.localRequestInboxUnboxRpcPromise).not.toHaveBeenCalled()
+
+  forceUnboxRowsForService([convID])
+  await flushPromises()
+
+  expect(T.RPCChat.localRequestInboxUnboxRpcPromise).toHaveBeenCalledTimes(1)
+})
+
+test('an ordinary reload of an untrusted conversation does reach the service', async () => {
+  jest.spyOn(T.RPCChat, 'localRequestInboxUnboxRpcPromise').mockResolvedValue(undefined)
+  metasReceived([makeMeta({inboxVersion: 1, trustedState: 'untrusted'})])
+
+  unboxRows([convID])
+  await flushPromises()
+
+  expect(T.RPCChat.localRequestInboxUnboxRpcPromise).toHaveBeenCalledTimes(1)
+})
+
+const uiParticipant = (assertion: string): T.RPCChat.UIParticipant => ({
+  assertion,
+  inConvName: false,
+  type: T.RPCChat.UIParticipantType.user,
+})
+
+test('a participants notification replaces the stored participants for that conversation', () => {
+  participantInfoReceived(convID, {all: ['testuser'], contactName: new Map(), name: []})
+
+  syncInboxParticipantsFromParticipantMap({
+    [T.Chat.conversationIDKeyToString(convID)]: [uiParticipant('testuser'), uiParticipant('testuser-mac')],
+  })
+
+  expect(useInboxMetadataState.getState().participants.get(convID)?.all).toEqual([
+    'testuser',
+    'testuser-mac',
+  ])
+})
+
+test('a participants notification for another conversation leaves this one alone', () => {
+  const otherConvID = T.Chat.conversationIDToKey(new Uint8Array([9, 9, 9, 9]))
+  participantInfoReceived(convID, {all: ['testuser'], contactName: new Map(), name: []})
+
+  syncInboxParticipantsFromParticipantMap({
+    [T.Chat.conversationIDKeyToString(otherConvID)]: [uiParticipant('someone-else')],
+  })
+
+  expect(useInboxMetadataState.getState().participants.get(convID)?.all).toEqual(['testuser'])
+})
+
+// an empty list is what the service sends before it has computed anything, so it must
+// not wipe a list that is already on screen
+test('an empty participants notification does not clear what is already known', () => {
+  participantInfoReceived(convID, {all: ['testuser'], contactName: new Map(), name: []})
+
+  syncInboxParticipantsFromParticipantMap({[T.Chat.conversationIDKeyToString(convID)]: []})
+
+  expect(useInboxMetadataState.getState().participants.get(convID)?.all).toEqual(['testuser'])
 })
 
 test('metasReceived version-gates: newer inbox version wins, older is ignored', () => {

--- a/shared/chat/inbox/refresh-participants.test.tsx
+++ b/shared/chat/inbox/refresh-participants.test.tsx
@@ -1,0 +1,238 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {cleanup, renderHook} from '@testing-library/react'
+import {notifyEngineActionListeners} from '@/engine/action-listener'
+import {resetAllStores} from '@/util/zustand'
+import logger from '@/logger'
+import {getBotsAndParticipants} from '@/constants/chat/helpers'
+import {makeConversationMeta} from '@/constants/chat/meta'
+import {handleConvoEngineIncoming} from './engine'
+import {participantInfoReceived, useInboxMetadataState} from './metadata'
+import {
+  refreshConversationParticipants,
+  useRefreshParticipantsOnTeamMembershipChange,
+} from './refresh-participants'
+
+const convA = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convB = T.Chat.conversationIDToKey(new Uint8Array([5, 6, 7, 8]))
+const teamID = 'team-1' as T.Teams.TeamID
+const otherTeamID = 'team-2' as T.Teams.TeamID
+
+const noChanges = {keyRotated: false, membershipChanged: false, misc: false, renamed: false}
+
+const teamChangedByID = (
+  params: Partial<{
+    changes: typeof noChanges
+    teamID: T.Teams.TeamID
+  }> = {}
+) =>
+  ({
+    payload: {
+      params: {
+        changes: params.changes ?? {...noChanges, membershipChanged: true},
+        implicitTeam: false,
+        latestHiddenSeqno: 0,
+        latestOffchainSeqno: 0,
+        latestSeqno: 1,
+        source: 0,
+        teamID: params.teamID ?? teamID,
+      },
+    },
+    type: 'keybase.1.NotifyTeam.teamChangedByID',
+  }) as never
+
+afterEach(() => {
+  cleanup()
+  jest.restoreAllMocks()
+  resetAllStores()
+})
+
+describe('refreshConversationParticipants', () => {
+  test('asks the service to recompute participants for each conversation', async () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+    await refreshConversationParticipants([convA, convB])
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledTimes(2)
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({
+      convID: T.Chat.keyToConversationID(convA),
+    })
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({
+      convID: T.Chat.keyToConversationID(convB),
+    })
+  })
+
+  test('a conversation named twice is refreshed once', async () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+    await refreshConversationParticipants([convA, convA, convB, convA])
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledTimes(2)
+  })
+
+  // these are not conversations, so they must be dropped before the attempt rather than
+  // failing their way through it
+  test('placeholder conversation ids are never sent to the service', async () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    jest.spyOn(logger, 'info').mockImplementation(() => {})
+
+    await refreshConversationParticipants([
+      T.Chat.noConversationIDKey,
+      T.Chat.pendingWaitingConversationIDKey,
+      T.Chat.pendingErrorConversationIDKey,
+    ])
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+
+  test('nothing to refresh resolves without an rpc', async () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+    await expect(refreshConversationParticipants([])).resolves.toBeUndefined()
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+  })
+
+  test('one conversation failing neither rejects nor skips the others', async () => {
+    jest
+      .spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise')
+      .mockImplementation(async ({convID}) => {
+        await Promise.resolve()
+        if (T.Chat.conversationIDToKey(convID) === convA) {
+          throw new Error('offline')
+        }
+      })
+
+    await expect(refreshConversationParticipants([convA, convB])).resolves.toBeUndefined()
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('useRefreshParticipantsOnTeamMembershipChange', () => {
+  test('a membership change in this team refreshes the conversation', () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    renderHook(() => useRefreshParticipantsOnTeamMembershipChange(teamID, convA))
+
+    notifyEngineActionListeners(teamChangedByID())
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({
+      convID: T.Chat.keyToConversationID(convA),
+    })
+  })
+
+  // teamChangedByID also fires for every message sent in the team; refreshing on those
+  // would be one participant rpc per message for as long as the list is open
+  test('a team change that did not touch membership is ignored', () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    renderHook(() => useRefreshParticipantsOnTeamMembershipChange(teamID, convA))
+
+    notifyEngineActionListeners(teamChangedByID({changes: {...noChanges, misc: true}}))
+    notifyEngineActionListeners(teamChangedByID({changes: {...noChanges, keyRotated: true}}))
+    notifyEngineActionListeners(teamChangedByID({changes: {...noChanges, renamed: true}}))
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+  })
+
+  test('a membership change in another team is ignored', () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    renderHook(() => useRefreshParticipantsOnTeamMembershipChange(teamID, convA))
+
+    notifyEngineActionListeners(teamChangedByID({teamID: otherTeamID}))
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+  })
+
+  test('a disabled watcher does not refresh', () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    renderHook(() => useRefreshParticipantsOnTeamMembershipChange(teamID, convA, false))
+
+    notifyEngineActionListeners(teamChangedByID())
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+  })
+
+  test('an adhoc conversation has no team to watch', () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    renderHook(() => useRefreshParticipantsOnTeamMembershipChange(T.Teams.noTeamID, convA))
+
+    notifyEngineActionListeners(teamChangedByID({teamID: T.Teams.noTeamID}))
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+  })
+
+  test('an unmounted list stops refreshing', () => {
+    jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+    const {unmount} = renderHook(() => useRefreshParticipantsOnTeamMembershipChange(teamID, convA))
+
+    unmount()
+    notifyEngineActionListeners(teamChangedByID())
+
+    expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+  })
+})
+
+// The whole point of the refresh: the service answers it with a ChatParticipantsInfo
+// notification, and that is what puts the new member on screen.
+describe('the refresh reaching the members list', () => {
+  const teamMeta = {
+    ...makeConversationMeta(),
+    channelname: 'random',
+    conversationIDKey: convA,
+    teamID,
+    teamType: 'big' as const,
+    teamname: 'acme',
+  }
+  const teamMembers = new Map<string, T.Teams.MemberInfo>([
+    ['testuser', {fullName: '', needsPUK: false, status: 'active', type: 'writer', username: 'testuser'}],
+    [
+      'testuser-mac',
+      {fullName: '', needsPUK: false, status: 'active', type: 'writer', username: 'testuser-mac'},
+    ],
+  ])
+
+  const deliverParticipants = (usernames: ReadonlyArray<string>) => {
+    handleConvoEngineIncoming({
+      payload: {
+        params: {
+          participants: {
+            [T.Chat.conversationIDKeyToString(convA)]: usernames.map(assertion => ({
+              assertion,
+              inConvName: false,
+              type: T.RPCChat.UIParticipantType.user,
+            })),
+          },
+        },
+      },
+      type: 'chat.1.NotifyChat.ChatParticipantsInfo',
+    } as never)
+  }
+
+  const currentMembers = () =>
+    getBotsAndParticipants(
+      teamMeta,
+      useInboxMetadataState.getState().participants.get(convA) ?? {
+        all: [],
+        contactName: new Map(),
+        name: [],
+      },
+      teamMembers
+    ).participants
+
+  test('a member added while the list is open shows up once the notification lands', () => {
+    participantInfoReceived(convA, {all: ['testuser'], contactName: new Map(), name: []})
+    expect(currentMembers()).toEqual(['testuser'])
+
+    deliverParticipants(['testuser', 'testuser-mac'])
+
+    expect(currentMembers()).toEqual(['testuser', 'testuser-mac'])
+  })
+
+  test('a member removed while the list is open disappears once the notification lands', () => {
+    participantInfoReceived(convA, {all: ['testuser', 'testuser-mac'], contactName: new Map(), name: []})
+
+    deliverParticipants(['testuser'])
+
+    expect(currentMembers()).toEqual(['testuser'])
+  })
+})

--- a/shared/chat/inbox/refresh-participants.tsx
+++ b/shared/chat/inbox/refresh-participants.tsx
@@ -1,0 +1,45 @@
+import * as T from '@/constants/types'
+import {useEngineActionListener} from '@/engine/action-listener'
+import logger from '@/logger'
+
+// The service recomputes a team channel's participant list only on demand
+// (CachingParticipantSource): no membership change pushes ChatParticipantsInfo by itself,
+// and an unbox of an already-trusted conv is dropped client-side. So every action that
+// changes who is in a conversation has to ask for the recompute that notifies the store,
+// or every open members list keeps rendering the pre-change participants.
+export const refreshConversationParticipants = async (
+  conversationIDKeys: ReadonlyArray<T.Chat.ConversationIDKey>
+) => {
+  const ids = [...new Set(conversationIDKeys)].filter(id => T.Chat.isValidConversationIDKey(id))
+  await Promise.all(
+    ids.map(async id => {
+      try {
+        await T.RPCChat.localRefreshParticipantsRpcPromise({convID: T.Chat.keyToConversationID(id)})
+      } catch {
+        // the mutation itself already landed; a stale list self-heals on the next refresh
+        logger.info(`refreshConversationParticipants: failed for ${id}`)
+      }
+    })
+  )
+}
+
+// Membership can also change from outside this client (someone else adds you, an admin
+// kicks a member, a reset user is let back in). teamChangedByID fires for every incoming
+// message in the team, so gate on membershipChanged - otherwise an open members list
+// issues a participant refresh per message.
+export const useRefreshParticipantsOnTeamMembershipChange = (
+  teamID: T.Teams.TeamID,
+  conversationIDKey: T.Chat.ConversationIDKey,
+  enabled = true
+) => {
+  useEngineActionListener(
+    'keybase.1.NotifyTeam.teamChangedByID',
+    action => {
+      const {changes, teamID: changedTeamID} = action.payload.params
+      if (changedTeamID === teamID && changes.membershipChanged) {
+        void refreshConversationParticipants([conversationIDKey])
+      }
+    },
+    enabled && !!teamID && teamID !== T.Teams.noTeamID
+  )
+}

--- a/shared/teams/channel/index.tsx
+++ b/shared/teams/channel/index.tsx
@@ -23,6 +23,7 @@ import {LoadedTeamChannelsProvider} from '../common/use-loaded-team-channels'
 import {useUsersState} from '@/stores/users'
 import {LoadedTeamProvider, useLoadedTeam} from '../team/use-loaded-team'
 import {unboxRows, useInboxMetadataState} from '@/chat/inbox/metadata'
+import {useRefreshParticipantsOnTeamMembershipChange} from '@/chat/inbox/refresh-participants'
 import {registerExternalResetter} from '@/util/zustand'
 
 export type OwnProps = {
@@ -170,6 +171,9 @@ const ChannelBody = (props: OwnProps) => {
   const participants: ReadonlyArray<string> =
     meta.channelname === 'general' && teamMembers.size > 0 ? _participants : channelParticipants
   useLoadDataForChannelPage(conversationIDKey, selectedTab, meta, participants)
+  // a kick, an add-to-team or a reset user let back in changes this channel's members
+  // too, including when another client does it
+  useRefreshParticipantsOnTeamMembershipChange(teamID, conversationIDKey, selectedTab === 'members')
 
   React.useEffect(() => {
     if (!props.selectedMembers?.length) {

--- a/shared/teams/confirm-modals/confirm-remove-from-channel.test.tsx
+++ b/shared/teams/confirm-modals/confirm-remove-from-channel.test.tsx
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {removeMembersFromChannel} from './confirm-remove-from-channel'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convID = T.Chat.keyToConversationID(conversationIDKey)
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('removing members refreshes the conversation participants', async () => {
+  jest.spyOn(T.RPCChat, 'localRemoveFromConversationLocalRpcPromise').mockResolvedValue({} as never)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await removeMembersFromChannel(conversationIDKey, ['testuser', 'testuser-mac'])
+
+  expect(T.RPCChat.localRemoveFromConversationLocalRpcPromise).toHaveBeenCalledWith({
+    convID,
+    usernames: ['testuser', 'testuser-mac'],
+  })
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('a failed removal never claims the participants are fresh', async () => {
+  jest
+    .spyOn(T.RPCChat, 'localRemoveFromConversationLocalRpcPromise')
+    .mockRejectedValue(new Error('not an admin'))
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await expect(removeMembersFromChannel(conversationIDKey, ['testuser'])).rejects.toThrow('not an admin')
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})

--- a/shared/teams/confirm-modals/confirm-remove-from-channel.tsx
+++ b/shared/teams/confirm-modals/confirm-remove-from-channel.tsx
@@ -7,11 +7,25 @@ import {useNavigation} from '@react-navigation/native'
 import setRouteParamsIfPresent from './set-route-params-if-present'
 import {useLoadedTeamChannels} from '../common/use-loaded-team-channels'
 import {useSafeNavigation} from '@/util/safe-navigation'
+import {refreshConversationParticipants} from '@/chat/inbox/refresh-participants'
 
 type Props = {
   members: string[]
   conversationIDKey: T.Chat.ConversationIDKey
   teamID: T.Teams.TeamID
+}
+
+// Removing from a channel changes its participants, and nothing recomputes them on its
+// own - see refreshConversationParticipants.
+export const removeMembersFromChannel = async (
+  conversationIDKey: T.Chat.ConversationIDKey,
+  usernames: ReadonlyArray<string>
+) => {
+  await T.RPCChat.localRemoveFromConversationLocalRpcPromise({
+    convID: T.Chat.keyToConversationID(conversationIDKey),
+    usernames: [...usernames],
+  })
+  await refreshConversationParticipants([conversationIDKey])
 }
 
 const ConfirmRemoveFromChannel = (props: Props) => {
@@ -27,14 +41,14 @@ const ConfirmRemoveFromChannel = (props: Props) => {
 
   const nav = useSafeNavigation()
   const navigation = useNavigation()
-  const removeFromChannel = C.useRPC(T.RPCChat.localRemoveFromConversationLocalRpcPromise)
+  const removeFromChannel = C.useRPC(removeMembersFromChannel)
 
   const onRemove = () => {
     setWaiting(true)
     setTimeout(() => setWaiting(false), 1000)
     removeFromChannel(
-      [{convID: T.Chat.keyToConversationID(conversationIDKey), usernames: members}],
-      _ => {
+      [conversationIDKey, members],
+      () => {
         setWaiting(false)
         setRouteParamsIfPresent(navigation, 'teamChannel', {selectedMembers: undefined})
         nav.safeNavigateUp()

--- a/shared/teams/team/member/add-to-channels-row.test.tsx
+++ b/shared/teams/team/member/add-to-channels-row.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {joinChannel, leaveChannel} from './add-to-channels-row'
+
+const conversationIDKey = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convID = T.Chat.keyToConversationID(conversationIDKey)
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('joining a channel refreshes its participants', async () => {
+  jest.spyOn(T.RPCChat, 'localJoinConversationByIDLocalRpcPromise').mockResolvedValue({} as never)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await joinChannel(conversationIDKey)
+
+  expect(T.RPCChat.localJoinConversationByIDLocalRpcPromise).toHaveBeenCalledWith({convID})
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('leaving a channel refreshes its participants', async () => {
+  jest.spyOn(T.RPCChat, 'localLeaveConversationLocalRpcPromise').mockResolvedValue({} as never)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await leaveChannel(conversationIDKey)
+
+  expect(T.RPCChat.localLeaveConversationLocalRpcPromise).toHaveBeenCalledWith({convID})
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledWith({convID})
+})
+
+test('a failed join never claims the participants are fresh', async () => {
+  jest
+    .spyOn(T.RPCChat, 'localJoinConversationByIDLocalRpcPromise')
+    .mockRejectedValue(new Error('cannot join'))
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await expect(joinChannel(conversationIDKey)).rejects.toThrow('cannot join')
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})

--- a/shared/teams/team/member/add-to-channels-row.tsx
+++ b/shared/teams/team/member/add-to-channels-row.tsx
@@ -4,6 +4,23 @@ import * as React from 'react'
 import * as Kb from '@/common-adapters'
 import * as Common from '@/teams/common'
 import {useSafeNavigation} from '@/util/safe-navigation'
+import {refreshConversationParticipants} from '@/chat/inbox/refresh-participants'
+
+// Joining or leaving changes who is in the channel, and nothing recomputes its
+// participants on its own - see refreshConversationParticipants.
+export const joinChannel = async (conversationIDKey: T.Chat.ConversationIDKey) => {
+  await T.RPCChat.localJoinConversationByIDLocalRpcPromise({
+    convID: T.Chat.keyToConversationID(conversationIDKey),
+  })
+  await refreshConversationParticipants([conversationIDKey])
+}
+
+export const leaveChannel = async (conversationIDKey: T.Chat.ConversationIDKey) => {
+  await T.RPCChat.localLeaveConversationLocalRpcPromise({
+    convID: T.Chat.keyToConversationID(conversationIDKey),
+  })
+  await refreshConversationParticipants([conversationIDKey])
+}
 
 // horizontal padding shared with the header row in add-to-channels.tsx
 export const itemStyle = Kb.Styles.platformStyles({
@@ -56,14 +73,13 @@ const SelfChannelActions = function SelfChannelActions(p: {
     })
   }
 
-  const joinRPC = C.useRPC(T.RPCChat.localJoinConversationByIDLocalRpcPromise)
-  const leaveRPC = C.useRPC(T.RPCChat.localLeaveConversationLocalRpcPromise)
+  const joinRPC = C.useRPC(joinChannel)
+  const leaveRPC = C.useRPC(leaveChannel)
 
-  const convID = T.Chat.keyToConversationID(meta.conversationIDKey)
   const onLeave = () => {
     setWaiting(true)
     leaveRPC(
-      [{convID}],
+      [meta.conversationIDKey],
       () => {
         reloadChannels()
           .then(stopWaiting, stopWaiting)
@@ -75,7 +91,7 @@ const SelfChannelActions = function SelfChannelActions(p: {
   const onJoin = () => {
     setWaiting(true)
     joinRPC(
-      [{convID}],
+      [meta.conversationIDKey],
       () => {
         reloadChannels()
           .then(stopWaiting, stopWaiting)

--- a/shared/teams/team/member/add-to-channels.test.tsx
+++ b/shared/teams/team/member/add-to-channels.test.tsx
@@ -1,0 +1,39 @@
+/** @jest-environment jsdom */
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {addMembersToChannels} from './add-to-channels'
+
+const convA = T.Chat.conversationIDToKey(new Uint8Array([1, 2, 3, 4]))
+const convB = T.Chat.conversationIDToKey(new Uint8Array([5, 6, 7, 8]))
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('adding someone to several channels refreshes every one of them', async () => {
+  jest.spyOn(T.RPCChat, 'localBulkAddToManyConvsRpcPromise').mockResolvedValue(undefined)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await addMembersToChannels([convA, convB], ['testuser'])
+
+  expect(T.RPCChat.localBulkAddToManyConvsRpcPromise).toHaveBeenCalledWith({
+    conversations: [T.Chat.keyToConversationID(convA), T.Chat.keyToConversationID(convB)],
+    usernames: ['testuser'],
+  })
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).toHaveBeenCalledTimes(2)
+})
+
+test('a failed add never claims the participants are fresh', async () => {
+  jest.spyOn(T.RPCChat, 'localBulkAddToManyConvsRpcPromise').mockRejectedValue(new Error('nope'))
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockResolvedValue(undefined)
+
+  await expect(addMembersToChannels([convA], ['testuser'])).rejects.toThrow('nope')
+  expect(T.RPCChat.localRefreshParticipantsRpcPromise).not.toHaveBeenCalled()
+})
+
+test('a failed refresh does not fail the add', async () => {
+  jest.spyOn(T.RPCChat, 'localBulkAddToManyConvsRpcPromise').mockResolvedValue(undefined)
+  jest.spyOn(T.RPCChat, 'localRefreshParticipantsRpcPromise').mockRejectedValue(new Error('offline'))
+
+  await expect(addMembersToChannels([convA], ['testuser'])).resolves.toBeUndefined()
+})

--- a/shared/teams/team/member/add-to-channels.tsx
+++ b/shared/teams/team/member/add-to-channels.tsx
@@ -11,10 +11,24 @@ import {useSafeNavigation} from '@/util/safe-navigation'
 import {useCurrentUserState} from '@/stores/current-user'
 import {LoadedTeamProvider, useLoadedTeam} from '../use-loaded-team'
 import ChannelRow, {itemStyle} from './add-to-channels-row'
+import {refreshConversationParticipants} from '@/chat/inbox/refresh-participants'
 
 type Props = {
   teamID: T.Teams.TeamID
   usernames?: Array<string> // undefined means the user themself
+}
+
+// bulkAddToManyConvs changes who is in each of these channels, and nothing recomputes
+// their participants on its own - see refreshConversationParticipants.
+export const addMembersToChannels = async (
+  conversationIDKeys: ReadonlyArray<T.Chat.ConversationIDKey>,
+  usernames: ReadonlyArray<string>
+) => {
+  await T.RPCChat.localBulkAddToManyConvsRpcPromise({
+    conversations: conversationIDKeys.map(T.Chat.keyToConversationID),
+    usernames: [...usernames],
+  })
+  await refreshConversationParticipants(conversationIDKeys)
 }
 
 type ChannelItem = {
@@ -129,7 +143,7 @@ const AddToChannelsBody = function AddToChannelsBody(props: Props) {
   const onSelectNone = convIDKeysAvailable.length === 0 ? undefined : () => setSelected(new Set())
   const onCancel = () => nav.safeNavigateUp()
 
-  const submit = C.useRPC(T.RPCChat.localBulkAddToManyConvsRpcPromise)
+  const submit = C.useRPC(addMembersToChannels)
   const [waiting, setWaiting] = React.useState(false)
   const onFinish = () => {
     if (!selected.size) {
@@ -138,7 +152,7 @@ const AddToChannelsBody = function AddToChannelsBody(props: Props) {
     }
     setWaiting(true)
     submit(
-      [{conversations: [...selected].map(T.Chat.keyToConversationID), usernames}],
+      [[...selected], usernames],
       () => {
         setWaiting(false)
         onCancel()


### PR DESCRIPTION
## The bug

Adding members to a channel from the chat info panel leaves the members list right above it showing the pre-add list. It refreshed in 6.6.3.

## Why

For team conversations the service recomputes participants only on demand. `localRefreshParticipants` reaches `CachingParticipantSource.GetWithNotifyNonblock`, which emits `ChatParticipantsInfo`, which is the only thing that fills `useInboxMetadataState.participants` — the source for both the chat info panel members list and the teams channel members tab.

Nothing else pushes it:

- `bulkAddToConv` only posts a system message. It arrives as an `incomingMessage` activity whose `InboxUIItem` carries no participants for team convs.
- `useConversationMetadataReload`'s `reload()` calls the non-forced `unboxRows`, which is dropped client-side for an already-trusted conv — and the conversation you are looking at is always trusted.

This used to be masked by `loadTeamChannelList`, which looped every channel in the team calling `localRefreshParticipants` ("ensure we refresh participants"). That fan-out was deliberately removed for performance, and with it went the accidental self-heal for every membership surface.

## Stale surfaces, all after a user action

| Action | Site |
| --- | --- |
| Add members to channel | `chat/conversation/info-panel/add-to-channel.tsx` |
| Add a member to many channels | `teams/team/member/add-to-channels.tsx` |
| Remove members from a channel | `teams/confirm-modals/confirm-remove-from-channel.tsx` |
| Join / leave a channel | `teams/team/member/add-to-channels-row.tsx` |
| Join a previewed conversation | `chat/conversation/status-actions.tsx` |
| Let a reset user back in | `chat/conversation/messages/reset-user.tsx` |

Team-level membership was already fine — `useChatTeamMembers` reloads on `teamChangedByID`. Only the per-conversation participant list was affected.

## The fix

New `chat/inbox/refresh-participants.tsx`:

- `refreshConversationParticipants(ids)` — dedupes, drops placeholder conversation ids, and swallows per-conversation failures so a refresh error cannot fail a mutation that already landed. Called after each of the six mutations above.
- `useRefreshParticipantsOnTeamMembershipChange(teamID, convID)` — on the two open members lists, so a kick, an add-to-team or a reset readmit performed elsewhere lands as well. Gated on `changes.membershipChanged`: `teamChangedByID` also fires for every message in the team, so an ungated watcher would be one participant rpc per message for as long as the panel is open.

`MembersTab` grows a `useChannelMembers` hook holding the list derivation and both refresh paths, so the reported surface is testable without standing up the section list.

## Tests

44 new tests across 8 files, each mutation-checked (every fix removed in turn; the matching test failed each time).

- `refresh-participants.test.tsx` — dedupe, placeholder filtering, partial-failure isolation, the `membershipChanged` / team-match / enabled / unmount gates, and an end-to-end pass from a real `ChatParticipantsInfo` notification through to the derived member list for both an add and a remove.
- `members.test.tsx` — refresh on open, refresh on membership change, no refresh on ordinary team activity, no re-ask on re-render, ordering with owners and admins first, bots excluded, spinner while empty, general listing the whole team, and a member appearing once the store updates.
- One file per mutation site asserting the refresh happens, and never happens when the mutation itself failed.
- `metadata.test.tsx` gains coverage of the root-cause mechanics: a non-forced reload of a trusted conversation never reaches the service while an untrusted one does, and a participants notification replaces, scopes, and does not clear stored participants.

`yarn lint:all` clean (0 bailouts, 0 whole-props deps, tsc green). Full suite: 2128 tests / 225 suites passing.

## Testing notes

Not yet exercised in a running client — worth confirming the lists repaint for an add, a remove, and a join.
