### PR TITLE
fix(chat): new chat lands in one navigation instead of two pushes

### DIFF
--- a/shared/chat/inbox/metadata.tsx
+++ b/shared/chat/inbox/metadata.tsx
@@ -153,6 +153,20 @@ export const maybeChangeSelectedConversation = (inboxLayout?: T.RPCChat.UIInboxL
     return
   }
 
+  // A pending placeholder means a conversation creation is in flight: that screen belongs to the
+  // create flow, which replaces it with the real conv (or the error screen) when the RPC returns.
+  // The service rebuilds the layout the moment the conv exists, and while it has never been told a
+  // selected conv it tags every layout with reselectInfo, so acting on one here yanks the screen
+  // away - navigateToInbox defers a tick, so it lands either just after the real conv arrives
+  // (bounced back to the inbox) or just before it (pending pushed, popped, then pushed again).
+  if (
+    selectedConversation === T.Chat.pendingWaitingConversationIDKey ||
+    selectedConversation === T.Chat.pendingErrorConversationIDKey
+  ) {
+    logger.info('maybeChangeSelectedConversation: creation in flight, ignoring reselect')
+    return
+  }
+
   const existingValid = T.Chat.isValidConversationIDKey(selectedConversation)
   if (!newConvID) {
     if (!existingValid && isMobile) {

--- a/shared/chat/inbox/reselect-conversation.test.ts
+++ b/shared/chat/inbox/reselect-conversation.test.ts
@@ -1,0 +1,67 @@
+/// <reference types="jest" />
+import * as T from '@/constants/types'
+import {resetAllStores} from '@/util/zustand'
+import {useConfigState} from '@/stores/config'
+
+jest.mock('@/constants/router', () => ({
+  getModalStack: jest.fn(() => []),
+  getVisibleScreen: jest.fn(() => undefined),
+  navigateToInbox: jest.fn(),
+  navigateToThread: jest.fn(),
+}))
+
+jest.mock('@/constants/chat/common', () => ({
+  ...jest.requireActual('@/constants/chat/common'),
+  getSelectedConversation: jest.fn(),
+}))
+
+import * as Common from '@/constants/chat/common'
+import {navigateToInbox, navigateToThread} from '@/constants/router'
+import {maybeChangeSelectedConversation} from './metadata'
+
+const newConvID = 'ff00ff00'
+const mockedSelected = Common.getSelectedConversation as jest.Mock
+
+const layout = (over: Partial<T.RPCChat.UIInboxReselectInfo>): T.RPCChat.UIInboxLayout =>
+  ({reselectInfo: {oldConvID: '', ...over}}) as T.RPCChat.UIInboxLayout
+
+beforeEach(() => {
+  useConfigState.setState({loggedIn: true})
+  global.isMobile = true
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+  resetAllStores()
+  global.isMobile = false
+})
+
+// Creating a conversation parks the thread screen on PENDING-WAITING while the RPC runs. The
+// service rebuilds the inbox layout as soon as the conv exists, and since it has never been told
+// a selected conv (nothing was ever loaded when the inbox was empty) that layout always carries
+// reselectInfo. Acting on it pops the screen the create flow is about to fill in.
+test('a reselect while a conversation creation is pending does not pop to the inbox', () => {
+  mockedSelected.mockReturnValue(T.Chat.pendingWaitingConversationIDKey)
+
+  maybeChangeSelectedConversation(layout({newConvID}))
+
+  expect(navigateToInbox).not.toHaveBeenCalled()
+  expect(navigateToThread).not.toHaveBeenCalled()
+})
+
+test('a reselect while the create error screen is up does not pop to the inbox', () => {
+  mockedSelected.mockReturnValue(T.Chat.pendingErrorConversationIDKey)
+
+  maybeChangeSelectedConversation(layout({newConvID}))
+
+  expect(navigateToInbox).not.toHaveBeenCalled()
+})
+
+// the real "we are on a dead conversation" case still has to bounce
+test('a reselect with nothing selected still goes to the inbox on mobile', () => {
+  mockedSelected.mockReturnValue(T.Chat.noConversationIDKey)
+
+  maybeChangeSelectedConversation(layout({newConvID}))
+
+  expect(navigateToInbox).toHaveBeenCalledWith(false)
+})

--- a/shared/chat/team-building-finished.tsx
+++ b/shared/chat/team-building-finished.tsx
@@ -1,12 +1,13 @@
-import * as T from '@/constants/types'
-import {createConversation, navigateToThread} from '@/constants/router'
+import type * as T from '@/constants/types'
+import {createConversation, navigateToPendingThread} from '@/constants/router'
 import {ignorePromise, timeoutPromise} from '@/constants/utils'
 
 export const onTeamBuildingFinished = (users: ReadonlySet<T.TB.User>) => {
   const f = async () => {
     await timeoutPromise(500)
-    navigateToThread(T.Chat.pendingWaitingConversationIDKey, 'justCreated')
-    createConversation([...users].map(u => u.id))
+    const participants = [...users].map(u => u.id)
+    navigateToPendingThread(participants)
+    createConversation(participants)
   }
   ignorePromise(f())
 }

--- a/shared/constants/navigate-to-thread.test.ts
+++ b/shared/constants/navigate-to-thread.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="jest" />
+// Phone layout: the thread is a root-level screen pushed above the tab navigator.
+jest.mock('@/constants/chat/layout', () => ({isSplit: false, threadRouteName: 'chatConversation'}))
+
+import * as T from '@/constants/types'
+import {navigateToPendingThread, navigateToThread, navigationRef, setModalRouteNames} from '@/constants/router'
+import {useInboxMetadataState} from '@/chat/inbox/metadata-store'
+import {useCurrentUserState} from '@/stores/current-user'
+
+const dispatch = jest.fn()
+
+const loggedIn = {
+  key: 'loggedIn-1',
+  name: 'loggedIn',
+  state: {
+    index: 0,
+    key: 'tabs-1',
+    routes: [
+      {
+        key: 'chatTab-1',
+        name: 'tabs.chatTab',
+        state: {index: 0, key: 'chatstack-1', routes: [{key: 'chatRoot-1', name: 'chatRoot'}], type: 'stack'},
+      },
+    ],
+    type: 'tab',
+  },
+}
+
+const setRootRoutes = (routes: Array<unknown>) => {
+  const state = {index: routes.length - 1, key: 'root-1', routeNames: [], routes, stale: false, type: 'stack'}
+  // the jest mock's container ref is a plain object, so stub its methods directly
+  const nr = navigationRef as unknown as Record<string, unknown>
+  nr['current'] = {}
+  nr['dispatch'] = dispatch
+  nr['getRootState'] = () => state
+  nr['isReady'] = () => true
+  nr['addListener'] = () => () => {}
+}
+
+const pendingRoute = {
+  key: 'conv-pending',
+  name: 'chatConversation',
+  params: {conversationIDKey: T.Chat.pendingWaitingConversationIDKey},
+}
+
+const realConvID = 'ff00ff00' as T.Chat.ConversationIDKey
+
+beforeEach(() => {
+  dispatch.mockClear()
+  setModalRouteNames(['chatNewChat'])
+})
+
+// Creating a conversation parks the thread screen on PENDING-WAITING while the RPC runs, so the
+// resolved conv is the same chat arriving on the same screen. react-native-screens always animates
+// a replace on iOS, so a StackActions.replace here (like a push) makes one new chat read as two
+// pushes: the blank pending thread slides in, then the real one slides in over it.
+test('pending -> resolved conversation retargets the live screen instead of animating a new one', () => {
+  setRootRoutes([loggedIn, pendingRoute])
+
+  navigateToThread(realConvID, 'justCreated')
+
+  expect(dispatch).toHaveBeenCalledTimes(1)
+  const action = dispatch.mock.calls[0]?.[0] as {type: string; payload: unknown; source?: string}
+  expect(action.type).toBe('SET_PARAMS')
+  expect(action.source).toBe(pendingRoute.key)
+  expect(action.payload).toMatchObject({conversationIDKey: realConvID})
+})
+
+test('no thread on screen still pushes the conversation', () => {
+  setRootRoutes([loggedIn])
+
+  navigateToThread(realConvID, 'justCreated')
+
+  expect(dispatch).toHaveBeenCalledTimes(1)
+  const action = dispatch.mock.calls[0]?.[0] as {type: string; payload: {name: string}}
+  expect(action.type).toBe('PUSH')
+  expect(action.payload.name).toBe('chatConversation')
+})
+
+// setParams keeps the native screen alive, and iOS never re-measures a header title subview it
+// first measured empty - so the pending thread has to have a title before it is shown.
+test('the pending thread is seeded with the participants so its header title is never empty', () => {
+  useCurrentUserState.setState({username: 'testuser'})
+  setRootRoutes([loggedIn])
+
+  navigateToPendingThread(['testuser-mac'])
+
+  const seeded = useInboxMetadataState.getState().participants.get(T.Chat.pendingWaitingConversationIDKey)
+  expect(seeded?.name).toEqual(['testuser', 'testuser-mac'])
+  const action = dispatch.mock.calls[0]?.[0] as {type: string; payload: {params: object}}
+  expect(action.payload.params).toMatchObject({
+    conversationIDKey: T.Chat.pendingWaitingConversationIDKey,
+  })
+})

--- a/shared/constants/router.tsx
+++ b/shared/constants/router.tsx
@@ -593,6 +593,24 @@ export const createConversation = (
   ignorePromise(f())
 }
 
+// Park the thread screen on the pending placeholder while localNewConversation runs, seeding it
+// with the participants we already know. The seed is what lets the switch to the created
+// conversation be a setParams instead of a new screen: iOS measures the header title subview once
+// and never re-measures one that started empty, so a title-less pending thread would leave the bar
+// blank for the real conv too (measured on device in bc6e852a97). It also just reads better - you
+// see who you're talking to while the conversation is being made.
+export const navigateToPendingThread = (participants: ReadonlyArray<string>) => {
+  const {username} = useCurrentUserState.getState()
+  // matches participants.name for a real conv: the tlf name, which includes you
+  const name = [...new Set([username, ...participants])]
+  participantInfoReceived(T.Chat.pendingWaitingConversationIDKey, {
+    all: name,
+    contactName: new Map(),
+    name,
+  })
+  navigateToThread(T.Chat.pendingWaitingConversationIDKey, 'justCreated')
+}
+
 export const previewConversation = (p: PreviewConversationParams) => {
   const previewConversationPersonMakesAConversation = () => {
     const {participants, teamname, highlightMessageID} = p
@@ -610,7 +628,7 @@ export const previewConversation = (p: PreviewConversationParams) => {
       }
     }
 
-    navigateToThread(T.Chat.pendingWaitingConversationIDKey, 'justCreated')
+    navigateToPendingThread(participants)
     createConversation(participants, highlightMessageID)
   }
 
@@ -975,13 +993,16 @@ export const navigateToThread = (
       threadSearch,
     }
     if (replace) {
-      // pendingWaiting -> real conversation. Must be a real replace, not
-      // navigateAppend's replace (which degrades to setParams for the same route
-      // name): setParams keeps the native screen alive, and its header title was
-      // measured while pendingWaiting rendered it empty — iOS never re-measures
-      // an initially-empty title subview, leaving the header blank. A fresh
-      // screen measures the title with its content already present.
-      _getNavigator()?.dispatch(StackActions.replace(threadRouteName, params))
+      // pendingWaiting -> real conversation: the same chat arriving, so retarget the live screen.
+      // It cannot be a StackActions.replace: react-native-screens always animates a replace on
+      // iOS (RNSScreenStack.mm passes `animated:previousTop.view.window != nil`, ignoring
+      // stackAnimation, and the animationTypeForReplace:'pop' branch is an animated pop), so the
+      // blank pending thread slides in and the real one slides in over it - one new chat reading
+      // as two pushes. setParams has no transition at all. It relies on the pending thread's
+      // header title already having content (seeded by navigateToPendingThread): iOS never
+      // re-measures a title subview it first measured empty, so a blank pending title would
+      // leave the bar blank for the real conv too.
+      _getNavigator()?.dispatch({...CommonActions.setParams(params), source: visible?.key})
     } else {
       navigateAppend({name: threadRouteName, params})
     }

--- a/shared/router-v2/screen-layout.test.tsx
+++ b/shared/router-v2/screen-layout.test.tsx
@@ -1,0 +1,24 @@
+/// <reference types="jest" />
+
+import {nativeMakeLayout} from './screen-layout'
+
+// react-navigation calls a screen's `layout` as a plain function from inside the
+// navigator's own render (useDescriptors builds every descriptor eagerly), NOT as a
+// component. Any hook a layout calls therefore lands in NativeStackNavigator's hook
+// list, and the count changes with the routes on the stack - pushing a modal shifts
+// the order and React errors out. So layouts must render components, never call hooks.
+type Layout = ReturnType<ReturnType<typeof nativeMakeLayout>>
+const callLayout = (layout: (p: any) => Layout): Layout =>
+  layout({children: null, navigation: {} as never, route: {name: 'chatNewChat', params: {}} as never})
+
+describe('native screen layouts', () => {
+  test.each([
+    ['modal', true, false],
+    ['logged out', false, true],
+    ['tab screen', false, false],
+  ])('%s layout calls no hooks outside a render', (_label, isModal, isLoggedOut) => {
+    const layout = nativeMakeLayout(isModal, isLoggedOut, false, () => ({}))
+
+    expect(() => callLayout(layout)).not.toThrow()
+  })
+})

--- a/shared/router-v2/screen-layout.tsx
+++ b/shared/router-v2/screen-layout.tsx
@@ -99,15 +99,51 @@ const desktopMakeLayout = (
   }
 }
 
-const nativeMakeLayout = (
+// Modal screens: their own SafeAreaProvider plus keyboard avoidance. Kept as a component
+// (not inlined into Layout below) because Layout runs inside the navigator's render and may
+// not call hooks.
+const ModalScreenWrapper = ({
+  children,
+  navigationOptions,
+}: {
+  children: React.ReactNode
+  navigationOptions: GetOptionsRet
+}) => {
+  const styles = useStyles()
+  return (
+    <SafeAreaProvider initialMetrics={initialWindowMetrics} pointerEvents="box-none">
+      {/* Android's default 'height' behavior is a no-op here: it animates height plus flex:0
+          onto a view whose static style is flexGrow:1 and whose child SafeAreaView forces
+          flex:1, so the shrink never reaches layout and the keyboard covers the content.
+          'padding' composes with those and is what iOS already uses. */}
+      <Kb.KeyboardAvoidingView2
+        behavior="padding"
+        extraOffset={isIOS ? 40 : 0}
+        compensateNotBeingOnBottom={isTablet}
+      >
+        <Kb.SafeAreaView
+          edges={navigationOptions?.safeAreaEdges}
+          style={Kb.Styles.collapseStyles([styles.keyboard, navigationOptions?.safeAreaStyle])}
+        >
+          {children}
+        </Kb.SafeAreaView>
+      </Kb.KeyboardAvoidingView2>
+    </SafeAreaProvider>
+  )
+}
+
+// react-navigation calls `layout` as a plain function from inside the navigator's render
+// (useDescriptors builds every descriptor eagerly), so anything here runs in
+// NativeStackNavigator's hook slot. Calling a hook makes the navigator's hook count depend
+// on which routes are on the stack, and pushing a screen then trips React's hook-order
+// check. Render components; never call hooks.
+export const nativeMakeLayout = (
   isModal: boolean,
   isLoggedOut: boolean,
   _isTabScreen: boolean,
   getOptions?: GetOptions
 ) => {
-  const modalOffset = isIOS ? 40 : 0
   return function Layout({children, route, navigation}: LayoutProps) {
-    const styles = useStyles()
     const navigationOptions = typeof getOptions === 'function' ? getOptions({navigation, route}) : getOptions
 
     const wrappedContent = <React.Suspense>{children}</React.Suspense>
@@ -119,26 +155,7 @@ const nativeMakeLayout = (
       return <LoggedOutScreenWrapper>{wrappedContent}</LoggedOutScreenWrapper>
     }
 
-    return (
-      <SafeAreaProvider initialMetrics={initialWindowMetrics} pointerEvents="box-none">
-        {/* Android's default 'height' behavior is a no-op here: it animates height plus flex:0
-            onto a view whose static style is flexGrow:1 and whose child SafeAreaView forces
-            flex:1, so the shrink never reaches layout and the keyboard covers the content.
-            'padding' composes with those and is what iOS already uses. */}
-        <Kb.KeyboardAvoidingView2
-          behavior="padding"
-          extraOffset={modalOffset}
-          compensateNotBeingOnBottom={isModal && isTablet}
-        >
-          <Kb.SafeAreaView
-            edges={navigationOptions?.safeAreaEdges}
-            style={Kb.Styles.collapseStyles([styles.keyboard, navigationOptions?.safeAreaStyle])}
-          >
-            {wrappedContent}
-          </Kb.SafeAreaView>
-        </Kb.KeyboardAvoidingView2>
-      </SafeAreaProvider>
-    )
+    return <ModalScreenWrapper navigationOptions={navigationOptions}>{wrappedContent}</ModalScreenWrapper>
   }
 }
 


### PR DESCRIPTION
Creating a chat animated twice on iOS: the blank pending thread slid in, then the created conversation slid in over it.

## Why

The stack was already right — `navigateToThread` does a `StackActions.replace` once the pending thread is visible, and back went straight to the inbox. The problem is that **react-native-screens always animates a replace on iOS**. `RNSScreenStack.mm`'s `updateContainer` handles it with:

```objc
[_controller setViewControllers:controllers animated:previousTop.view.window != nil];
```

The flag comes from whether the outgoing screen is on screen, not from `stackAnimation` — so `animation: 'none'` does nothing, and the `animationTypeForReplace: 'pop'` branch is an animated pop. Only `setParams` on the live screen has no transition.

`setParams` is what this used to do, and it was swapped for a real replace in bc6e852a97 because the header went blank: iOS measures the title subview once and never re-measures one that started empty while `pendingWaiting` rendered it. Forcing a fresh `headerTitle` through `setOptions` afterwards doesn't help either (measured on device there — the JS title laid out at 105pt with the bar still empty).

## What

Don't let the title start empty. `navigateToPendingThread` seeds `participantInfo` for `PENDING-WAITING` with the participants the create flow already has, so the pending thread's title is measured with content and `setParams` is safe. Side benefit: you see who you're talking to while the conversation is being made, instead of a blank header.

Both callers (`onTeamBuildingFinished`, `previewConversation`) go through the new helper.

## Also here

Both found while chasing this:

- **A reselect arriving mid-creation yanked the screen away.** The service rebuilds the inbox layout the moment the conv exists and tags it with `reselectInfo` (it has never been told a selected conv), so `maybeChangeSelectedConversation` acted on it and either bounced back to the inbox or popped the pending screen and pushed it again. It now ignores a reselect while a creation is in flight.
- **Modal screen layouts called hooks.** react-navigation runs a screen's `layout` as a plain function from inside the navigator's render, so those hooks landed in `NativeStackNavigator`'s hook list and the count changed with the routes on the stack — pushing a screen tripped React's hook-order check. The wrapper is a component now.

## Testing

- `shared/constants/navigate-to-thread.test.ts` — pending→real retargets the live screen (`SET_PARAMS` at the pending route's key) rather than animating a new one; a fresh nav still pushes; `navigateToPendingThread` seeds the participants.
- `shared/chat/inbox/reselect-conversation.test.ts` — a reselect during a pending creation neither pops to the inbox nor navigates.
- `shared/router-v2/screen-layout.test.tsx` — layouts call no hooks outside a render.
- `yarn lint:all` clean (0 bailouts, 0 whole-props deps), `yarn jest` 228 suites / 2137 tests pass.
- Verified on the iOS simulator: new chat shows the pending thread with the participant names already in the header, then swaps to the real conversation with no animation, header still populated.
