### PR TITLE
fix(chat): drive edit/reply from context, not a router round-trip

### DIFF
--- a/shared/chat/conversation/input-area/input-state.tsx
+++ b/shared/chat/conversation/input-area/input-state.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as T from '@/constants/types'
+import logger from '@/logger'
 import {clearThreadInputAction} from '@/constants/router'
 import {findLast} from '@/util/arrays'
 import {useChatThreadRouteParams, type ThreadInputAction} from '../thread-search-route'
@@ -164,7 +165,12 @@ export const ConversationInputProvider = (p: React.PropsWithChildren<{id: T.Chat
       ordinal = e
     }
 
-    if (!ordinal) return
+    // Both bails leave the composer exactly as it was, so from the message menu they read as
+    // "Edit did nothing". Say which one happened; there is no other signal that it did.
+    if (!ordinal) {
+      logger.error(`[chat] setEditing found no editable message (${e === 'last' ? 'last' : 'ordinal'})`)
+      return
+    }
     const message = messageMap.get(ordinal)
     if (message?.type === 'text' || message?.type === 'attachment') {
       dispatchState({
@@ -172,6 +178,8 @@ export const ConversationInputProvider = (p: React.PropsWithChildren<{id: T.Chat
         text: message.type === 'text' ? message.text.stringValue() : message.title,
         type: 'setEditing',
       })
+    } else {
+      logger.error(`[chat] setEditing ignored ordinal ${ordinal}: message is ${message?.type ?? 'missing'}`)
     }
   })
   const sendComposerText = React.useEffectEvent((text: string) => {
@@ -274,6 +282,14 @@ export const ConversationInputProvider = (p: React.PropsWithChildren<{id: T.Chat
       <StateContext value={state}>{children}</StateContext>
     </DispatchContext>
   )
+}
+
+// For callers that may or may not sit inside the provider — the message popup is rendered inline
+// in the thread on desktop but as its own modal route on phones, and from the info panel and the
+// attachment viewer it is outside the thread entirely. Inside, talk to the store directly; the
+// router round-trip is only there to reach across a screen boundary.
+export function useConversationInputDispatchOptional(): ConversationInputDispatch | undefined {
+  return React.useContext(DispatchContext)
 }
 
 export function useConversationInput<T>(selector: (state: ConversationInputState) => T): T {

--- a/shared/chat/conversation/input-area/normal/index.tsx
+++ b/shared/chat/conversation/input-area/normal/index.tsx
@@ -1,6 +1,7 @@
 import * as C from '@/constants'
 import * as Kb from '@/common-adapters'
 import * as React from 'react'
+import logger from '@/logger'
 import CommandMarkdown from '../../command-markdown'
 import CommandStatus from '../../command-status'
 import Giphy from '../../giphy'
@@ -105,7 +106,10 @@ const Input = function Input() {
 
 const doInjectText = (inputRef: React.RefObject<InputRef | null>, text: string, focus?: boolean) => {
   if (!inputRef.current) {
-    console.log('injectText injectingTextRef null')
+    // Silently loses the text: the caller has already moved the value into unsentText, and the
+    // effect that got us here clears it straight after. An edit prefill dropped here looks like
+    // edit mode never opened.
+    logger.error('[chat] injectText dropped: input ref is null')
     return
   }
   if (!text) {

--- a/shared/chat/conversation/messages/message-popup/hooks.tsx
+++ b/shared/chat/conversation/messages/message-popup/hooks.tsx
@@ -13,6 +13,10 @@ import {linkFromConvAndMessage} from '@/constants/deeplinks'
 import {markConversationAsUnread, useConversationParticipants} from '../../data-hooks'
 import {showForwardMessagePicker} from '../../fwd-msg'
 import {navToProfile, setThreadInputEditing, setThreadInputReplyTo} from '@/constants/router'
+import {
+  useConversationInputDispatchOptional,
+  type ConversationInputState,
+} from '../../input-area/input-state'
 import {SetOrangeLineContext} from '../../orange-line-context'
 import {useChatTeam, useChatTeamMembers} from '../../team-hooks'
 import {useCurrentUserState} from '@/stores/current-user'
@@ -52,12 +56,16 @@ type ItemActions = {
 const useItemsForMessage = (p: {
   actions: ItemActions
   conversationIDKey: T.Chat.ConversationIDKey
+  // Set only when this popup is rendered inside the thread's input provider, i.e. it is this
+  // conversation's composer we are driving. Absent for the phone modal route, the info panel and
+  // the attachment viewer, which reach the composer through the router instead.
+  inputDispatch?: ConversationInputState['dispatch']
   message: T.Chat.Message
   meta: T.Chat.ConversationMeta
   onHidden: () => void
   participantInfo: T.Chat.ParticipantInfo
 }) => {
-  const {actions, conversationIDKey, message, meta, onHidden, participantInfo} = p
+  const {actions, conversationIDKey, inputDispatch, message, meta, onHidden, participantInfo} = p
   const ordinal = message.ordinal
   const isAttach = message.type === 'attachment'
   const {author, id, deviceName, timestamp, deviceRevokedAt} = message
@@ -126,7 +134,11 @@ const useItemsForMessage = (p: {
 
   const setOrangeLine = React.useContext(SetOrangeLineContext)
   const onReply = () => {
-    setThreadInputReplyTo(conversationIDKey, ordinal)
+    if (inputDispatch) {
+      inputDispatch.setReplyTo(ordinal)
+    } else {
+      setThreadInputReplyTo(conversationIDKey, ordinal)
+    }
   }
   const itemReply = message.exploded
     ? []
@@ -135,7 +147,11 @@ const useItemsForMessage = (p: {
       : []
 
   const _onEdit = () => {
-    setThreadInputEditing(conversationIDKey, ordinal)
+    if (inputDispatch) {
+      inputDispatch.setEditing(ordinal)
+    } else {
+      setThreadInputEditing(conversationIDKey, ordinal)
+    }
   }
 
   const you = useCurrentUserState(s => s.username)
@@ -339,6 +355,8 @@ const useThreadItems = (ordinal: T.Chat.Ordinal, onHidden: () => void) => {
   const participantInfo = useConversationParticipants(conversationIDKey)
   const {messageDelete, toggleMessageReaction} = useConversationThreadMessageActions()
   const setMarkAsUnread = useConversationThreadSetMarkAsUnread()
+  // Rendered inline in the thread, so the composer is right here in context.
+  const inputDispatch = useConversationInputDispatchOptional()
   return useItemsForMessage({
     actions: {
       deleteMessage: () => messageDelete(ordinal),
@@ -346,6 +364,7 @@ const useThreadItems = (ordinal: T.Chat.Ordinal, onHidden: () => void) => {
       toggleReaction: emoji => toggleMessageReaction(ordinal, emoji),
     },
     conversationIDKey,
+    inputDispatch,
     message,
     meta,
     onHidden,

--- a/shared/constants/router.tsx
+++ b/shared/constants/router.tsx
@@ -768,12 +768,37 @@ export const setChatRootParams = (params: Partial<NonNullable<KBRootParamList['c
   })
 }
 
+// The navigator holding this route, i.e. the one whose router can act on a setParams naming it.
+const findNavKeyForRouteKey = (routeKey: string): string | undefined => {
+  const walk = (state: T.Immutable<NavState> | undefined): string | undefined => {
+    const routes = state?.routes as Array<Route> | undefined
+    if (!routes) return undefined
+    if (state?.key && routes.some(r => r.key === routeKey)) return state.key
+    for (const r of routes) {
+      const found = walk(r.state)
+      if (found) return found
+    }
+    return undefined
+  }
+  return walk(getRootState())
+}
+
+// Both halves matter for the thread setParams helpers below. The route is what we check and what
+// `source` names; navKey is what `target` must name, and without it the action never arrives.
+// navigationRef.dispatch starts at the *deepest focused* navigator (BaseNavigationContainer routes
+// it through listeners.focus, which recurses into focused children), and useOnAction only bubbles
+// an action DOWN when action.target is set — upward otherwise. On desktop the thread lives at
+// root > loggedIn > tabs > chatTab > chatStack, so with anything else focused the action bubbles up
+// past the chat stack, which is a sibling and never an ancestor, and is dropped. That drop is
+// silent here: our onUnhandledAction downgrades react-navigation's warning to logger.info. Phones
+// are unaffected — chatConversation is a direct route of the root stack, so bubbling up finds it.
+// Note this scan looks *past* modals, which is exactly when the focused navigator is not ours.
 const getVisibleThreadScreen = () => {
   const visiblePath = getVisiblePath()
   for (let i = visiblePath.length - 1; i >= 0; --i) {
     const route = visiblePath[i]
-    if (route?.name === threadRouteName) {
-      return route
+    if (route?.name === threadRouteName && route.key) {
+      return {navKey: findNavKeyForRouteKey(route.key), route}
     }
   }
   return undefined
@@ -782,11 +807,12 @@ const getVisibleThreadScreen = () => {
 export const clearThreadHighlightMessageID = () => {
   const n = _getNavigator()
   if (!n) return
-  const visible = getVisibleThreadScreen()
-  if (!visible?.key || visible.name !== threadRouteName) return
+  const found = getVisibleThreadScreen()
+  if (!found?.navKey) return
   n.dispatch({
     ...CommonActions.setParams({highlightMessageID: undefined}),
-    source: visible.key,
+    source: found.route.key,
+    target: found.navKey,
   })
 }
 
@@ -807,29 +833,36 @@ const setThreadInputAction = (
 ) => {
   const n = _getNavigator()
   if (!n) return
-  const visible = getVisibleThreadScreen()
-  const params = visible?.params as {conversationIDKey?: T.Chat.ConversationIDKey} | undefined
-  if (!visible?.key || visible.name !== threadRouteName || params?.conversationIDKey !== conversationIDKey) {
+  const found = getVisibleThreadScreen()
+  const params = found?.route.params as {conversationIDKey?: T.Chat.ConversationIDKey} | undefined
+  if (!found?.navKey || params?.conversationIDKey !== conversationIDKey) {
+    // Reached from the message menu, so a bail here is a menu item that visibly does nothing.
+    logger.error(
+      `[chat] dropped thread input action ${action.type}: ` +
+        `${!found ? 'no visible thread screen' : !found.navKey ? 'thread route has no owning navigator' : 'thread route is on another conversation'}`
+    )
     return
   }
   n.dispatch({
     ...CommonActions.setParams({inputAction: makeThreadInputAction(action)}),
-    source: visible.key,
+    source: found.route.key,
+    target: found.navKey,
   })
 }
 
 export const clearThreadInputAction = (key?: string) => {
   const n = _getNavigator()
   if (!n) return
-  const visible = getVisibleThreadScreen()
-  if (!visible?.key || visible.name !== threadRouteName) return
-  const params = visible.params as {inputAction?: ThreadInputAction} | undefined
+  const found = getVisibleThreadScreen()
+  if (!found?.navKey) return
+  const params = found.route.params as {inputAction?: ThreadInputAction} | undefined
   if (key && params?.inputAction?.key !== key) {
     return
   }
   n.dispatch({
     ...CommonActions.setParams({inputAction: undefined}),
-    source: visible.key,
+    source: found.route.key,
+    target: found.navKey,
   })
 }
 

--- a/shared/constants/thread-input-action.test.ts
+++ b/shared/constants/thread-input-action.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="jest" />
+// Desktop/tablet split layout: the thread is chatRoot, nested two navigators below the root stack.
+jest.mock('@/constants/chat/layout', () => ({isSplit: true, threadRouteName: 'chatRoot'}))
+
+import * as T from '@/constants/types'
+import {
+  clearThreadInputAction,
+  navigationRef,
+  setModalRouteNames,
+  setThreadInputEditing,
+} from '@/constants/router'
+
+const dispatch = jest.fn()
+const convID = 'ff00ff00' as T.Chat.ConversationIDKey
+const ordinal = T.Chat.numberToOrdinal(101)
+
+const chatStackKey = 'chatstack-1'
+const makeLoggedIn = (chatRootParams: object) => ({
+  key: 'loggedIn-1',
+  name: 'loggedIn',
+  state: {
+    index: 0,
+    key: 'tabs-1',
+    routes: [
+      {
+        key: 'chatTab-1',
+        name: 'tabs.chatTab',
+        state: {
+          index: 0,
+          key: chatStackKey,
+          routes: [{key: 'chatRoot-1', name: 'chatRoot', params: chatRootParams}],
+          type: 'stack',
+        },
+      },
+    ],
+    type: 'tab',
+  },
+})
+
+const modal = {key: 'modal-1', name: 'someModal', params: {}}
+
+const setRootRoutes = (routes: Array<unknown>) => {
+  const state = {index: routes.length - 1, key: 'root-1', routeNames: [], routes, stale: false, type: 'stack'}
+  // the jest mock's container ref is a plain object, so stub its methods directly
+  const nr = navigationRef as unknown as Record<string, unknown>
+  nr['current'] = {}
+  nr['dispatch'] = dispatch
+  nr['getRootState'] = () => state
+  nr['isReady'] = () => true
+  nr['addListener'] = () => () => {}
+}
+
+beforeEach(() => {
+  dispatch.mockClear()
+  setModalRouteNames(['someModal'])
+})
+
+const lastAction = () => dispatch.mock.calls[0]?.[0] as {type: string; source?: string; target?: string}
+
+// navigationRef.dispatch starts at the deepest focused navigator, and useOnAction only bubbles an
+// action DOWN when action.target is set. chatRoot lives under the tab navigator, so a source-only
+// setParams bubbles up past its stack — a sibling, never an ancestor — and is dropped, silently:
+// our onUnhandledAction downgrades react-navigation's warning to logger.info. Naming the owning
+// navigator is what lets the action be routed down to the stack that can act on it.
+test('editing a message names the navigator that owns the thread route', () => {
+  setRootRoutes([makeLoggedIn({conversationIDKey: convID})])
+
+  setThreadInputEditing(convID, ordinal)
+
+  expect(dispatch).toHaveBeenCalledTimes(1)
+  expect(lastAction().type).toBe('SET_PARAMS')
+  expect(lastAction().source).toBe('chatRoot-1')
+  expect(lastAction().target).toBe(chatStackKey)
+})
+
+// The visible-thread scan deliberately looks past modals, so the guard passes here. That is exactly
+// when the focused navigator is not ours, so this is the case the target has to carry.
+test('editing still names the thread stack while a modal holds focus', () => {
+  setRootRoutes([makeLoggedIn({conversationIDKey: convID}), modal])
+
+  setThreadInputEditing(convID, ordinal)
+
+  expect(dispatch).toHaveBeenCalledTimes(1)
+  expect(lastAction().target).toBe(chatStackKey)
+})
+
+test('clearing a consumed input action names the thread stack too', () => {
+  setRootRoutes([makeLoggedIn({conversationIDKey: convID, inputAction: {key: 'edit-1', type: 'setEditing'}})])
+
+  clearThreadInputAction('edit-1')
+
+  expect(dispatch).toHaveBeenCalledTimes(1)
+  expect(lastAction().type).toBe('SET_PARAMS')
+  expect(lastAction().target).toBe(chatStackKey)
+})
+
+test('a thread showing another conversation is still left alone', () => {
+  setRootRoutes([makeLoggedIn({conversationIDKey: 'aabbccdd' as T.Chat.ConversationIDKey})])
+
+  setThreadInputEditing(convID, ordinal)
+
+  expect(dispatch).not.toHaveBeenCalled()
+})

--- a/shared/router-v2/router.tsx
+++ b/shared/router-v2/router.tsx
@@ -80,7 +80,10 @@ const lightTheme = makeTheme(colors, false)
 
 // Shared NavigationContainer plumbing (identical on both platforms)
 const onUnhandledAction = (a: Readonly<{type: string}>) => {
-  logger.info(`[NAV] Unhandled action: ${a.type}`, a, C.Router2.logState())
+  // error, not info: an action nothing handled is a user-visible no-op (a menu item that does
+  // nothing). Error is the only level retained at full depth in both dev and release and dumped
+  // periodically in both, so it is the one that survives to a remote log send.
+  logger.error(`[NAV] Unhandled action: ${a.type}`, a, C.Router2.logState())
 }
 const onStateChange = () => {
   const navState = C.Router2.getRootState()


### PR DESCRIPTION
Two users reported that editing a message from the message menu on desktop did nothing — the menu closes, the row never highlights, the composer never fills. Not reproduced locally; this removes the mechanism it would have happened through, and makes the remaining failure modes audible.

## The round-trip

`onEdit` was one line: `setThreadInputEditing(conversationIDKey, ordinal)`. Everything after it was react-navigation:

```
getVisibleThreadScreen() → guard on chatRoot's conversationIDKey param
  → SET_PARAMS dispatch carrying a uuid key
  → provider re-render → effect → consumedInputActionRef dedupe
  → setEditing(ordinal)
  → clearThreadInputAction(key) → a second dispatch
```

Two nav dispatches and four silent bail-outs to move an ordinal between two components in the same React tree. Any of them reads identically to the user: the item runs, the menu closes, nothing happens.

## The fix

The popup is inside `ConversationInputProvider` whenever it is inline in the thread, so it now calls `setEditing`/`setReplyTo` through context. `useConversationInputDispatchOptional` is a non-throwing `useContext`, threaded in from `useThreadItems` only.

`useStorelessItems` deliberately does **not** get it — that variant carries a message belonging to another conversation, and must not drive this thread's composer. Scoping by caller rather than by "is a context present" keeps that impossible.

| Caller | Path |
| --- | --- |
| Thread row popup (desktop + phone inline) | context |
| Phone `MessagePopupModal` route | router |
| Info panel attachments | router |
| Attachment fullscreen | router |

Reply went through the identical helper and got the same treatment.

## The router callers were broken too

`navigationRef.dispatch` resolves through `listeners.focus` to the deepest **focused** navigator, and `useOnAction` only bubbles an action *down* when `action.target` is set. These three helpers passed `source` alone — unlike `setChatRootParams` and `navigateAppend`, which both pass `target`.

On desktop the thread sits at `root > loggedIn > tabs > chatTab > chatStack`, so with any sibling branch focused the action bubbles up past the chat stack and is dropped. Attachment fullscreen is a modal route, so Edit from there failed **every time**.

Verified against real react-navigation (four cases): with a sibling focused, a source-only `setParams` aimed at the nested route is dropped and one carrying `target` lands; the same action aimed at a root-level route — the phone shape — lands either way, which is why phones were unaffected.

## Why nobody caught it

`onUnhandledAction` downgraded react-navigation's own warning to `logger.info`. That, and every silent bail-out on this path, now logs at `error` — the only level retained at full depth and dumped periodically in both dev and release builds, so a reproduction arrives with the stage named rather than as "Edit does nothing".

## Testing

- New `constants/thread-input-action.test.ts`: 4 tests under the desktop split layout. Mutation-checked — remove `target` and 3 fail; the 4th is the wrong-conversation guard, correctly unaffected.
- Driven live over CDP against the running app: hover → ••• → Edit on four non-latest messages and the most recent, plus Reply. All enter edit mode with the right text.
- `yarn lint:all` clean (1722 compiled, 0 bailouts, 0 whole-props deps); 229 suites / 2141 tests pass.

## Not covered

The original report is still unreproduced, so this is not proven to be the users' bug. The in-tree path can now only fail inside `setEditing` itself, and both of those branches log.