### PR TITLE
fix(chat): keep the thread pinned when you start typing on iOS

### DIFF
--- a/shared/chat/conversation/list-area/index.tsx
+++ b/shared/chat/conversation/list-area/index.tsx
@@ -35,7 +35,6 @@ import type {ScrollViewProps} from 'react-native'
 import {mobileTypingContainerHeight} from '../input-area/normal/typing'
 import {
   KeyboardChatScrollView,
-  KeyboardEvents,
   useKeyboardState,
   useReanimatedKeyboardAnimation,
 } from 'react-native-keyboard-controller'
@@ -747,10 +746,6 @@ const maintainVisibleContentPositionNoAutoscroll = {
   minIndexForVisible: 0,
 }
 
-// Smallest offset (px) the keyboard-inset clamp can start from: it only ever fires from
-// inside the inset region, so anything shallower is an ordinary scroll, not the clamp.
-const minClampJump = 40
-
 const NativeConversationList = function NativeConversationList() {
   const nativeStyles = useNativeStyles()
   const List = FlatList as unknown as React.ComponentType<
@@ -793,11 +788,6 @@ const NativeConversationList = function NativeConversationList() {
 
   const insets = useSafeAreaInsets()
   const isKeyboardVisible = useKeyboardState((s: {isVisible: boolean}) => s.isVisible)
-  // read from the scroll handler and from deferred timers, both of which run after render
-  const isKeyboardVisibleRef = React.useRef(isKeyboardVisible)
-  React.useLayoutEffect(() => {
-    isKeyboardVisibleRef.current = isKeyboardVisible
-  })
 
   // While the thread-search bar is open it overlays the bottom of the list. Reserve
   // that height as extra content padding so centered/newest messages clear it.
@@ -864,90 +854,20 @@ const NativeConversationList = function NativeConversationList() {
       listRef.current?.scrollToOffset({animated: false, offset: newOffset})
     }
   )
-  // iOS: the keyboard inset on this list's scroll view lives only in the UI-thread props
-  // KeyboardChatScrollView animates — the React tree still carries contentInset 0. Any commit
-  // that reaches the scroll view node re-mounts that 0, and UIKit's
-  // _adjustContentOffsetIfNecessary then clamps contentOffset to 0, dropping the thread by the
-  // keyboard's height so the newest messages sit behind it (typing is the usual trigger, since
-  // it is the first commit after the keyboard opens). Reanimated restores the inset on its next
-  // pass but never the offset, so only the offset needs putting back. The clamp is
-  // recognizable: it lands exactly on 0 from inside the inset region (offset < 0, i.e. pinned
-  // at the newest message), teleports the whole inset in one frame, and arrives with no drag or
-  // keyboard transition in flight — none of which a real scroll to the end does.
-  const isUserScrollingRef = React.useRef(false)
-  const isKeyboardAnimatingRef = React.useRef(false)
   const [onScrollNative] = React.useState(
     () =>
       (e: {nativeEvent: {contentOffset: {y: number}; contentSize: {height: number}}}) => {
-        const y = e.nativeEvent.contentOffset.y
-        const prevY = scrollOffsetRef.current
-        scrollOffsetRef.current = y
+        scrollOffsetRef.current = e.nativeEvent.contentOffset.y
         contentHeightRef.current = e.nativeEvent.contentSize.height
-        if (
-          isIOS &&
-          y === 0 &&
-          prevY <= -minClampJump &&
-          isKeyboardVisibleRef.current &&
-          !isUserScrollingRef.current &&
-          !isKeyboardAnimatingRef.current
-        ) {
-          scrollOffsetRef.current = prevY
-          listRef.current?.scrollToOffset({animated: false, offset: prevY})
-        }
       }
   )
   const [onContentSizeChangeNative] = React.useState(() => (_w: number, h: number) => {
     contentHeightRef.current = h
   })
-  const userScrollTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  const [clearUserScrollTimer] = React.useState(() => () => {
-    if (userScrollTimerRef.current !== undefined) {
-      clearTimeout(userScrollTimerRef.current)
-      userScrollTimerRef.current = undefined
-    }
-  })
   // user touched the list: stop fighting them
   const [onScrollBeginDrag] = React.useState(() => () => {
-    clearUserScrollTimer()
-    isUserScrollingRef.current = true
     correctRef.current.active = false
   })
-  const [onScrollEndDrag] = React.useState(() => () => {
-    clearUserScrollTimer()
-    userScrollTimerRef.current = setTimeout(() => {
-      userScrollTimerRef.current = undefined
-      isUserScrollingRef.current = false
-    }, 400)
-  })
-  const [onMomentumScrollEnd] = React.useState(() => () => {
-    clearUserScrollTimer()
-    isUserScrollingRef.current = false
-  })
-
-  React.useEffect(() => {
-    return () => {
-      clearUserScrollTimer()
-    }
-  }, [clearUserScrollTimer])
-  // the keyboard transition moves the offset itself; don't read those frames as the clamp
-  React.useEffect(() => {
-    if (!isIOS) return undefined
-    const subs = [
-      ...(['keyboardWillShow', 'keyboardWillHide'] as const).map(ev =>
-        KeyboardEvents.addListener(ev, () => {
-          isKeyboardAnimatingRef.current = true
-        })
-      ),
-      ...(['keyboardDidShow', 'keyboardDidHide'] as const).map(ev =>
-        KeyboardEvents.addListener(ev, () => {
-          isKeyboardAnimatingRef.current = false
-        })
-      ),
-    ]
-    return () => {
-      subs.forEach(sub => sub.remove())
-    }
-  }, [])
 
   const jumpToRecent = useJumpToRecent(scrollToBottom, messageOrdinals.length)
 
@@ -960,6 +880,10 @@ const NativeConversationList = function NativeConversationList() {
   // baseline resets on a real conversation switch (value compare) rather than on
   // a react-native-screens freeze/thaw, which re-mounts effects.
   const numBaselineConvRef = React.useRef(conversationIDKey)
+  const isKeyboardVisibleRef = React.useRef(isKeyboardVisible)
+  React.useLayoutEffect(() => {
+    isKeyboardVisibleRef.current = isKeyboardVisible
+  })
   React.useLayoutEffect(() => {
     const sameConv = numBaselineConvRef.current === conversationIDKey
     numBaselineConvRef.current = conversationIDKey
@@ -1098,8 +1022,6 @@ const NativeConversationList = function NativeConversationList() {
             scrollEventThrottle={16}
             onContentSizeChange={onContentSizeChangeNative}
             onScrollBeginDrag={onScrollBeginDrag}
-            onScrollEndDrag={onScrollEndDrag}
-            onMomentumScrollEnd={onMomentumScrollEnd}
             keyboardDismissMode="on-drag"
             keyboardShouldPersistTaps="handled"
             keyExtractor={keyExtractor}

--- a/shared/chat/conversation/list-area/index.tsx
+++ b/shared/chat/conversation/list-area/index.tsx
@@ -35,6 +35,7 @@ import type {ScrollViewProps} from 'react-native'
 import {mobileTypingContainerHeight} from '../input-area/normal/typing'
 import {
   KeyboardChatScrollView,
+  KeyboardEvents,
   useKeyboardState,
   useReanimatedKeyboardAnimation,
 } from 'react-native-keyboard-controller'
@@ -746,6 +747,10 @@ const maintainVisibleContentPositionNoAutoscroll = {
   minIndexForVisible: 0,
 }
 
+// Smallest offset (px) the keyboard-inset clamp can start from: it only ever fires from
+// inside the inset region, so anything shallower is an ordinary scroll, not the clamp.
+const minClampJump = 40
+
 const NativeConversationList = function NativeConversationList() {
   const nativeStyles = useNativeStyles()
   const List = FlatList as unknown as React.ComponentType<
@@ -788,6 +793,11 @@ const NativeConversationList = function NativeConversationList() {
 
   const insets = useSafeAreaInsets()
   const isKeyboardVisible = useKeyboardState((s: {isVisible: boolean}) => s.isVisible)
+  // read from the scroll handler and from deferred timers, both of which run after render
+  const isKeyboardVisibleRef = React.useRef(isKeyboardVisible)
+  React.useLayoutEffect(() => {
+    isKeyboardVisibleRef.current = isKeyboardVisible
+  })
 
   // While the thread-search bar is open it overlays the bottom of the list. Reserve
   // that height as extra content padding so centered/newest messages clear it.
@@ -854,20 +864,90 @@ const NativeConversationList = function NativeConversationList() {
       listRef.current?.scrollToOffset({animated: false, offset: newOffset})
     }
   )
+  // iOS: the keyboard inset on this list's scroll view lives only in the UI-thread props
+  // KeyboardChatScrollView animates — the React tree still carries contentInset 0. Any commit
+  // that reaches the scroll view node re-mounts that 0, and UIKit's
+  // _adjustContentOffsetIfNecessary then clamps contentOffset to 0, dropping the thread by the
+  // keyboard's height so the newest messages sit behind it (typing is the usual trigger, since
+  // it is the first commit after the keyboard opens). Reanimated restores the inset on its next
+  // pass but never the offset, so only the offset needs putting back. The clamp is
+  // recognizable: it lands exactly on 0 from inside the inset region (offset < 0, i.e. pinned
+  // at the newest message), teleports the whole inset in one frame, and arrives with no drag or
+  // keyboard transition in flight — none of which a real scroll to the end does.
+  const isUserScrollingRef = React.useRef(false)
+  const isKeyboardAnimatingRef = React.useRef(false)
   const [onScrollNative] = React.useState(
     () =>
       (e: {nativeEvent: {contentOffset: {y: number}; contentSize: {height: number}}}) => {
-        scrollOffsetRef.current = e.nativeEvent.contentOffset.y
+        const y = e.nativeEvent.contentOffset.y
+        const prevY = scrollOffsetRef.current
+        scrollOffsetRef.current = y
         contentHeightRef.current = e.nativeEvent.contentSize.height
+        if (
+          isIOS &&
+          y === 0 &&
+          prevY <= -minClampJump &&
+          isKeyboardVisibleRef.current &&
+          !isUserScrollingRef.current &&
+          !isKeyboardAnimatingRef.current
+        ) {
+          scrollOffsetRef.current = prevY
+          listRef.current?.scrollToOffset({animated: false, offset: prevY})
+        }
       }
   )
   const [onContentSizeChangeNative] = React.useState(() => (_w: number, h: number) => {
     contentHeightRef.current = h
   })
+  const userScrollTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const [clearUserScrollTimer] = React.useState(() => () => {
+    if (userScrollTimerRef.current !== undefined) {
+      clearTimeout(userScrollTimerRef.current)
+      userScrollTimerRef.current = undefined
+    }
+  })
   // user touched the list: stop fighting them
   const [onScrollBeginDrag] = React.useState(() => () => {
+    clearUserScrollTimer()
+    isUserScrollingRef.current = true
     correctRef.current.active = false
   })
+  const [onScrollEndDrag] = React.useState(() => () => {
+    clearUserScrollTimer()
+    userScrollTimerRef.current = setTimeout(() => {
+      userScrollTimerRef.current = undefined
+      isUserScrollingRef.current = false
+    }, 400)
+  })
+  const [onMomentumScrollEnd] = React.useState(() => () => {
+    clearUserScrollTimer()
+    isUserScrollingRef.current = false
+  })
+
+  React.useEffect(() => {
+    return () => {
+      clearUserScrollTimer()
+    }
+  }, [clearUserScrollTimer])
+  // the keyboard transition moves the offset itself; don't read those frames as the clamp
+  React.useEffect(() => {
+    if (!isIOS) return undefined
+    const subs = [
+      ...(['keyboardWillShow', 'keyboardWillHide'] as const).map(ev =>
+        KeyboardEvents.addListener(ev, () => {
+          isKeyboardAnimatingRef.current = true
+        })
+      ),
+      ...(['keyboardDidShow', 'keyboardDidHide'] as const).map(ev =>
+        KeyboardEvents.addListener(ev, () => {
+          isKeyboardAnimatingRef.current = false
+        })
+      ),
+    ]
+    return () => {
+      subs.forEach(sub => sub.remove())
+    }
+  }, [])
 
   const jumpToRecent = useJumpToRecent(scrollToBottom, messageOrdinals.length)
 
@@ -880,10 +960,6 @@ const NativeConversationList = function NativeConversationList() {
   // baseline resets on a real conversation switch (value compare) rather than on
   // a react-native-screens freeze/thaw, which re-mounts effects.
   const numBaselineConvRef = React.useRef(conversationIDKey)
-  const isKeyboardVisibleRef = React.useRef(isKeyboardVisible)
-  React.useLayoutEffect(() => {
-    isKeyboardVisibleRef.current = isKeyboardVisible
-  })
   React.useLayoutEffect(() => {
     const sameConv = numBaselineConvRef.current === conversationIDKey
     numBaselineConvRef.current = conversationIDKey
@@ -1022,6 +1098,8 @@ const NativeConversationList = function NativeConversationList() {
             scrollEventThrottle={16}
             onContentSizeChange={onContentSizeChangeNative}
             onScrollBeginDrag={onScrollBeginDrag}
+            onScrollEndDrag={onScrollEndDrag}
+            onMomentumScrollEnd={onMomentumScrollEnd}
             keyboardDismissMode="on-drag"
             keyboardShouldPersistTaps="handled"
             keyExtractor={keyExtractor}

--- a/shared/patches/react-native-keyboard-controller+1.22.4.patch
+++ b/shared/patches/react-native-keyboard-controller+1.22.4.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/react-native-keyboard-controller/src/components/ScrollViewWithBottomPadding/index.tsx b/node_modules/react-native-keyboard-controller/src/components/ScrollViewWithBottomPadding/index.tsx
+index 637f79a..6fa60f1 100644
+--- a/node_modules/react-native-keyboard-controller/src/components/ScrollViewWithBottomPadding/index.tsx
++++ b/node_modules/react-native-keyboard-controller/src/components/ScrollViewWithBottomPadding/index.tsx
+@@ -155,6 +155,13 @@ const ScrollViewWithBottomPadding = forwardRef<
+           // offset), making the list mount scrolled to the top natively.
+           // eslint-disable-next-line react-compiler/react-compiler
+           prevContentOffsetY.value = curr;
++          // Declare the key even though the value is swallowed. Reanimated decides whether a
++          // settled update is a prop or a style from the keys of the FIRST evaluation
++          // (AnimatedComponent's `animatedPropsKeys`, built from `initial.value`). A key that
++          // only ever shows up later is filed as a style, which switches on the settled-props
++          // render path -- and that path re-renders a stale `settledProps` over the real props,
++          // putting `contentInset` back to 0 so UIKit clamps `contentOffset` to 0.
++          result.contentOffset = undefined;
+         } else if (curr !== prevContentOffsetY.value) {
+           prevContentOffsetY.value = curr;
+           result.contentOffset = { x: 0, y: curr };


### PR DESCRIPTION
On iOS, with the keyboard open and the thread pinned at the newest message, the first keystroke dropped the whole list by the keyboard's height — new messages ended up behind the keyboard, and nothing brought them back until the keyboard closed. Once per keyboard session.

## Cause

`KeyboardChatScrollView` carries the keyboard inset only in the UI-thread props Reanimated animates; the React tree still has `contentInset: 0`. When a commit re-mounts that `0`, UIKit clamps the offset:

```
RCTScrollViewComponentView updateProps:oldProps:   <- a React commit (the keystroke)
  UIScrollView setContentInset:                    <- writes 0
    _updateForChangedScrollRelatedInsets
      _adjustContentOffsetIfNecessary              <- UIKit clamps the offset
        RCTEnhancedScrollView setContentOffset: (0,0)
```

(captured with an lldb breakpoint on `-[UIScrollView setContentOffset:]`, conditioned on a `(0,0)` target)

What puts that `0` back into the tree is the part that took the longest to find. Reanimated 4.6.0 decides whether a *settled* animated value is a prop or a style from the keys of the animated-props worklet's **first** evaluation:

```js
// react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.native.tsx
const animatedPropsKeys = new Set([
  ...this._animatedProps.flatMap((animatedProp) =>
    Object.keys(animatedProp.initial?.value ?? {})
  ),
```

`ScrollViewWithBottomPadding` deliberately swallows `contentOffset` on that first evaluation, guarding a separate bug where emitting `{0,0}` overrides a list's own initial offset. So the key never reaches `initial.value`, later settled `contentOffset` updates are filed as a *style*, `settledStyle` turns non-null, and that switches on the settled-props render path:

```js
if (FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS && this.state.settledStyle) {
  return super.render({
    nativeID,
    ...filteredProps,
    ...this.state.settledProps,   // stale snapshot, wins over the real props
```

From then on, every commit re-renders a stale `settledProps.contentInset` of 0 over the real props. Typing is the trigger only because it is the first commit after the keyboard opens.

## Fix

One line in `patches/react-native-keyboard-controller+1.22.4.patch` — declare the key on the first evaluation while still swallowing the value, so the classification is right and the initial-offset guard stays intact:

```diff
           prevContentOffsetY.value = curr;
+          result.contentOffset = undefined;
         } else if (curr !== prevContentOffsetY.value) {
```

This replaces the 83-line `onScroll` corrector an earlier commit on this branch added; `list-area/index.tsx` is back to master.

## What was ruled out

- **Rolling back keyboard-controller** — 1.22.3 and 1.21.14 both still reproduce, and `contentInset` has lived in `animatedProps` since `ScrollViewWithBottomPadding` was introduced, so every version with `KeyboardChatScrollView` has the same shape.
- **Pinning Reanimated to 4.5.x** — does fix it (4.5.5 and 4.5.3 are clean, 4.6.0 reproduces), but masks the bug while holding us a minor version behind.
- **Disabling `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS`** via `reanimated.staticFeatureFlags` — also fixes it, and is what proved the mechanism, but turns off a Reanimated optimization for the whole app.
- **Mirroring the inset into the React tree** — has no effect: `...this.state.settledProps` is spread *after* the props, so it overrides an explicit `contentInset`.
- Earlier: `maintainVisibleContentPosition`, the controlled `selection` prop, any JS-side scroll, `scrollRectToVisible`.

## Verification

In a bare Expo app that drives itself (focus the composer, wait for the keyboard to settle, inject one keystroke, print a verdict carrying the versions it is running): patched **clean, 3 runs**; reverting just that line on the same build **reproduces, 2 runs**. Confirmed in the app by hand as well.

`yarn lint:all` clean — 0 react-compiler bailouts, 0 whole-props deps, tsc passes. The patch was re-applied from a clean `yarn install --check-files`.

Note for anyone building this branch: the patch is JS-only, so no Xcode rebuild, but Metro needs `--clear` once, since it caches `node_modules` transforms.

## Upstream

Filed with the root cause and this diff at kirillzyusko/react-native-keyboard-controller#1623. The patch comes out when a fix ships.
