### PR TITLE
fix(search): compile indexMetadata.Size on 32-bit android

### DIFF
--- a/go/chat/search/md.go
+++ b/go/chat/search/md.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 	"unsafe"
 
@@ -47,12 +46,7 @@ func (m *indexMetadata) dup() (res *indexMetadata) {
 }
 
 func (m *indexMetadata) Size() int64 {
-	size := unsafe.Sizeof(m.Version)
-	size += uintptr(len(m.SeenIDs)) * unsafe.Sizeof(chat1.MessageID(0))
-	if size > math.MaxInt64 {
-		return math.MaxInt64
-	}
-	return int64(size)
+	return int64(unsafe.Sizeof(m.Version)) + int64(len(m.SeenIDs))*int64(unsafe.Sizeof(chat1.MessageID(0)))
 }
 
 func (m *indexMetadata) MissingIDForConv(conv chat1.Conversation) (res []chat1.MessageID) {


### PR DESCRIPTION
The Android build fails compiling \`go/chat/search\` for armeabi-v7a:

\`\`\`
md.go:52:12: math.MaxInt64 (untyped int constant 9223372036854775807) overflows uintptr
\`\`\`

The overflow guard added in #29621 compares a \`uintptr\` against \`math.MaxInt64\`; on 32-bit ARM \`uintptr\` is 32 bits, so the constant doesn't fit. Host builds and golangci-lint run 64-bit, so they didn't catch it.

\`Size()\` now computes directly in \`int64\` (the \`Sizeof\` operands are constants, so no G115 conversion warning), and the unused \`math\` import is dropped.

Verified: \`GOOS=android GOARCH={arm,arm64,amd64} CGO_ENABLED=0 go build -tags android,prerelease,production ./chat/search/\` all build; gofmt and \`golangci-lint --new-from-rev master\` are clean.