### PR TITLE
fix(ios): never register an empty header right item (blank glass pill)

### DIFF
--- a/shared/chat/conversation/header-area/index.tsx
+++ b/shared/chat/conversation/header-area/index.tsx
@@ -26,9 +26,6 @@ type HeaderConversationProps = {conversationIDKey: T.Chat.ConversationIDKey}
 const HeaderAreaRight = (props: HeaderConversationProps) => {
   const styles = useStyles()
   const {conversationIDKey} = props
-  const pendingWaiting =
-    conversationIDKey === Chat.pendingWaitingConversationIDKey ||
-    conversationIDKey === Chat.pendingErrorConversationIDKey
 
   const onShowInfoPanel = () => {
     Keyboard.dismiss()
@@ -48,7 +45,7 @@ const HeaderAreaRight = (props: HeaderConversationProps) => {
       direction="horizontal"
       gap="small"
       noShrink={true}
-      style={Kb.Styles.collapseStyles([styles.headerRight, {opacity: pendingWaiting ? 0 : 1}])}
+      style={styles.headerRight}
     >
       <Kb.Icon type="iconfont-search" onClick={onToggleThreadSearch} />
       <Kb.Icon type="iconfont-info" onClick={onShowInfoPanel} testID={TestIDs.CHAT_HEADER_INFO_BUTTON} />
@@ -174,6 +171,13 @@ const iosBackOptions = (badgeNumber: number) =>
 export const headerNavigationOptions = (route: {params?: {conversationIDKey?: T.Chat.ConversationIDKey}}) => {
   if (!isMobile) return {}
   const conversationIDKey = route.params?.conversationIDKey ?? Chat.noConversationIDKey
+  // pending convs have no thread to search and no info panel to show, and an item that
+  // renders nothing (or at opacity 0) still draws an empty glass pill on iOS 26, so the
+  // right slot is left unset until the real conv replaces the pending one (setParams
+  // re-evaluates these options).
+  const pendingWaiting =
+    conversationIDKey === Chat.pendingWaitingConversationIDKey ||
+    conversationIDKey === Chat.pendingErrorConversationIDKey
   return {
     // iOS 26: the back button (badged or not) is decided synchronously here so the header is
     // complete in the screen's initial options — swapping bar items via setOptions while the
@@ -190,7 +194,9 @@ export const headerNavigationOptions = (route: {params?: {conversationIDKey?: T.
         }
       : iosBackOptions(getBackBadge(conversationIDKey))),
     // iOS 26: single overflow menu (one glass pill) housing search + info actions.
-    ...(isIOS
+    ...(pendingWaiting
+      ? {}
+      : isIOS
       ? {
           unstable_headerRightItems: () => [
             {

--- a/shared/profile/routes.tsx
+++ b/shared/profile/routes.tsx
@@ -41,7 +41,6 @@ const EditAvatarHeaderRight = ({
     )
     navigateAppend(getNextRouteAfterAvatar(wizardState, parentTeamMemberCount))
   }
-  if (!wizard) return null
   if (isMobile) {
     return <Kb.Text type="BodyBigLink" onClick={onSkip}>Skip</Kb.Text>
   }
@@ -131,7 +130,11 @@ export const newModalRoutes = defineRouteMap({
               <EditAvatarHeaderLeft wizard={route.params.wizard} showBack={route.params.showBack} />
             ),
           }),
-      headerRight: () => <EditAvatarWizardHeaderRight route={route} />,
+      // Only register a right item when the Skip button actually renders: on iOS 26 a
+      // custom header view that renders nothing still draws an empty glass pill.
+      ...(route.params.wizard
+        ? {headerRight: () => <EditAvatarWizardHeaderRight route={route} />}
+        : {}),
       headerTitle: () => (
         <EditAvatarHeaderTitle
           hasImage={!!route.params.image}

--- a/shared/teams/routes.tsx
+++ b/shared/teams/routes.tsx
@@ -202,10 +202,6 @@ const AddFromWhereSkip = ({wizard}: {wizard: AddMembersWizard}) => {
   )
 }
 
-const AddFromWhereHeaderRight = ({wizard}: {wizard: AddMembersWizard}) => {
-  return wizard.teamID === T.Teams.newTeamWizardTeamID ? <AddFromWhereSkip wizard={wizard} /> : null
-}
-
 const AddFromWhereHeaderTitle = ({wizard}: {wizard: AddMembersWizard}) => (
   <ModalTitle
     title={isMobile ? 'Add/Invite people' : 'Add or invite people'}
@@ -336,7 +332,11 @@ export const newModalRoutes = defineRouteMap({
                 : [Kb.nativeCancelHeaderItem(C.Router2.clearModals)],
           }
         : {headerLeft: () => <AddFromWhereHeaderLeft wizard={route.params.wizard} />}),
-      headerRight: () => <AddFromWhereHeaderRight wizard={route.params.wizard} />,
+      // Only register a right item when Skip actually renders: on iOS 26 a custom header
+      // view that renders nothing still draws an empty glass pill.
+      ...(route.params.wizard.teamID === T.Teams.newTeamWizardTeamID
+        ? {headerRight: () => <AddFromWhereSkip wizard={route.params.wizard} />}
+        : {}),
       headerTitle: () => <AddFromWhereHeaderTitle wizard={route.params.wizard} />,
       modalSize: 'wide',
     }),


### PR DESCRIPTION
On iOS 26 every custom header view becomes a liquid-glass bar item, and the glass pill is drawn whether or not the component renders anything. Header rights that decide "nothing to show" by returning `null` — or by rendering at `opacity: 0` — therefore leave a **blank glass pill** in the right slot.

Reported case: editing your own avatar in the profile modal. Fix is to decide in `getOptions` and omit the key entirely, so no bar item is created.

### Changes

- **`profile/routes.tsx`** — `profileEditAvatar` always set `headerRight`, but the Skip button only exists in the team-creation wizard, so the ordinary avatar edit showed an empty pill the whole time. `headerRight` is now spread in only when `route.params.wizard` is set; removed the now-unreachable `if (!wizard) return null`.
- **`teams/routes.tsx`** — same latent bug in `teamAddToTeamFromWhere`: the wrapper returned `null` for non-new-team wizards. Gated the option instead and render `AddFromWhereSkip` directly, dropping the wrapper.
- **`chat/conversation/header-area/index.tsx`** — pending conversations have no thread to search and no info panel, and the right slot was hidden with `opacity: 0` (which still draws the pill). The slot — iOS overflow menu, Android search+info icons — is now omitted for pending/pending-error conversations. The new-chat flow swaps params on the same screen, which re-evaluates `headerNavigationOptions`, so the items come back with the real conversation.

Audited the other `headerRight:` sites: they are either non-iOS gated or always render content.

### Test plan

- `yarn lint:all` clean (0 bailouts, 0 whole-props deps, tsc clean).
- Manual iOS: profile → edit avatar shows a bare right side; the team-creation wizard still shows Skip; new chat shows no right item until the conversation resolves, then the overflow menu appears.