### PR TITLE
fix(mobile): assorted small fixes, and share a text file's contents on iOS

### DIFF
--- a/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
+++ b/rnmodules/react-native-kb/android/src/main/java/com/reactnativekb/KbModule.kt
@@ -739,6 +739,11 @@ class KbModule(reactContext: ReactApplicationContext?) : KbSpec(reactContext), T
     }
 
     @ReactMethod
+    override fun iosShareFile(path: String, text: String, promise: Promise) {
+        promise.reject(Exception("wrong platform"))
+    }
+
+    @ReactMethod
     override fun processMedia(
         path: String,
         isVideo: Boolean,

--- a/rnmodules/react-native-kb/ios/Kb.mm
+++ b/rnmodules/react-native-kb/ios/Kb.mm
@@ -717,8 +717,14 @@ RCT_EXPORT_METHOD(iosShareFile:(NSString *)path text:(NSString *)text resolve:(R
     }
     UIActivityViewController *share = [[UIActivityViewController alloc] initWithActivityItems:items
                                                                        applicationActivities:nil];
+    // both of these run on the main thread, so the flag needs no other guarding
+    __block BOOL settled = NO;
     share.completionWithItemsHandler =
         ^(UIActivityType activityType, BOOL completed, NSArray *returned, NSError *activityError) {
+          if (settled) {
+            return;
+          }
+          settled = YES;
           if (activityError) {
             reject(@"share_error", activityError.localizedDescription, activityError);
           } else {
@@ -734,7 +740,17 @@ RCT_EXPORT_METHOD(iosShareFile:(NSString *)path text:(NSString *)text resolve:(R
                                       CGRectGetMidY(presenter.view.bounds), 0, 0);
       popover.permittedArrowDirections = 0;
     }
-    [presenter presentViewController:share animated:YES completion:nil];
+    [presenter presentViewController:share
+                            animated:YES
+                          completion:^{
+                            // a refused presentation never reaches
+                            // completionWithItemsHandler, which would leave the
+                            // caller awaiting the share forever
+                            if (share.presentingViewController == nil && !settled) {
+                              settled = YES;
+                              reject(@"share_error", @"Could not present the share sheet", nil);
+                            }
+                          }];
   });
 }
 

--- a/rnmodules/react-native-kb/ios/Kb.mm
+++ b/rnmodules/react-native-kb/ios/Kb.mm
@@ -184,6 +184,52 @@ static NSDictionary *kbConstants(void) {
   return constants;
 }
 
+// Targets that only take text (Reminders, Notes) activate on the share item's
+// attributedContentText, which nothing but a plain string item fills in, so the
+// contents have to go over as their own item next to the file. The two then
+// carry the same bytes, and anything that writes an item out saves both -- Save
+// to Files ends up with two identical copies -- so the text sits out those.
+@interface KbShareItem : NSObject <UIActivityItemSource>
+- (instancetype)initWithItem:(id)item subject:(NSString *)subject skipping:(NSSet<UIActivityType> *)skipping;
+@end
+
+@implementation KbShareItem {
+  id _item;
+  NSString *_subject;
+  NSSet<UIActivityType> *_skipping;
+}
+
+- (instancetype)initWithItem:(id)item subject:(NSString *)subject skipping:(NSSet<UIActivityType> *)skipping {
+  if ((self = [super init])) {
+    _item = item;
+    _subject = subject;
+    _skipping = skipping;
+  }
+  return self;
+}
+
+// the sheet builds its activity list from the placeholders, so this has to be
+// the real thing even where itemForActivityType later declines
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController {
+  return _item;
+}
+
+- (id)activityViewController:(UIActivityViewController *)activityViewController
+         itemForActivityType:(UIActivityType)activityType {
+  if (activityType != nil && [_skipping containsObject:activityType]) {
+    return nil;
+  }
+  return _item;
+}
+
+- (NSString *)activityViewController:(UIActivityViewController *)activityViewController
+              subjectForActivityType:(UIActivityType)activityType {
+  return _subject;
+}
+
+@end
+
+
 @implementation Kb {
   // Guarded by kbBridgeMutex: written on the JS thread in
   // installJSIBindingsWithRuntime, read and cleared on the TurboModule shared
@@ -642,6 +688,54 @@ RCT_EXPORT_METHOD(processMedia:(NSString *)path isVideo:(BOOL)isVideo compress:(
   } else {
     [MediaUtils processImageFromOriginal:url compress:compress completion:done];
   }
+}
+
+RCT_EXPORT_METHOD(iosShareFile:(NSString *)path text:(NSString *)text resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  NSString *barePath = kbBarePath(path);
+  if (barePath.length == 0) {
+    reject(@"share_error", @"No file to share", nil);
+    return;
+  }
+  NSURL *fileURL = [NSURL fileURLWithPath:barePath];
+  NSString *name = fileURL.lastPathComponent;
+
+  NSMutableArray<KbShareItem *> *items = [NSMutableArray array];
+  if (text.length > 0) {
+    // no public constant for Save to Files
+    NSSet<UIActivityType> *writesAFile = [NSSet setWithObjects:@"com.apple.DocumentManagerUICore.SaveToFiles",
+                                                              @"com.apple.CloudDocsUI.AddToiCloudDrive",
+                                                              UIActivityTypeAirDrop, nil];
+    [items addObject:[[KbShareItem alloc] initWithItem:text subject:name skipping:writesAFile]];
+  }
+  [items addObject:[[KbShareItem alloc] initWithItem:fileURL subject:name skipping:nil]];
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIViewController *presenter = RCTPresentedViewController();
+    if (presenter == nil) {
+      reject(@"share_error", @"Nothing to present the share sheet from", nil);
+      return;
+    }
+    UIActivityViewController *share = [[UIActivityViewController alloc] initWithActivityItems:items
+                                                                       applicationActivities:nil];
+    share.completionWithItemsHandler =
+        ^(UIActivityType activityType, BOOL completed, NSArray *returned, NSError *activityError) {
+          if (activityError) {
+            reject(@"share_error", activityError.localizedDescription, activityError);
+          } else {
+            resolve(@(completed));
+          }
+        };
+    // the menu that started this is already gone, so there is nothing left to
+    // anchor an iPad popover to; centre it on the presenter instead
+    UIPopoverPresentationController *popover = share.popoverPresentationController;
+    if (popover) {
+      popover.sourceView = presenter.view;
+      popover.sourceRect = CGRectMake(CGRectGetMidX(presenter.view.bounds),
+                                      CGRectGetMidY(presenter.view.bounds), 0, 0);
+      popover.permittedArrowDirections = 0;
+    }
+    [presenter presentViewController:share animated:YES completion:nil];
+  });
 }
 
 RCT_EXPORT_METHOD(checkPushPermissions: (RCTPromiseResolveBlock)resolve reject: (RCTPromiseRejectBlock)reject) {

--- a/rnmodules/react-native-kb/src/NativeKb.ts
+++ b/rnmodules/react-native-kb/src/NativeKb.ts
@@ -42,6 +42,10 @@ export interface Spec extends TurboModule {
     endMs: number,
     removeAudio: boolean
   ): Promise<string>
+  // iOS only: presents the system share sheet for a local file. `text` is the
+  // file's contents when it is worth offering as text, '' otherwise (codegen
+  // has no optional string). Resolves true when an activity ran.
+  iosShareFile(path: string, text: string): Promise<boolean>
   androidShareText(text: string, mimeType: string): Promise<boolean>
   androidShare(text: string, mimeType: string): Promise<boolean>
   androidAddCompleteDownload(o: {

--- a/rnmodules/react-native-kb/src/index.tsx
+++ b/rnmodules/react-native-kb/src/index.tsx
@@ -38,6 +38,16 @@ export const processMedia = (
   return Promise.resolve(path)
 }
 
+// iOS only. Shares the file, offering `text` (pass '' for none) alongside it so
+// targets that only take text get the contents, without the ones that write a
+// file getting both.
+export const iosShareFile = (path: string, text: string): Promise<boolean> => {
+  if (Platform.OS === 'ios') {
+    return Kb.iosShareFile(path, text)
+  }
+  return Promise.reject(new Error('wrong platform'))
+}
+
 export const androidShareText = (text: string, mimeType: string): Promise<boolean> => {
   if (Platform.OS === 'android') {
     return Kb.androidShareText(text, mimeType)

--- a/shared/common-adapters/avatar/index.tsx
+++ b/shared/common-adapters/avatar/index.tsx
@@ -18,8 +18,6 @@ type Props = {
   imageOverrideUrl?: string
   isTeam?: boolean
   onClick?: ((e?: React.BaseSyntheticEvent) => void) | 'profile'
-  onError?: () => void
-  onLoad?: () => void
   testID?: string
   size: 128 | 96 | 64 | 48 | 32 | 24 | 16
   // for callsites that will never have a name (e.g. the 'create a team' button); without it
@@ -175,8 +173,6 @@ function Avatar(p: Props) {
     style,
     children,
     testID,
-    onError,
-    onLoad,
   } = p
   const {showPlaceholder} = p
   const {imageOverrideUrl, crop} = p
@@ -282,14 +278,8 @@ function Avatar(p: Props) {
             style={cached.image}
             recyclingKey={name}
             cachePolicy="memory-disk"
-            onError={() => {
-              setErrorUri(source.uri)
-              onError?.()
-            }}
-            onLoad={() => {
-              setErrorUri(undefined)
-              onLoad?.()
-            }}
+            onError={() => setErrorUri(source.uri)}
+            onLoad={() => setErrorUri(undefined)}
           />
         </>
       ) : name || !isTeam || showPlaceholder ? (

--- a/shared/common-adapters/switch.tsx
+++ b/shared/common-adapters/switch.tsx
@@ -99,7 +99,12 @@ function Switch(props: Props & {ref?: React.Ref<MeasureRef>}) {
   )
 
   return isMobile || !props.labelTooltip ? (
-    <Kb.Box2 direction={props.align !== 'right' ? 'horizontal' : 'horizontalReverse'} fullWidth={true} style={Styles.collapseStyles([styles.container, props.style])}>{content}</Kb.Box2>
+    <Kb.Box2
+      direction={props.align !== 'right' ? 'horizontal' : 'horizontalReverse'}
+      style={Styles.collapseStyles([styles.autoAlignSelf, styles.container, props.style])}
+    >
+      {content}
+    </Kb.Box2>
   ) : (
     <Kb.WithTooltip
       containerStyle={getStyle(props, styles)}
@@ -114,6 +119,10 @@ function Switch(props: Props & {ref?: React.Ref<MeasureRef>}) {
 export default Switch
 
 const useStyles = Styles.createStyleHook(() => ({
+  // undo Box2's alignSelf:center default (applied whenever fullWidth/fullHeight are unset) so we
+  // inherit the parent's alignItems. Deliberately not fullWidth: width:100% makes a Switch inside a
+  // horizontal row shrink-fit the leftover space and push its siblings right.
+  autoAlignSelf: {alignSelf: 'auto'},
   container: Styles.platformStyles({
     isElectron: {
       alignItems: 'center',

--- a/shared/fs/browser/rows/placeholder.tsx
+++ b/shared/fs/browser/rows/placeholder.tsx
@@ -1,6 +1,7 @@
 import {useRowStyles} from './common'
 import * as T from '@/constants/types'
 import * as Kb from '@/common-adapters'
+import PathStatusIcon from '@/fs/common/path-status-icon'
 
 type PlaceholderProps = {
   type: T.FS.PathType.Folder | T.FS.PathType.File
@@ -9,14 +10,19 @@ type PlaceholderProps = {
 const PlaceholderRow = ({type}: PlaceholderProps) => {
   const styles = useStyles()
   const rowStyles = useRowStyles()
+  const isFolder = type === T.FS.PathType.Folder
   return (
     <Kb.ListItem
       type="Small"
       firstItem={true /* we add divider in Rows */}
-      statusIcon={<Kb.Box2 direction="vertical" />}
+      // Rows almost always resolve to online-only, so show that status now and
+      // avoid an empty gap popping into an icon once the row loads.
+      statusIcon={
+        <PathStatusIcon isFolder={isFolder} statusIcon={T.FS.NonUploadStaticSyncStatus.OnlineOnly} />
+      }
       icon={
         <Kb.IconAuto
-          type={type === T.FS.PathType.Folder ? 'icon-folder-placeholder-32' : 'icon-file-placeholder-32'}
+          type={isFolder ? 'icon-folder-placeholder-32' : 'icon-file-placeholder-32'}
           style={rowStyles.pathItemIcon}
         />
       }

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -1354,6 +1354,12 @@ export const useFsWatchDownloadForMobile = isMobile
             dismissDownload(downloadID)
             setJustDoneWithIntent(true)
           } catch (err) {
+            // the hand-off is over either way: without this the download sits in
+            // the footer with nothing left to dismiss it, and whoever is waiting
+            // on the intent never hears back
+            handledIntentKeyRef.current = handledIntentKey
+            dismissDownload(downloadID)
+            setJustDoneWithIntent(true)
             errorToActionOrThrow(err)
           }
         }

--- a/shared/fs/common/hooks.tsx
+++ b/shared/fs/common/hooks.tsx
@@ -1342,10 +1342,15 @@ export const useFsWatchDownloadForMobile = isMobile
             handledIntentKeyRef.current = handledIntentKey
             return
           }
+          // Both failure paths below report done the way the success path does.
+          // Without it the download sits in the footer with nothing left to
+          // dismiss it, and whoever is waiting on the intent never hears back --
+          // for a share that means a popup left mounted and permanently hidden.
           if (dlState.error) {
             handledIntentKeyRef.current = handledIntentKey
             redbar(dlState.error)
             dismissDownload(downloadID)
+            setJustDoneWithIntent(true)
             return
           }
           try {
@@ -1354,9 +1359,6 @@ export const useFsWatchDownloadForMobile = isMobile
             dismissDownload(downloadID)
             setJustDoneWithIntent(true)
           } catch (err) {
-            // the hand-off is over either way: without this the download sits in
-            // the footer with nothing left to dismiss it, and whoever is waiting
-            // on the intent never hears back
             handledIntentKeyRef.current = handledIntentKey
             dismissDownload(downloadID)
             setJustDoneWithIntent(true)

--- a/shared/fs/common/path-item-action/layout.test.ts
+++ b/shared/fs/common/path-item-action/layout.test.ts
@@ -165,25 +165,23 @@ test('iOS drops download', () => {
   ).toBe(false)
 })
 
-test('mobile consolidates the two share actions into one Share entry', () => {
+test('mobile lists both share actions inline, never behind a submenu', () => {
   g.isMobile = true
   const path = p('/keybase/private/testuser/a.txt')
   const root = getRootLayout('row', path, file(), FS.emptyFileContext, me)
-  expect(root.share).toBe(true)
-  expect(root.sendAttachmentToChat).toBe(false)
-  expect(root.sendToOtherApp).toBe(false)
+  expect(root.sendAttachmentToChat).toBe(true)
+  expect(root.sendToOtherApp).toBe(true)
 
-  // the share submenu still lists both, and nothing else
+  // the share-only menu lists both, and nothing else
   expect(enabled(getShareLayout('row', path, file(), FS.emptyFileContext, me))).toEqual([
     'sendAttachmentToChat',
     'sendToOtherApp',
   ])
 })
 
-test('desktop has a single share action, so it is not consolidated', () => {
+test('desktop only shares to chat', () => {
   const path = p('/keybase/private/testuser/a.txt')
   const root = getRootLayout('row', path, file(), FS.emptyFileContext, me)
-  expect(root.share).toBe(false)
   expect(root.sendAttachmentToChat).toBe(true)
   expect(root.sendToOtherApp).toBe(false)
 })

--- a/shared/fs/common/path-item-action/layout.tsx
+++ b/shared/fs/common/path-item-action/layout.tsx
@@ -15,7 +15,6 @@ export type Layout = {
   showInSystemFileManager: boolean
   sendAttachmentToChat: boolean
   sendToOtherApp: boolean
-  share: boolean
 }
 
 const empty = {
@@ -34,13 +33,12 @@ const empty = {
   // eslint-disable-next-line sort-keys
   sendAttachmentToChat: false,
   sendToOtherApp: false,
-  share: false,
 }
 
 const isMyOwn = (parsedPath: T.FS.ParsedPathGroupTlf, me: string) =>
   !parsedPath.readers?.length && parsedPath.writers.length === 1 && parsedPath.writers[0] === me
 
-const getRawLayout = (
+export const getRootLayout = (
   mode: 'row' | 'screen',
   path: T.FS.Path,
   pathItem: T.FS.PathItem,
@@ -106,29 +104,11 @@ const getRawLayout = (
 
 const totalShare = (layout: Layout) => (layout.sendAttachmentToChat ? 1 : 0) + (layout.sendToOtherApp ? 1 : 0)
 
-const consolidateShares = (layout: Layout): Layout =>
-  isMobile && totalShare(layout) > 1
-    ? {
-        ...layout,
-        sendAttachmentToChat: false,
-        sendToOtherApp: false,
-        share: true,
-      }
-    : layout
-
 const filterForOnlyShares = (layout: Layout): Layout => ({
   ...empty,
   sendAttachmentToChat: layout.sendAttachmentToChat,
   sendToOtherApp: layout.sendToOtherApp,
 })
-
-export const getRootLayout = (
-  mode: 'row' | 'screen',
-  path: T.FS.Path,
-  pathItem: T.FS.PathItem,
-  fileContext: T.FS.FileContext,
-  me: string
-): Layout => consolidateShares(getRawLayout(mode, path, pathItem, fileContext, me))
 
 export const getShareLayout = (
   mode: 'row' | 'screen',
@@ -136,7 +116,7 @@ export const getShareLayout = (
   pathItem: T.FS.PathItem,
   fileContext: T.FS.FileContext,
   me: string
-): Layout => filterForOnlyShares(getRawLayout(mode, path, pathItem, fileContext, me))
+): Layout => filterForOnlyShares(getRootLayout(mode, path, pathItem, fileContext, me))
 
 export const hasShare = (
   mode: 'row' | 'screen',
@@ -144,4 +124,5 @@ export const hasShare = (
   pathItem: T.FS.PathItem,
   fileContext: T.FS.FileContext
 ): boolean =>
-  totalShare(getRawLayout(mode, path, pathItem, fileContext, '' /* username doesn't matter for shares */)) > 0
+  totalShare(getRootLayout(mode, path, pathItem, fileContext, '' /* username doesn't matter for shares */)) >
+  0

--- a/shared/fs/common/path-item-action/menu-container.tsx
+++ b/shared/fs/common/path-item-action/menu-container.tsx
@@ -344,12 +344,25 @@ const Container = (op: OwnProps) => {
     }
   }, [justDoneWithIntent, hide])
 
-  const userInitiatedHide = () => {
+  // The OS share sheet presents below our bottom sheet, which lives in a
+  // FullWindowOverlay, so the sheet has to be down before the download lands.
+  // Only the sheet goes: this component owns the hand-off to the OS and has to
+  // stay mounted for it, so it hides itself rather than calling hide().
+  const sheetVisible = visible && !sharing
+
+  // The sheet closing on its own above isn't the user dismissing the menu, and
+  // gorhom reports that close through onDismiss all the same. Read the latest
+  // sharing through an effect event: the callback the sheet was unmounted with
+  // is the stale one.
+  const userInitiatedHide = React.useEffectEvent(() => {
+    if (sharing) {
+      return
+    }
     hide()
     if (downloadID) {
       dismissDownload(downloadID)
     }
-  }
+  })
 
   return (
     <Kb.FloatingMenu
@@ -357,7 +370,7 @@ const Container = (op: OwnProps) => {
       closeOnSelect={false}
       containerStyle={containerStyle}
       attachTo={attachTo}
-      visible={visible}
+      visible={sheetVisible}
       onHidden={userInitiatedHide}
       position="left center"
       header={

--- a/shared/fs/common/path-item-action/menu-container.tsx
+++ b/shared/fs/common/path-item-action/menu-container.tsx
@@ -168,18 +168,6 @@ const Container = (op: OwnProps) => {
     }
   })()
 
-  const itemShare = layout.share
-    ? ([
-        {
-          icon: 'iconfont-share',
-          onClick: () => {
-            setView(T.FS.PathItemActionMenuView.Share)
-          },
-          title: 'Share...',
-        },
-      ] as const)
-    : []
-
   const itemSendToChat = layout.sendAttachmentToChat
     ? ([
         {
@@ -192,7 +180,7 @@ const Container = (op: OwnProps) => {
           subTitle: `The ${
             pathItem.type === T.FS.PathType.Folder ? 'folder' : 'file'
           } will be sent as an attachment.`,
-          title: 'Attach in another conversation',
+          title: 'Share to Chat',
         },
       ] as const)
     : []
@@ -206,7 +194,7 @@ const Container = (op: OwnProps) => {
           icon: 'iconfont-share',
           inProgress: true,
           onClick: undefined,
-          title: 'Send to another app',
+          title: 'Share to another app',
         },
       ] as const
     } else {
@@ -218,7 +206,7 @@ const Container = (op: OwnProps) => {
           download(path, 'share', onDownloadStarted)
         }
       })
-      return [{icon: 'iconfont-share', onClick, title: 'Send to another app'}] as const
+      return [{icon: 'iconfont-share', onClick, title: 'Share to another app'}] as const
     }
   })()
 
@@ -339,7 +327,6 @@ const Container = (op: OwnProps) => {
     ...itemChat,
     ...itemFinder,
     ...itemSave,
-    ...itemShare,
     ...itemSendToChat,
     ...itemSendToApp,
     ...itemDownload,

--- a/shared/fs/nav-header/ios-header.tsx
+++ b/shared/fs/nav-header/ios-header.tsx
@@ -68,7 +68,7 @@ type MenuProps = {
 }
 
 // iOS 26: a single overflow menu (one glass pill) replaces the old row of
-// upload + actions buttons. Search / Upload / More each fire the same popups
+// upload + actions buttons. Filter / Upload / More each fire the same popups
 // the Android header uses (the folder-view filter, the upload menu, and the
 // path-item actions menu). Because the native menu's onPress needs to reach
 // React state, the menu is attached from the screen body via setOptions rather
@@ -87,46 +87,60 @@ const IosHeaderMenuInner = ({path, mayUpload}: MenuProps) => {
   const canUpload = mayUpload && pathItem.type === T.FS.PathType.Folder && pathItem.writable
 
   React.useEffect(() => {
+    // Filter and Upload only apply to some screens; on a file preview neither
+    // does, and a menu holding a lone "More" is just an extra tap — so drop
+    // straight to a button that opens the actions popup.
+    const extras = [
+      ...(canFilter
+        ? [
+            {
+              icon: sfIcon('line.3.horizontal.decrease'),
+              label: 'Filter',
+              onPress: () => setFolderViewFilter(''),
+              type: 'action' as const,
+            },
+          ]
+        : []),
+      ...(canUpload
+        ? [
+            {
+              icon: sfIcon('arrow.up.doc'),
+              label: 'Upload',
+              onPress: () => uploadRef.current?.open(),
+              type: 'action' as const,
+            },
+          ]
+        : []),
+    ]
+    const openMore = () => moreRef.current?.open()
     navigation.setOptions({
       unstable_headerRightItems:
         hasSoftError || path === FS.defaultPath
           ? undefined
           : () => [
-              {
-                icon: sfIcon('ellipsis'),
-                label: 'More',
-                menu: {
-                  items: [
-                    ...(canFilter
-                      ? [
-                          {
-                            icon: sfIcon('magnifyingglass'),
-                            label: 'Search',
-                            onPress: () => setFolderViewFilter(''),
-                            type: 'action' as const,
-                          },
-                        ]
-                      : []),
-                    ...(canUpload
-                      ? [
-                          {
-                            icon: sfIcon('arrow.up.doc'),
-                            label: 'Upload',
-                            onPress: () => uploadRef.current?.open(),
-                            type: 'action' as const,
-                          },
-                        ]
-                      : []),
-                    {
-                      icon: sfIcon('ellipsis'),
-                      label: 'More',
-                      onPress: () => moreRef.current?.open(),
-                      type: 'action' as const,
+              extras.length
+                ? {
+                    icon: sfIcon('ellipsis'),
+                    label: 'More',
+                    menu: {
+                      items: [
+                        ...extras,
+                        {
+                          icon: sfIcon('ellipsis'),
+                          label: 'More',
+                          onPress: openMore,
+                          type: 'action' as const,
+                        },
+                      ],
                     },
-                  ],
-                },
-                type: 'menu' as const,
-              },
+                    type: 'menu' as const,
+                  }
+                : {
+                    icon: sfIcon('ellipsis'),
+                    label: 'More',
+                    onPress: openMore,
+                    type: 'button' as const,
+                  },
             ],
     })
   }, [navigation, hasSoftError, path, canFilter, canUpload, setFolderViewFilter])

--- a/shared/profile/routes.tsx
+++ b/shared/profile/routes.tsx
@@ -158,6 +158,6 @@ export const newModalRoutes = defineRouteMap({
     getOptions: {modalSize: 'wide'},
   }),
   profileShowcaseTeamOffer: C.makeScreen(React.lazy(async () => import('./showcase-team-offer')), {
-    getOptions: {modalSize: 'wide', title: 'Feature your teams'},
+    getOptions: {...Kb.doneModalOptions('Feature your teams'), modalSize: 'wide'},
   }),
 })

--- a/shared/profile/showcase-team-offer.tsx
+++ b/shared/profile/showcase-team-offer.tsx
@@ -80,6 +80,7 @@ const TeamRow = (p: RowProps) => {
             label={showcased ? 'Featured' : 'Feature'}
             onClick={() => onPromote(!showcased)}
             small={true}
+            style={styles.promoteButton}
             type="Success"
             mode={showcased ? 'Secondary' : 'Primary'}
             waiting={waiting}
@@ -139,6 +140,12 @@ const useStyles = Kb.Styles.createStyleHook(
       noteText: {
         ...Kb.Styles.padding(Kb.Styles.globalMargins.tiny, Kb.Styles.globalMargins.large, Kb.Styles.globalMargins.small),
       },
+      // Feature / Featured are different lengths; pin a width wide enough for the
+      // longer label so the button doesn't resize as rows toggle.
+      promoteButton: Kb.Styles.platformStyles({
+        isElectron: {minWidth: 88},
+        isMobile: {minWidth: 112},
+      }),
       teamNameShowcaseTeamOffer: {flexShrink: 1},
       teamRowShowcaseTeamOffer: Kb.Styles.platformStyles({
         common: {

--- a/shared/profile/user/teams/team-row.tsx
+++ b/shared/profile/user/teams/team-row.tsx
@@ -13,23 +13,39 @@ type Props = {
 
 const TeamRow = ({isOpen, loading = false, name, onClick, popup, popupAnchor}: Props) => {
   const styles = useStyles()
+  // mobile columns are narrow, so an inline OPEN tag eats the name; badge the avatar instead
+  const showOpen = isOpen === true
   return (
     <Kb.ClickableBox direction="horizontal" fullWidth={true} gap="tiny" style={styles.row} ref={popupAnchor} onClick={onClick}>
       <>
         {popup}
-        <Kb.Avatar size={32} teamname={name} isTeam={true} />
+        <Kb.Box2 direction="vertical" relative={true} style={styles.avatar}>
+          <Kb.Avatar size={32} teamname={name} isTeam={true} />
+          {showOpen && isMobile && (
+            <Kb.Box2 direction="vertical" alignItems="center" style={styles.openBadge} pointerEvents="none">
+              <Kb.Meta variant="open" size="Small" />
+            </Kb.Box2>
+          )}
+        </Kb.Box2>
       </>
       <Kb.Text type="BodySemiboldLink" lineClamp={1} style={styles.title}>
         {name}
       </Kb.Text>
-      {typeof isOpen === 'boolean' && <OpenMeta isOpen={isOpen} />}
+      {!isMobile && typeof isOpen === 'boolean' && <OpenMeta isOpen={isOpen} />}
       {loading && <Kb.ProgressIndicator style={styles.loading} />}
     </Kb.ClickableBox>
   )
 }
 
 const useStyles = Kb.Styles.createStyleHook(theme => ({
+  avatar: {flexShrink: 0, ...Kb.Styles.size(32)},
   loading: Kb.Styles.size(16),
+  openBadge: {
+    bottom: -2,
+    left: -8,
+    position: 'absolute',
+    right: -8,
+  },
   row: {
     alignItems: 'center',
   },

--- a/shared/router-v2/account-switch-header-avatar.native.tsx
+++ b/shared/router-v2/account-switch-header-avatar.native.tsx
@@ -7,7 +7,6 @@ import {useConfigState} from '@/stores/config'
 import {useCurrentUserState} from '@/stores/current-user'
 import * as React from 'react'
 import {Pressable} from 'react-native'
-import logger from '@/logger'
 
 const openAccountSwitcher = () => {
   C.Router2.navigateAppend({name: 'accountSwitcher', params: {}})
@@ -16,10 +15,9 @@ const openAccountSwitcher = () => {
 const AccountSwitchHeaderAvatar = () => {
   const styles = useStyles()
   const username = useCurrentUserState(s => s.username)
-  const {configuredAccounts, httpSrvReady, login, setUserSwitching, userSwitching} = useConfigState(
+  const {configuredAccounts, login, setUserSwitching, userSwitching} = useConfigState(
     C.useShallow(s => ({
       configuredAccounts: s.configuredAccounts,
-      httpSrvReady: !!s.httpSrv.address,
       login: s.dispatch.login,
       setUserSwitching: s.dispatch.setUserSwitching,
       userSwitching: s.userSwitching,
@@ -27,19 +25,6 @@ const AccountSwitchHeaderAvatar = () => {
   )
   const recentAccount = getMostRecentlyUsedAccount(configuredAccounts, username)
   const handledLongPressRef = React.useRef(false)
-
-  React.useEffect(() => {
-    logger.info('[AccountSwitcherHeader] mounted')
-    return () => {
-      logger.info('[AccountSwitcherHeader] unmounted')
-    }
-  }, [])
-
-  React.useEffect(() => {
-    logger.info(
-      `[AccountSwitcherHeader] state tab=${C.Router2.getTab() ?? 'none'} username=${username || 'none'} http=${httpSrvReady ? 'ready' : 'missing'} accounts=${configuredAccounts.length} recent=${recentAccount?.username ?? 'none'}`
-    )
-  }, [configuredAccounts.length, httpSrvReady, recentAccount?.username, username])
 
   const switchToRecentAccount = () => {
     if (userSwitching || !recentAccount) return
@@ -63,16 +48,6 @@ const AccountSwitchHeaderAvatar = () => {
     openAccountSwitcher()
   }
 
-  const onAvatarError = () => {
-    logger.warn(
-      `[AccountSwitcherHeader] avatar error username=${username || 'none'} http=${httpSrvReady ? 'ready' : 'missing'}`
-    )
-  }
-
-  const onAvatarLoad = () => {
-    logger.info(`[AccountSwitcherHeader] avatar loaded username=${username || 'none'}`)
-  }
-
   return (
     <Pressable
       accessibilityHint={
@@ -86,7 +61,7 @@ const AccountSwitchHeaderAvatar = () => {
       style={Kb.Styles.castStyleNative(styles.container)}
       testID={TestIDs.PEOPLE_HEADER_AVATAR}
     >
-      <Kb.Avatar size={32} username={username} onError={onAvatarError} onLoad={onAvatarLoad} />
+      <Kb.Avatar size={32} username={username} />
     </Pressable>
   )
 }

--- a/shared/router-v2/router.tsx
+++ b/shared/router-v2/router.tsx
@@ -86,16 +86,7 @@ const onUnhandledAction = (a: Readonly<{type: string}>) => {
   logger.error(`[NAV] Unhandled action: ${a.type}`, a, C.Router2.logState())
 }
 const onStateChange = () => {
-  const navState = C.Router2.getRootState()
-  C.useRouterState.getState().dispatch.setNavState(navState)
-  if (isMobile && navState) {
-    const tab = C.Router2.getTab(navState)
-    const visible = C.Router2.getVisibleScreen(navState)?.name ?? 'none'
-    const tabRoot = tab ? tabRoots[tab] : undefined
-    logger.info(
-      `[AccountSwitcherHeader] navigation tab=${tab ?? 'none'} visible=${visible} root=${tabRoot || 'none'} expected=${visible === tabRoot ? 'yes' : 'no'}`
-    )
-  }
+  C.useRouterState.getState().dispatch.setNavState(C.Router2.getRootState())
 }
 const setNavRef = (ref: typeof C.Router2.navigationRef.current) => {
   if (ref) {
@@ -346,20 +337,24 @@ const tabStackOptions = ({
   navigation,
   route,
 }: {
-  navigation: {canGoBack: () => boolean}
-  route: {name: string}
+  navigation: {getState: () => {routes: ReadonlyArray<{key: string}>}}
+  route: {key: string}
 }): NativeStackNavigationOptions => {
-  const canGoBack = navigation.canGoBack()
-  logger.info(
-    `[AccountSwitcherHeader] options route=${route.name} canGoBack=${canGoBack ? 'yes' : 'no'} install=${canGoBack ? 'no' : 'yes'}`
-  )
+  // Ask THIS stack, not canGoBack(): canGoBack delegates to the parent navigators
+  // (@react-navigation/core useNavigationHelpers), and on a phone each tab stack holds
+  // only its root screen, so it always answered about the root stack instead. Anything
+  // pushed above the tabs then made every tab root look pushed, and since options are
+  // only recomputed when the tab stack re-renders, the avatar stayed gone after the
+  // push was popped — until some unrelated re-render (badge, theme) happened to land
+  // at depth 1.
+  const isRoot = navigation.getState().routes[0]?.key === route.key
   return {
     ...Common.defaultNavigationOptions,
     // Root screens show the account switcher avatar. Pushed screens use the
     // native back button (liquid glass pill on iOS 26).
-    headerBackVisible: canGoBack,
-    headerLeft: isAndroid && !canGoBack ? () => <AccountSwitchHeaderAvatar /> : undefined,
-    ...(isIOS && !canGoBack
+    headerBackVisible: !isRoot,
+    headerLeft: isAndroid && isRoot ? () => <AccountSwitchHeaderAvatar /> : undefined,
+    ...(isIOS && isRoot
       ? {
           unstable_headerLeftItems: () => [
             {

--- a/shared/tracker/assertion.tsx
+++ b/shared/tracker/assertion.tsx
@@ -95,9 +95,12 @@ const Assertion = (ownProps: OwnProps) => {
     if (metas.find(m => m.label === 'unreachable')) {
       return {
         header: (
-          <Kb.Text center={true} type="BodySmallSemibold" style={styles.popupHeaderTextRed}>
-            Your proof could not be found, and Keybase has stopped checking. How would you like to proceed?
-          </Kb.Text>
+          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.popupHeaderRed}>
+            <Kb.Text center={true} type="BodySmallSemibold" style={styles.popupHeaderText}>
+              Your proof could not be found, and Keybase has stopped checking. How would you like to
+              proceed?
+            </Kb.Text>
+          </Kb.Box2>
         ),
         items: [
           {onClick: onShowProof, title: 'View proof'},
@@ -120,9 +123,11 @@ const Assertion = (ownProps: OwnProps) => {
       }
       return {
         header: pendingMessage ? (
-          <Kb.Text center={true} type="BodySmallSemibold" style={styles.popupHeaderTextBlue}>
-            {pendingMessage}
-          </Kb.Text>
+          <Kb.Box2 direction="vertical" fullWidth={true} style={styles.popupHeaderBlue}>
+            <Kb.Text center={true} type="BodySmallSemibold" style={styles.popupHeaderText}>
+              {pendingMessage}
+            </Kb.Text>
+          </Kb.Box2>
         ) : null,
         items: [onRevoke],
       }
@@ -445,10 +450,13 @@ const AssertionSiteIcon = (p: SIProps) => {
   )
 }
 
-const popupHeaderTextBase = (theme: Kb.Styles.Theme) =>
+const popupHeaderBase = () =>
   ({
-    color: theme.white,
     ...Kb.Styles.padding(Kb.Styles.globalMargins.tiny, Kb.Styles.globalMargins.small),
+    // the menu's card is rounded but can't clip its children — the valid-proof
+    // header hangs a decoration icon outside its bounds — so the banner rounds itself
+    borderTopLeftRadius: Kb.Styles.borderRadius,
+    borderTopRightRadius: Kb.Styles.borderRadius,
   }) as const
 
 const useStyles = Kb.Styles.createStyleHook(
@@ -458,10 +466,9 @@ const useStyles = Kb.Styles.createStyleHook(
       crypto: Kb.Styles.platformStyles({
         isElectron: {display: 'inline-block', fontSize: 11, wordBreak: 'break-all'},
       }),
-      floatingMenu: {
-        maxWidth: 240,
-        minWidth: 196,
-      },
+      floatingMenu: Kb.Styles.platformStyles({
+        isElectron: {maxWidth: 240, minWidth: 196},
+      }),
       // desktop is handled by css
       halfOpacity: Kb.Styles.platformStyles({isMobile: {opacity: 0.5}}),
       menuHeader: {
@@ -469,14 +476,15 @@ const useStyles = Kb.Styles.createStyleHook(
         padding: Kb.Styles.globalMargins.small,
       },
       metaAssertion: {flexShrink: 0, paddingLeft: 20 + Kb.Styles.globalMargins.tiny * 2 - 4}, // icon spacing plus meta has 2 padding for some reason
-      popupHeaderTextBlue: {
-        ...popupHeaderTextBase(theme),
+      popupHeaderBlue: {
+        ...popupHeaderBase(),
         backgroundColor: theme.blue,
       },
-      popupHeaderTextRed: {
-        ...popupHeaderTextBase(theme),
+      popupHeaderRed: {
+        ...popupHeaderBase(),
         backgroundColor: theme.red,
       },
+      popupHeaderText: {color: theme.white},
       site: {color: theme.black_20},
       siteIconFullDecoration: {bottom: -8, position: 'absolute', right: -10},
       statusAssertion: Kb.Styles.platformStyles({

--- a/shared/util/platform-specific/index.tsx
+++ b/shared/util/platform-specific/index.tsx
@@ -100,7 +100,10 @@ export async function saveAttachmentToCameraRoll(filePath: string, mimeType: str
 // a file they either save the file:// path as the reminder or don't show up at
 // all. iosShareFile sends the contents as their own item next to the file, and
 // keeps the text away from whatever would write it out a second time.
-const kMaxInlineShareTextBytes = 10 * 1024 * 1024
+
+// the text crosses the bridge as a string and is held as one until the sheet
+// closes, and no target that takes text has any use for more than this
+const kMaxInlineShareTextBytes = 256 * 1024
 
 const inlineShareText = async (filePath: string, mimeType: string): Promise<string | undefined> => {
   if (!mimeType.startsWith('text/')) {
@@ -108,7 +111,7 @@ const inlineShareText = async (filePath: string, mimeType: string): Promise<stri
   }
   try {
     const file = new File(filePath.startsWith('file://') ? filePath : 'file://' + filePath)
-    // a text file this big is not going into a reminder; let it stay a file
+    // a text file past that is not going into a reminder; let it stay a file
     if (file.size > kMaxInlineShareTextBytes) {
       return undefined
     }

--- a/shared/util/platform-specific/index.tsx
+++ b/shared/util/platform-specific/index.tsx
@@ -3,7 +3,7 @@ import logger from '@/logger'
 import * as MediaLibrary from 'expo-media-library'
 import * as ExpoLocation from 'expo-location'
 import {File} from 'expo-file-system'
-import {addNotificationRequest, androidShare, androidShareText} from 'react-native-kb'
+import {addNotificationRequest, androidShare, androidShareText, iosShareFile} from 'react-native-kb'
 import {ActionSheetIOS} from 'react-native'
 
 export const requestPermissionsToWrite = async () => {
@@ -95,6 +95,30 @@ export async function saveAttachmentToCameraRoll(filePath: string, mimeType: str
   }
 }
 
+// Reminders and the other text targets activate on the share item's
+// attributedContentText, which only a plain string item fills in -- handed just
+// a file they either save the file:// path as the reminder or don't show up at
+// all. iosShareFile sends the contents as their own item next to the file, and
+// keeps the text away from whatever would write it out a second time.
+const kMaxInlineShareTextBytes = 10 * 1024 * 1024
+
+const inlineShareText = async (filePath: string, mimeType: string): Promise<string | undefined> => {
+  if (!mimeType.startsWith('text/')) {
+    return undefined
+  }
+  try {
+    const file = new File(filePath.startsWith('file://') ? filePath : 'file://' + filePath)
+    // a text file this big is not going into a reminder; let it stay a file
+    if (file.size > kMaxInlineShareTextBytes) {
+      return undefined
+    }
+    return await file.text()
+  } catch (e) {
+    logger.info('failed to read share text, sharing the file alone: ' + String(e))
+    return undefined
+  }
+}
+
 export const showShareActionSheet = async (options: {
   filePath?: string
   message?: string
@@ -104,6 +128,11 @@ export const showShareActionSheet = async (options: {
     return Promise.reject(new Error('Show Share Action - unsupported on this platform'))
   }
   if (isIOS) {
+    if (options.filePath) {
+      const text = options.message ?? (await inlineShareText(options.filePath, options.mimeType))
+      await iosShareFile(options.filePath, text ?? '')
+      return
+    }
     return new Promise<void>((resolve, reject) => {
       ActionSheetIOS.showShareActionSheetWithOptions(
         {


### PR DESCRIPTION
A batch of small mobile fixes, mostly iOS. Each commit stands on its own.

### Sharing from KBFS

The item menu rolled the two share actions up into a single `Share...` entry
that opened a second sheet just to pick between them. They are now listed
directly, named for what they do.

Tapping "Share to another app" left the menu up while the download ran and only
took it down once the hand-off resolved. The OS share sheet is a UIKit
presentation on the root view controller, so it renders *below* the bottom
sheet's `FullWindowOverlay` -- the sheet now goes as soon as the download
starts. Only the sheet: the menu component owns the hand-off and has to stay
mounted for it, so it drops its own `visible` rather than hiding the popup.
`onHidden` reads the current state through an effect event, since gorhom
reports that programmatic close through `onDismiss` too and the callback it was
unmounted with is stale.

Sharing a text file then saved a `file:///` path into Reminders and Notes
instead of what the file says, because the sheet was handed nothing but the
path. Those targets activate on the share item's `attributedContentText`, which
only a plain string item fills in -- an `NSItemProvider` carrying the text as a
representation does not, and leaves them out of the sheet entirely. So the
contents now go over as their own item beside the file. Both items carry the
same bytes and anything that writes an item out takes both, which put two
identical copies in Save to Files, hence the `UIActivityItemSource` wrapper that
lets the text sit out those activities. Only `text/*` under 256KB is read --
it crosses the bridge as a string and is held as one until the sheet closes,
and nothing that takes text has a use for more. Everything else shares as it
did.

### Elsewhere

- The overflow menu on iOS file previews is skipped when it would hold a single
  item.
- Loading placeholder rows show the online-only cloud.
- The mobile toggle no longer eats a row's leftover space.
- The featured-teams modal dismisses with Done rather than Cancel, and the
  avatar is badged with OPEN so long team names stop clipping.
- Tab roots keep the account switcher avatar on mobile.
- The proof menu fills the mobile bottom sheet.

### Note for reviewers

The last commit touches `rnmodules/react-native-kb`, so building it needs
`yarn sync:kb-modules` first. No podspec change, so `Podfile.lock` is untouched.

