### PR TITLE
fix(chat): keep a fresh 24h exploding message reading 24h

### DIFF
--- a/shared/chat/conversation/messages/wrapper/exploding-meta.test.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.test.tsx
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 /// <reference types="jest" />
-import {getLoopInterval, makeInitialTimerState} from './exploding-meta'
+import {getLoopInterval, makeInitialTimerState, syncTimerState} from './exploding-meta'
+import {formatDurationShort} from '@/util/timestamp'
 
 const second = 1000
 const minute = 60 * second
@@ -14,20 +15,23 @@ describe('getLoopInterval', () => {
     expect(getLoopInterval(minute)).toBe(500)
   })
 
-  test('within half a unit of the boundary it wakes exactly on the boundary', () => {
-    // the remainder is returned so the displayed unit flips on time
-    expect(getLoopInterval(70 * second)).toBe(10 * second)
-    expect(getLoopInterval(90 * second)).toBe(30 * second)
-    expect(getLoopInterval(hour + 20 * minute)).toBe(20 * minute)
+  test('wakes when the rounded-up display next drops a unit', () => {
+    // a fresh 24h fuse reads 24h until 23h are left
+    expect(getLoopInterval(day - 1)).toBe(hour - 1)
+    expect(getLoopInterval(23 * hour + 20 * minute)).toBe(20 * minute)
     expect(getLoopInterval(day + 8 * hour)).toBe(8 * hour)
+    expect(getLoopInterval(90 * second)).toBe(30 * second)
+    expect(getLoopInterval(100 * second)).toBe(40 * second)
   })
 
-  test('further into a unit it wakes on the next half-unit mark', () => {
-    // 100s = 1m40s; past the half-minute mark, so wake 10s later at 1m30s
-    expect(getLoopInterval(100 * second)).toBe(10 * second)
-    // exactly 2 units in: half a unit until the next half mark
-    expect(getLoopInterval(2 * hour)).toBe(hour / 2)
-    expect(getLoopInterval(3 * day)).toBe(day / 2)
+  test('on an exact boundary it waits a whole unit', () => {
+    expect(getLoopInterval(2 * hour)).toBe(hour)
+    expect(getLoopInterval(3 * day)).toBe(day)
+  })
+
+  test('above a minute it never asks for sub-second ticks', () => {
+    // a timer that fires a hair early lands just past a boundary
+    expect(getLoopInterval(hour + 1)).toBe(second)
   })
 })
 
@@ -45,6 +49,7 @@ describe('makeInitialTimerState', () => {
   test('a pending send shows nothing yet', () => {
     expect(makeInitialTimerState({exploded: false, explodesAt: now + hour, pending: true})).toEqual({
       exploded: false,
+      explodesAt: now + hour,
       inter: 0,
       mode: 'none',
       now,
@@ -54,6 +59,7 @@ describe('makeInitialTimerState', () => {
   test('an already exploded message is hidden', () => {
     expect(makeInitialTimerState({exploded: true, explodesAt: now + hour, pending: false})).toEqual({
       exploded: true,
+      explodesAt: now + hour,
       inter: 0,
       mode: 'hidden',
       now,
@@ -63,6 +69,7 @@ describe('makeInitialTimerState', () => {
   test('a message past its explode time is hidden', () => {
     expect(makeInitialTimerState({exploded: false, explodesAt: now - 1, pending: false})).toEqual({
       exploded: false,
+      explodesAt: now - 1,
       inter: 0,
       mode: 'hidden',
       now,
@@ -72,6 +79,7 @@ describe('makeInitialTimerState', () => {
   test('a live message counts down on the loop interval', () => {
     expect(makeInitialTimerState({exploded: false, explodesAt: now + 90 * second, pending: false})).toEqual({
       exploded: false,
+      explodesAt: now + 90 * second,
       inter: minute / 2,
       mode: 'countdown',
       now,
@@ -86,5 +94,51 @@ describe('makeInitialTimerState', () => {
     })
     expect(mode).toBe('countdown')
     expect(inter).toBe(minute)
+  })
+})
+
+describe('syncTimerState', () => {
+  const t0 = 1_700_000_000_000
+  let clock = t0
+
+  beforeEach(() => {
+    clock = t0
+    jest.spyOn(Date, 'now').mockImplementation(() => clock)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('unchanged props keep the same state', () => {
+    const p = {exploded: false, explodesAt: t0 + day - 50, pending: false}
+    const s = makeInitialTimerState(p)
+    clock += 2 * second
+    expect(syncTimerState(s, p)).toBe(s)
+  })
+
+  test('a later explodesAt from a re-unbox is measured from the current time', () => {
+    // the service stamps a fresh receive time on every unbox, so a reload can push a
+    // just-sent 24h message's explodesAt a little later than it was when the row mounted
+    const s = makeInitialTimerState({exploded: false, explodesAt: t0 + day - 50, pending: false})
+    expect(formatDurationShort(s.explodesAt - s.now)).toBe('24h')
+    clock += 2 * second
+    const next = syncTimerState(s, {exploded: false, explodesAt: t0 + day + 1500, pending: false})
+    expect(next.now).toBe(clock)
+    expect(next.mode).toBe('countdown')
+    expect(formatDurationShort(next.explodesAt - next.now)).toBe('24h')
+  })
+
+  test('exploding goes to boom even if explodesAt moved with it', () => {
+    const s = makeInitialTimerState({exploded: false, explodesAt: t0 + hour, pending: false})
+    const next = syncTimerState(s, {exploded: true, explodesAt: t0, pending: false})
+    expect(next.mode).toBe('boom')
+    expect(next.inter).toBe(0)
+    expect(syncTimerState(next, {exploded: true, explodesAt: t0, pending: false})).toBe(next)
+  })
+
+  test('a countdown that reached boom is not reset by a moved explodesAt', () => {
+    const s = {...makeInitialTimerState({exploded: false, explodesAt: t0 + second, pending: false}), mode: 'boom' as const}
+    expect(syncTimerState(s, {exploded: false, explodesAt: t0 + 2 * second, pending: false})).toBe(s)
   })
 })

--- a/shared/chat/conversation/messages/wrapper/exploding-meta.tsx
+++ b/shared/chat/conversation/messages/wrapper/exploding-meta.tsx
@@ -28,6 +28,7 @@ type ExplodingMetaInnerProps = OwnProps & {pending: boolean}
 type Mode = 'none' | 'countdown' | 'boom' | 'hidden'
 export type TimerState = {
   exploded: boolean
+  explodesAt: number
   inter: number
   mode: Mode
   now: number
@@ -38,16 +39,38 @@ const isPendingSubmitState = (submitState?: T.Chat.Message['submitState']) =>
 
 const cappedLoopInterval = (difference: number) => Math.min(getLoopInterval(difference), 60000)
 
-export const makeInitialTimerState = (p: {exploded: boolean; explodesAt: number; pending: boolean}): TimerState => {
+type TimerProps = {exploded: boolean; explodesAt: number; pending: boolean}
+
+export const makeInitialTimerState = (p: TimerProps): TimerState => {
+  const {exploded, explodesAt} = p
   const now = Date.now()
   if (p.pending) {
-    return {exploded: p.exploded, inter: 0, mode: 'none', now}
+    return {exploded, explodesAt, inter: 0, mode: 'none', now}
   }
-  const difference = p.explodesAt - now
-  if (difference <= 0 || p.exploded) {
-    return {exploded: p.exploded, inter: 0, mode: 'hidden', now}
+  const difference = explodesAt - now
+  if (difference <= 0 || exploded) {
+    return {exploded, explodesAt, inter: 0, mode: 'hidden', now}
   }
-  return {exploded: p.exploded, inter: cappedLoopInterval(difference), mode: 'countdown', now}
+  return {exploded, explodesAt, inter: cappedLoopInterval(difference), mode: 'countdown', now}
+}
+
+// The service derives explodesAt from its receive time on every unbox, so a reload can move it
+// after the row mounted. Measuring the new value against the mount-time now overshoots the fuse,
+// which reads a fresh 24h message as 1d.
+export const syncTimerState = (s: TimerState, p: TimerProps): TimerState => {
+  if (s.exploded !== p.exploded) {
+    return produce(s, draft => {
+      draft.exploded = p.exploded
+      if (p.exploded) {
+        draft.inter = 0
+        draft.mode = 'boom'
+      }
+    })
+  }
+  if (s.explodesAt !== p.explodesAt && !p.exploded && s.mode !== 'boom') {
+    return makeInitialTimerState(p)
+  }
+  return s
 }
 
 function ExplodingMetaInner(p: ExplodingMetaInnerProps) {
@@ -58,15 +81,8 @@ function ExplodingMetaInner(p: ExplodingMetaInnerProps) {
     makeInitialTimerState({exploded, explodesAt, pending})
   )
 
-  let currentTimerState = timerState
-  if (timerState.exploded !== exploded) {
-    currentTimerState = produce(timerState, draft => {
-      draft.exploded = exploded
-      if (exploded) {
-        draft.inter = 0
-        draft.mode = 'boom'
-      }
-    })
+  const currentTimerState = syncTimerState(timerState, {exploded, explodesAt, pending})
+  if (currentTimerState !== timerState) {
     setTimerState(currentTimerState)
   }
   const {inter, mode, now} = currentTimerState
@@ -224,46 +240,17 @@ const oneMinuteInMs = 60 * 1000
 const oneHourInMs = oneMinuteInMs * 60
 const oneDayInMs = oneHourInMs * 24
 
+// formatDurationShort rounds up, so the display drops a unit exactly when the time left
+// reaches a whole multiple of it; wake then
 export const getLoopInterval = (diff: number) => {
-  let nearestUnit: number = 0
-
-  // If diff is less than half a unit away,
-  // we need to return the remainder so we
-  // update when the unit changes
-  const shouldReturnRemainder = (diff: number, nearestUnit: number) => diff - nearestUnit <= nearestUnit / 2
-
-  if (diff > oneDayInMs) {
-    nearestUnit = oneDayInMs
-
-    // special case for when we're coming on 1 day
-    if (shouldReturnRemainder(diff, nearestUnit)) {
-      return diff - nearestUnit
-    }
-  } else if (diff > oneHourInMs) {
-    nearestUnit = oneHourInMs
-
-    // special case for when we're coming on 1 hour
-    if (shouldReturnRemainder(diff, nearestUnit)) {
-      return diff - nearestUnit
-    }
-  } else if (diff > oneMinuteInMs) {
-    nearestUnit = oneMinuteInMs
-
-    // special case for when we're coming on 1 minute
-    if (shouldReturnRemainder(diff, nearestUnit)) {
-      return diff - nearestUnit
-    }
-  }
-  if (!nearestUnit) {
+  const unit = diff > oneDayInMs ? oneDayInMs : diff > oneHourInMs ? oneHourInMs : diff > oneMinuteInMs ? oneMinuteInMs : 0
+  if (!unit) {
     // less than a minute, check every half second
     return 500
   }
-  const deltaMS = diff - Math.floor(diff / nearestUnit) * nearestUnit
-  const halfNearestUnit = nearestUnit / 2
-  if (deltaMS > halfNearestUnit) {
-    return deltaMS - halfNearestUnit
-  }
-  return deltaMS + halfNearestUnit
+  // under a second the effect switches to the per-second ticker, which never recomputes the
+  // interval, so a timer landing just past a boundary would tick every second from then on
+  return Math.max(diff % unit || unit, 1000)
 }
 
 const useStyles = Kb.Styles.createStyleHook(

--- a/shared/util/timestamp.test.ts
+++ b/shared/util/timestamp.test.ts
@@ -72,6 +72,16 @@ describe('formatDurationShort', () => {
     expect(formatDurationShort(hour)).toBe('60m')
     expect(formatDurationShort(day)).toBe('24h')
   })
+
+  test('rounds up, so a unit only drops once a whole unit has elapsed', () => {
+    // a fresh 24h fuse reads 24h, and 23h only once an hour has passed
+    expect(formatDurationShort(day - 1)).toBe('24h')
+    expect(formatDurationShort(23 * hour + 20 * minute)).toBe('24h')
+    expect(formatDurationShort(23 * hour)).toBe('23h')
+    expect(formatDurationShort(2 * day + hour)).toBe('3d')
+    expect(formatDurationShort(61 * second)).toBe('2m')
+    expect(formatDurationShort(500)).toBe('1s')
+  })
 })
 
 describe('formatDuration', () => {

--- a/shared/util/timestamp.tsx
+++ b/shared/util/timestamp.tsx
@@ -252,18 +252,19 @@ export function msToDHMS(ms: number): string {
   return `${days}d ${hours}h ${mins}m ${secs}s`
 }
 
+// rounds up, so a fresh 24h fuse reads 24h and only reads 23h once a whole hour has passed
 export function formatDurationShort(ms: number): string {
   if (ms < 0) {
     return '0s'
   }
   if (ms > oneDayInMs) {
-    return `${Math.round(ms / oneDayInMs)}d`
+    return `${Math.ceil(ms / oneDayInMs)}d`
   }
   if (ms > oneHourInMs) {
-    return `${Math.round(ms / oneHourInMs)}h`
+    return `${Math.ceil(ms / oneHourInMs)}h`
   }
   if (ms > oneMinuteInMs) {
-    return `${Math.round(ms / oneMinuteInMs)}m`
+    return `${Math.ceil(ms / oneMinuteInMs)}m`
   }
-  return `${Math.floor(ms / 1000)}s`
+  return `${Math.ceil(ms / 1000)}s`
 }


### PR DESCRIPTION
## Problem

Sending an exploding message with the 24h option, the badge on the right of the message sometimes read **1d** instead of **24h**, and it dropped to **23h** after only 30 minutes.

## Cause

- **1d:** the badge measured time left against a `now` captured when the row mounted. The service re-derives a message's explode time from its receive time on every unbox, so a reload shortly after sending moves `explodesAt` slightly later, and the store merges it in place without a remount. Against the stale `now` the difference overshot 24h, so the badge read "1d" until its next timer tick (up to a minute). This dates from the move off `Date.now()`-in-render, not from the recent timestamp utility changes.
- **23h after 30 minutes:** `formatDurationShort` rounded to the nearest unit.

## Fix

- `exploding-meta.tsx`: new `syncTimerState` re-measures from the current time when `explodesAt` moves, unless the message has already exploded (the boom animation is untouched). `getLoopInterval` wakes exactly when the displayed value drops, and never asks for less than a second above a minute. Previously a timer landing just past a boundary could leave the badge re-rendering every second for the rest of its countdown.
- `util/timestamp.tsx`: `formatDurationShort` rounds up, so the badge reads 24h until a whole hour has passed, then 23h, and likewise for days, minutes and seconds. The last second now reads "1s" rather than "0s". The exploding-mode label next to the input is unchanged, since every option is a whole unit.

## Testing

- New unit tests for the round-up formatting, the loop interval, and re-measuring after `explodesAt` moves. They fail against the old code, and removing the re-measure makes the relevant test fail again.
- Full jest suite and `yarn lint:all` pass.
