### PR TITLE
fix(chat): let clicks reach giphy results on desktop

### DIFF
--- a/shared/chat/conversation/giphy/index.tsx
+++ b/shared/chat/conversation/giphy/index.tsx
@@ -167,6 +167,8 @@ const useStyles = Kb.Styles.createStyleHook(
       },
       poweredBy: {
         bottom: 0,
+        // sits over the bottom-right of the results grid; must not eat tile clicks
+        pointerEvents: 'none',
         position: 'absolute',
         right: 0,
       },

--- a/shared/chat/conversation/messages/text/unfurl/unfurl-list/image/video.tsx
+++ b/shared/chat/conversation/messages/text/unfurl/unfurl-list/image/video.tsx
@@ -77,7 +77,13 @@ const DesktopVideo = (p: Props) => {
 
   return (
     <Kb.Box2 direction="horizontal" relative={true} alignSelf="flex-start">
-      <Kb.Box2 direction="vertical" style={Kb.Styles.collapseStyles([sharedStyles.absoluteContainer, {height, width}])}>
+      {/* Positioned siblings paint above the in-flow video, so this overlay would
+          otherwise swallow every click meant for it (e.g. picking a giphy result). */}
+      <Kb.Box2
+        direction="vertical"
+        pointerEvents="none"
+        style={Kb.Styles.collapseStyles([sharedStyles.absoluteContainer, {height, width}])}
+      >
         {!playing && <Kb.ImageIcon type="icon-play-64" style={sharedStyles.playButton} />}
       </Kb.Box2>
       <video


### PR DESCRIPTION
Clicking a GIF in the desktop giphy popup did nothing. The popup rendered, the tiles animated, they just weren't clickable.

## Cause

The service only hands back the plain gif for mobile; on desktop `getPreferredPreview` returns the mp4 and sets `previewIsVideo`, so **every** desktop giphy tile goes through the video unfurl component.

That component's play-button overlay is an absolutely positioned sibling of the `<video>`, sized to exactly match it:

```jsx
<Kb.Box2 relative={true}>
  <Kb.Box2 style={[absoluteContainer, {height, width}]}>   // position: absolute
    {!playing && <Kb.ImageIcon type="icon-play-64" />}
  </Kb.Box2>
  <video onClick={_onClick} ... />                          // static
</Kb.Box2>
```

Positioned elements paint above in-flow content regardless of DOM order, so the overlay sat on top of the video and took every click. Giphy autoplays, so `playing` was true and the overlay was an empty div — nothing to see, nothing to click through.

## Why it started now

This structure is unchanged since June 2019, and the service has preferred mp4 on desktop just as long — so this looks like it was never a regression. It is one. **Chromium used to let a `<video>` win the hit test against a covering absolutely positioned sibling, and stopped doing so in Chromium 148.**

A/B'd on a minimal page reproducing the exact DOM above, hidden `BrowserWindow`, `document.elementFromPoint` at the tile centre:

| Electron | Chromium | element hit |
| --- | --- | --- |
| 39.2.7 (shipped in 6.6.3) | 142 | `VIDEO` |
| 40.4.0 | 144 | `VIDEO` |
| 41.5.0 | 146 | `VIDEO` |
| 42.0.0 | 148 | overlay `DIV` |
| 43.0.0 / 44.0.0 | 150 / 152 | overlay `DIV` |

It is specific to `<video>`: on Chromium 146 the same overlay over a `<div>`, `<img>` or `<canvas>` sibling already swallowed the click. Only `<video>` was special-cased, and 148 removed that.

It reached us in #29122, which jumped electron 39.2.7 → 42.3.3. That is why 6.6.3 works and why bisecting the client finds nothing — the only thing that moved was the bundled Chromium.

## Fix

`pointerEvents="none"` on the overlay. Clicks fall through to the video, which is where the handler already lives. Side benefit: the play icon on a paused unfurl video now toggles playback instead of absorbing the click — click-to-pause on ordinary video unfurls in the thread broke at the same time, and is fixed by the same line.

The "powered by GIPHY" badge had the same shape — absolutely positioned over the bottom-right of the results grid, no handler of its own — so it blocked tiles in that corner. Same one-line fix.

Native is unaffected: there the overlay lives inside the `ClickableBox` that carries the handler, and the mobile giphy picker is a WebView.

## Verified

Confirmed working in the desktop app. `yarn lint:all` clean (0 bailouts, 0 whole-props deps).
