### PR TITLE
fix(chat): center the attachment collapse caret with its label

### DIFF
--- a/shared/chat/conversation/messages/attachment/image/index.tsx
+++ b/shared/chat/conversation/messages/attachment/image/index.tsx
@@ -40,7 +40,7 @@ function Image(p: Props) {
 
   const filename =
     isMobile || !fileName ? null : (
-      <Kb.Box2 direction="horizontal" alignSelf="flex-start" gap="xtiny">
+      <Kb.Box2 direction="horizontal" alignSelf="flex-start" alignItems="center" gap="xtiny">
         <Kb.Text type="BodySmall">{fileName}</Kb.Text>
         {collapseIcon}
       </Kb.Box2>

--- a/shared/chat/conversation/messages/attachment/shared.tsx
+++ b/shared/chat/conversation/messages/attachment/shared.tsx
@@ -311,7 +311,7 @@ const useCollapseAction = (ordinal: T.Chat.Ordinal) => {
 const useCollapseIconDesktop = (ordinal: T.Chat.Ordinal, isCollapsed: boolean, isWhite: boolean) => {
   const onCollapse = useCollapseAction(ordinal)
   return (
-    <Kb.ClickableBox direction="horizontal" alignSelf="flex-start" gap="xtiny" onClick={onCollapse}>
+    <Kb.ClickableBox direction="horizontal" alignSelf="center" gap="xtiny" onClick={onCollapse}>
       <CollapseIcon isCollapsed={isCollapsed} isWhite={isWhite} />
     </Kb.ClickableBox>
   )
@@ -324,7 +324,7 @@ export const Collapsed = ({isCollapsed, ordinal}: {isCollapsed: boolean; ordinal
   const onCollapse = useCollapseAction(ordinal)
   const collapseIcon = useCollapseIcon(ordinal, isCollapsed, false)
   return (
-    <Kb.Box2 direction="horizontal" fullWidth={true}>
+    <Kb.Box2 direction="horizontal" fullWidth={true} alignItems="center">
       <Kb.Text type="BodyTiny" onClick={onCollapse}>
         Collapsed
       </Kb.Text>

--- a/shared/chat/conversation/messages/attachment/video/index.tsx
+++ b/shared/chat/conversation/messages/attachment/video/index.tsx
@@ -39,7 +39,7 @@ function Video(p: Props) {
 
   const filename =
     isMobile || !fileName ? null : (
-      <Kb.Box2 direction="horizontal" alignSelf="flex-start" gap="xtiny">
+      <Kb.Box2 direction="horizontal" alignSelf="flex-start" alignItems="center" gap="xtiny">
         <Kb.Text type="BodySmall">{fileName}</Kb.Text>
         {collapseIcon}
       </Kb.Box2>


### PR DESCRIPTION
The collapse caret next to an attachment's filename was top-aligned instead of centered against the text.

Its `ClickableBox` wrapper carried an explicit `alignSelf="flex-start"`, which pinned it to the top of the row. Switched to `alignSelf="center"`, and gave the rows that hold it `alignItems="center"` so they stop stretching their children.

- `attachment/shared.tsx` — `useCollapseIconDesktop` wrapper, and the `Collapsed` row
- `attachment/image/index.tsx`, `attachment/video/index.tsx` — filename rows

Desktop only; the mobile collapse icon renders `null`.

`yarn lint:all` clean (0 bailouts, 0 whole-props deps, tsc green).